### PR TITLE
rfm22b: Allow selection of hardware band.

### DIFF
--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -659,6 +659,7 @@ void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
 		uint8_t board_type, uint8_t board_rev,
 		HwSharedMaxRfPowerOptions max_power,
 		HwSharedMaxRfSpeedOptions max_speed,
+		HwSharedRfBandOptions rf_band,
 		const struct pios_openlrs_cfg *openlrs_cfg,
 		const struct pios_rfm22b_cfg *rfm22b_cfg,
 		uint8_t min_chan, uint8_t max_chan, uint32_t coord_id,
@@ -679,7 +680,7 @@ void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
 #if defined(PIOS_INCLUDE_OPENLRS_RCVR)
 		uintptr_t openlrs_id;
 
-		PIOS_OpenLRS_Init(&openlrs_id, PIOS_RFM22_SPI_PORT, 0, openlrs_cfg);
+		PIOS_OpenLRS_Init(&openlrs_id, PIOS_RFM22_SPI_PORT, 0, openlrs_cfg, rf_band);
 
 		{
 			uintptr_t rfm22brcvr_id;
@@ -695,7 +696,7 @@ void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
 			max_power == HWSHARED_MAXRFPOWER_0) {
 		// When radio disabled, it is ok for init to fail. This allows
 		// boards without populating this component.
-		if (PIOS_RFM22B_Init(&pios_rfm22b_id, PIOS_RFM22_SPI_PORT, rfm22b_cfg->slave_num, rfm22b_cfg) == 0) {
+		if (PIOS_RFM22B_Init(&pios_rfm22b_id, PIOS_RFM22_SPI_PORT, rfm22b_cfg->slave_num, rfm22b_cfg, rf_band) == 0) {
 			PIOS_RFM22B_SetTxPower(pios_rfm22b_id, RFM22_tx_pwr_txpow_0);
 			rfm22bstatus.DeviceID = PIOS_RFM22B_DeviceID(pios_rfm22b_id);
 			rfm22bstatus.BoardRevision = PIOS_RFM22B_ModuleVersion(pios_rfm22b_id);
@@ -713,7 +714,7 @@ void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
 			// Sparky2 can only receive PPM only
 
 		/* Configure the RFM22B device. */
-		if (PIOS_RFM22B_Init(&pios_rfm22b_id, PIOS_RFM22_SPI_PORT, rfm22b_cfg->slave_num, rfm22b_cfg)) {
+		if (PIOS_RFM22B_Init(&pios_rfm22b_id, PIOS_RFM22_SPI_PORT, rfm22b_cfg->slave_num, rfm22b_cfg, rf_band)) {
 			PIOS_Assert(0);
 		}
 

--- a/flight/PiOS/Common/pios_openlrs.c
+++ b/flight/PiOS/Common/pios_openlrs.c
@@ -104,6 +104,54 @@ const uint8_t default_hop_list[] = {DEFAULT_HOPLIST};
 const struct rfm22_modem_regs bind_params =
 { 9600, 0x05, 0x40, 0x0a, 0xa1, 0x20, 0x4e, 0xa5, 0x00, 0x20, 0x24, 0x4e, 0xa5, 0x2c, 0x23, 0x30 };
 
+static uint32_t minFreq(HwSharedRfBandOptions band) {
+	switch (band) {
+		default:
+		case HWSHARED_RFBAND_433:
+			return MIN_RFM_FREQUENCY_433;
+		case HWSHARED_RFBAND_868:
+			return MIN_RFM_FREQUENCY_868;
+		case HWSHARED_RFBAND_915:
+			return MIN_RFM_FREQUENCY_915;
+	}
+}
+
+static uint32_t maxFreq(HwSharedRfBandOptions band) {
+	switch (band) {
+		default:
+		case HWSHARED_RFBAND_433:
+			return MAX_RFM_FREQUENCY_433;
+		case HWSHARED_RFBAND_868:
+			return MAX_RFM_FREQUENCY_868;
+		case HWSHARED_RFBAND_915:
+			return MAX_RFM_FREQUENCY_915;
+	}
+}
+
+static uint32_t defCarrierFreq(HwSharedRfBandOptions band) {
+	switch (band) {
+		default:
+		case HWSHARED_RFBAND_433:
+			return DEFAULT_CARRIER_FREQUENCY_433;
+		case HWSHARED_RFBAND_868:
+			return DEFAULT_CARRIER_FREQUENCY_868;
+		case HWSHARED_RFBAND_915:
+			return DEFAULT_CARRIER_FREQUENCY_915;
+	}
+}
+
+static uint32_t bindingFreq(HwSharedRfBandOptions band) {
+	switch (band) {
+		default:
+		case HWSHARED_RFBAND_433:
+			return BINDING_FREQUENCY_433;
+		case HWSHARED_RFBAND_868:
+			return BINDING_FREQUENCY_868;
+		case HWSHARED_RFBAND_915:
+			return BINDING_FREQUENCY_915;
+	}
+}
+
 /*****************************************************************************
 * OpenLRS data formatting utilities
 *****************************************************************************/
@@ -262,6 +310,14 @@ static void setModemRegs(struct pios_openlrs_dev *openlrs_dev, const struct rfm2
 
 static void rfmSetCarrierFrequency(struct pios_openlrs_dev *openlrs_dev, uint32_t f)
 {
+	/* Protect ourselves from out-of-band frequencies.  Ideally we'd latch
+	 * an error here and prevent tx, but this is good enough to protect
+	 * the hardware. */
+	if ((f < minFreq(openlrs_dev->band)) ||
+			(f > maxFreq(openlrs_dev->band))) {
+		f = defCarrierFreq(openlrs_dev->band);
+	}
+
 	DEBUG_PRINTF(3,"rfmSetCarrierFrequency %d\r\n", f);
 	uint16_t fb, fc, hbsel;
 	if (f < 480000000) {
@@ -368,7 +424,7 @@ static void init_rfm(struct pios_openlrs_dev *openlrs_dev, uint8_t isbind)
 
 	rfm22_releaseBus(openlrs_dev);
 
-	rfmSetCarrierFrequency(openlrs_dev, isbind ? BINDING_FREQUENCY : openlrs_dev->bind_data.rf_frequency);
+	rfmSetCarrierFrequency(openlrs_dev, isbind ? bindingFreq(openlrs_dev->band) : openlrs_dev->bind_data.rf_frequency);
 }
 
 static void to_rx_mode(struct pios_openlrs_dev *openlrs_dev)
@@ -1096,7 +1152,8 @@ static struct pios_openlrs_dev * g_openlrs_dev;
  */
 int32_t PIOS_OpenLRS_Init(uintptr_t * openlrs_id, uint32_t spi_id,
 			 uint32_t slave_num,
-			 const struct pios_openlrs_cfg *cfg)
+			 const struct pios_openlrs_cfg *cfg,
+			 HwSharedRfBandOptions rf_band)
 {
 	PIOS_DEBUG_Assert(rfm22b_id);
 	PIOS_DEBUG_Assert(cfg);
@@ -1113,6 +1170,9 @@ int32_t PIOS_OpenLRS_Init(uintptr_t * openlrs_id, uint32_t spi_id,
 	openlrs_dev->slave_num = slave_num;
 	openlrs_dev->spi_id = spi_id;
 
+	// and the frequency
+	openlrs_dev->band = rf_band;
+
 	// Before initializing everything, make sure device found
 	uint8_t device_type = rfm22_read(openlrs_dev, RFM22_DEVICE_TYPE) & RFM22_DT_MASK;
 	if (device_type != 0x08)
@@ -1122,7 +1182,7 @@ int32_t PIOS_OpenLRS_Init(uintptr_t * openlrs_id, uint32_t spi_id,
 	openlrs_dev->rx_in_cb = NULL;
 	openlrs_dev->tx_out_cb = NULL;
 
-	// Initialzie the PPM callback.
+	// Initialize the "PPM" callback.
 	openlrs_dev->openlrs_rcvr_id = 0;
 
 	OpenLRSInitialize();

--- a/flight/PiOS/inc/pios_hal.h
+++ b/flight/PiOS/inc/pios_hal.h
@@ -62,12 +62,13 @@ void PIOS_HAL_ConfigureHID(HwSharedUSB_HIDPortOptions port_type,
 		const struct pios_usb_hid_cfg *hid_cfg);
 
 void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
-                uint8_t board_type, uint8_t board_rev,
-                HwSharedMaxRfPowerOptions max_power,
-                HwSharedMaxRfSpeedOptions max_speed,
-                const struct pios_openlrs_cfg *openlrs_cfg,
-                const struct pios_rfm22b_cfg *rfm22b_cfg,
-                uint8_t min_chan, uint8_t max_chan, uint32_t coord_id,
+		uint8_t board_type, uint8_t board_rev,
+		HwSharedMaxRfPowerOptions max_power,
+		HwSharedMaxRfSpeedOptions max_speed,
+		HwSharedRfBandOptions rf_band,
+		const struct pios_openlrs_cfg *openlrs_cfg,
+		const struct pios_rfm22b_cfg *rfm22b_cfg,
+		uint8_t min_chan, uint8_t max_chan, uint32_t coord_id,
 		int status_inst);
 
 #endif

--- a/flight/PiOS/inc/pios_openlrs.h
+++ b/flight/PiOS/inc/pios_openlrs.h
@@ -31,6 +31,8 @@
 #ifndef PIOS_OPENLRS_H
 #define PIOS_OPENLRS_H
 
+#include <hwshared.h>
+
 /* Global Types */
 struct pios_openlrs_cfg {
   const struct pios_spi_cfg *spi_cfg; /* Pointer to SPI interface configuration */
@@ -39,7 +41,9 @@ struct pios_openlrs_cfg {
 };
 
 extern int32_t PIOS_OpenLRS_Init(uintptr_t * openlrs_id, uint32_t spi_id,
-        uint32_t slave_num, const struct pios_openlrs_cfg *cfg);
+		uint32_t slave_num, const struct pios_openlrs_cfg *cfg, 
+		HwSharedRfBandOptions rf_band);
+
 extern void PIOS_OpenLRS_RegisterRcvr(uintptr_t openlrs_id, uintptr_t rfm22b_rcvr_id);
 extern uint8_t PIOS_OpenLRS_RSSI_Get(void);
 #endif /* PIOS_OPENLRS_H */

--- a/flight/PiOS/inc/pios_openlrs_priv.h
+++ b/flight/PiOS/inc/pios_openlrs_priv.h
@@ -93,22 +93,20 @@
 #define BINDING_VERSION ((OPENLRSNG_VERSION & 0x0ff0)>>4)
 
 // HW frequency limits
-#if (RFMTYPE == 868)
-#  define MIN_RFM_FREQUENCY 848000000
-#  define MAX_RFM_FREQUENCY 888000000
-#  define DEFAULT_CARRIER_FREQUENCY 868000000  // Hz  (ch 0)
-#  define BINDING_FREQUENCY 868000000 // Hz
-#elif (RFMTYPE == 915)
-#  define MIN_RFM_FREQUENCY 895000000
-#  define MAX_RFM_FREQUENCY 935000000
-#  define DEFAULT_CARRIER_FREQUENCY 915000000  // Hz  (ch 0)
-#  define BINDING_FREQUENCY 915000000 // Hz
-#else
-#  define MIN_RFM_FREQUENCY 413000000
-#  define MAX_RFM_FREQUENCY 463000000
-#  define DEFAULT_CARRIER_FREQUENCY 435000000  // Hz  (ch 0)
-#  define BINDING_FREQUENCY 435000000 // Hz
-#endif
+#define MIN_RFM_FREQUENCY_868 848000000
+#define MAX_RFM_FREQUENCY_868 888000000
+#define DEFAULT_CARRIER_FREQUENCY_868 868000000  // Hz  (ch 0)
+#define BINDING_FREQUENCY_868 868000000 // Hz
+
+#define MIN_RFM_FREQUENCY_915 895000000
+#define MAX_RFM_FREQUENCY_915 935000000
+#define DEFAULT_CARRIER_FREQUENCY_915 915000000  // Hz  (ch 0)
+#define BINDING_FREQUENCY_915 915000000 // Hz
+
+#define MIN_RFM_FREQUENCY_433 413000000
+#define MAX_RFM_FREQUENCY_433 463000000
+#define DEFAULT_CARRIER_FREQUENCY_433 435000000  // Hz  (ch 0)
+#define BINDING_FREQUENCY_433 435000000 // Hz
 
 #define RFM22_DEVICE_TYPE                         0x00  // R
 #define RFM22_DT_MASK                             0x1F
@@ -140,6 +138,8 @@ struct pios_openlrs_dev {
   // The SPI bus information
   uint32_t spi_id;
   uint32_t slave_num;
+
+  HwSharedRfBandOptions band;
 
   // The task handle
   struct pios_thread *taskHandle;

--- a/flight/PiOS/inc/pios_rfm22b.h
+++ b/flight/PiOS/inc/pios_rfm22b.h
@@ -86,7 +86,8 @@ struct rfm22b_stats {
 /* Public Functions */
 extern int32_t PIOS_RFM22B_Init(uint32_t * rfb22b_id, uint32_t spi_id,
 				uint32_t slave_num,
-				const struct pios_rfm22b_cfg *cfg);
+				const struct pios_rfm22b_cfg *cfg,
+				HwSharedRfBandOptions band);
 extern void PIOS_RFM22B_Reinit(uint32_t rfb22b_id);
 extern void PIOS_RFM22B_SetTxPower(uint32_t rfm22b_id,
 				   enum rfm22b_tx_power tx_pwr);

--- a/flight/PiOS/inc/pios_rfm22b_priv.h
+++ b/flight/PiOS/inc/pios_rfm22b_priv.h
@@ -181,6 +181,9 @@ struct pios_rfm22b_dev {
 	uint32_t spi_id;
 	uint32_t slave_num;
 
+	// The base frequency
+	uint32_t base_freq;
+
 	// Should this modem ack as a coordinator.
 	bool coordinator;
 

--- a/flight/targets/pipxtreme/fw/pios_board.c
+++ b/flight/targets/pipxtreme/fw/pios_board.c
@@ -181,7 +181,7 @@ void PIOS_Board_Init(void) {
 	const struct pios_rfm22b_cfg *rfm22b_cfg = PIOS_BOARD_HW_DEFS_GetRfm22Cfg(bdinfo->board_rev);
 	PIOS_HAL_ConfigureRFM22B(hwTauLink.Radio, bdinfo->board_type,
 	    bdinfo->board_rev, hwTauLink.MaxRfPower,
-	    hwTauLink.MaxRfSpeed, NULL, rfm22b_cfg,
+	    hwTauLink.MaxRfSpeed, hwTauLink.RfBand, NULL, rfm22b_cfg,
 	    hwTauLink.MinChannel, hwTauLink.MaxChannel,
 	    hwTauLink.CoordID, 0);
 

--- a/flight/targets/revomini/fw/pios_board.c
+++ b/flight/targets/revomini/fw/pios_board.c
@@ -353,6 +353,7 @@ void PIOS_Board_Init(void) {
 	PIOS_HAL_ConfigureRFM22B(hwRevoMini.Radio,
 			bdinfo->board_type, bdinfo->board_rev,
 			hwRevoMini.MaxRfPower, hwRevoMini.MaxRfSpeed,
+			hwRevoMini.RfBand,
 			openlrs_cfg, rfm22b_cfg, hwRevoMini.MinChannel,
 			hwRevoMini.MaxChannel, hwRevoMini.CoordID, 1);
 #endif /* PIOS_INCLUDE_RFM22B */

--- a/flight/targets/sparky2/fw/pios_board.c
+++ b/flight/targets/sparky2/fw/pios_board.c
@@ -462,6 +462,7 @@ void PIOS_Board_Init(void) {
 	PIOS_HAL_ConfigureRFM22B(hwSparky2.Radio,
 			bdinfo->board_type, bdinfo->board_rev,
 			hwSparky2.MaxRfPower, hwSparky2.MaxRfSpeed,
+			hwSparky2.RfBand,
 			openlrs_cfg, rfm22b_cfg,
 			hwSparky2.MinChannel, hwSparky2.MaxChannel,
 			hwSparky2.CoordID, 1);

--- a/shared/uavobjectdefinition/hwrevomini.xml
+++ b/shared/uavobjectdefinition/hwrevomini.xml
@@ -69,6 +69,7 @@
 		<!-- radio settings -->
 		<field name="MaxRfSpeed" units="bps" type="enum" elements="1" options="9600,19200,32000,64000,100000,192000" defaultvalue="64000"/>
 		<field name="MaxRfPower" units="mW" type="enum" elements="1" options="0,1.25,1.6,3.16,6.3,12.6,25,50,100" defaultvalue="0"/>
+		<field name="RfBand" units="MHz" type="enum" elements="1" parent="HwShared.RfBand" defaultvalue="BoardDefault"/>
 		<field name="MinChannel" units="" type="uint8" elements="1" defaultvalue="0"/>
 		<field name="MaxChannel" units="" type="uint8" elements="1" defaultvalue="250"/>
 		<field name="ChannelSet" units="" type="uint8" elements="1" defaultvalue="39"/>

--- a/shared/uavobjectdefinition/hwshared.xml
+++ b/shared/uavobjectdefinition/hwshared.xml
@@ -34,6 +34,7 @@
 		<field name="MaxRfSpeed" units="bps" type="enum" elements="1" options="9600,19200,32000,64000,100000,192000" defaultvalue="64000"/>
 		<field name="MaxRfPower" units="mW" type="enum" elements="1" options="0,1.25,1.6,3.16,6.3,12.6,25,50,100" defaultvalue="1.25"/>
 		<field name="DSMxMode" units="mode" type="enum" elements="1" options="Autodetect,Force 10-bit,Force 11-bit,Bind 3 pulses,Bind 4 pulses,Bind 5 pulses,Bind 6 pulses,Bind 7 pulses,Bind 8 pulses,Bind 9 pulses,Bind 10 pulses" defaultvalue="Autodetect"/>
+		<field name="RfBand" units="MHz" type="enum" elements="1" options="BoardDefault,433,868,915" defaultvalue="BoardDefault"/>
 
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>

--- a/shared/uavobjectdefinition/hwsparky2.xml
+++ b/shared/uavobjectdefinition/hwsparky2.xml
@@ -67,6 +67,7 @@
 		<!-- radio settings -->
 		<field name="MaxRfSpeed" units="bps" type="enum" elements="1" parent="HwShared.MaxRfSpeed" defaultvalue="64000"/>
 		<field name="MaxRfPower" units="mW" type="enum" elements="1" parent="HwShared.MaxRfPower"  defaultvalue="1.25"/>
+		<field name="RfBand" units="MHz" type="enum" elements="1" parent="HwShared.RfBand" defaultvalue="BoardDefault"/>
 		<field name="MinChannel" units="" type="uint8" elements="1" defaultvalue="0"/>
 		<field name="MaxChannel" units="" type="uint8" elements="1" defaultvalue="250"/>
 

--- a/shared/uavobjectdefinition/hwtaulink.xml
+++ b/shared/uavobjectdefinition/hwtaulink.xml
@@ -21,6 +21,7 @@
 		<!-- radio settings -->
 		<field name="MaxRfSpeed" units="bps" type="enum" elements="1" parent="HwShared.MaxRfSpeed" defaultvalue="64000"/>
 		<field name="MaxRfPower" units="mW" type="enum" elements="1" parent="HwShared.MaxRfPower" defaultvalue="3.16"/>
+		<field name="RfBand" units="MHz" type="enum" elements="1" parent="HwShared.RfBand" defaultvalue="BoardDefault"/>
 		<field name="MinChannel" units="" type="uint8" elements="1" defaultvalue="0"/>
 		<field name="MaxChannel" units="" type="uint8" elements="1" defaultvalue="250"/>
 


### PR DESCRIPTION
For both Tau-style telemetry and OpenLRS.  Initial frequencies chosen
for Tau-style telemetry on 868 and 915 bands.
