### PR TITLE
MSP Alarm Support

### DIFF
--- a/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
+++ b/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
@@ -150,6 +150,8 @@ struct msp_bridge {
 
 #define MAX_ALARM_LEN 30
 
+#define BOOT_DISPLAY_TIME_MS (10*1000)
+
 static bool module_enabled;
 extern uintptr_t pios_com_msp_id;
 static struct msp_bridge *msp;
@@ -395,7 +397,7 @@ static void msp_send_boxids(struct msp_bridge *m) {
 	msp_send(m, MSP_BOXIDS, boxes, len);
 }
 
-const char ALARM_NAMES[][8] = {
+static const char alarm_names[][8] = {
 	[SYSTEMALARMS_ALARM_OUTOFMEMORY] = "MEMORY",
 	[SYSTEMALARMS_ALARM_CPUOVERLOAD] = "CPU",
 	[SYSTEMALARMS_ALARM_STACKOVERFLOW] = "STACK",
@@ -422,7 +424,50 @@ const char ALARM_NAMES[][8] = {
 };
 
 // If someone adds a new alarm, we'd like it added to the array above.
-DONT_BUILD_IF(NELEMENTS(ALARM_NAMES) != SYSTEMALARMS_ALARM_NUMELEM, AlarmArrayMismatch);
+DONT_BUILD_IF(NELEMENTS(alarm_names) != SYSTEMALARMS_ALARM_NUMELEM, AlarmArrayMismatch);
+DONT_BUILD_IF(sizeof(*alarm_names) >= MAX_ALARM_LEN, BufferOverflow);
+
+static const char config_error_names[][14] = {
+	[SYSTEMALARMS_CONFIGERROR_STABILIZATION] = "CFG:STAB",
+	[SYSTEMALARMS_CONFIGERROR_MULTIROTOR] = "CFG:MULTIROTOR",
+	[SYSTEMALARMS_CONFIGERROR_AUTOTUNE] = "CFG:AUTOTUNE",
+	[SYSTEMALARMS_CONFIGERROR_ALTITUDEHOLD] = "CFG:AH1",
+	[SYSTEMALARMS_CONFIGERROR_POSITIONHOLD] = "CFG:POS-HOLD",
+	[SYSTEMALARMS_CONFIGERROR_PATHPLANNER] = "CFG:PATHPLAN",
+	[SYSTEMALARMS_CONFIGERROR_DUPLICATEPORTCFG] = "CFG:DUP PORT",
+	[SYSTEMALARMS_CONFIGERROR_NAVFILTER] = "CFG:NAVFILTER",
+	[SYSTEMALARMS_CONFIGERROR_UNSAFETOARM] = "CFG:UNSAFE",
+	[SYSTEMALARMS_CONFIGERROR_UNDEFINED] = "CFG:UNDEF",
+	[SYSTEMALARMS_CONFIGERROR_NONE] = {0},
+};
+
+// DONT_BUILD_IF(NELEMENTS(CONFIG_ERROR_NAMES) != SYSTEMALARMS_CONFIGERROR_NUMELEM, AlarmArrayMismatch);
+DONT_BUILD_IF(sizeof(*config_error_names) >= MAX_ALARM_LEN, BufferOverflow);
+
+static const char manual_control_names[][12] = {
+	[SYSTEMALARMS_MANUALCONTROL_SETTINGS] = "MAN:SETTINGS",
+	[SYSTEMALARMS_MANUALCONTROL_NORX] = "MAN:NO RX",
+	[SYSTEMALARMS_MANUALCONTROL_ACCESSORY] = "MAN:ACC",
+	[SYSTEMALARMS_MANUALCONTROL_ALTITUDEHOLD] = "MAN:A-HOLD",
+	[SYSTEMALARMS_MANUALCONTROL_PATHFOLLOWER] = "MAN:PATH-F",
+	[SYSTEMALARMS_MANUALCONTROL_UNDEFINED] = "MAN:UNDEF",
+	[SYSTEMALARMS_MANUALCONTROL_NONE] = {0},
+};
+
+// DONT_BUILD_IF(NELEMENTS(MANUAL_CONTROL_NAMES) != SYSTEMALARMS_MANUALCONTROL_NUMELEM, AlarmArrayMismatch);
+
+static const char boot_reason_names[][15] = {
+	[SYSTEMALARMS_REBOOTCAUSE_BROWNOUT] = "BOOT:BROWNOUT",
+	[SYSTEMALARMS_REBOOTCAUSE_PINRESET] = "BOOT:PIN RESET",
+	[SYSTEMALARMS_REBOOTCAUSE_POWERONRESET] = "BOOT:PWR ON RST",
+	[SYSTEMALARMS_REBOOTCAUSE_SOFTWARERESET] = "BOOT:SW RESET",
+	[SYSTEMALARMS_REBOOTCAUSE_INDEPENDENTWATCHDOG] "BOOT:INDY WDOG",
+	[SYSTEMALARMS_REBOOTCAUSE_WINDOWWATCHDOG] = "BOOT:WIN WDOG",
+	[SYSTEMALARMS_REBOOTCAUSE_LOWPOWER] = "BOOT:LOW POWER",
+	[SYSTEMALARMS_REBOOTCAUSE_UNDEFINED] = "BOOT:UNDEFINED",
+};
+
+DONT_BUILD_IF(sizeof(*boot_reason_names) >= MAX_ALARM_LEN, BufferOverflow);
 
 #define ALARM_OK 0
 #define ALARM_WARN 1
@@ -434,17 +479,28 @@ static void msp_send_alarms(struct msp_bridge *m) {
 		uint8_t buf[0];
 		struct {
 			uint8_t state;
-			uint8_t msg[MAX_ALARM_LEN];
+			char msg[MAX_ALARM_LEN];
 		} __attribute__((packed)) alarm;
 	} data;
 
 	SystemAlarmsData alarm;
 	SystemAlarmsGet(&alarm);
 
+	// Special case early boot times -- just report boot reason
+	if (PIOS_Thread_Systime() < BOOT_DISPLAY_TIME_MS) {
+		data.alarm.state = ALARM_CRIT;
+		strncpy((char*)data.alarm.msg,
+			(const char*)boot_reason_names[alarm.RebootCause],
+			sizeof(*boot_reason_names));
+		data.alarm.msg[sizeof(*boot_reason_names)] = '\0';
+		msp_send(m, MSP_ALARMS, data.buf, strlen((char*)data.alarm.msg)+1);
+		return;
+	}
+
 	data.alarm.state = ALARM_OK;
 
 	for (int i = 0; i < SYSTEMALARMS_ALARM_NUMELEM; i++) {
-		if (ALARM_NAMES[i][0] != 0 &&
+		if (alarm_names[i][0] != 0 &&
 		    ((alarm.Alarm[i] == SYSTEMALARMS_ALARM_WARNING) ||
 		     (alarm.Alarm[i] == SYSTEMALARMS_ALARM_ERROR) ||
 		     (alarm.Alarm[i] == SYSTEMALARMS_ALARM_CRITICAL))) {
@@ -464,8 +520,24 @@ static void msp_send_alarms(struct msp_bridge *m) {
 			// Only take this alarm if it's worse than the previous one.
 			if (state > data.alarm.state) {
 				data.alarm.state = state;
-				strncpy((char*)data.alarm.msg, (const char*)ALARM_NAMES[i], sizeof(*ALARM_NAMES));
-				data.alarm.msg[sizeof(*ALARM_NAMES)] = 0;
+				switch (i) {
+				case SYSTEMALARMS_ALARM_SYSTEMCONFIGURATION:
+					strncpy((char*)data.alarm.msg,
+						(const char*)config_error_names[alarm.ConfigError],
+						sizeof(*config_error_names));
+					data.alarm.msg[sizeof(*config_error_names)] = '\0';
+					break;
+				case SYSTEMALARMS_ALARM_MANUALCONTROL:
+					strncpy((char*)data.alarm.msg,
+						(const char*)manual_control_names[alarm.ManualControl],
+						sizeof(*manual_control_names));
+					data.alarm.msg[sizeof(*manual_control_names)] = '\0';
+					break;
+				default:
+					strncpy((char*)data.alarm.msg,
+						(const char*)alarm_names[i], sizeof(*alarm_names));
+					data.alarm.msg[sizeof(*alarm_names)] = '\0';
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This change creates a new MSP command that allows the peer (e.g. OSD) to ask for alarms from the flight controller. The alarm message includes severity and a message. In its current form, only one alarm is sent (fairly arbitrarily, other than severity taking precedence). Also, as a special and very useful case, boot reason is considered a warning from the perspective of the MSP code for the first few seconds. It might be worth generally considering that an alarm which would allow this special case code to be removed.

This has been very useful to me in showing both regular alarms (e.g. I let someone fly my sparky yesterday and saw 'MAN:NO RX' flashing on the screen because OpenTX companion turned off the radio for that profile) as well as boot reasons (saw watchdog firing in flight instead of mysteriously crashing).

STATUS: Flown a lot. Used to diagnose bugs.
CAVEAT: MWOSD side is not yet accepted (waiting for @ShikOfTheRa in ShikOfTheRa/scarab-osd#141)