### PR TITLE
UAVO: Add description element to fields, add tooltips in UAVO Browser

### DIFF
--- a/ground/gcs/src/plugins/uavobjectbrowser/treeitem.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/treeitem.h
@@ -111,11 +111,17 @@ public:
     int columnCount() const;
     QVariant data(int column = 1) const;
     QString description() { return m_description; }
-    void setDescription(QString d) { // Split around 40 characters
-        int idx = d.indexOf(" ",40);
-        d.insert(idx,QString("<br>"));
-        d.remove("@Ref", Qt::CaseInsensitive);
-        m_description = d;
+    void setDescription(QString d) {
+        if(d.trimmed().isEmpty()) {
+            m_description = QString();
+        }
+        else {
+            // insert html tags to make this rich text so Qt will take care of wrapping
+            d.prepend("<span style='font-style: normal'>");
+            d.remove("@Ref", Qt::CaseInsensitive);
+            d.append("</span>");
+            m_description = d;
+        }
     }
     // only column 1 (TreeItem::dataColumn) is changed with setData currently
     // other columns are initialized in constructor

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.cpp
@@ -272,6 +272,7 @@ void UAVObjectTreeModel::addArrayField(UAVObjectField *field, TreeItem *parent)
     for (uint i = 0; i < field->getNumElements(); ++i) {
         addSingleField(i, field, item);
     }
+    item->setDescription(field->getDescription());
     parent->appendChild(item);
 }
 
@@ -313,6 +314,7 @@ void UAVObjectTreeModel::addSingleField(int index, UAVObjectField *field, TreeIt
     default:
         Q_ASSERT(false);
     }
+    item->setDescription(field->getDescription());
     item->setHighlightManager(m_highlightManager);
     connect(item, SIGNAL(updateHighlight(TreeItem*)), this, SLOT(updateHighlight(TreeItem*)));
     parent->appendChild(item);

--- a/ground/gcs/src/plugins/uavobjects/uavobjectfield.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectfield.cpp
@@ -29,7 +29,7 @@
 #include <QtEndian>
 #include <QDebug>
 
-UAVObjectField::UAVObjectField(const QString& name, const QString& units, FieldType type, quint32 numElements, const QStringList& options, const QList<int>& indices, const QString &limits)
+UAVObjectField::UAVObjectField(const QString& name, const QString& units, FieldType type, quint32 numElements, const QStringList& options, const QList<int>& indices, const QString &limits, const QString &description)
 {
     QStringList elementNames;
     // Set element names
@@ -38,16 +38,16 @@ UAVObjectField::UAVObjectField(const QString& name, const QString& units, FieldT
         elementNames.append(QString("%1").arg(n));
     }
     // Initialize
-    constructorInitialize(name, units, type, elementNames, options, indices, limits);
+    constructorInitialize(name, units, type, elementNames, options, indices, limits, description);
 
 }
 
-UAVObjectField::UAVObjectField(const QString& name, const QString& units, FieldType type, const QStringList& elementNames, const QStringList& options, const QList<int>& indices, const QString &limits)
+UAVObjectField::UAVObjectField(const QString& name, const QString& units, FieldType type, const QStringList& elementNames, const QStringList& options, const QList<int>& indices, const QString &limits, const QString &description)
 {
-    constructorInitialize(name, units, type, elementNames, options, indices, limits);
+    constructorInitialize(name, units, type, elementNames, options, indices, limits, description);
 }
 
-void UAVObjectField::constructorInitialize(const QString& name, const QString& units, FieldType type, const QStringList& elementNames, const QStringList& options, const QList<int>& indices, const QString &limits)
+void UAVObjectField::constructorInitialize(const QString& name, const QString& units, FieldType type, const QStringList& elementNames, const QStringList& options, const QList<int>& indices, const QString &limits, const QString &description)
 {
     // Copy params
     this->name = name;
@@ -60,6 +60,7 @@ void UAVObjectField::constructorInitialize(const QString& name, const QString& u
     this->data = NULL;
     this->obj = NULL;
     this->elementNames = elementNames;
+    this->description = description;
     // Set field size
     switch (type)
     {
@@ -1054,3 +1055,7 @@ void UAVObjectField::setDouble(double value, quint32 index)
     setValue(QVariant(value), index);
 }
 
+QString UAVObjectField::getDescription()
+{
+    return description;
+}

--- a/ground/gcs/src/plugins/uavobjects/uavobjectfield.h
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectfield.h
@@ -51,8 +51,8 @@ public:
         int board;
     } LimitStruct;
 
-    UAVObjectField(const QString& name, const QString& units, FieldType type, quint32 numElements, const QStringList& options, const QList<int>& indices, const QString& limits=QString());
-    UAVObjectField(const QString& name, const QString& units, FieldType type, const QStringList& elementNames, const QStringList& options, const QList<int>& indices, const QString& limits=QString());
+    UAVObjectField(const QString& name, const QString& units, FieldType type, quint32 numElements, const QStringList& options, const QList<int>& indices, const QString& limits=QString(), const QString& description=QString());
+    UAVObjectField(const QString& name, const QString& units, FieldType type, const QStringList& elementNames, const QStringList& options, const QList<int>& indices, const QString& limits=QString(), const QString& description=QString());
     void initialize(quint8* data, quint32 dataOffset, UAVObject* obj);
     UAVObject* getObject();
     FieldType getType();
@@ -74,6 +74,7 @@ public:
     bool isNumeric();
     bool isText();
     QString toString();
+    QString getDescription();
 
     bool isWithinLimits(QVariant var, quint32 index, int board=0);
     QVariant getMaxLimit(quint32 index, int board=0);
@@ -94,8 +95,9 @@ protected:
     quint8* data;
     UAVObject* obj;
     QMap<quint32, QList<LimitStruct> > elementLimits;
+    QString description;
     void clear();
-    void constructorInitialize(const QString& name, const QString& units, FieldType type, const QStringList& elementNames, const QStringList& options, const QList<int> &indices, const QString &limits);
+    void constructorInitialize(const QString& name, const QString& units, FieldType type, const QStringList& elementNames, const QStringList& options, const QList<int> &indices, const QString &limits, const QString &description);
     void limitsInitialize(const QString &limits);
 
 

--- a/ground/gcs/src/plugins/uavobjects/uavobjecttemplate.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjecttemplate.cpp
@@ -36,6 +36,8 @@
 const QString $(NAME)::NAME = QString("$(NAME)");
 const QString $(NAME)::DESCRIPTION = QString("$(DESCRIPTION)");
 const QString $(NAME)::CATEGORY = QString("$(CATEGORY)");
+const QHash<QString, QString> $(NAME)::FIELD_DESCRIPTIONS{
+$(FIELDDESCRIPTIONS_STRINGS)};
 
 /**
  * Constructor

--- a/ground/gcs/src/plugins/uavobjects/uavobjecttemplate.h
+++ b/ground/gcs/src/plugins/uavobjects/uavobjecttemplate.h
@@ -70,6 +70,7 @@ $(DATAFIELDINFO)
     static const bool ISSINGLEINST = $(ISSINGLEINST);
     static const bool ISSETTINGS = $(ISSETTINGS);
     static const quint32 NUMBYTES = $(NUMBYTES);
+    static const QHash<QString, QString> FIELD_DESCRIPTIONS;
 
     // Functions
     $(NAME)();

--- a/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.cpp
+++ b/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.cpp
@@ -148,6 +148,7 @@ bool UAVObjectGeneratorGCS::process_object(ObjectInfo* info)
     QString propertySetters;
     QString propertyNotifications;
     QString propertyNotificationsImpl;
+    QString fieldDescriptionsStrings;
 
     //to avoid name conflicts
     QStringList reservedProperties;
@@ -263,6 +264,21 @@ bool UAVObjectGeneratorGCS::process_object(ObjectInfo* info)
                             "            emit %1Changed(data.%1);\n")
                     .arg(field->name);
         }
+
+        properties += QString("    Q_PROPERTY(QString %1_Description READ get%1_Description);\n")
+                    .arg(field->name);
+        propertyGetters +=
+                    QString("    Q_INVOKABLE QString get%1_Description() const;\n")
+                    .arg(field->name);
+        propertiesImpl +=
+                        QString("QString %1::get%2_Description() const\n"
+                                "{\n"
+                                "   return FIELD_DESCRIPTIONS[\"%2\"];\n"
+                                "}\n")
+                        .arg(info->name).arg(field->name);
+        fieldDescriptionsStrings += 
+                        QString("    {\"%1\", \"%2\"},\n")
+                        .arg(field->name).arg(escape_raw_string(field->description));
     }
 
     outInclude.replace(QString("$(PROPERTIES)"), properties);
@@ -272,6 +288,7 @@ bool UAVObjectGeneratorGCS::process_object(ObjectInfo* info)
 
     outCode.replace(QString("$(PROPERTIES_IMPL)"), propertiesImpl);
     outCode.replace(QString("$(NOTIFY_PROPERTIES_CHANGED)"), propertyNotificationsImpl);
+    outCode.replace(QString("$(FIELDDESCRIPTIONS_STRINGS)"), fieldDescriptionsStrings);
 
     // Replace the $(FIELDSINIT) tag
     QString finit;
@@ -322,7 +339,7 @@ bool UAVObjectGeneratorGCS::process_object(ObjectInfo* info)
 
             finit.append("};\n");
 
-            finit.append( QString("    fields.append( new UAVObjectField(QString(\"%1\"), QString(\"%2\"), UAVObjectField::ENUM, %3, %4, %5, QString(\"%6\")));\n")
+            finit.append( QString("    fields.append( new UAVObjectField(QString(\"%1\"), QString(\"%2\"), UAVObjectField::ENUM, %3, %4, %5, QString(\"%6\"), FIELD_DESCRIPTIONS[\"%1\"]));\n")
                           .arg(info->fields[n]->name)
                           .arg(info->fields[n]->units)
                           .arg(varElemName)
@@ -332,7 +349,7 @@ bool UAVObjectGeneratorGCS::process_object(ObjectInfo* info)
         }
         // For all other types
         else {
-            finit.append( QString("    fields.append( new UAVObjectField(QString(\"%1\"), QString(\"%2\"), UAVObjectField::%3, %4, QStringList(), QList<int>(), QString(\"%5\")));\n")
+            finit.append( QString("    fields.append( new UAVObjectField(QString(\"%1\"), QString(\"%2\"), UAVObjectField::%3, %4, QStringList(), QList<int>(), QString(\"%5\"), FIELD_DESCRIPTIONS[\"%1\"]));\n")
                           .arg(info->fields[n]->name)
                           .arg(info->fields[n]->units)
                           .arg(fieldTypeStrCPPClass[info->fields[n]->type])
@@ -479,4 +496,13 @@ bool UAVObjectGeneratorGCS::process_object(ObjectInfo* info)
     }
 
     return true;
+}
+
+/**
+ * Escapes a raw string so it can be used in generated C/C++ source
+ * Whitespace will be gobbled
+ */
+QString UAVObjectGeneratorGCS::escape_raw_string(QString raw)
+{
+    return raw.replace("\\", "\\\\").replace("\"", "\\\"").simplified();
 }

--- a/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.h
+++ b/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.h
@@ -40,6 +40,7 @@ private:
     bool process_object(ObjectInfo* info);
     QString form_enum_name(const QString& objectName,
             const QString& fieldName, const QString& option);
+    QString escape_raw_string(QString raw);
 
     QString gcsCodeTemplate,gcsIncludeTemplate;
     QStringList fieldTypeStrCPP,fieldTypeStrCPPClass;

--- a/ground/uavobjgenerator/uavobjectparser.cpp
+++ b/ground/uavobjgenerator/uavobjectparser.cpp
@@ -811,6 +811,16 @@ QString UAVObjectParser::processObjectFields(QDomNode& childNode, ObjectInfo* in
     else{
         field->limitValues=elemAttr.nodeValue();
     }
+
+    // Look for description string (for UI usage)
+    QDomNode node = childNode.firstChildElement("description");
+    if (!node.isNull()) {
+        QDomNode description = node.firstChild();
+        if (!description.isNull() && description.isText() && !description.nodeValue().isEmpty()) {
+            field->description = description.nodeValue().trimmed();
+        }
+    }
+
     // Add field to object
     info->fields.append(field);
     // Done

--- a/ground/uavobjgenerator/uavobjectparser.h
+++ b/ground/uavobjgenerator/uavobjectparser.h
@@ -70,6 +70,7 @@ struct FieldInfo_s {
     bool defaultElementNames;
     QStringList defaultValues;
     QString limitValues;
+    QString description;
 
     FieldInfo *parent;
     ObjectInfo *parentObj;

--- a/python/dronin/uavo.py
+++ b/python/dronin/uavo.py
@@ -268,6 +268,9 @@ def make_class(collection, xml_file, update_globals=True):
             if info['elements'] > 1 and not isinstance(info['defaultvalue'], tuple):
                 info['defaultvalue'] = (info['defaultvalue'],) * info['elements']
 
+            if field.find('description') != None:
+                info['description'] = field.find('description').text
+
         fields.append(info)
 
     # Sort fields by size (bigger to smaller) to ensure alignment when packed

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -1,16 +1,31 @@
 <xml>
     <object name="ActuatorSettings" singleinstance="true" settings="true">
         <description>Settings for the @ref ActuatorModule that controls the channel assignments for the mixer based on AircraftType</description>
-        <field name="TimerUpdateFreq" units="Hz" type="uint16" elements="6" defaultvalue="50"/>
-        <field name="TimerPwmResolution" units="" type="enum" elements="6" options="1MHz,12MHz" defaultvalue="1MHz"/>
-        <field name="ChannelMax" units="us" type="uint16" elements="10" defaultvalue="2000"/>
-        <field name="ChannelNeutral" units="us" type="uint16" elements="10" defaultvalue="1000"/>
-        <field name="ChannelMin" units="us" type="uint16" elements="10" defaultvalue="1000"/>
-        <field name="ChannelType" units="" type="enum" elements="10" options="PWM,PWM Alarm,Arming LED,Info LED" defaultvalue="PWM"/>
-        <field name="MotorsSpinWhileArmed" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
+        <field name="TimerUpdateFreq" units="Hz" type="uint16" elements="6" defaultvalue="50">
+            <description>The frequency of the PWM signal output to the actuator. 0 specifies synchronous PWM.</description>
+        </field>
+        <field name="TimerPwmResolution" units="" type="enum" elements="6" options="1MHz,12MHz" defaultvalue="1MHz">
+            <description>Internal timer frequency. Use 1 MHz for traditional RC signals (1000-2000 us) or 12 MHz for FastPWM (125-250 us).</description>
+        </field>
+        <field name="ChannelMax" units="us" type="uint16" elements="10" defaultvalue="2000">
+            <description>Maxmium output pulse length. Actuator commands will be scaled [0,1] > [ChannelMin,ChannelMax].</description>
+        </field>
+        <field name="ChannelNeutral" units="us" type="uint16" elements="10" defaultvalue="1000">
+            <description>Neutral output pulse length. For motors, should be set to the minimum pulse that causes the motor to start and spin reliably.</description>
+        </field>
+        <field name="ChannelMin" units="us" type="uint16" elements="10" defaultvalue="1000">
+            <description>Minimum output pulse length. Actuator commands will be scaled from [-1,1] to [ChannelMin,ChannelMax].</description>
+        </field>
+        <field name="ChannelType" units="" type="enum" elements="10" options="PWM,PWM Alarm,Arming LED,Info LED" defaultvalue="PWM">
+            <description>The type of output signal. Use PWM for motors.</description>
+        </field>
+        <field name="MotorsSpinWhileArmed" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE">
+            <description>When enabled, the motors will spin at the ChannelNeutral command when armed with zero throttle.</description>
+        </field>
 
-        <!-- Actuator mapping of input in [-1,1] to output on [-1,1], using power equation of type a*x^b-->
-        <field name="MotorInputOutputCurveFit" units="-" type="float" elementnames="A,B" defaultvalue="1,1"/>
+        <field name="MotorInputOutputCurveFit" units="-" type="float" elementnames="A,B" defaultvalue="1,1">
+            <description>Actuator mapping of input in [-1,1] to output on [-1,1], using power equation of type a*x^b.</description>
+        </field>
 
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="true" updatemode="onchange" period="0"/>

--- a/shared/uavobjectdefinition/attitudesettings.xml
+++ b/shared/uavobjectdefinition/attitudesettings.xml
@@ -1,16 +1,30 @@
 <xml>
     <object name="AttitudeSettings" singleinstance="true" settings="true">
-        <description>Settings for the @ref Attitude module used on CopterControl</description>
-        <field name="BoardRotation" units="deg*100" type="int16" elementnames="Roll,Pitch,Yaw" defaultvalue="0,0,0"/>
-        <field name="MagKp" units="channel" type="float" elements="1" defaultvalue="0.05"/>
-        <field name="MagKi" units="channel" type="float" elements="1" defaultvalue="0.0001"/>
-        <field name="AccelKp" units="channel" type="float" elements="1" defaultvalue="0.05"/>
-        <field name="AccelKi" units="channel" type="float" elements="1" defaultvalue="0.0001"/>
+        <description>Settings for the @ref Attitude module</description>
+        <field name="BoardRotation" units="deg*100" type="int16" elementnames="Roll,Pitch,Yaw" defaultvalue="0,0,0">
+            <description>Board rotation angles.</description>
+        </field>
+        <field name="MagKp" units="channel" type="float" elements="1" defaultvalue="0.05">
+            <description>Magnetometer proportional gain for the attitude filter.</description>
+        </field>
+        <field name="MagKi" units="channel" type="float" elements="1" defaultvalue="0.0001">
+            <description>Magnetometer integral gain for the attitude filter.</description>
+        </field>
+        <field name="AccelKp" units="channel" type="float" elements="1" defaultvalue="0.05">
+            <description>Accelerometer proportional gain for the attitude filter.</description>
+        </field>
+        <field name="AccelKi" units="channel" type="float" elements="1" defaultvalue="0.0001">
+            <description>Accelerometer integral gain for the attitude filter.</description>
+        </field>
         <field name="AccelTau" units="" type="float" elements="1" defaultvalue="0.1"/>
         <field name="VertPositionTau" units="" type="float" elements="1" defaultvalue="2"/>
         <field name="YawBiasRate" units="channel" type="float" elements="1" defaultvalue="0.000001"/>
-        <field name="ZeroDuringArming" units="channel" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="TRUE"/>
-        <field name="BiasCorrectGyro" units="channel" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="TRUE"/>
+        <field name="ZeroDuringArming" units="channel" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="TRUE">
+            <description>Zero the attitude estimate during arming when enabled.</description>
+        </field>
+        <field name="BiasCorrectGyro" units="channel" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="TRUE">
+            <description>Apply a calculated bias correction to the gyro when enabled.</description>
+        </field>
         <field name="FilterChoice" units="channel" type="enum" elements="1" options="CCC,PREMERLANI,PREMERLANI_GPS" defaultvalue="CCC"/>
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="true" updatemode="onchange" period="0"/>

--- a/shared/uavobjectdefinition/homelocation.xml
+++ b/shared/uavobjectdefinition/homelocation.xml
@@ -1,10 +1,18 @@
 <xml>
     <object name="HomeLocation" singleinstance="true" settings="true">
         <description>HomeLocation setting which contains the constants to tranlate from longitutde and latitude to NED reference frame.  Automatically set by @ref GPSModule after acquiring a 3D lock.  Used by @ref AHRSCommsModule.</description>
-        <field name="Set" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
-        <field name="Latitude" units="deg * 10e6" type="int32" elements="1" defaultvalue="0"/>
-        <field name="Longitude" units="deg * 10e6" type="int32" elements="1" defaultvalue="0"/>
-        <field name="Altitude" units="m over geoid" type="float" elements="1" defaultvalue="0"/>
+        <field name="Set" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE">
+            <description>Use preset home location when enabled, otherwise use location where GPS lock occurs. BE CAREFUL with this.</description>
+        </field>
+        <field name="Latitude" units="deg * 10e6" type="int32" elements="1" defaultvalue="0">
+            <description>Latitude of preset home location.</description>
+        </field>
+        <field name="Longitude" units="deg * 10e6" type="int32" elements="1" defaultvalue="0">
+            <description>Longitude of preset home location.</description>
+        </field>
+        <field name="Altitude" units="m over geoid" type="float" elements="1" defaultvalue="0">
+            <description>Altitude of preset home location.</description>
+        </field>
         <field name="Be" units="" type="float" elements="3" defaultvalue="0,0,0"/>
         <field name="GroundTemperature" units="deg C * 10" type="int16" elements="1" defaultvalue="150"/>
         <field name="SeaLevelPressure" units="millibar" type="uint16" elements="1" defaultvalue="1013"/>

--- a/shared/uavobjectdefinition/taskinfo.xml
+++ b/shared/uavobjectdefinition/taskinfo.xml
@@ -42,7 +42,8 @@
 			<elementname>UAVOFrSkySPortBridge</elementname>
 			<elementname>FlightStats</elementname>
 		</elementnames>
-	</field>
+		<description>The remaining free space in each task's stack. Disabled tasks will show 0 bytes free.</description>
+	</field> 
 	<field name="Running" units="bool" type="enum">
 		<elementnames>
 			<elementname>System</elementname>
@@ -88,6 +89,7 @@
 			<option>False</option>
 			<option>True</option>
 		</options>
+		<description>The run state of each task.</description>
 	</field>
 	<field name="RunningTime" units="%" type="uint8">
 		<elementnames>
@@ -130,6 +132,7 @@
 			<elementname>UAVOFrSkySPortBridge</elementname>
 			<elementname>FlightStats</elementname>
 		</elementnames>
+		<description>The percentage of CPU time used by each task.</description>
 	</field> 
 	<access gcs="readwrite" flight="readwrite"/>
 	<telemetrygcs acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
I was going to sleep but then I kept thinking about this :-P. Fixes #41.
UAVOs can now have an optional description element inside each field. This field is used in the GCS object browser to display tooltips on each UAVO field. No field descriptions are actually defined in this PR (an issue will be created once merged). To test you will need to add a description to one or more fields, e.g. in https://github.com/d-ronin/dronin/blob/next/shared/uavobjectdefinition/actuatorsettings.xml#L4:
```xml
        <field name="TimerUpdateFreq" units="Hz" type="uint16" elements="6" defaultvalue="50">
            <description>How often your spinny things get a fresh command.</description>
        </field>
```