### PR TITLE
More detailed alarms.

### DIFF
--- a/flight/Modules/OnScreenDisplay/onscreendisplay.c
+++ b/flight/Modules/OnScreenDisplay/onscreendisplay.c
@@ -128,6 +128,9 @@ static void onScreenDisplayTask(void *parameters);
 #define UPDATE_PERIOD    100
 #define BLINK_INTERVAL_FRAMES 12
 
+// The reboot cause is considered a warning for this long.
+#define BOOT_DISPLAY_TIME_MS (10*1000)
+
 const char METRIC_DIST_UNIT_LONG[] = "km";
 const char METRIC_DIST_UNIT_SHORT[] = "m";
 const char METRIC_SPEED_UNIT[] = "km/h";
@@ -700,65 +703,125 @@ void draw_flight_mode(int x, int y, int xs, int ys, int va, int ha, int flags, i
 	}
 }
 
-const uint8_t ALL_ALRARMS[] = {SYSTEMALARMS_ALARM_OUTOFMEMORY,
-								SYSTEMALARMS_ALARM_CPUOVERLOAD,
-								SYSTEMALARMS_ALARM_STACKOVERFLOW,
-								SYSTEMALARMS_ALARM_SYSTEMCONFIGURATION,
-								SYSTEMALARMS_ALARM_EVENTSYSTEM,
-//								SYSTEMALARMS_ALARM_TELEMETRY,
-								SYSTEMALARMS_ALARM_MANUALCONTROL,
-								SYSTEMALARMS_ALARM_ACTUATOR,
-								SYSTEMALARMS_ALARM_ATTITUDE,
-								SYSTEMALARMS_ALARM_SENSORS,
-								SYSTEMALARMS_ALARM_STABILIZATION,
-								SYSTEMALARMS_ALARM_PATHFOLLOWER,
-								SYSTEMALARMS_ALARM_PATHPLANNER,
-								SYSTEMALARMS_ALARM_BATTERY,
-								SYSTEMALARMS_ALARM_FLIGHTTIME,
-								SYSTEMALARMS_ALARM_I2C,
-								SYSTEMALARMS_ALARM_GPS,
-								SYSTEMALARMS_ALARM_ALTITUDEHOLD,
-								SYSTEMALARMS_ALARM_BOOTFAULT};
+static const char alarm_names[][8] = {
+	[SYSTEMALARMS_ALARM_OUTOFMEMORY] = "MEMORY",
+	[SYSTEMALARMS_ALARM_CPUOVERLOAD] = "CPU",
+	[SYSTEMALARMS_ALARM_STACKOVERFLOW] = "STACK",
+	[SYSTEMALARMS_ALARM_SYSTEMCONFIGURATION] = "CONFIG",
+	[SYSTEMALARMS_ALARM_EVENTSYSTEM] = "EVENT",
+	[SYSTEMALARMS_ALARM_TELEMETRY] = {0}, // ignored
+	[SYSTEMALARMS_ALARM_MANUALCONTROL] = "MANUAL",
+	[SYSTEMALARMS_ALARM_ACTUATOR] = "ACTUATOR",
+	[SYSTEMALARMS_ALARM_ATTITUDE] = "ATTITUDE",
+	[SYSTEMALARMS_ALARM_SENSORS] = "SENSORS",
+	[SYSTEMALARMS_ALARM_STABILIZATION] = "STAB",
+	[SYSTEMALARMS_ALARM_PATHFOLLOWER] = "PATH-F",
+	[SYSTEMALARMS_ALARM_PATHPLANNER] = "PATH-P",
+	[SYSTEMALARMS_ALARM_BATTERY] = "BATTERY",
+	[SYSTEMALARMS_ALARM_FLIGHTTIME] = "TIME",
+	[SYSTEMALARMS_ALARM_I2C] = "I2C",
+	[SYSTEMALARMS_ALARM_GPS] = "GPS",
+	[SYSTEMALARMS_ALARM_ALTITUDEHOLD] = "A-HOLD",
+	[SYSTEMALARMS_ALARM_BOOTFAULT] = "BOOT",
+	[SYSTEMALARMS_ALARM_GEOFENCE] = "GEOFENCE",
+	[SYSTEMALARMS_ALARM_TEMPBARO] = "TEMPBARO",
+	[SYSTEMALARMS_ALARM_GYROBIAS] = "GYROBIAS",
+	[SYSTEMALARMS_ALARM_ADC] = "ADC",
+};
+DONT_BUILD_IF(NELEMENTS(alarm_names) != SYSTEMALARMS_ALARM_NUMELEM, AlarmArrayMismatch);
 
-const char * ALL_ALRARM_NAMES[] = {"MEMORY",
-									"CPU",
-									"STACK",
-									"CONFIG",
-									"EVENT",
-//									"TELEMETRY",
-									"MANUAL",
-									"ACTUATOR",
-									"ATTITUDE",
-									"SENSORS",
-									"STAB",
-									"PATH-F",
-									"PATH-P",
-									"BATTERY",
-									"TIME",
-									"I2C",
-									"GPS",
-									"A-HOLD",
-									"BOOT"};
+static const char config_error_names[][14] = {
+	[SYSTEMALARMS_CONFIGERROR_STABILIZATION] = "CFG:STAB",
+	[SYSTEMALARMS_CONFIGERROR_MULTIROTOR] = "CFG:MULTIROTOR",
+	[SYSTEMALARMS_CONFIGERROR_AUTOTUNE] = "CFG:AUTOTUNE",
+	[SYSTEMALARMS_CONFIGERROR_ALTITUDEHOLD] = "CFG:AH1",
+	[SYSTEMALARMS_CONFIGERROR_POSITIONHOLD] = "CFG:POS-HOLD",
+	[SYSTEMALARMS_CONFIGERROR_PATHPLANNER] = "CFG:PATHPLAN",
+	[SYSTEMALARMS_CONFIGERROR_DUPLICATEPORTCFG] = "CFG:DUP PORT",
+	[SYSTEMALARMS_CONFIGERROR_NAVFILTER] = "CFG:NAVFILTER",
+	[SYSTEMALARMS_CONFIGERROR_UNSAFETOARM] = "CFG:UNSAFE",
+	[SYSTEMALARMS_CONFIGERROR_UNDEFINED] = "CFG:UNDEF",
+	[SYSTEMALARMS_CONFIGERROR_NONE] = {0},
+};
+
+// This variable doesn't exist, but would be nice.
+// DONT_BUILD_IF(NELEMENTS(config_error_names) != SYSTEMALARMS_CONFIGERROR_NUMELEM, AlarmArrayMismatch);
+
+static const char manual_control_names[][12] = {
+	[SYSTEMALARMS_MANUALCONTROL_SETTINGS] = "MAN:SETTINGS",
+	[SYSTEMALARMS_MANUALCONTROL_NORX] = "MAN:NO RX",
+	[SYSTEMALARMS_MANUALCONTROL_ACCESSORY] = "MAN:ACC",
+	[SYSTEMALARMS_MANUALCONTROL_ALTITUDEHOLD] = "MAN:A-HOLD",
+	[SYSTEMALARMS_MANUALCONTROL_PATHFOLLOWER] = "MAN:PATH-F",
+	[SYSTEMALARMS_MANUALCONTROL_UNDEFINED] = "MAN:UNDEF",
+	[SYSTEMALARMS_MANUALCONTROL_NONE] = {0},
+};
+
+// This variable doesn't exist, but would be nice.
+// DONT_BUILD_IF(NELEMENTS(manual_control_names) != SYSTEMALARMS_MANUALCONTROL_NUMELEM, AlarmArrayMismatch);
+
+static const char boot_reason_names[][15] = {
+	[SYSTEMALARMS_REBOOTCAUSE_BROWNOUT] = "BOOT:BROWNOUT",
+	[SYSTEMALARMS_REBOOTCAUSE_PINRESET] = "BOOT:PIN RESET",
+	[SYSTEMALARMS_REBOOTCAUSE_POWERONRESET] = "BOOT:PWR ON RST",
+	[SYSTEMALARMS_REBOOTCAUSE_SOFTWARERESET] = "BOOT:SW RESET",
+	[SYSTEMALARMS_REBOOTCAUSE_INDEPENDENTWATCHDOG] "BOOT:INDY WDOG",
+	[SYSTEMALARMS_REBOOTCAUSE_WINDOWWATCHDOG] = "BOOT:WIN WDOG",
+	[SYSTEMALARMS_REBOOTCAUSE_LOWPOWER] = "BOOT:LOW POWER",
+	[SYSTEMALARMS_REBOOTCAUSE_UNDEFINED] = "BOOT:UNDEFINED",
+};
+
+// This variable doesn't exist, but would be nice.
+// DONT_BUILD_IF(NELEMENTS(boot_reason_names) != SYSTEMALARMS_REBOOTCAUSE_NUMELEM, AlarmArrayMismatch);
 
 void draw_alarms(int x, int y, int xs, int ys, int va, int ha, int flags, int font)
 {
 	uint8_t str_pos = 0;
-	uint8_t this_len;
 	char temp[100]  = { 0 };
 	SystemAlarmsData alarm;
 
 	SystemAlarmsGet(&alarm);
 
-	for (uint8_t pos = 0; pos < sizeof(ALL_ALRARMS); pos++)
+	if (PIOS_Thread_Systime() < BOOT_DISPLAY_TIME_MS) {
+		strncpy(temp,
+			(const char*)boot_reason_names[alarm.RebootCause],
+			sizeof(*boot_reason_names));
+		temp[sizeof(*boot_reason_names)] = 0;
+		str_pos = strlen(temp);
+		temp[str_pos++] = ' ';
+	}
+
+	for (uint8_t i = 0; SYSTEMALARMS_ALARM_NUMELEM; i++)
 	{
-		if ((alarm.Alarm[ALL_ALRARMS[pos]] == SYSTEMALARMS_ALARM_WARNING) ||
-			(alarm.Alarm[ALL_ALRARMS[pos]] == SYSTEMALARMS_ALARM_ERROR) ||
-			(alarm.Alarm[ALL_ALRARMS[pos]] == SYSTEMALARMS_ALARM_CRITICAL)){
-			this_len = strlen(ALL_ALRARM_NAMES[pos]);
+		if (alarm_names[i][0] != 0 &&
+		    ((alarm.Alarm[i] == SYSTEMALARMS_ALARM_WARNING) ||
+		     (alarm.Alarm[i] == SYSTEMALARMS_ALARM_ERROR) ||
+		     (alarm.Alarm[i] == SYSTEMALARMS_ALARM_CRITICAL))){
+			char current_msg[sizeof(*config_error_names)+1] = {0};
+			switch (i) {
+			case SYSTEMALARMS_ALARM_SYSTEMCONFIGURATION:
+				strncpy(current_msg,
+					(const char*)config_error_names[alarm.ConfigError],
+					sizeof(*config_error_names));
+				current_msg[sizeof(*config_error_names)] = 0;
+				break;
+			case SYSTEMALARMS_ALARM_MANUALCONTROL:
+				strncpy(current_msg,
+					(const char*)manual_control_names[alarm.ManualControl],
+					sizeof(*manual_control_names));
+				current_msg[sizeof(*manual_control_names)] = 0;
+				break;
+			default:
+				strncpy(current_msg, (const char*)alarm_names[i], sizeof(*alarm_names));
+				current_msg[sizeof(*alarm_names)] = 0;
+			}
+
+			int this_len = strlen(current_msg);
+
 			if (str_pos + this_len + 2 >= sizeof(temp))
 				break;
 
-			if ((alarm.Alarm[ALL_ALRARMS[pos]] != SYSTEMALARMS_ALARM_WARNING) && !blink){
+			if ((alarm.Alarm[i] != SYSTEMALARMS_ALARM_WARNING) && !blink){
 				// for alarms, we blink
 				this_len += 1;
 				while (this_len > 0){
@@ -768,10 +831,9 @@ void draw_alarms(int x, int y, int xs, int ys, int va, int ha, int flags, int fo
 				continue;
 			}
 
-			memcpy((void*)&temp[str_pos], (void*)ALL_ALRARM_NAMES[pos], this_len);
+			memcpy((void*)&temp[str_pos], (void*)current_msg, this_len);
 			str_pos += this_len;
-			temp[str_pos] = ' ';
-			str_pos += 1;
+			temp[str_pos++] = ' ';
 		}
 	}
 	if (str_pos > 0){


### PR DESCRIPTION
This is based on the work I did in MSP in TL proper.  It's a slightly
more condensed form to store the names of alarms, but should fail to
compile if new alarms are added and not described here, provides more
detail on system configuration and manual control alarms, and considers
the boot cause to be an alarm for a bit at startup so you can see why it
booted.

This is a rework of https://github.com/BrainFPV/TauLabs/pull/36 to fit the dronin tree.