### PR TITLE
flight: brain: add -Werror to compile flags

### DIFF
--- a/flight/targets/brain/fw/Makefile
+++ b/flight/targets/brain/fw/Makefile
@@ -312,7 +312,7 @@ CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -Wdouble-promotion
 
 CFLAGS += -Wall
-#CFLAGS += -Werror
+CFLAGS += -Werror
 CFLAGS += -Wa,-adhlns=$(addprefix $(OUTDIR)/, $(notdir $(addsuffix .lst, $(basename $<))))
 # Compiler flags to generate dependency files:
 CFLAGS += -MD -MP -MF $(OUTDIR)/dep/$(@F).d


### PR DESCRIPTION
exposed by #78 ; need #80 to successfully build with this.
