### PR TITLE
GCS: Fix all of the compiler warnings

### DIFF
--- a/ground/gcs/gcs.pri
+++ b/ground/gcs/gcs.pri
@@ -126,6 +126,9 @@ linux-g++* {
     # Bail out on non-selfcontained libraries. Just a security measure
     # to prevent checking in code that does not compile on other platforms.
     QMAKE_LFLAGS += -Wl,--allow-shlib-undefined -Wl,--no-undefined
+
+    # Enable -Werror on Linux, should do this for all platforms once warnings are all eliminated
+    QMAKE_CXXFLAGS_WARN_ON += -Werror
 }
 
 win32 {

--- a/ground/gcs/src/libs/libcrashreporter-qt/breakpad/client/linux/handler/exception_handler.cc
+++ b/ground/gcs/src/libs/libcrashreporter-qt/breakpad/client/linux/handler/exception_handler.cc
@@ -385,6 +385,8 @@ int ExceptionHandler::ThreadEntry(void *arg) {
 // This function runs in a compromised context: see the top of the file.
 // Runs on the crashing thread.
 bool ExceptionHandler::HandleSignal(int sig, siginfo_t* info, void* uc) {
+  (void)sig;
+
   if (filter_ && !filter_(callback_context_))
     return false;
 
@@ -421,7 +423,8 @@ bool ExceptionHandler::HandleSignal(int sig, siginfo_t* info, void* uc) {
 // This is a public interface to HandleSignal that allows the client to
 // generate a crash dump. This function may run in a compromised context.
 bool ExceptionHandler::SimulateSignalDelivery(int sig) {
-  siginfo_t siginfo = {};
+  siginfo_t siginfo;
+  memset(&siginfo, 0, sizeof(siginfo_t));
   // Mimic a trusted signal to allow tracing the process (see
   // ExceptionHandler::HandleSignal().
   siginfo.si_code = SI_USER;

--- a/ground/gcs/src/libs/libcrashreporter-qt/breakpad/common/linux/ignore_ret.h
+++ b/ground/gcs/src/libs/libcrashreporter-qt/breakpad/common/linux/ignore_ret.h
@@ -35,6 +35,6 @@
 // the call fails, IGNORE_RET() can be used to mark the return code as ignored.
 // This avoids spurious compiler warnings.
 
-#define IGNORE_RET(x) do { if (x); } while (0)
+#define IGNORE_RET(x) do { if (x) {} } while (0)
 
 #endif  // COMMON_LINUX_IGNORE_RET_H_

--- a/ground/gcs/src/plugins/config/configosdwidget.cpp
+++ b/ground/gcs/src/plugins/config/configosdwidget.cpp
@@ -345,10 +345,10 @@ void ConfigOsdWidget::handle_button_3_2()
 void ConfigOsdWidget::setCustomText()
 {
     const QString text = ui->le_custom_text->displayText();
-    int n_string = text.size();
+    unsigned int n_string = text.size();
 
-    for (int i=0; i<OnScreenDisplaySettings::CUSTOMTEXT_NUMELEM; i++){
-        if (i < n_string){
+    for (unsigned int i = 0; i < OnScreenDisplaySettings::CUSTOMTEXT_NUMELEM; ++i) {
+        if (i < n_string) {
             osdSettingsObj->setCustomText(i, (quint8)(text.data()[i].toLatin1()));
         } else {
             osdSettingsObj->setCustomText(i, 0);
@@ -360,7 +360,7 @@ void ConfigOsdWidget::getCustomText()
 {
     char text[OnScreenDisplaySettings::CUSTOMTEXT_NUMELEM];
 
-    for (int i=0; i<OnScreenDisplaySettings::CUSTOMTEXT_NUMELEM; i++){
+    for (unsigned int i = 0; i < OnScreenDisplaySettings::CUSTOMTEXT_NUMELEM; ++i) {
         text[i] =  osdSettingsObj->getCustomText(i);
     }
     QString q_text = QString::fromLatin1(text, OnScreenDisplaySettings::CUSTOMTEXT_NUMELEM);

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -342,7 +342,6 @@ void ConfigOutputWidget::startESCCalibration()
     mbox.setText(QString(tr("Starting ESC calibration.<br/><b>Please remove all propellers and disconnect battery from ESCs.</b>")));
     mbox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
     mbox.setDefaultButton(QMessageBox::Cancel);
-    QMessageBox::StandardButton butt;
     
     if (mbox.exec() != QMessageBox::Ok) return;
 

--- a/ground/gcs/src/plugins/config/expocurve.h
+++ b/ground/gcs/src/plugins/config/expocurve.h
@@ -30,7 +30,9 @@
 
 
 #include <QWidget>
-#define QWT_DLL
+#ifndef QWT_DLL
+    #define QWT_DLL
+#endif
 #include "qwt/src/qwt.h"
 #include "qwt/src/qwt_plot.h"
 #include "qwt/src/qwt_plot_curve.h"


### PR DESCRIPTION
Fixes #84 
After this:
```
mike@mike-desktop:~/Dev/dronin$ make all_clean
[ ! -d "/home/mike/Dev/dronin/build" ] || rm -r "/home/mike/Dev/dronin/build"
mike@mike-desktop:~/Dev/dronin$ make -j8 gcs 1> /dev/null
Project MESSAGE: tlfw_resource.qrc not found.  Automatically firmware updates disabled.
```