### PR TITLE
Docs: Disable LaTeX output for ground

### DIFF
--- a/Doxygen/ground_doxygen.cfg
+++ b/Doxygen/ground_doxygen.cfg
@@ -1549,7 +1549,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
I disabled this for flight, but missed it on ground. It was generating broken tex files thus was just cluttering the build dir with useless files.