### PR TITLE
flight: disable stack checking on targets that were missed

### DIFF
--- a/flight/targets/brain/fw/FreeRTOSConfig.h
+++ b/flight/targets/brain/fw/FreeRTOSConfig.h
@@ -43,7 +43,7 @@
 #define configUSE_RECURSIVE_MUTEXES				1
 #define configUSE_COUNTING_SEMAPHORES			0
 #define configUSE_ALTERNATIVE_API				0
-#define configCHECK_FOR_STACK_OVERFLOW			2
+#define configCHECK_FOR_STACK_OVERFLOW			0
 #define configQUEUE_REGISTRY_SIZE				0
 
 #define configUSE_TIMERS						0

--- a/flight/targets/brain/fw/chconf.h
+++ b/flight/targets/brain/fw/chconf.h
@@ -405,7 +405,7 @@
  *          @p panic_msg variable set to @p NULL.
  */
 #if !defined(CH_DBG_ENABLE_STACK_CHECK) || defined(__DOXYGEN__)
-#define CH_DBG_ENABLE_STACK_CHECK       TRUE
+#define CH_DBG_ENABLE_STACK_CHECK       FALSE
 #endif
 
 /**

--- a/flight/targets/flyingf3/fw/chconf.h
+++ b/flight/targets/flyingf3/fw/chconf.h
@@ -405,7 +405,7 @@
  *          @p panic_msg variable set to @p NULL.
  */
 #if !defined(CH_DBG_ENABLE_STACK_CHECK) || defined(__DOXYGEN__)
-#define CH_DBG_ENABLE_STACK_CHECK       TRUE
+#define CH_DBG_ENABLE_STACK_CHECK       FALSE
 #endif
 
 /**


### PR DESCRIPTION
Not sure why FlyingF3 was missed; Brain was missed because it was not-yet-in-tree.