### PR TITLE
GCS:ConnectionMgr: Messagebox on connect failed

### DIFF
--- a/ground/gcs/src/plugins/coreplugin/connectionmanager.h
+++ b/ground/gcs/src/plugins/coreplugin/connectionmanager.h
@@ -115,6 +115,7 @@ signals:
     void deviceAboutToDisconnect();
     void deviceDisconnected();
     void availableDevicesChanged(const QLinkedList<Core::DevListItem> devices);
+    void connectDeviceFailed(DevListItem *device);
 
 public slots:
     void telemetryConnected();
@@ -132,6 +133,7 @@ private slots:
     void connectionsCallBack(); //used to call devChange after all the plugins are loaded
     void reconnectSlot();
     void reconnectCheckSlot();
+    void onConnectDeviceFailed(DevListItem *device);
 
 protected:
     QComboBox *m_availableDevList;


### PR DESCRIPTION
If the attempted connection fails, we fail silently except for a message to the debug log, not super friendly to users who will see that nothing happened when they clicked connect. This adds a popup message box.