### PR TITLE
gcs: module configuration: remove duplicate txpid

### DIFF
--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -239,16 +239,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="cbOnScreenDisplay">
-         <property name="toolTip">
-          <string></string>
-         </property>
-         <property name="text">
-          <string>TxPID</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <spacer name="verticalSpacer_4">
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
txpid shows up on the module tab twice.  It looks like one was intended
for the on-screen display, but that currently doesn't have a module
flag.
