### PR TITLE
Configurable expoM for Rate Mode

### DIFF
--- a/flight/Libraries/math/misc_math.c
+++ b/flight/Libraries/math/misc_math.c
@@ -115,6 +115,20 @@ float expo3(float x, int32_t g)
 }
 
 /**
+ * Approximate a configurable exponential scale curve.
+ * @param[in] input       Input to scale (from [-1,1])
+ * @param[in] exponent    The exponent passed to powf, or inverted and called recursively 
+ * @param[in] amount      Sets the exponential amount [0,100]
+ * @return  rescaled input
+ */
+float expoM(float input, float exponent, int32_t amount)
+{
+	if (input < 0)
+		return -expoM(-input, exponent, amount);
+	return (input * ((100 - amount) / 100.0f) + powf(input, exponent) * (amount / 100.0f));
+}
+
+/**
  * Interpolate values (groundspeeds, altitudes) over flight legs
  * @param[in] fraction how far we are through the leg
  * @param[in] beginVal the configured value for the beginning of the leg

--- a/flight/Libraries/math/misc_math.h
+++ b/flight/Libraries/math/misc_math.h
@@ -52,8 +52,9 @@ float bound_min_max(float val, float min, float max);
 float circular_modulus_deg(float err);
 float circular_modulus_rad(float err);
 
-//! Approximation an exponential scale curve
+//! Approximation of common exponential curves.
 float expo3(float x, int32_t g);
+float expoM(float input, float exponent, int32_t amount);
 
 float interpolate_value(const float fraction, const float beginVal,
 			const float endVal);

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -985,7 +985,7 @@ static void update_stabilization_desired(ManualControlCommandData * cmd, ManualC
 	stabilization.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW]   = stab_settings[2];
 
 	stabilization.Roll = (stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_NONE) ? cmd->Roll :
-	     (stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_RATE) ? expo3(cmd->Roll, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_ROLL]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_ROLL] :
+	     (stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_RATE) ? expoM(cmd->Roll, stabSettings.RateExponent[STABILIZATIONSETTINGS_RATEEXPONENT_ROLL], stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_ROLL]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_ROLL] :
 	     (stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_ACROPLUS) ? expo3(cmd->Roll, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_ROLL]) :
 	     (stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_WEAKLEVELING) ? expo3(cmd->Roll, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_ROLL]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_ROLL]:
 	     (stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE) ? expo3(cmd->Roll, stabSettings.AttitudeExpo[STABILIZATIONSETTINGS_ATTITUDEEXPO_ROLL]) * stabSettings.RollMax :
@@ -998,7 +998,7 @@ static void update_stabilization_desired(ManualControlCommandData * cmd, ManualC
 	     0; // this is an invalid mode
 
 	stabilization.Pitch = (stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_NONE) ? cmd->Pitch :
-	     (stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_RATE) ? expo3(cmd->Pitch, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_PITCH]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_PITCH] :
+	     (stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_RATE) ? expoM(cmd->Pitch, stabSettings.RateExponent[STABILIZATIONSETTINGS_RATEEXPONENT_PITCH], stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_PITCH]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_PITCH] :
 	     (stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_ACROPLUS) ? expo3(cmd->Pitch, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_PITCH]) :
 	     (stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_WEAKLEVELING) ? expo3(cmd->Pitch, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_PITCH]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_PITCH] :
 	     (stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE) ? expo3(cmd->Pitch, stabSettings.AttitudeExpo[STABILIZATIONSETTINGS_ATTITUDEEXPO_PITCH]) * stabSettings.PitchMax :
@@ -1011,7 +1011,7 @@ static void update_stabilization_desired(ManualControlCommandData * cmd, ManualC
 	     0; // this is an invalid mode
 
 	stabilization.Yaw = (stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_NONE) ? cmd->Yaw :
-	     (stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_RATE) ? expo3(cmd->Yaw, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_YAW]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_YAW] :
+	     (stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_RATE) ? expoM(cmd->Yaw, stabSettings.RateExponent[STABILIZATIONSETTINGS_RATEEXPONENT_YAW], stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_YAW]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_YAW] :
 	     (stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_ACROPLUS) ? expo3(cmd->Yaw, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_YAW]) :
 	     (stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_WEAKLEVELING) ? expo3(cmd->Yaw, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_YAW]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_YAW] :
 	     (stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE) ? expo3(cmd->Yaw, stabSettings.AttitudeExpo[STABILIZATIONSETTINGS_ATTITUDEEXPO_YAW]) * stabSettings.YawMax :

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -7,6 +7,7 @@
 	<field name="ManualRate" units="degrees/sec" type="float" elementnames="Roll,Pitch,Yaw" defaultvalue="150,150,150" limits="%BE:0:500,%BE:0:500,%BE:0:500"/>
 	<field name="MaximumRate" units="degrees/sec" type="float" elementnames="Roll,Pitch,Yaw" defaultvalue="300,300,300" limits="%BE:0:500,%BE:0:500,%BE:0:500"/>
 	<field name="RateExpo" units="%" type="uint8" elementnames="Roll,Pitch,Yaw" defaultvalue="0,0,0" limits="%BE:0:100,%BE:0:100,%BE:0:100"/>
+	<field name="RateExponent" units="" type="float" elementnames="Roll,Pitch,Yaw" defaultvalue="3,3,3" limits="%BE:0:25sy,%BE:0:25,"/>  
 	<field name="AttitudeExpo" units="%" type="uint8" elementnames="Roll,Pitch,Yaw" defaultvalue="0,0,0" limits="%BE:0:100,%BE:0:100,%BE:0:100"/>
 	<field name="HorizonExpo" units="%" type="uint8" elementnames="Roll,Pitch,Yaw" defaultvalue="30,30,30" limits="%BE:0:100,%BE:0:100,%BE:0:100"/>
 	<field name="PoiMaximumRate" units="degrees/sec" type="float" elementnames="Roll,Pitch,Yaw" defaultvalue="30,30,30" limits="%BE:0:500,%BE:0:500,%BE:0:500"/>


### PR DESCRIPTION
- Add expoM functionality/proto to misc_math supplied by @mlyle;
  allows the  user to specify the exponent for the curve generation.
- Add expoM calls to transmitter control for rate axis
- UAVo for RateExponent. Maxes at 25 for now.
- [ ] inverse expoM for horizon GCS

References TauLabs/TauLabs#1785
Closes d-ronin/dRonin#108

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/109)

<!-- Reviewable:end -->
