### PR TITLE
Naze32 - Implement serial only receiver port mode.

### DIFF
--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -396,6 +396,7 @@ void PIOS_Board_Init(void) {
 #endif	/* PIOS_INCLUDE_PWM */
 		break;
 	case HWNAZE_RCVRPORT_PPMSERIAL:
+	case HWNAZE_RCVRPORT_SERIAL:
 		{
 			uint8_t hw_rcvrserial;
 			HwNazeRcvrSerialGet(&hw_rcvrserial);
@@ -420,7 +421,10 @@ void PIOS_Board_Init(void) {
 					false);                              // sbus_toggle
 		}
 
-		// Fall through to set up PPM.
+		if (hw_rcvrport == HWNAZE_RCVRPORT_SERIAL)
+			break;
+		
+		// Else fall through to set up PPM.
 
 	case HWNAZE_RCVRPORT_PPM:
 	case HWNAZE_RCVRPORT_PPMOUTPUTS:

--- a/shared/uavobjectdefinition/hwnaze.xml
+++ b/shared/uavobjectdefinition/hwnaze.xml
@@ -4,7 +4,7 @@
 
 		<field name="MainPort" units="function" type="enum" elements="1" options="Telemetry,MSP" defaultvalue="Telemetry"/>
 
-		<field name="RcvrPort" units="function" type="enum" elements="1" options="Disabled,PWM,PPM,PPM+PWM,PPM+Serial,PPM+Outputs,Outputs" defaultvalue="PPM"/>
+		<field name="RcvrPort" units="function" type="enum" elements="1" options="Disabled,PWM,PPM,PPM+PWM,PPM+Serial,PPM+Outputs,Outputs,Serial" defaultvalue="PPM"/>
 
 		<field name="RcvrSerial" units="function" type="enum" elements="1" options="Disabled,Telemetry,GPS,DSM,DebugConsole,ComBridge,MavLinkTX,MSP,FrSKY Sensor Hub,LighttelemetryTx,HoTT SUMD,HoTT SUMH" parent="HwShared.PortTypes" defaultvalue="Disabled"/>
 		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>


### PR DESCRIPTION
This PR adds another receiver mode that enables only the serial port.

Testing:

All tests performed with RcvrSerial set to DSM.

1)RcvrPort set to PPM.  Connect PPM receiver.  PPM rx recognized, and after setup, operates correctly.  Disconnect PPM receiver and connect DSM satellite receiver.  DSM receiver not recognized.

2)RcvrPort set to PPM+Serial.  Connect PPM receiver.  PPM rx recognized, and after setup, operates correctly.  Disconnect PPM receiver and connect DSM satellite receiver.  DSM Satellite receiver recognized, and after setup operates correctly.

3)RcvrPort set to Serial.  Connect PPM receiver.  PPM receiver not recognized.  Disconnect PPM receiver and connect DSM satellite receiver.  DSM Satellite receiver recognized, and after setup operates correctly.

I did have some issues saving configurations at first (got the red x in a circle next to save), along with an alert of improper flight modes being setup.  The board, however, responded to the configuration changes correctly, and changed modes and armed as expected in repsonse to tx commands.  After a power cycle, I no longer had the saving issues or the alert, and everything worked as expected.  

I did do an erase entire flash while loading the code with the ST Flashloader, so maybe the initial issues were related to that?

I did not fly the changes as my Naze32 board is not in a frame.

Now I can wait for my SciFly micro controller board to arrive..........

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/145)
<!-- Reviewable:end -->
