### PR TITLE
GCS:Splash: Smooth scroolbar and logo

### DIFF
--- a/ground/gcs/src/app/customsplash.cpp
+++ b/ground/gcs/src/app/customsplash.cpp
@@ -30,9 +30,9 @@
 #include <QCoreApplication>
 #include <QDebug>
 
-#define PROGRESS_BAR_WIDTH  100
+#define PROGRESS_BAR_WIDTH  150
 #define PROGRESS_BAR_HEIGHT 12
-#define TEXT_BACKGROUND_WIDTH  480
+#define TEXT_BACKGROUND_WIDTH  496
 #define TEXT_BACKGROUND_HEIGHT 20
 
 /**
@@ -43,7 +43,7 @@
 CustomSplash::CustomSplash(const QPixmap &pixmap, Qt::WindowFlags f):
     QSplashScreen(pixmap,f),m_progress(0),m_progress_bar_color(QColor(13, 125, 102, 255)),message_number(0)
 {
-    QPixmap original_scaled = pixmap.scaledToHeight(180);
+    QPixmap original_scaled = pixmap.scaledToHeight(180, Qt::SmoothTransformation);
     QPixmap pix(500,180);
     pix.fill(QColor(255,0,0,0));
     QPainter p(&pix);
@@ -58,6 +58,7 @@ CustomSplash::CustomSplash(const QPixmap &pixmap, Qt::WindowFlags f):
 
 void CustomSplash::drawContents(QPainter *painter)
 {
+    painter->setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform);
     painter->setBrush(QBrush(QColor(222, 222, 222, 200)));
     painter->drawRoundedRect(QRect(this->rect().center().x()-PROGRESS_BAR_WIDTH/2,this->rect().bottom()-PROGRESS_BAR_HEIGHT-30,PROGRESS_BAR_WIDTH,PROGRESS_BAR_HEIGHT), 5,5);
     painter->drawRoundedRect(QRect(this->rect().center().x()-TEXT_BACKGROUND_WIDTH/2,this->rect().bottom()-2-TEXT_BACKGROUND_HEIGHT,TEXT_BACKGROUND_WIDTH,TEXT_BACKGROUND_HEIGHT), 5,5);


### PR DESCRIPTION
By setting some render hints. Should be nice for @VArcht's new logo.I also tweaked the widths slightly.
Before:
![screenshot from 2015-12-05 17 15 31](https://cloud.githubusercontent.com/assets/9995998/11605970/0a51cbdc-9b74-11e5-8ac0-a2e188484273.png)
After:
![screenshot from 2015-12-05 17 13 09](https://cloud.githubusercontent.com/assets/9995998/11605969/0a4e1230-9b74-11e5-869a-ce62eb8e9e72.png)

With the new orange for progressbar (not in this PR):
![screenshot from 2015-12-05 17 21 10](https://cloud.githubusercontent.com/assets/9995998/11605984/ad69e048-9b74-11e5-9345-238c798c6a2b.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/146)

<!-- Reviewable:end -->
