### PR TITLE
flight: f1: use expf/powf approximations to hopefully drop fewer points

### DIFF
--- a/flight/Libraries/math/misc_math.h
+++ b/flight/Libraries/math/misc_math.h
@@ -78,6 +78,94 @@ static inline bool IS_NOT_FINITE(float x) {
 	return (!isfinite(x));
 }
 
+/* Following functions from fastapprox https://code.google.com/p/fastapprox/
+ * are governed by this license agreement: */
+
+/*=====================================================================*
+ *                   Copyright (C) 2011 Paul Mineiro                   *
+ * All rights reserved.                                                *
+ *                                                                     *
+ * Redistribution and use in source and binary forms, with             *
+ * or without modification, are permitted provided that the            *
+ * following conditions are met:                                       *
+ *                                                                     *
+ *     * Redistributions of source code must retain the                *
+ *     above copyright notice, this list of conditions and             *
+ *     the following disclaimer.                                       *
+ *                                                                     *
+ *     * Redistributions in binary form must reproduce the             *
+ *     above copyright notice, this list of conditions and             *
+ *     the following disclaimer in the documentation and/or            *
+ *     other materials provided with the distribution.                 *
+ *                                                                     *
+ *     * Neither the name of Paul Mineiro nor the names                *
+ *     of other contributors may be used to endorse or promote         *
+ *     products derived from this software without specific            *
+ *     prior written permission.                                       *
+ *                                                                     *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND              *
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,         *
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES               *
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE             *
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER               *
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                 *
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES            *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE           *
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR                *
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF          *
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT           *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY              *
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE             *
+ * POSSIBILITY OF SUCH DAMAGE.                                         *
+ *                                                                     *
+ * Contact: Paul Mineiro <paul@mineiro.com>                            *
+ *=====================================================================*/
+
+static inline float 
+fastlog2 (float x)
+{
+	union { float f; uint32_t i; } vx = { x };
+	union { uint32_t i; float f; } mx = { (vx.i & 0x007FFFFF) | (0x7e << 23) };
+	float y = vx.i;
+	y *= 1.0f / (1 << 23);
+
+	return y - 124.22551499f
+		- 1.498030302f * mx.f 
+		- 1.72587999f / (0.3520887068f + mx.f);
+}
+
+static inline float
+fastpow2 (float p)
+{
+	float offset = (p < 0) ? 1.0f : 0.0f;
+	int w = p;
+	float z = p - w + offset;
+	union { uint32_t i; float f; } v = { (1 << 23) * (p + 121.2740838f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z) };
+
+	return v.f;
+}
+
+
+static inline float
+fastpow (float x, float p)
+{
+	return fastpow2 (p * fastlog2 (x));
+}
+
+static inline float
+fastexp (float p)
+{
+	  return fastpow2 (1.442695040f * p);
+}
+
+#ifdef SMALLF1
+#define powapprox fastpow
+#define expapprox fastexp
+#else
+#define powapprox powf
+#define expapprox expf
+#endif
+
 #endif /* MISC_MATH_H */
 
 /**

--- a/flight/Libraries/math/misc_math.h
+++ b/flight/Libraries/math/misc_math.h
@@ -121,6 +121,12 @@ static inline bool IS_NOT_FINITE(float x) {
  * Contact: Paul Mineiro <paul@mineiro.com>                            *
  *=====================================================================*/
 
+#ifdef __cplusplus
+#define cast_uint32_t static_cast<uint32_t>
+#else
+#define cast_uint32_t (uint32_t)
+#endif
+
 static inline float 
 fastlog2 (float x)
 {
@@ -140,7 +146,7 @@ fastpow2 (float p)
 	float offset = (p < 0) ? 1.0f : 0.0f;
 	int w = p;
 	float z = p - w + offset;
-	union { uint32_t i; float f; } v = { (1 << 23) * (p + 121.2740838f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z) };
+	union { uint32_t i; float f; } v = { cast_uint32_t ((1 << 23) * (p + 121.2740838f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z)) };
 
 	return v.f;
 }

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -625,8 +625,7 @@ static float mix_channel(int ct, ActuatorDesiredData *desired,
 
 		if (val > 0) {
 			// Apply curve fitting, mapping the input to the propeller output.
-			val = actuatorSettings.MotorInputOutputCurveFit[ACTUATORSETTINGS_MOTORINPUTOUTPUTCURVEFIT_A] *
-					powf(val, actuatorSettings.MotorInputOutputCurveFit[ACTUATORSETTINGS_MOTORINPUTOUTPUTCURVEFIT_B]);
+			val = powapprox(val, actuatorSettings.MotorInputOutputCurveFit);
 		} else {
 			// Idle throttle
 			val = 0.0f;

--- a/flight/Modules/Attitude/acro/attitude.c
+++ b/flight/Modules/Attitude/acro/attitude.c
@@ -581,19 +581,26 @@ static void updateTemperatureComp(float temperature, float *temp_bias)
 		temp_accum = 0;
 		temp_counter = 0;
 
-		// Compute a third order polynomial for each chanel after each 500 samples
-		temp_bias[0] = sensorSettings.XGyroTempCoeff[0] + 
-		               sensorSettings.XGyroTempCoeff[1] * t + 
-		               sensorSettings.XGyroTempCoeff[2] * powf(t,2) + 
-		               sensorSettings.XGyroTempCoeff[3] * powf(t,3);
-		temp_bias[1] = sensorSettings.YGyroTempCoeff[0] + 
-		               sensorSettings.YGyroTempCoeff[1] * t + 
-		               sensorSettings.YGyroTempCoeff[2] * powf(t,2) + 
-		               sensorSettings.YGyroTempCoeff[3] * powf(t,3);
+		// Compute a third order polynomial for each channel after each 500 samples
+#if 0
+		for reference :
 		temp_bias[2] = sensorSettings.ZGyroTempCoeff[0] + 
 		               sensorSettings.ZGyroTempCoeff[1] * t + 
 		               sensorSettings.ZGyroTempCoeff[2] * powf(t,2) + 
 		               sensorSettings.ZGyroTempCoeff[3] * powf(t,3);
+#endif
+		temp_bias[0] = sensorSettings.XGyroTempCoeff[0] + 
+		               t * (sensorSettings.XGyroTempCoeff[1] + 
+		               t * (sensorSettings.XGyroTempCoeff[2] + 
+		               t * sensorSettings.XGyroTempCoeff[3]));
+		temp_bias[1] = sensorSettings.YGyroTempCoeff[0] + 
+		               t * (sensorSettings.YGyroTempCoeff[1] + 
+		               t * (sensorSettings.YGyroTempCoeff[2] + 
+		               t * sensorSettings.YGyroTempCoeff[3]));
+		temp_bias[2] = sensorSettings.ZGyroTempCoeff[0] + 
+		               t * (sensorSettings.ZGyroTempCoeff[1] + 
+		               t * (sensorSettings.ZGyroTempCoeff[2] + 
+		               t * sensorSettings.ZGyroTempCoeff[3]));
 	}
 }
 

--- a/flight/Modules/Attitude/acro/attitude.c
+++ b/flight/Modules/Attitude/acro/attitude.c
@@ -582,13 +582,7 @@ static void updateTemperatureComp(float temperature, float *temp_bias)
 		temp_counter = 0;
 
 		// Compute a third order polynomial for each channel after each 500 samples
-#if 0
-		for reference :
-		temp_bias[2] = sensorSettings.ZGyroTempCoeff[0] + 
-		               sensorSettings.ZGyroTempCoeff[1] * t + 
-		               sensorSettings.ZGyroTempCoeff[2] * powf(t,2) + 
-		               sensorSettings.ZGyroTempCoeff[3] * powf(t,3);
-#endif
+		// a + t * (b + t * (c + t * d)) = a + b*t + c*t^2 + d*t^3
 		temp_bias[0] = sensorSettings.XGyroTempCoeff[0] + 
 		               t * (sensorSettings.XGyroTempCoeff[1] + 
 		               t * (sensorSettings.XGyroTempCoeff[2] + 

--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -47,6 +47,7 @@
 #include "pios_thread.h"
 
 #include "circqueue.h"
+#include "misc_math.h"
 
 // Private constants
 #define STACK_SIZE_BYTES 1504
@@ -429,13 +430,13 @@ __attribute__((always_inline)) static inline void af_predict(float X[AF_NUMX], f
 	float u1 = X[3];           // scaled roll torque 
 	float u2 = X[4];           // scaled pitch torque
 	float u3 = X[5];           // scaled yaw torque
-	const float e_b1 = expf(X[6]);   // roll torque scale
+	const float e_b1 = expapprox(X[6]);   // roll torque scale
 	const float b1 = X[6];
-	const float e_b2 = expf(X[7]);   // pitch torque scale
+	const float e_b2 = expapprox(X[7]);   // pitch torque scale
 	const float b2 = X[7];
-	const float e_b3 = expf(X[8]);   // yaw torque scale
+	const float e_b3 = expapprox(X[8]);   // yaw torque scale
 	const float b3 = X[8];
-	const float e_tau = expf(X[9]); // time response of the motors
+	const float e_tau = expapprox(X[9]); // time response of the motors
 	const float tau = X[9];
 	const float bias1 = X[10];        // bias in the roll torque
 	const float bias2 = X[11];       // bias in the pitch torque

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -23,8 +23,8 @@
             <description>When enabled, the motors will spin at the ChannelNeutral command when armed with zero throttle.</description>
         </field>
 
-        <field name="MotorInputOutputCurveFit" units="-" type="float" elementnames="A,B" defaultvalue="1,1">
-            <description>Actuator mapping of input in [-1,1] to output on [-1,1], using power equation of type a*x^b.</description>
+        <field name="MotorInputOutputCurveFit" units="-" type="float" elements="1" defaultvalue="1">
+            <description>Actuator mapping of input in [-1,1] to output on [-1,1], using power equation of type x^value.</description>
         </field>
 
         <access gcs="readwrite" flight="readwrite"/>


### PR DESCRIPTION
This also removes the constant-multiplication (a term) of MotorInputOutputCurveFit.

Connect #112

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/151)

<!-- Reviewable:end -->
