### PR TITLE
Build: Update default windows env bash_profile

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -581,7 +581,7 @@ endif
 
 # OPENSSL download URL
 ifdef WINDOWS
-  openssl_install: OPENSSL_URL  := https://slproweb.com/download/Win32OpenSSL-1_0_2d.exe
+  openssl_install: OPENSSL_URL  := https://slproweb.com/download/Win32OpenSSL-1_0_2e.exe
 
 openssl_install: OPENSSL_FILE := $(notdir $(OPENSSL_URL))
 OPENSSL_DIR = $(TOOLS_DIR)/win32openssl

--- a/make/winx86/bash_profile
+++ b/make/winx86/bash_profile
@@ -1,7 +1,7 @@
 # bashrc for TauLabs development on Windows
 # Michael Lyle - 2015
 
-QT_VERSION_FULL=5.5.1
+QT_VERSION_FULL=5.5.0
 QT_VERSION=`echo "$QT_VERSION_FULL" | cut -d '.' -f1-2`
 QT_BASEDIR="/C/Qt"
 

--- a/make/winx86/bash_profile
+++ b/make/winx86/bash_profile
@@ -1,7 +1,7 @@
 # bashrc for TauLabs development on Windows
 # Michael Lyle - 2015
 
-QT_VERSION_FULL=5.5.0
+QT_VERSION_FULL=5.5.1
 QT_VERSION=`echo "$QT_VERSION_FULL" | cut -d '.' -f1-2`
 QT_BASEDIR="/C/Qt"
 


### PR DESCRIPTION
Current Qt version available for download is 5.5.1 which resides in a different directory than 5.5.0. This changes allows new development environment setups to work out of the box. I suggest also changing the wiki to link directly to a specific version, or even the desired .exe as there are a lot to choose from and only one is the correct one.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/153)
<!-- Reviewable:end -->
