### PR TITLE
Make: Add EF target for Naze, make Intel hex of EF image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -897,8 +897,8 @@ all_$(1)_clean: $$(addsuffix _clean, $$(filter ef_$(1), $$(EF_TARGETS)))
 endef
 
 # Some boards don't use the bootloader
-NOBL_BOARDS    := naze32
 FW_BOARDS      := $(ALL_BOARDS)
+NOBL_BOARDS    := $(strip $(foreach BOARD, $(ALL_BOARDS),$(if $(filter no,$($(BOARD)_bootloader)),$(BOARD))))
 BL_BOARDS      := $(filter-out $(NOBL_BOARDS), $(ALL_BOARDS))
 BU_BOARDS      := $(BL_BOARDS)
 EF_BOARDS_NOBL := $(NOBL_BOARDS)

--- a/Makefile
+++ b/Makefile
@@ -758,20 +758,36 @@ bu_$(1)_clean:
 endef
 
 # $(1) = Canonical board name all in lower case (e.g. coptercontrol)
+# $(2) = Friendly board name
+# $(3) = Short board name
+# $(4) = BL for bootloader or NOBL for no bootloader
 define EF_TEMPLATE
 .PHONY: ef_$(1)
-ef_$(1): ef_$(1)_bin
+ef_$(1): ef_$(1)_bin ef_$(1)_hex
 
 ef_$(1)_%: TARGET=ef_$(1)
 ef_$(1)_%: OUTDIR=$(BUILD_DIR)/$$(TARGET)
 ef_$(1)_%: BOARD_ROOT_DIR=$(ROOT_DIR)/flight/targets/$(1)
-ef_$(1)_%: bl_$(1)_bin fw_$(1)_tlfw
+$(eval $(call EF_TEMPLATE_$(4),$(1),$(2),$(3)))
+
+.PHONY: ef_$(1)_clean
+ef_$(1)_clean: TARGET=ef_$(1)
+ef_$(1)_clean: OUTDIR=$(BUILD_DIR)/$$(TARGET)
+ef_$(1)_clean:
+	$(V0) @echo " CLEAN      $$@"
+	$(V1) [ ! -d "$$(OUTDIR)" ] || $(RM) -r "$$(OUTDIR)"
+endef
+
+# $(1) = Canonical board name all in lower case (e.g. coptercontrol)
+define EF_TEMPLATE_NOBL
+ef_$(1)_%: fw_$(1)_tlfw
 	$(V1) mkdir -p $$(OUTDIR)/dep
 	$(V1) cd $(ROOT_DIR)/flight/targets/EntireFlash && \
 		$$(MAKE) -r --no-print-directory \
 		BOARD_NAME=$(1) \
 		BOARD_SHORT_NAME=$(3) \
 		BUILD_TYPE=ef \
+		INCLUDE_BOOTLOADER=no \
 		TCHAIN_PREFIX="$(ARM_SDK_PREFIX)" \
 		REMOVE_CMD="$(RM)" OOCD_EXE="$(OPENOCD)" \
 		DFU_CMD="$(DFUUTIL_DIR)/bin/dfu-util" \
@@ -784,13 +800,30 @@ ef_$(1)_%: bl_$(1)_bin fw_$(1)_tlfw
 		OUTDIR=$$(OUTDIR) \
 		\
 		$$*
+endef
 
-.PHONY: ef_$(1)_clean
-ef_$(1)_clean: TARGET=ef_$(1)
-ef_$(1)_clean: OUTDIR=$(BUILD_DIR)/$$(TARGET)
-ef_$(1)_clean:
-	$(V0) @echo " CLEAN      $$@"
-	$(V1) [ ! -d "$$(OUTDIR)" ] || $(RM) -r "$$(OUTDIR)"
+# $(1) = Canonical board name all in lower case (e.g. coptercontrol)
+define EF_TEMPLATE_BL
+ef_$(1)_%: bl_$(1)_bin fw_$(1)_tlfw
+	$(V1) mkdir -p $$(OUTDIR)/dep
+	$(V1) cd $(ROOT_DIR)/flight/targets/EntireFlash && \
+		$$(MAKE) -r --no-print-directory \
+		BOARD_NAME=$(1) \
+		BOARD_SHORT_NAME=$(3) \
+		BUILD_TYPE=ef \
+		INCLUDE_BOOTLOADER=yes \
+		TCHAIN_PREFIX="$(ARM_SDK_PREFIX)" \
+		REMOVE_CMD="$(RM)" OOCD_EXE="$(OPENOCD)" \
+		DFU_CMD="$(DFUUTIL_DIR)/bin/dfu-util" \
+		\
+		MAKE_INC_DIR=$(MAKE_INC_DIR) \
+		ROOT_DIR=$(ROOT_DIR) \
+		BOARD_ROOT_DIR=$$(BOARD_ROOT_DIR) \
+		BOARD_INFO_DIR=$$(BOARD_ROOT_DIR)/board-info \
+		TARGET=$$(TARGET) \
+		OUTDIR=$$(OUTDIR) \
+		\
+		$$*
 endef
 
 # When building any of the "all_*" targets, tell all sub makefiles to display
@@ -863,11 +896,14 @@ all_$(1)_clean: $$(addsuffix _clean, $$(filter bu_$(1), $$(BU_TARGETS)))
 all_$(1)_clean: $$(addsuffix _clean, $$(filter ef_$(1), $$(EF_TARGETS)))
 endef
 
-# Start out assuming that we'll build fw, bl and bu for all boards
-FW_BOARDS  := $(ALL_BOARDS)
-BL_BOARDS  := $(filter-out naze32, $(ALL_BOARDS))
-BU_BOARDS  := $(BL_BOARDS)
-EF_BOARDS  := $(filter-out naze32, $(ALL_BOARDS))
+# Some boards don't use the bootloader
+NOBL_BOARDS    := naze32
+FW_BOARDS      := $(ALL_BOARDS)
+BL_BOARDS      := $(filter-out $(NOBL_BOARDS), $(ALL_BOARDS))
+BU_BOARDS      := $(BL_BOARDS)
+EF_BOARDS_NOBL := $(NOBL_BOARDS)
+EF_BOARDS_BL   := $(BL_BOARDS)
+EF_BOARDS      := $(EF_BOARDS_BL) $(EF_BOARDS_NOBL)
 
 # Sim targets are different for each host OS
 ifeq ($(UNAME), Linux)
@@ -923,7 +959,8 @@ $(foreach board, $(FW_BOARDS), $(eval $(call FW_TEMPLATE,$(board),$($(board)_fri
 $(foreach board, $(BL_BOARDS), $(eval $(call BL_TEMPLATE,$(board),$($(board)_cpuarch),$($(board)_short))))
 
 # Expand the entire-flash rules
-$(foreach board, $(EF_BOARDS), $(eval $(call EF_TEMPLATE,$(board),$($(board)_friendly),$($(board)_short))))
+$(foreach board, $(EF_BOARDS_BL), $(eval $(call EF_TEMPLATE,$(board),$($(board)_friendly),$($(board)_short),BL)))
+$(foreach board, $(EF_BOARDS_NOBL), $(eval $(call EF_TEMPLATE,$(board),$($(board)_friendly),$($(board)_short),NOBL)))
 
 # Expand the available simulator rules
 $(eval $(call SIM_TEMPLATE,simulation,Simulation,'sim ',posix,elf))

--- a/flight/targets/EntireFlash/Makefile
+++ b/flight/targets/EntireFlash/Makefile
@@ -44,13 +44,12 @@ FW_BIN := $(ROOT_DIR)/build/fw_$(BOARD_NAME)/fw_$(BOARD_NAME).bin
 FWINFO_BIN := $(FW_BIN).firmwareinfo.bin
 INCLUDE_BOOTLOADER ?= yes
 
-ifeq ($(INCLUDE_BOOTLOADER),yes)
-BL_BIN := $(ROOT_DIR)/build/bl_$(BOARD_NAME)/bl_$(BOARD_NAME).bin
-FW_PRE_PAD := $(shell echo $$[$(FW_BANK_BASE)-$(BL_BANK_BASE)-$(BL_BANK_SIZE)])
-else
-# no bootloader for this board
+ifeq ($(INCLUDE_BOOTLOADER),no)
 BL_BIN :=
 FW_PRE_PAD := $(shell echo $$[$(FW_BANK_BASE)-$(EF_BANK_BASE)])
+else
+BL_BIN := $(ROOT_DIR)/build/bl_$(BOARD_NAME)/bl_$(BOARD_NAME).bin
+FW_PRE_PAD := $(shell echo $$[$(FW_BANK_BASE)-$(BL_BANK_BASE)-$(BL_BANK_SIZE)])
 endif # INCLUDE_BOOTLOADER
 
 # force this target as FW_PRE_PAD could have been changed without us knowing

--- a/flight/targets/EntireFlash/Makefile
+++ b/flight/targets/EntireFlash/Makefile
@@ -38,13 +38,22 @@ FORCE:
 
 .PHONY: bin
 bin: $(OUTDIR)/$(TARGET).bin
+hex: $(OUTDIR)/$(TARGET).hex
 
-BL_BIN := $(ROOT_DIR)/build/bl_$(BOARD_NAME)/bl_$(BOARD_NAME).bin
 FW_BIN := $(ROOT_DIR)/build/fw_$(BOARD_NAME)/fw_$(BOARD_NAME).bin
 FWINFO_BIN := $(FW_BIN).firmwareinfo.bin
+INCLUDE_BOOTLOADER ?= yes
+
+ifeq ($(INCLUDE_BOOTLOADER),yes)
+BL_BIN := $(ROOT_DIR)/build/bl_$(BOARD_NAME)/bl_$(BOARD_NAME).bin
+FW_PRE_PAD := $(shell echo $$[$(FW_BANK_BASE)-$(BL_BANK_BASE)-$(BL_BANK_SIZE)])
+else
+# no bootloader for this board
+BL_BIN :=
+FW_PRE_PAD := $(shell echo $$[$(FW_BANK_BASE)-$(EF_BANK_BASE)])
+endif # INCLUDE_BOOTLOADER
 
 # force this target as FW_PRE_PAD could have been changed without us knowing
-FW_PRE_PAD := $(shell echo $$[$(FW_BANK_BASE)-$(BL_BANK_BASE)-$(BL_BANK_SIZE)])
 $(OUTDIR)/$(TARGET).fw_pre.pad: FORCE
 	$(V0) @echo $(MSG_PADDING) $(call toprel, $@)
 	$(V1) dd if=/dev/zero count=$(FW_PRE_PAD) bs=1 2> /dev/null | LC_CTYPE=c tr '\000' '\377' > $@ && [ $${PIPESTATUS[0]} -eq "0" ]
@@ -60,6 +69,11 @@ $(OUTDIR)/$(TARGET).fw_post.pad: FORCE
 $(OUTDIR)/$(TARGET).bin: $(BL_BIN) $(FW_BIN) $(OUTDIR)/$(TARGET).fw_pre.pad $(OUTDIR)/$(TARGET).fw_post.pad FORCE
 	$(V0) @echo $(MSG_FLASH_IMG) $(call toprel, $@)
 	$(V1) cat $(BL_BIN) $(OUTDIR)/$(TARGET).fw_pre.pad $(FW_BIN) $(FWINFO_BIN) $(OUTDIR)/$(TARGET).fw_post.pad $(FWINFO_BIN) > $@
+
+$(OUTDIR)/$(TARGET).hex: $(OUTDIR)/$(TARGET).bin
+	$(V0) @echo $(MSG_FLASH_IMG) $(call toprel, $@)
+	$(V1) $(OBJCOPY) --change-addresses=$(EF_BANK_BASE) -I binary -O ihex $^ $@
+
 
 .PHONY: dfu
 dfu: $(OUTDIR)/$(TARGET).bin

--- a/flight/targets/naze32/target-defs.mk
+++ b/flight/targets/naze32/target-defs.mk
@@ -8,3 +8,6 @@ naze32_cpuarch := f1
 # Short name of this board (used to display board name in parallel builds)
 # Should be exactly 4 characters long.
 naze32_short := 'naze'
+
+# Whether the board uses the bootloader or not (some use the ST bootloader in ROM)
+naze32_bootloader := no


### PR DESCRIPTION
This allows a complete Intel hex image for the Naze to be produced, which can then be flashed with other utilities like baseflight configurator. This should be useful until GCS is able to flash these boards. Intel hex files are now produced for all EF targets.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/168)

<!-- Reviewable:end -->
