### PR TITLE
Adding SystemIdent object to flash logging

### DIFF
--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -172,7 +172,8 @@ static void loggingTask(void *parameters)
 
 	// Connect callbacks for UAVOs being logged on change
 	FlightStatusConnectCallbackCtx(UAVObjCbSetFlag, &flightstatus_updated);
-	SystemIdentConnectCallbackCtx(UAVObjCbSetFlag, &systemident_updated);
+	if (SystemIdentActiveHandle())
+		SystemIdentConnectCallbackCtx(UAVObjCbSetFlag, &systemident_updated);
 	if (WaypointActiveHandle())
 		WaypointActiveConnectCallbackCtx(UAVObjCbSetFlag, &waypoint_updated);
 
@@ -333,7 +334,7 @@ static void loggingTask(void *parameters)
 				flightstatus_updated = false;
 			}
 			
-			if (systemident_updated){
+			if (systemident_updated && SystemIdentActiveHandle()){
 				UAVTalkSendObjectTimestamped(uavTalkCon, SystemIdentHandle(), 0, false, 0);
 				systemident_updated = false;
 			}

--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -7,7 +7,7 @@
  *
  * @file       logging.c
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2014
- # @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @author     dRonin, http://dronin.org Copyright (C) 2015
  * @brief      Forward a set of UAVObjects when updated out a PIOS_COM port
  * @see        The GNU Public License (GPL) Version 3
  *

--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -172,7 +172,7 @@ static void loggingTask(void *parameters)
 
 	// Connect callbacks for UAVOs being logged on change
 	FlightStatusConnectCallbackCtx(UAVObjCbSetFlag, &flightstatus_updated);
-	if (SystemIdentActiveHandle())
+	if (SystemIdentHandle())
 		SystemIdentConnectCallbackCtx(UAVObjCbSetFlag, &systemident_updated);
 	if (WaypointActiveHandle())
 		WaypointActiveConnectCallbackCtx(UAVObjCbSetFlag, &waypoint_updated);
@@ -334,7 +334,7 @@ static void loggingTask(void *parameters)
 				flightstatus_updated = false;
 			}
 			
-			if (systemident_updated && SystemIdentActiveHandle()){
+			if (systemident_updated && SystemIdentHandle()){
 				UAVTalkSendObjectTimestamped(uavTalkCon, SystemIdentHandle(), 0, false, 0);
 				systemident_updated = false;
 			}

--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -7,6 +7,7 @@
  *
  * @file       logging.c
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2014
+ # @author     dRonin, http://dronin.org Copyright (C) 2015
  * @brief      Forward a set of UAVObjects when updated out a PIOS_COM port
  * @see        The GNU Public License (GPL) Version 3
  *
@@ -50,6 +51,7 @@
 #include "magnetometer.h"
 #include "manualcontrolcommand.h"
 #include "positionactual.h"
+#include "systemident.h"
 #include "loggingsettings.h"
 #include "loggingstats.h"
 #include "velocityactual.h"
@@ -69,6 +71,7 @@ static struct pios_thread *loggingTaskHandle;
 static bool module_enabled;
 static volatile LoggingSettingsData settings;
 static bool flightstatus_updated = false;
+static bool systemident_updated = false;
 static bool waypoint_updated = false;
 
 // Private functions
@@ -169,6 +172,7 @@ static void loggingTask(void *parameters)
 
 	// Connect callbacks for UAVOs being logged on change
 	FlightStatusConnectCallbackCtx(UAVObjCbSetFlag, &flightstatus_updated);
+	SystemIdentConnectCallbackCtx(UAVObjCbSetFlag, &systemident_updated);
 	if (WaypointActiveHandle())
 		WaypointActiveConnectCallbackCtx(UAVObjCbSetFlag, &waypoint_updated);
 
@@ -317,6 +321,7 @@ static void loggingTask(void *parameters)
 
 				// Trigger logging for objects that are logged on change
 				flightstatus_updated = true;
+				systemident_updated = true;
 				waypoint_updated = true;
 
 				first_run = false;
@@ -327,7 +332,12 @@ static void loggingTask(void *parameters)
 				UAVTalkSendObjectTimestamped(uavTalkCon, FlightStatusHandle(), 0, false, 0);
 				flightstatus_updated = false;
 			}
-
+			
+			if (systemident_updated){
+				UAVTalkSendObjectTimestamped(uavTalkCon, SystemIdentHandle(), 0, false, 0);
+				systemident_updated = false;
+			}
+			
 			if (waypoint_updated && WaypointActiveHandle()){
 				UAVTalkSendObjectTimestamped(uavTalkCon, WaypointActiveHandle(), 0, false, 0);
 				waypoint_updated = false;


### PR DESCRIPTION
Adding SystemIdent object to flash logging, only logged on change (currently once every 256 autotune cycles)

Related to #170

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/172)
<!-- Reviewable:end -->
