### PR TITLE
Logging Module Improvements V3

### DIFF
--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -68,7 +68,6 @@ static void    loggingTask(void *parameters);
 static int32_t send_data(uint8_t *data, int32_t length);
 static void register_object(UAVObjHandle obj);
 static void logSettings(UAVObjHandle obj);
-static void SettingsUpdatedCb(UAVObjEvent * ev);
 static void writeHeader();
 
 // Local variables
@@ -393,8 +392,10 @@ static int32_t send_data(uint8_t *data, int32_t length)
  * @brief Callback for adding an object to the logging queue
  * @param ev the event
  */
-static void obj_updated_callback(UAVObjEvent * ev)
+static void obj_updated_callback(UAVObjEvent * ev, void* cb_ctx, void *uavo_data, int uavo_len)
 {
+	(void) cb_ctx; (void) uavo_data; (void) uavo_len;
+
 	if (loggingData.Operation != LOGGINGSTATS_OPERATION_LOGGING){
 		// We are not logging, so all events are discarded
 		return;
@@ -421,7 +422,7 @@ static void register_object(UAVObjHandle obj)
 	}
 
 	uint16_t interval = MAX(meta_data.loggingUpdatePeriod, LOGGING_PERIOD_MS);
-	UAVObjConnectCallbackThrottled(obj, obj_updated_callback, EV_UPDATED | EV_UNPACKED, interval);
+	UAVObjConnectCallbackThrottled(obj, obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, interval);
 }
 
 
@@ -472,14 +473,6 @@ static void writeHeader()
 	}
 	tmp_str[pos++] = '\n';
 	send_data((uint8_t*)tmp_str, pos);
-}
-
-/**
- * Callback triggered when the module settings are updated
- */
-static void SettingsUpdatedCb(UAVObjEvent * ev)
-{
-	LoggingSettingsGet(&settings);
 }
 
 /**

--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -30,36 +30,27 @@
 #include "openpilot.h"
 #include "modulesettings.h"
 #include "pios_thread.h"
+#include "pios_queue.h"
+#include "pios_mutex.h"
+#include "uavobjectmanager.h"
+#include "misc_math.h"
 #include "timeutils.h"
 #include "uavobjectmanager.h"
 
 #include "pios_streamfs.h"
 #include <pios_board_info.h>
 
-#include "airspeedactual.h"
-#include "attitudeactual.h"
-#include "accels.h"
-#include "actuatorcommand.h"
 #include "flightstatus.h"
-#include "gyros.h"
-#include "baroaltitude.h"
-#include "flightstatus.h"
-#include "gpsposition.h"
-#include "gpstime.h"
-#include "gpssatellites.h"
-#include "magnetometer.h"
-#include "manualcontrolcommand.h"
-#include "positionactual.h"
 #include "loggingsettings.h"
 #include "loggingstats.h"
-#include "velocityactual.h"
-#include "waypoint.h"
-#include "waypointactive.h"
 
 // Private constants
 #define STACK_SIZE_BYTES 1200
 #define TASK_PRIORITY PIOS_THREAD_PRIO_LOW
 const char DIGITS[16] = "0123456789abcdef";
+
+#define LOGGING_PERIOD_MS 10
+#define LOGGING_QUEUE_SIZE 64
 
 // Private types
 
@@ -68,13 +59,16 @@ static UAVTalkConnection uavTalkCon;
 static struct pios_thread *loggingTaskHandle;
 static bool module_enabled;
 static volatile LoggingSettingsData settings;
-static bool flightstatus_updated = false;
-static bool waypoint_updated = false;
+static LoggingStatsData loggingData;
+struct pios_queue *logging_queue;
+static struct pios_recursive_mutex *mutex;
 
 // Private functions
 static void    loggingTask(void *parameters);
 static int32_t send_data(uint8_t *data, int32_t length);
+static void register_object(UAVObjHandle obj);
 static void logSettings(UAVObjHandle obj);
+static void SettingsUpdatedCb(UAVObjEvent * ev);
 static void writeHeader();
 
 // Local variables
@@ -142,6 +136,21 @@ int32_t LoggingStart(void)
 		return -1;
 	}
 
+	// create logging queue
+	logging_queue = PIOS_Queue_Create(LOGGING_QUEUE_SIZE, sizeof(UAVObjEvent));
+	if (!logging_queue){
+		return -1;
+	}
+
+	// Create mutex
+	mutex = PIOS_Recursive_Mutex_Create();
+	if (mutex == NULL){
+		return -2;
+	}
+
+	// Process all registered objects and connect queue for updates
+	UAVObjIterate(&register_object);
+
 	// Start logging task
 	loggingTaskHandle = PIOS_Thread_Create(loggingTask, "Logging", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 
@@ -154,11 +163,13 @@ MODULE_INITCALL(LoggingInitialize, LoggingStart);
 
 static void loggingTask(void *parameters)
 {
+	UAVObjEvent ev;
+
 	bool armed = false;
-	bool write_open = false;
-	bool first_run = true;
+	uint32_t now = PIOS_Thread_Systime();
 	
 #if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
+	bool write_open = false;
 	bool read_open = false;
 	int32_t read_sector = 0;
 	uint8_t read_data[LOGGINGSTATS_FILESECTOR_NUMELEM];
@@ -167,12 +178,7 @@ static void loggingTask(void *parameters)
 	// Get settings automatically for now on
 	LoggingSettingsConnectCopy(&settings);
 
-	// Connect callbacks for UAVOs being logged on change
-	FlightStatusConnectCallbackCtx(UAVObjCbSetFlag, &flightstatus_updated);
-	if (WaypointActiveHandle())
-		WaypointActiveConnectCallbackCtx(UAVObjCbSetFlag, &waypoint_updated);
 
-	LoggingStatsData loggingData;
 	LoggingStatsGet(&loggingData);
 	loggingData.BytesLogged = 0;
 	
@@ -185,55 +191,16 @@ static void loggingTask(void *parameters)
 #endif
 
 	if (settings.LogBehavior == LOGGINGSETTINGS_LOGBEHAVIOR_LOGONSTART) {
-		loggingData.Operation = LOGGINGSTATS_OPERATION_LOGGING;
-		write_open = true;
-		first_run = true;
-
-#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
-		if (destination_spi_flash)
-		{
-			if (PIOS_STREAMFS_OpenWrite(streamfs_id) != 0) 
-			{
-				loggingData.Operation = LOGGINGSTATS_OPERATION_ERROR;
-				write_open = false;
-				first_run = false;
-			} 
-		}
-#endif
-
+		loggingData.Operation = LOGGINGSTATS_OPERATION_INITIALIZING;
 	} else {
 		loggingData.Operation = LOGGINGSTATS_OPERATION_IDLE;
 	}
 
 	LoggingStatsSet(&loggingData);
 
-	int i = 0;
-
 	// Loop forever
 	while (1) 
 	{
-
-		// Sleep for some time depending on logging rate
-		switch(settings.MaxLogRate){
-			case LOGGINGSETTINGS_MAXLOGRATE_5:
-				PIOS_Thread_Sleep(200);
-				break;
-			case LOGGINGSETTINGS_MAXLOGRATE_10:
-				PIOS_Thread_Sleep(100);
-				break;
-			case LOGGINGSETTINGS_MAXLOGRATE_25:
-				PIOS_Thread_Sleep(40);
-				break;
-			case LOGGINGSETTINGS_MAXLOGRATE_50:
-				PIOS_Thread_Sleep(20);
-				break;
-			case LOGGINGSETTINGS_MAXLOGRATE_100:
-				PIOS_Thread_Sleep(10);
-				break;
-			default:
-				PIOS_Thread_Sleep(1000);
-		}
-
 		LoggingStatsGet(&loggingData);
 
 		// Check for change in armed state if logging on armed
@@ -244,7 +211,7 @@ static void loggingTask(void *parameters)
 
 			if (flightStatus.Armed == FLIGHTSTATUS_ARMED_ARMED && !armed) {
 				// Start logging because just armed
-				loggingData.Operation = LOGGINGSTATS_OPERATION_LOGGING;
+				loggingData.Operation = LOGGINGSTATS_OPERATION_INITIALIZING;
 				armed = true;
 				LoggingStatsSet(&loggingData);
 			} else if (flightStatus.Armed == FLIGHTSTATUS_ARMED_DISARMED && armed) {
@@ -254,128 +221,82 @@ static void loggingTask(void *parameters)
 			}
 		}
 
-		///////////////////////////////////////////////////////////////////////
-		
-#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
-		if (destination_spi_flash) {
-			if (loggingData.Operation == LOGGINGSTATS_OPERATION_LOGGING && read_open) { // If currently downloading a log, close the file
-				PIOS_STREAMFS_Close(streamfs_id);
-				read_open = false;
-			}
-		}
-#endif
-
-		if (loggingData.Operation == LOGGINGSTATS_OPERATION_LOGGING && !write_open) {
-			write_open = true;
-			
-#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
-			if (destination_spi_flash) {
-				if (PIOS_STREAMFS_OpenWrite(streamfs_id) != 0) {
-					loggingData.Operation = LOGGINGSTATS_OPERATION_ERROR;
-					write_open = false;
-				} 
-			
-				loggingData.MinFileId = PIOS_STREAMFS_MinFileId(streamfs_id);
-				loggingData.MaxFileId = PIOS_STREAMFS_MaxFileId(streamfs_id);
-				LoggingStatsSet(&loggingData);
-			}
-#endif
-		} else if (loggingData.Operation != LOGGINGSTATS_OPERATION_LOGGING && write_open) {
-			write_open = false;
-			
-#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
-			if (destination_spi_flash) {
-				PIOS_STREAMFS_Close(streamfs_id);
-				loggingData.MinFileId = PIOS_STREAMFS_MinFileId(streamfs_id);
-				loggingData.MaxFileId = PIOS_STREAMFS_MaxFileId(streamfs_id);
-				LoggingStatsSet(&loggingData);
-			}
-#endif
-		}
-
 		switch (loggingData.Operation) {
-		case LOGGINGSTATS_OPERATION_LOGGING:
-			if (!write_open)
-				continue;
-
-			if (first_run){
-				// Write information at start of the log file
-				writeHeader();
-
-				// Log settings
-				if (settings.LogSettingsOnStart == LOGGINGSETTINGS_LOGSETTINGSONSTART_TRUE){
-					UAVObjIterate(&logSettings);
+		case LOGGINGSTATS_OPERATION_FORMAT:
+			// Format the file system
+#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
+			if (destination_spi_flash){
+				if (read_open || write_open) {
+					PIOS_STREAMFS_Close(streamfs_id);
+					read_open = false;
+					write_open = false;
 				}
 
-				// Log some data objects that are unlikely to change during flight
-				// Waypoints
-				if (WaypointHandle()){
-					for (int i = 0; i < UAVObjGetNumInstances(WaypointHandle()); i++) {
-						UAVTalkSendObjectTimestamped(uavTalkCon, WaypointHandle(), i, false, 0);
+				PIOS_STREAMFS_Format(streamfs_id);
+			}
+#endif /* defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC) */
+			loggingData.Operation = LOGGINGSTATS_OPERATION_IDLE;
+			LoggingStatsSet(&loggingData);
+			break;
+		case LOGGINGSTATS_OPERATION_INITIALIZING:
+#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
+			if (destination_spi_flash){
+				// Close the file if it is open for reading
+				if (read_open) {
+					PIOS_STREAMFS_Close(streamfs_id);
+					read_open = false;
+				}
+				// Open the file if it is not open for writing
+				if (!write_open) {
+					if (PIOS_STREAMFS_OpenWrite(streamfs_id) != 0) {
+						loggingData.Operation = LOGGINGSTATS_OPERATION_ERROR;
+						continue;
+					} else {
+						write_open = true;
 					}
+					loggingData.MinFileId = PIOS_STREAMFS_MinFileId(streamfs_id);
+					loggingData.MaxFileId = PIOS_STREAMFS_MaxFileId(streamfs_id);
+					LoggingStatsSet(&loggingData);
 				}
+			}
+			else {
+				read_open = false;
+				write_open = true;
+			}
+#endif /* defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC) */
 
-				// Trigger logging for objects that are logged on change
-				flightstatus_updated = true;
-				waypoint_updated = true;
+			// Write information at start of the log file
+			writeHeader();
 
-				first_run = false;
+			// Log settings
+			if (settings.LogSettingsOnStart == LOGGINGSETTINGS_LOGSETTINGSONSTART_TRUE){
+				UAVObjIterate(&logSettings);
 			}
 
-			// Log objects on change
-			if (flightstatus_updated){
-				UAVTalkSendObjectTimestamped(uavTalkCon, FlightStatusHandle(), 0, false, 0);
-				flightstatus_updated = false;
-			}
-
-			if (waypoint_updated && WaypointActiveHandle()){
-				UAVTalkSendObjectTimestamped(uavTalkCon, WaypointActiveHandle(), 0, false, 0);
-				waypoint_updated = false;
-			}
-
-			// Log very fast
-			UAVTalkSendObjectTimestamped(uavTalkCon, AccelsHandle(), 0, false, 0);
-			UAVTalkSendObjectTimestamped(uavTalkCon, GyrosHandle(), 0, false, 0);
-
-			// Log a bit slower
-			if ((i % 2) == 0) {
-				UAVTalkSendObjectTimestamped(uavTalkCon, AttitudeActualHandle(), 0, false, 0);
-				UAVTalkSendObjectTimestamped(uavTalkCon, MagnetometerHandle(), 0, false, 0);
-				UAVTalkSendObjectTimestamped(uavTalkCon, ManualControlCommandHandle(), 0, false, 0);
-				UAVTalkSendObjectTimestamped(uavTalkCon, ActuatorCommandHandle(), 0, false, 0);
-			}
-
-			// Log slower
-			if ((i % 10) == 1) {
-				UAVTalkSendObjectTimestamped(uavTalkCon, BaroAltitudeHandle(), 0, false, 0);
-				if (AirspeedActualHandle())
-					UAVTalkSendObjectTimestamped(uavTalkCon, AirspeedActualHandle(), 0, false, 0);
-				if (GPSPositionHandle())
-					UAVTalkSendObjectTimestamped(uavTalkCon, GPSPositionHandle(), 0, false, 0);
-				if (PositionActualHandle())
-					UAVTalkSendObjectTimestamped(uavTalkCon, PositionActualHandle(), 0, false, 0);
-				if (VelocityActualHandle())
-					UAVTalkSendObjectTimestamped(uavTalkCon, VelocityActualHandle(), 0, false, 0);
-			}
-
-			// Log slow
-			if ((i % 50) == 2 && GPSTimeHandle()) {
-				UAVTalkSendObjectTimestamped(uavTalkCon, GPSTimeHandle(), 0, false, 0);
-			}
-
-			// Log very slow
-			if ((i % 500) == 3 && GPSSatellitesHandle()) {
-				UAVTalkSendObjectTimestamped(uavTalkCon, GPSSatellitesHandle(), 0, false, 0);
-			}
+			// Empty the queue
+			while(PIOS_Queue_Receive(logging_queue, &ev, 0))
 
 			LoggingStatsBytesLoggedSet(&written_bytes);
-
+			loggingData.Operation = LOGGINGSTATS_OPERATION_LOGGING;
+			LoggingStatsSet(&loggingData);
 			break;
+		case LOGGINGSTATS_OPERATION_LOGGING:
+			{
+				// Sleep between writing
+				PIOS_Thread_Sleep_Until(&now, LOGGING_PERIOD_MS);
 
+				// Log the objects registred to the shared queue
+				while (PIOS_Queue_Receive(logging_queue, &ev, 0) == true) {
+					UAVTalkSendObjectTimestamped(uavTalkCon, ev.obj, ev.instId, false, 0);
+				}
+				LoggingStatsBytesLoggedSet(&written_bytes);
+
+				now = PIOS_Thread_Systime();
+			}
+			break;
 		case LOGGINGSTATS_OPERATION_DOWNLOAD:
 #if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
-			if (destination_spi_flash)
-			{
+			if (destination_spi_flash) {
 				if (!read_open) {
 					// Start reading
 					if (PIOS_STREAMFS_OpenRead(streamfs_id, loggingData.FileRequest) != 0) {
@@ -385,25 +306,21 @@ static void loggingTask(void *parameters)
 						read_sector = -1;
 					}
 				}
-
 				if (read_open && read_sector == loggingData.FileSectorNum) {
 					// Request received for same sector. Reupdate.
 					memcpy(loggingData.FileSector, read_data, LOGGINGSTATS_FILESECTOR_NUMELEM);
 					loggingData.Operation = LOGGINGSTATS_OPERATION_IDLE;
 				} else if (read_open && (read_sector + 1) == loggingData.FileSectorNum) {
 					int32_t bytes_read = PIOS_COM_ReceiveBuffer(logging_com_id, read_data, LOGGINGSTATS_FILESECTOR_NUMELEM, 1);
-
 					if (bytes_read < 0 || bytes_read > LOGGINGSTATS_FILESECTOR_NUMELEM) {
 						// close on error
 						loggingData.Operation = LOGGINGSTATS_OPERATION_ERROR;
 						PIOS_STREAMFS_Close(streamfs_id);
 						read_open = false;
 					} else if (bytes_read < LOGGINGSTATS_FILESECTOR_NUMELEM) {
-
 						// Check it has really run out of bytes by reading again
 						int32_t bytes_read2 = PIOS_COM_ReceiveBuffer(logging_com_id, &read_data[bytes_read], LOGGINGSTATS_FILESECTOR_NUMELEM - bytes_read, 1);
 						memcpy(loggingData.FileSector, read_data, LOGGINGSTATS_FILESECTOR_NUMELEM);
-
 						if ((bytes_read + bytes_read2) < LOGGINGSTATS_FILESECTOR_NUMELEM) {
 							// indicate end of file
 							loggingData.Operation = LOGGINGSTATS_OPERATION_COMPLETE;
@@ -420,27 +337,93 @@ static void loggingTask(void *parameters)
 					}
 					read_sector = loggingData.FileSectorNum;
 				}
-				LoggingStatsSet(&loggingData);		
+				LoggingStatsSet(&loggingData);
 			}
-#endif
-			break;
+#endif /* defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC) */
+
+			// fall-through to default case
+		default:
+			//  Makes sure that we are not hogging the processor
+			PIOS_Thread_Sleep(10);
+#if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
+			if (destination_spi_flash) {
+				// Close the file if necessary
+				if (write_open) {
+					PIOS_STREAMFS_Close(streamfs_id);
+					loggingData.MinFileId = PIOS_STREAMFS_MinFileId(streamfs_id);
+					loggingData.MaxFileId = PIOS_STREAMFS_MaxFileId(streamfs_id);
+					LoggingStatsSet(&loggingData);
+					write_open = false;
+				}
+			}
+#endif /* defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC) */
 		}
-        
-		i++;
 	}
 }
-
 
 /**
  * Log all settings objects
  * \param[in] obj Object to log
- */
+*/
 static void logSettings(UAVObjHandle obj)
 {
 	if (UAVObjIsSettings(obj)) {
 		UAVTalkSendObjectTimestamped(uavTalkCon, obj, 0, false, 0);
 	}
 }
+
+/**
+ * Forward data from UAVTalk out the serial port
+ * \param[in] data Data buffer to send
+ * \param[in] length Length of buffer
+ * \return -1 on failure
+ * \return number of bytes transmitted on success
+ */
+static int32_t send_data(uint8_t *data, int32_t length)
+{
+	if( PIOS_COM_SendBuffer(logging_com_id, data, length) < 0)
+		return -1;
+
+	written_bytes += length;
+
+	return length;
+}
+
+/**
+ * @brief Callback for adding an object to the logging queue
+ * @param ev the event
+ */
+static void obj_updated_callback(UAVObjEvent * ev)
+{
+	if (loggingData.Operation != LOGGINGSTATS_OPERATION_LOGGING){
+		// We are not logging, so all events are discarded
+		return;
+	}
+	PIOS_Recursive_Mutex_Lock(mutex, PIOS_MUTEX_TIMEOUT_MAX);
+	PIOS_Queue_Send(logging_queue, ev, 0);
+	PIOS_Recursive_Mutex_Unlock(mutex);
+}
+
+/**
+ * Register a new object, adds object to local list and connects the update callback
+ * \param[in] obj Object to connect
+ */
+static void register_object(UAVObjHandle obj)
+{
+	// check whether we want to log this object
+	UAVObjMetadata meta_data;
+	if (UAVObjGetMetadata(obj, &meta_data) < 0){
+		return;
+	}
+
+	if (meta_data.loggingUpdatePeriod == 0){
+		return;
+	}
+
+	uint16_t interval = MAX(meta_data.loggingUpdatePeriod, LOGGING_PERIOD_MS);
+	UAVObjConnectCallbackThrottled(obj, obj_updated_callback, EV_UPDATED | EV_UNPACKED, interval);
+}
+
 
 /**
  * Write log file header
@@ -492,20 +475,11 @@ static void writeHeader()
 }
 
 /**
- * Forward data from UAVTalk out the serial port
- * \param[in] data Data buffer to send
- * \param[in] length Length of buffer
- * \return -1 on failure
- * \return number of bytes transmitted on success
+ * Callback triggered when the module settings are updated
  */
-static int32_t send_data(uint8_t *data, int32_t length)
+static void SettingsUpdatedCb(UAVObjEvent * ev)
 {
-	if( PIOS_COM_SendBuffer(logging_com_id, data, length) < 0)
-		return -1;
-
-	written_bytes += length;
-
-	return length;
+	LoggingSettingsGet(&settings);
 }
 
 /**

--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -316,9 +316,15 @@ static void loggingTask(void *parameters)
 				PIOS_Thread_Sleep_Until(&now, LOGGING_PERIOD_MS);
 
 				// Log the objects registred to the shared queue
-				while (PIOS_Queue_Receive(logging_queue, &ev, 0) == true) {
-					UAVTalkSendObjectTimestamped(uavTalkCon, ev.obj, ev.instId, false, 0);
+				for (int i=0; i<LOGGING_QUEUE_SIZE; i++) {
+					if (PIOS_Queue_Receive(logging_queue, &ev, 0) == true) {
+						UAVTalkSendObjectTimestamped(uavTalkCon, ev.obj, ev.instId, false, 0);
+					}
+					else {
+						break;
+					}
 				}
+
 				LoggingStatsBytesLoggedSet(&written_bytes);
 
 				now = PIOS_Thread_Systime();
@@ -519,15 +525,15 @@ static void register_default_profile()
 	// For the default profile, we limit things to 100Hz (for now)
 	uint16_t min_period = MAX(get_minimum_logging_period(), 10);
 
-	// Objects for which we log all changes
-	UAVObjConnectCallback(FlightStatusHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED);
-	UAVObjConnectCallback(SystemAlarmsHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED);
+	// Objects for which we log all changes (use 100Hz to limit max data rate)
+	UAVObjConnectCallbackThrottled(FlightStatusHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 10);
+	UAVObjConnectCallbackThrottled(SystemAlarmsHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 10);
 	if (WaypointActiveHandle()) {
-		UAVObjConnectCallback(WaypointActiveHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED);
+		UAVObjConnectCallbackThrottled(WaypointActiveHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 10);
 	}
 
 	if (SystemIdentHandle()){
-		UAVObjConnectCallback(SystemIdentHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED);
+		UAVObjConnectCallbackThrottled(SystemIdentHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 10);
 	}
 
 	// Log fast

--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -40,9 +40,24 @@
 #include "pios_streamfs.h"
 #include <pios_board_info.h>
 
+#include "accels.h"
+#include "actuatorcommand.h"
+#include "airspeedactual.h"
+#include "attitudeactual.h"
+#include "baroaltitude.h"
+#include "flightbatterystate.h"
 #include "flightstatus.h"
+#include "gpsposition.h"
+#include "gpstime.h"
+#include "gpssatellites.h"
+#include "gyros.h"
 #include "loggingsettings.h"
 #include "loggingstats.h"
+#include "magnetometer.h"
+#include "manualcontrolcommand.h"
+#include "positionactual.h"
+#include "velocityactual.h"
+#include "waypointactive.h"
 
 // Private constants
 #define STACK_SIZE_BYTES 1200
@@ -66,7 +81,9 @@ static struct pios_recursive_mutex *mutex;
 // Private functions
 static void    loggingTask(void *parameters);
 static int32_t send_data(uint8_t *data, int32_t length);
+static void unregister_object(UAVObjHandle obj);
 static void register_object(UAVObjHandle obj);
+static void register_default_profile();
 static void logSettings(UAVObjHandle obj);
 static void writeHeader();
 
@@ -146,9 +163,6 @@ int32_t LoggingStart(void)
 	if (mutex == NULL){
 		return -2;
 	}
-
-	// Process all registered objects and connect queue for updates
-	UAVObjIterate(&register_object);
 
 	// Start logging task
 	loggingTaskHandle = PIOS_Thread_Create(loggingTask, "Logging", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
@@ -238,6 +252,17 @@ static void loggingTask(void *parameters)
 			LoggingStatsSet(&loggingData);
 			break;
 		case LOGGINGSTATS_OPERATION_INITIALIZING:
+			// Unregister all objects
+			UAVObjIterate(&unregister_object);
+			// Register objects to be logged
+			switch (settings.Profile) {
+				case LOGGINGSETTINGS_PROFILE_DEFAULT:
+					register_default_profile();
+					break;
+				case LOGGINGSETTINGS_PROFILE_CUSTOM:
+					UAVObjIterate(&register_object);
+					break;
+			}
 #if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
 			if (destination_spi_flash){
 				// Close the file if it is open for reading
@@ -405,8 +430,55 @@ static void obj_updated_callback(UAVObjEvent * ev, void* cb_ctx, void *uavo_data
 	PIOS_Recursive_Mutex_Unlock(mutex);
 }
 
+
 /**
- * Register a new object, adds object to local list and connects the update callback
+ * Get the minimum logging period in milliseconds
+*/
+uint16_t get_minimum_logging_period()
+{
+	uint16_t max_freq = 5;
+	switch (settings.MaxLogRate) {
+		case LOGGINGSETTINGS_MAXLOGRATE_5:
+			max_freq = 5;
+			break;
+		case LOGGINGSETTINGS_MAXLOGRATE_10:
+			max_freq = 10;
+			break;
+		case LOGGINGSETTINGS_MAXLOGRATE_25:
+			max_freq = 25;
+			break;
+		case LOGGINGSETTINGS_MAXLOGRATE_50:
+			max_freq = 50;
+			break;
+		case LOGGINGSETTINGS_MAXLOGRATE_100:
+			max_freq = 100;
+			break;
+		case LOGGINGSETTINGS_MAXLOGRATE_250:
+			max_freq = 250;
+			break;
+		case LOGGINGSETTINGS_MAXLOGRATE_500:
+			max_freq = 500;
+			break;
+		case LOGGINGSETTINGS_MAXLOGRATE_1000:
+			max_freq = 1000;
+			break;
+	}
+	uint16_t min_period = 1000 / max_freq;
+	return min_period;
+}
+
+
+/**
+ * Unregister an object
+ * \param[in] obj Object to unregister
+ */
+static void unregister_object(UAVObjHandle obj) {
+	UAVObjDisconnectCallback(obj, obj_updated_callback, NULL);
+}
+
+
+/**
+ * Register a new object: connect the update callback
  * \param[in] obj Object to connect
  */
 static void register_object(UAVObjHandle obj)
@@ -421,8 +493,70 @@ static void register_object(UAVObjHandle obj)
 		return;
 	}
 
-	uint16_t interval = MAX(meta_data.loggingUpdatePeriod, LOGGING_PERIOD_MS);
-	UAVObjConnectCallbackThrottled(obj, obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, interval);
+	uint16_t period = MAX(meta_data.loggingUpdatePeriod, get_minimum_logging_period());
+	if (period == 1) {
+		// log every update
+		UAVObjConnectCallback(obj, obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED);
+	}
+	else {
+		// log updates throttled
+		UAVObjConnectCallbackThrottled(obj, obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, period);
+	}
+}
+
+
+/**
+ * Register objects for the default logging profile
+ */
+static void register_default_profile()
+{
+	uint16_t min_period = get_minimum_logging_period();
+
+	// Objects for which we log all changes
+	UAVObjConnectCallback(FlightStatusHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED);
+	if (WaypointActiveHandle()) {
+		UAVObjConnectCallback(WaypointActiveHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED);
+	}
+
+	// Log fast
+	UAVObjConnectCallbackThrottled(AccelsHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, min_period);
+	UAVObjConnectCallbackThrottled(GyrosHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, min_period);
+
+	// Log a bit slower
+	UAVObjConnectCallbackThrottled(AttitudeActualHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 2 * min_period);
+	UAVObjConnectCallbackThrottled(MagnetometerHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 2 * min_period);
+	UAVObjConnectCallbackThrottled(ManualControlCommandHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 2 * min_period);
+	UAVObjConnectCallbackThrottled(ActuatorCommandHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 2 * min_period);
+
+	// Log slow
+	if (FlightBatteryStateHandle()) {
+		UAVObjConnectCallbackThrottled(FlightBatteryStateHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 10 * min_period);
+	}
+	if (BaroAltitudeHandle()) {
+		UAVObjConnectCallbackThrottled(BaroAltitudeHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 10 * min_period);
+	}
+	if (AirspeedActualHandle()) {
+		UAVObjConnectCallbackThrottled(AirspeedActualHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 10 * min_period);
+	}
+	if (GPSPositionHandle()) {
+		UAVObjConnectCallbackThrottled(GPSPositionHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 10 * min_period);
+	}
+	if (PositionActualHandle()) {
+		UAVObjConnectCallbackThrottled(PositionActualHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 10 * min_period);
+	}
+	if (VelocityActualHandle()) {
+		UAVObjConnectCallbackThrottled(VelocityActualHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 10 * min_period);
+	}
+
+	// Log very slow
+	if (GPSTimeHandle()) {
+		UAVObjConnectCallbackThrottled(GPSTimeHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 50 * min_period);
+	}
+
+	// Log very very slow
+	if (GPSSatellitesHandle()) {
+		UAVObjConnectCallbackThrottled(GPSSatellitesHandle(), obj_updated_callback, NULL, EV_UPDATED | EV_UNPACKED, 500 * min_period);
+	}
 }
 
 

--- a/flight/PiOS/Common/pios_streamfs.c
+++ b/flight/PiOS/Common/pios_streamfs.c
@@ -135,7 +135,7 @@ struct streamfs_footer {
  * @return 0 if success, < 0 on failure
  * @note Must be called while holding the flash transaction lock
  */
-static int32_t streamfs_erase_arena(const struct streamfs_state *streamfs, uint16_t arena_id)
+static int32_t streamfs_erase_arena(const struct streamfs_state *streamfs, uint32_t arena_id)
 {
 	uintptr_t arena_addr = streamfs_get_addr(streamfs, arena_id, 0);
 
@@ -155,9 +155,9 @@ static int32_t streamfs_erase_arena(const struct streamfs_state *streamfs, uint1
  */
 static int32_t streamfs_erase_all_arenas(const struct streamfs_state *streamfs)
 {
-	uint16_t num_arenas = streamfs->partition_size / streamfs->cfg->arena_size;
+	uint32_t num_arenas = streamfs->partition_size / streamfs->cfg->arena_size;
 
-	for (uint16_t arena = 0; arena < num_arenas; arena++) {
+	for (uint32_t arena = 0; arena < num_arenas; arena++) {
 		if (streamfs_erase_arena(streamfs, arena) != 0)
 			return -1;
 	}
@@ -213,8 +213,20 @@ static int32_t streamfs_new_sector(struct streamfs_state *streamfs)
 	streamfs->active_file_arena_offset = 0;
 	streamfs->active_file_segment++;
 
-	if (streamfs_erase_arena(streamfs, streamfs->active_file_arena) != 0) {
+	// Test whether the sector has already been erased by checking the footer
+	start_address = streamfs_get_addr(streamfs, streamfs->active_file_arena,
+			                          streamfs->cfg->arena_size - sizeof(footer));
+	if (PIOS_FLASH_read_data(streamfs->partition_id, start_address, (uint8_t *) &footer, sizeof(footer)) != 0) {
 		return -2;
+	}
+
+	for (int i=0; i < sizeof(footer); i++) {
+		if (((uint8_t*)&footer)[i] != 0xFF) {
+			if (streamfs_erase_arena(streamfs, streamfs->active_file_arena) != 0) {
+				return -3;
+			}
+			break;
+		}
 	}
 
 	return 0;

--- a/flight/PiOS/Common/pios_streamfs.c
+++ b/flight/PiOS/Common/pios_streamfs.c
@@ -110,7 +110,7 @@ struct streamfs_state {
  * @brief Return the offset in flash of a particular slot within an arena
  * @return address of the requested slot
  */
-static uintptr_t streamfs_get_addr(const struct streamfs_state *streamfs, uint16_t arena_id, uint16_t arena_offset)
+static uintptr_t streamfs_get_addr(const struct streamfs_state *streamfs, uint32_t arena_id, uint16_t arena_offset)
 {
 	PIOS_Assert(arena_id < (streamfs->partition_size / streamfs->cfg->arena_size));
 	PIOS_Assert(arena_offset < streamfs->cfg->arena_size);

--- a/flight/PiOS/Common/pios_streamfs.c
+++ b/flight/PiOS/Common/pios_streamfs.c
@@ -2,6 +2,7 @@
  ******************************************************************************
  * @file       pios_flashfs_streamfs.c
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2014
+ * @author     dRonin, http://dronin.org Copyright (C) 2015
  * @addtogroup PIOS PIOS Core hardware abstraction layer
  * @{
  * @addtogroup PIOS_FLASHFS Flash Filesystem Function

--- a/flight/PiOS/Common/pios_streamfs.c
+++ b/flight/PiOS/Common/pios_streamfs.c
@@ -810,7 +810,7 @@ int32_t PIOS_STREAMFS_Close(uintptr_t fs_id)
 		goto out_exit;
 	}
 
-	if (streamfs->active_file_segment != 0 && streamfs->active_file_arena_offset != 0) {
+	if (streamfs->active_file_arena_offset != 0) {
 		// Close segment when something has been written. This avoids creating
 		// null files with an open/close operation
 		if (streamfs_close_sector(streamfs) != 0) {

--- a/flight/UAVObjects/uavobjectmanager.c
+++ b/flight/UAVObjects/uavobjectmanager.c
@@ -2011,18 +2011,18 @@ static int32_t connectObj(UAVObjHandle obj_handle, struct pios_queue *queue,
 	}
 
 	int mallocSize = sizeof(*event);
-	struct ObjectEventEntry * unused = events_unused;
+	struct ObjectEventEntry ** unused = &events_unused;
 
 	if (interval) {
 		mallocSize = sizeof(*throttled);
-		unused = events_unused_throttled;
+		unused = &events_unused_throttled;
 	}
 
 	PIOS_Recursive_Mutex_Lock(mutex, PIOS_MUTEX_TIMEOUT_MAX);
-	if (unused != NULL) {
+	if (*unused != NULL) {
 		// We can re-use the memory of a previously disconnected event
-		event = unused;
-		LL_DELETE(unused, event);
+		event = *unused;
+		LL_DELETE(*unused, event);
 	}
 	else {
 		event =	(struct ObjectEventEntry *) PIOS_malloc_no_dma(mallocSize);
@@ -2033,6 +2033,7 @@ static int32_t connectObj(UAVObjHandle obj_handle, struct pios_queue *queue,
 	}
 	PIOS_Recursive_Mutex_Unlock(mutex);
 
+	memset(event, 0, mallocSize);
 	event->cb = cb;
 
 	if (!cb) {

--- a/flight/UAVObjects/uavobjectmanager.c
+++ b/flight/UAVObjects/uavobjectmanager.c
@@ -181,6 +181,8 @@ static int32_t disconnectObj(UAVObjHandle obj_handle, struct pios_queue *queue,
 
 // Private variables
 static struct UAVOData * uavo_list;
+static struct ObjectEventEntry * events_unused;
+static struct ObjectEventEntry * events_unused_throttled;
 static struct pios_recursive_mutex *mutex;
 static const UAVObjMetadata defMetadata = {
 	.flags = (ACCESS_READWRITE << UAVOBJ_ACCESS_SHIFT |
@@ -210,6 +212,8 @@ int32_t UAVObjInitialize()
 {
 	// Initialize variables
 	uavo_list = NULL;
+	events_unused = NULL;
+	events_unused_throttled = NULL;
 
 	// Allocate the stack used for callbacks.
 	cb_stack = PIOS_malloc_no_dma(UAVO_CB_STACK_SIZE);
@@ -2007,16 +2011,28 @@ static int32_t connectObj(UAVObjHandle obj_handle, struct pios_queue *queue,
 	}
 
 	int mallocSize = sizeof(*event);
+	struct ObjectEventEntry * unused = events_unused;
 
 	if (interval) {
 		mallocSize = sizeof(*throttled);
+		unused = events_unused_throttled;
 	}
 
-	// Add queue to list
-	event =	(struct ObjectEventEntry *) PIOS_malloc_no_dma(mallocSize);
-	if (event == NULL) {
-		return -1;
+	PIOS_Recursive_Mutex_Lock(mutex, PIOS_MUTEX_TIMEOUT_MAX);
+	if (unused != NULL) {
+		// We can re-use the memory of a previously disconnected event
+		event = unused;
+		LL_DELETE(unused, event);
 	}
+	else {
+		event =	(struct ObjectEventEntry *) PIOS_malloc_no_dma(mallocSize);
+		if (event == NULL) {
+			PIOS_Recursive_Mutex_Unlock(mutex);
+			return -1;
+		}
+	}
+	PIOS_Recursive_Mutex_Unlock(mutex);
+
 	event->cb = cb;
 
 	if (!cb) {
@@ -2061,7 +2077,15 @@ static int32_t disconnectObj(UAVObjHandle obj_handle, struct pios_queue *queue,
 		if ((event->cb == cb && event->cbInfo.cbCtx == cbCtx) ||
 				((!event->cb) && event->cbInfo.queue == queue)) {
 			LL_DELETE(obj->next_event, event);
-			PIOS_free(event);
+			// store the unused memory for future reuse
+			PIOS_Recursive_Mutex_Lock(mutex, PIOS_MUTEX_TIMEOUT_MAX);
+			if (event->hasThrottle) {
+				LL_APPEND(events_unused_throttled, event);
+			}
+			else {
+				LL_APPEND(events_unused, event);
+			}
+			PIOS_Recursive_Mutex_Unlock(mutex);
 			return 0;
 		}
 	}

--- a/flight/targets/brain/board-info/board_hw_defs.c
+++ b/flight/targets/brain/board-info/board_hw_defs.c
@@ -226,7 +226,7 @@ static const struct flashfs_logfs_cfg flashfs_waypoints_cfg = {
 #include "pios_streamfs_priv.h"
 const struct streamfs_cfg streamfs_settings = {
 	.fs_magic      = 0x89abceef,
-	.arena_size    = 0x00001000, /* 64 KB */
+	.arena_size    = 0x00001000, /* 4 KB */
 	.write_size    = 0x00000100, /* 256 bytes */
 };
 

--- a/ground/gcs/src/plugins/logging/flightlogdownload.cpp
+++ b/ground/gcs/src/plugins/logging/flightlogdownload.cpp
@@ -2,6 +2,7 @@
  ******************************************************************************
  *
  * @file       flightlogdownload.cpp
+ * @author     dRonin, http://dronin.org Copyright (C) 2015
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2014
  * @see        The GNU Public License (GPL) Version 3
  * @brief      Import/Export Plugin
@@ -57,7 +58,7 @@ FlightLogDownload::FlightLogDownload(QWidget *parent) :
     connect(ui->saveButton, SIGNAL(clicked()), this, SLOT(startDownload()));
 
     // Create default file name
-    QString fileName = tr("TauLabs-%0.tll").arg(QDateTime::currentDateTime().toString("yyyy-MM-dd_hh-mm-ss"));
+	QString fileName = tr("dRonin-%0.drlog").arg(QDateTime::currentDateTime().toString("yyyy-MM-dd_hh-mm-ss"));
     ui->fileName->setText(QDir::current().relativeFilePath(fileName));
 
     // Get the current status
@@ -74,7 +75,7 @@ FlightLogDownload::~FlightLogDownload()
 void FlightLogDownload::getFilename()
 {
     QString fileName = QFileDialog::getSaveFileName(this, tr("Save log as..."),
-                                       tr("TauLabs-%0.tll").arg(QDateTime::currentDateTime().toString("yyyy-MM-dd_hh-mm-ss")),
+									   tr("dRonin-%0.drlog").arg(QDateTime::currentDateTime().toString("yyyy-MM-dd_hh-mm-ss")),
                                        tr("Log (*.tll)"));
     if (!fileName.isEmpty())
         ui->fileName->setText(fileName);

--- a/ground/gcs/src/plugins/logging/flightlogdownload.cpp
+++ b/ground/gcs/src/plugins/logging/flightlogdownload.cpp
@@ -76,7 +76,7 @@ void FlightLogDownload::getFilename()
 {
     QString fileName = QFileDialog::getSaveFileName(this, tr("Save log as..."),
 									   tr("dRonin-%0.drlog").arg(QDateTime::currentDateTime().toString("yyyy-MM-dd_hh-mm-ss")),
-                                       tr("Log (*.tll)"));
+                                       tr("Log (*.drlog)"));
     if (!fileName.isEmpty())
         ui->fileName->setText(fileName);
 }

--- a/shared/uavobjectdefinition/loggingsettings.xml
+++ b/shared/uavobjectdefinition/loggingsettings.xml
@@ -3,6 +3,8 @@
 		<description>Settings for the logging module</description>
 		<field name="LogBehavior" units="" type="enum" options="LogOnStart,LogOnArm,LogOff" elements="1" defaultvalue="LogOnArm"/>
 		<field name="LogSettingsOnStart" units="" type="enum" options="True,False" elements="1" defaultvalue="True"/>
+		<field name="MaxLogRate" units="Hz" type="enum" options="5,10,25,50,100,250,500,1000" elements="1" defaultvalue="25"/>
+		<field name="Profile" units="" type="enum" options="Default,Custom" elements="1" defaultvalue="Default"/>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>

--- a/shared/uavobjectdefinition/loggingsettings.xml
+++ b/shared/uavobjectdefinition/loggingsettings.xml
@@ -3,7 +3,6 @@
 		<description>Settings for the logging module</description>
 		<field name="LogBehavior" units="" type="enum" options="LogOnStart,LogOnArm,LogOff" elements="1" defaultvalue="LogOnArm"/>
 		<field name="LogSettingsOnStart" units="" type="enum" options="True,False" elements="1" defaultvalue="True"/>
-		<field name="MaxLogRate" units="Hz" type="enum" options="5,10,25,50,100" elements="1" defaultvalue="25"/>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>

--- a/shared/uavobjectdefinition/loggingstats.xml
+++ b/shared/uavobjectdefinition/loggingstats.xml
@@ -5,7 +5,7 @@
 	<field name="MinFileId" units="" type="uint16" elements="1"/>
 	<field name="MaxFileId" units="" type="uint16" elements="1"/>
 
-	<field name="Operation" units="" type="enum" elements="1" options="LOGGING, IDLE, DOWNLOAD, COMPLETE, ERROR"/>
+	<field name="Operation" units="" type="enum" elements="1" options="INITIALIZING, LOGGING, IDLE, DOWNLOAD, COMPLETE, FORMAT, ERROR"/>
 
 	<field name="FileRequest" units="" type="uint16" elements="1"/>
 	<field name="FileSectorNum" units="" type="uint16" elements="1"/>


### PR DESCRIPTION
This is an improved version of https://github.com/TauLabs/TauLabs/pull/2031 Improvements:

- Configurable max logging frequency
- Logging profiles: The Default profile will just log a small subset of UAVOs (as we did previously) and the Custom profile will use the per UAVO logging period. This is useful for development to e.g. log a few UAVOs with high rates. If we add a nice way to the GCS to configure the rates, we can remove the profiles in the future.
- Modified the UAVO manager so that deregistering callbacks doesn't leak memory, i.e., the same memory can be reused for new callbacks

This WIP and has not yet been tested..

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/180)
<!-- Reviewable:end -->
