### PR TITLE
Remove ccache spam from fw makefile on Windows build env

### DIFF
--- a/make/firmware-defs.mk
+++ b/make/firmware-defs.mk
@@ -5,14 +5,19 @@ CCACHE :=
 
 ifeq ($(FLIGHT_BUILD_CONF), debug)
 export DEBUG:=YES
-CCACHE := $(shell which ccache)
 else ifeq ($(FLIGHT_BUILD_CONF), default)
 # In the default case, keep the old "DEBUG"  variable handling
-CCACHE := $(shell which ccache)
 else ifeq ($(FLIGHT_BUILD_CONF), release)
 export DEBUG:=NO
 else
 $(error Only debug, release, or default allowed for FLIGHT_BUILD_CONF)
+endif
+
+ifneq ($(OS), Windows_NT)
+ifneq ($(FLIGHT_BUILD_CONF), release)
+# Only use ccache if we are not on windows, and this is not a release build
+CCACHE := $(shell which ccache)
+endif
 endif
 
 # Define toolchain component names.


### PR DESCRIPTION
I do not have much experience with makefiles, so please let me know if there is a better way to accomplish this.

Tested on Windows build env, not tested on other platforms.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/191)
<!-- Reviewable:end -->
