### PR TITLE
GCS: Remove WelcomeMode object

### DIFF
--- a/ground/gcs/src/plugins/welcome/welcomeplugin.cpp
+++ b/ground/gcs/src/plugins/welcome/welcomeplugin.cpp
@@ -55,6 +55,7 @@ WelcomePlugin::WelcomePlugin()
 WelcomePlugin::~WelcomePlugin()
 {
     if (m_welcomeMode) {
+        removeObject(m_welcomeMode);
         m_welcomeMode->deleteLater();
     }
 }


### PR DESCRIPTION
One too many lines removed in #134, results in m_welcomeMode and not being cleaned up and a subsequent warning on exiting GCS.

`There are 1 objects left in the plugin manager pool:  (Welcome::WelcomeMode(0xe84e80))`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/203)
<!-- Reviewable:end -->
