### PR TITLE
make: eliminate astyle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,6 @@ help:
 	@echo "     dfuutil_install      - Install the dfu-util tool for unbricking F4-based boards"
 	@echo "     android_sdk_install  - Install the Android SDK tools"
 	@echo "     gtest_install        - Install the google unit test suite"
-	@echo "     astyle_install       - Install the astyle code formatter (deprecated)"
 	@echo "     uncrustify_install   - Install the uncrustify code formatter"
 	@echo "     openssl_install      - Install the openssl libraries on windows machines"	
 	@echo
@@ -209,8 +208,6 @@ help:
 	@echo "                            the GCS and all target board firmwares."
 	@echo
 	@echo "   [Misc]"
-	@echo "     astyle_flight FILE=<name>   - Executes the astyle code formatter to reformat"
-	@echo "                                   a c source file (deprecated)"
 	@echo "     uncrustify_flight FILE=<name> - Executes uncrustify to reformat a c source"
 	@echo "                                     file according to the flight code style"
 	@echo
@@ -1060,20 +1057,9 @@ package_resources:
 
 ##############################
 #
-# AStyle
+# uncrustify 
 #
 ##############################
-
-ifneq ($(strip $(filter astyle_flight,$(MAKECMDGOALS))),)
-  ifeq ($(FILE),)
-    $(error pass files to astyle by adding FILE=<file> to the make command line)
-  endif
-endif
-
-.PHONY: astyle_flight
-astyle_flight: ASTYLE_OPTIONS := --suffix=none --lineend=linux --mode=c --align-pointer=name --align-reference=name --indent=tab=4 --style=linux --pad-oper --pad-header --unpad-paren
-astyle_flight:
-	$(V1) $(ASTYLE) $(ASTYLE_OPTIONS) $(FILE)
 
 ifneq ($(strip $(filter uncrustify_flight,$(MAKECMDGOALS))),)
   ifeq ($(FILE),)

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -407,38 +407,6 @@ gtest_clean:
 	$(V1) [ ! -d "$(GTEST_DIR)" ] || $(RM) -rf "$(GTEST_DIR)"
 
 
-# Set up astyle tools
-ASTYLE_DIR := $(TOOLS_DIR)/astyle
-ASTYLE_BUILD_DIR := $(DL_DIR)/astyle
-
-.PHONY: astyle_install
-astyle_install: | $(DL_DIR) $(TOOLS_DIR)
-astyle_install: ASTYLE_URL := https://svn.code.sf.net/p/astyle/code/trunk/AStyle
-astyle_install: ASTYLE_REV := 376
-astyle_install: ASTYLE_OPTIONS := prefix=$(ASTYLE_DIR)
-astyle_install: astyle_clean
-        # download the source
-	$(V0) @echo " DOWNLOAD     $(ASTYLE_URL) @ $(ASTYLE_REV)"
-	$(V1) svn export -q "$(ASTYLE_URL)" -r $(ASTYLE_REV) "$(ASTYLE_BUILD_DIR)"
-
-        # build and install
-	$(V0) @echo " BUILD        $(ASTYLE_DIR)"
-	$(V1) mkdir -p "$(ASTYLE_DIR)"
-	$(V1) ( \
-	  $(MAKE) -C $(ASTYLE_BUILD_DIR)/build/gcc $(ASTYLE_OPTIONS) ; \
-	  $(MAKE) -C $(ASTYLE_BUILD_DIR)/build/gcc $(ASTYLE_OPTIONS) install ; \
-	)
-
-        # delete the extracted source when we're done
-	$(V1) [ ! -d "$(ASTYLE_BUILD_DIR)" ] || $(RM) -r "$(ASTYLE_BUILD_DIR)"
-
-.PHONY: astyle_clean
-astyle_clean:
-	$(V0) @echo " CLEAN        $(ASTYLE_DIR)"
-	$(V1) [ ! -d "$(ASTYLE_DIR)" ] || $(RM) -r "$(ASTYLE_DIR)"
-	$(V0) @echo " CLEAN        $(ASTYLE_BUILD_DIR)"
-	$(V1) [ ! -d "$(ASTYLE_BUILD_DIR)" ] || $(RM) -r "$(ASTYLE_BUILD_DIR)"
-
 # Set up uncrustify tools
 UNCRUSTIFY_DIR := $(TOOLS_DIR)/uncrustify-0.61
 UNCRUSTIFY_BUILD_DIR := $(DL_DIR)/uncrustify


### PR DESCRIPTION
In favor of uncrustify.  Uncrustify more closely matches our desired style and reformats code much less.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/212)

<!-- Reviewable:end -->
