### PR TITLE
tools: add zip installer to windows, some minor cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1008,7 +1008,7 @@ $(PACKAGE_TARGETS):
 package_flight: $(FLIGHTPKGNAME)
 
 $(FLIGHTPKGNAME): all_flight
-	zip -j $@ $(FW_FILES) $^
+	$(ZIP) -j $@ $(FW_FILES) $^
 
 ##############################
 #

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ help:
 	@echo "     qt_sdk_install       - Install the Qt tools"
 	@echo "     arm_sdk_install      - Install the GNU ARM gcc toolchain"
 	@echo "     openocd_install      - Install the OpenOCD SWD/JTAG daemon"
+	@echo "     zip_install          - Install Info-Zip compression tool"
 	@echo "        \$$OPENOCD_FTDI     - Set to no in order not to install legacy FTDI support for OpenOCD."
 	@echo "     stm32flash_install   - Install the stm32flash tool for unbricking boards"
 	@echo "     dfuutil_install      - Install the dfu-util tool for unbricking F4-based boards"

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -495,8 +495,12 @@ ZIP_DIR = $(TOOLS_DIR)/zip30
 zip_install : | $(DL_DIR) $(TOOLS_DIR)
 zip_install: zip_clean
 	$(V1) curl -L -k -o "$(DL_DIR)/$(ZIP_FILE)" "$(ZIP_URL)"
-	$(V1) cd "$(TOOLS_DIR)" && tar xzf "$(DL_DIR)/$(ZIP_FILE)"
-	$(V1) cd "$(ZIP_DIR)" && make -f unix/Makefile generic_gcc
+	$(V1) tar --force-local -C $(TOOLS_DIR) -xzf "$(DL_DIR)/$(ZIP_FILE)"
+ifneq ($(OSFAMILY), windows)
+	$(V1) cd "$(ZIP_DIR)" && $(MAKE) -f unix/Makefile generic_gcc
+else
+	$(V1) cd "$(ZIP_DIR)" && $(MAKE) -f win32/makefile.gcc
+endif
 
 .PHONY: zip_clean
 zip_clean:

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -406,7 +406,6 @@ gtest_clean:
 	$(V0) @echo " CLEAN        $(GTEST_DIR)"
 	$(V1) [ ! -d "$(GTEST_DIR)" ] || $(RM) -rf "$(GTEST_DIR)"
 
-
 # Set up uncrustify tools
 UNCRUSTIFY_DIR := $(TOOLS_DIR)/uncrustify-0.61
 UNCRUSTIFY_BUILD_DIR := $(DL_DIR)/uncrustify
@@ -493,10 +492,6 @@ libkml_clean:
 
 ifeq ($(shell [ -d "$(QT_SDK_DIR)" ] && echo "exists"), exists)
   QMAKE = $(QT_SDK_QMAKE_PATH)
-ifdef WINDOWS
-  # Windows needs to be told where to find Qt libraries
-  export PATH := $(QT_SDK_DIR)/5.5/mingw492_32/bin:$(PATH)
-endif
 else
   # not installed, hope it's in the path...
   QMAKE = qmake
@@ -506,7 +501,7 @@ ifeq ($(shell [ -d "$(ARM_SDK_DIR)" ] && echo "exists"), exists)
   ARM_SDK_PREFIX := $(ARM_SDK_DIR)/bin/arm-none-eabi-
 else
   ifneq ($(MAKECMDGOALS),arm_sdk_install)
-    $(info **WARNING** ARM-SDK not in $(ARM_SDK_DIR)  Please run 'make arm_sdk_install')
+    $(error **WARNING** ARM-SDK not in $(ARM_SDK_DIR)  Please run 'make arm_sdk_install')
   endif
   # not installed, hope it's in the path...
   ARM_SDK_PREFIX ?= arm-none-eabi-

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -526,9 +526,9 @@ else
 endif
 
 ifeq ($(shell [ -d "$(ZIP_DIR)" ] && echo "exists"), exists)
-  ZIP := $(ZIP_DIR)/zip
+  export ZIP := $(ZIP_DIR)/zip
 else
-  ZIP := zip
+  export ZIP := zip
 endif
 
 ifeq ($(shell [ -d "$(OPENOCD_DIR)" ] && echo "exists"), exists)

--- a/package/Makefile.osx
+++ b/package/Makefile.osx
@@ -35,11 +35,11 @@ ground_package_os_specific: | standalone
 .PHONY: gcs ground_package osx_package
 
 package_ground_compress: package_ground
-	$(V1)cd $(PACKAGE_DIR) && zip -9 -r $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME) $(GCS_PACKAGE_NAME)
+	$(V1)cd $(PACKAGE_DIR) && $(ZIP) -9 -r $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME) $(GCS_PACKAGE_NAME)
 package_matlab_compress: package_matlab
-	$(V1)cd $(PACKAGE_DIR) && zip -9 -r $(PACKAGE_DIR)/matlab-$(PACKAGE_LBL) $(ML_DIR)
+	$(V1)cd $(PACKAGE_DIR) && $(ZIP) -9 -r $(PACKAGE_DIR)/matlab-$(PACKAGE_LBL) $(ML_DIR)
 package_all_compress: package_all
-	$(V1)cd $(PACKAGE_DIR)/../ && zip -9 -r --exclude=*.zip $(BUILD_DIR)/$(PACKAGE_LBL) $(PACKAGE_DIR)
+	$(V1)cd $(PACKAGE_DIR)/../ && $(ZIP)  -9 -r --exclude=*.zip $(BUILD_DIR)/$(PACKAGE_LBL) $(PACKAGE_DIR)
 
 .PHONY: standalone installer_package
 .PHONY: package_ground_compress package_matlab_compress

--- a/package/Makefile.winx86
+++ b/package/Makefile.winx86
@@ -34,11 +34,11 @@ endif
 	$(V1)find $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME) -type f -name "*.exp" -exec rm -f {} \;
 
 package_ground_compress: package_ground
-	$(V1)cd $(PACKAGE_DIR) && zip -r $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME) $(GCS_PACKAGE_NAME)
+	$(V1)cd $(PACKAGE_DIR) && $(ZIP) -r $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME) $(GCS_PACKAGE_NAME)
 package_matlab_compress: package_matlab
-	$(V1)cd $(PACKAGE_DIR) && zip -r $(PACKAGE_DIR)/matlab-$(PACKAGE_LBL) $(ML_DIR)
+	$(V1)cd $(PACKAGE_DIR) && $(ZIP) -r $(PACKAGE_DIR)/matlab-$(PACKAGE_LBL) $(ML_DIR)
 package_all_compress: package_all
-	$(V1)cd $(PACKAGE_DIR)/../ && zip -r --exclude=*.zip $(BUILD_DIR)/$(PACKAGE_LBL) $(PACKAGE_DIR)
+	$(V1)cd $(PACKAGE_DIR)/../ && $(ZIP) -r --exclude=*.zip $(BUILD_DIR)/$(PACKAGE_LBL) $(PACKAGE_DIR)
 
 .PHONY: standalone
 .PHONY: package_ground_compress package_matlab_compress


### PR DESCRIPTION
1. make zip_install works, and zip tools use the appropriate path in subsidiary makes.
2. Code to update PATH on Windows for QT is removed, because it is already in our path in preferred build environment.
3. ARM SDK installation in tree is mandatory now, instead of warned.

Fixes #214

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/222)

<!-- Reviewable:end -->
