### PR TITLE
Check remaining size on fast heap

### DIFF
--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -564,6 +564,7 @@ static void updateStats()
 	SystemStatsGet(&stats);
 	stats.FlightTime = PIOS_Thread_Systime();
 	stats.HeapRemaining = PIOS_heap_get_free_size();
+	stats.FastHeapRemaining = PIOS_fastheap_get_free_size();
 
 	// Get Irq stack status
 	stats.IRQStackRemaining = GetFreeIrqStackSize();

--- a/flight/PiOS.posix/posix/pios_heap.c
+++ b/flight/PiOS.posix/posix/pios_heap.c
@@ -88,6 +88,11 @@ size_t PIOS_heap_get_free_size(void)
 	return 1024;
 }
 
+size_t PIOS_fastheap_get_free_size(void)
+{
+	return 0;
+}
+
 /**
  * @}
  * @}

--- a/flight/PiOS/Common/pios_heap.c
+++ b/flight/PiOS/Common/pios_heap.c
@@ -202,6 +202,33 @@ size_t PIOS_heap_get_free_size(void)
 	return free_bytes;
 }
 
+
+#if defined(PIOS_INCLUDE_FASTHEAP)
+
+size_t PIOS_fastheap_get_free_size(void)
+{
+#if defined(PIOS_INCLUDE_FREERTOS)
+	PIOS_Thread_Scheduler_Suspend();
+#endif	/* PIOS_INCLUDE_FREERTOS */
+
+	size_t free_bytes = simple_get_free_bytes(&pios_nodma_heap);
+
+#if defined(PIOS_INCLUDE_FREERTOS)
+	PIOS_Thread_Scheduler_Resume();
+#endif	/* PIOS_INCLUDE_FREERTOS */
+
+	return free_bytes;
+}
+
+#else
+
+size_t PIOS_fastheap_get_free_size(void)
+{
+	return 0;
+}
+
+#endif // PIOS_INCLUDE_FASTHEAP
+
 void vPortInitialiseBlocks(void) __attribute__((alias ("PIOS_heap_initialize_blocks")));
 void PIOS_heap_initialize_blocks(void)
 {

--- a/flight/PiOS/inc/pios_heap.h
+++ b/flight/PiOS/inc/pios_heap.h
@@ -38,6 +38,7 @@ extern void * PIOS_malloc(size_t size);
 extern void PIOS_free(void * buf);
 
 extern size_t PIOS_heap_get_free_size(void);
+extern size_t PIOS_fastheap_get_free_size(void);
 extern void PIOS_heap_initialize_blocks(void);
 extern void PIOS_heap_increase_size(size_t bytes);
 

--- a/shared/uavobjectdefinition/systemstats.xml
+++ b/shared/uavobjectdefinition/systemstats.xml
@@ -1,14 +1,33 @@
 <xml>
     <object name="SystemStats" singleinstance="true" settings="false">
-        <description>CPU and memory usage from OpenPilot computer. </description>
-        <field name="FlightTime" units="ms" type="uint32" elements="1"/>
-        <field name="HeapRemaining" units="bytes" type="uint32" elements="1"/>
-        <field name="IRQStackRemaining" units="bytes" type="uint16" elements="1"/>
-        <field name="CPULoad" units="%" type="uint8" elements="1"/>
-        <field name="CPUTemp" units="C" type="int8" elements="1"/>
-        <field name="EventSystemWarningID" units="uavoid" type="uint32" elements="1"/>
-        <field name="ObjectManagerCallbackID" units="uavoid" type="uint32" elements="1"/>
-        <field name="ObjectManagerQueueID" units="uavoid" type="uint32" elements="1"/>
+        <description>Flight controller runtime statistics.</description>
+        <field name="FlightTime" units="ms" type="uint32" elements="1">
+            <description>Time elapsed since boot.</description>
+        </field>
+        <field  name="HeapRemaining" units="bytes" type="uint32" elements="1">
+            <description>Unused memory on the normal heap (since boot).</description>
+        </field>
+        <field name="FastHeapRemaining" units="bytes" type="uint32" elements="1">
+            <description>Unused memory on the "fast" heap (located in core-coupled memory).</description>
+        </field>
+        <field name="IRQStackRemaining" units="bytes" type="uint16" elements="1">
+            <description>Unused space on the IRQ stack since boot.</description>
+        </field>
+        <field name="CPULoad" units="%" type="uint8" elements="1">
+            <description>Indicative measure of current CPU load.</description>
+        </field>
+        <field name="CPUTemp" units="C" type="int8" elements="1">
+            <description>Current internal CPU temperature.</description>
+        </field>
+        <field name="EventSystemWarningID" units="uavoid" type="uint32" elements="1">
+            <description>ID of the last object to cause an event system warning.</description>
+        </field>
+        <field name="ObjectManagerCallbackID" units="uavoid" type="uint32" elements="1">
+            <description>ID of the last object to cause an object manager callback warning.</description>
+        </field>
+        <field name="ObjectManagerQueueID" units="uavoid" type="uint32" elements="1">
+            <description>ID of the last object to cause an object manager queue overflow.</description>
+        </field>
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="false" updatemode="manual" period="0"/>
         <telemetryflight acked="false" updatemode="periodic" period="1000"/>


### PR DESCRIPTION
Also adds descriptions to SystemStats UAVO fields while I was in there.

Tested on Quanton.
To test:
- [x] F1
- [x] F3/4 FreeRTOS

Possible that the PIOS_SYSTEM_STACK_SIZE may need bumped on F1s.

Fixes #183

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/235)
<!-- Reviewable:end -->
