### PR TITLE
uavobjectmanager: mark floating point registers as clobbers

### DIFF
--- a/flight/UAVObjects/uavobjectmanager.c
+++ b/flight/UAVObjects/uavobjectmanager.c
@@ -1721,6 +1721,9 @@ static void invokeCallback(struct ObjectEventEntry *event, UAVObjEvent *msg,
 		: // no pure read-only registers
 		: "memory",		// callback may clobber memory,
 		"r4", "ip", "lr"	// we clobber r4, ip, and lr
+		// And call-clobbered floating point registers
+		, "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7",
+		"s8", "s9", "s10", "s11", "s12", "s13", "s14", "s15"
 	);
 }
 #else


### PR DESCRIPTION
Alteration to #29.  Previously the floating point registers were not marked as clobbers.  Per conversation with @tracernz, this would be technically unsafe if we did cross-module optimization or if we did floating point math in the uavobjectmanager.  

This currently produces identical binary code, so it fixes nothing (nor breaks anything).

Previously I had this conditionalized to only add these couple of lines on hard-float calling conventions... But GCC doesn't mind it on F1 so I removed the conditional / always mark these optional registers as clobbers.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/238)

<!-- Reviewable:end -->
