### PR TITLE
Unbreak release build

### DIFF
--- a/ground/gcs/src/plugins/coreplugin/iboardtype.h
+++ b/ground/gcs/src/plugins/coreplugin/iboardtype.h
@@ -57,6 +57,14 @@ public:
      *       is relevant.
      */
     struct USBInfo {
+        USBInfo() : 
+            UsagePage(0),
+            Usage(0),
+            bootloaderMode(0),
+            runningMode(0),
+            bcdDevice(0)
+        {}
+
         QString serialNumber;
         QString manufacturer;
         QString product;

--- a/ground/gcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
+++ b/ground/gcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
@@ -200,10 +200,6 @@ void VehicleConfigurationHelper::applyActuatorConfiguration()
         qint16 updateFrequency = LEGACY_ESC_FREQUENCY;
         ActuatorSettings::TimerPwmResolutionOptions resolution;
         switch (m_configSource->getESCType()) {
-        case VehicleConfigurationSource::ESC_LEGACY:
-            updateFrequency = LEGACY_ESC_FREQUENCY;
-            resolution = ActuatorSettings::TIMERPWMRESOLUTION_1MHZ;
-            break;
         case VehicleConfigurationSource::ESC_RAPID:
             updateFrequency = RAPID_ESC_FREQUENCY;
             resolution = ActuatorSettings::TIMERPWMRESOLUTION_1MHZ;
@@ -212,7 +208,10 @@ void VehicleConfigurationHelper::applyActuatorConfiguration()
             updateFrequency = ONESHOT_ESC_FREQUENCY;
             resolution = ActuatorSettings::TIMERPWMRESOLUTION_12MHZ;
             break;
+        case VehicleConfigurationSource::ESC_LEGACY:
         default:
+            updateFrequency = LEGACY_ESC_FREQUENCY;
+            resolution = ActuatorSettings::TIMERPWMRESOLUTION_1MHZ;
             break;
         }
 


### PR DESCRIPTION
The USBInfo fix isn't my favourite work. There doesn't seem to be any way to init all the fields of a struct to a default value without doing so explicitly(and thus writing code that breaks every time the struct definition changes) with GCC & C++11?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/247)
<!-- Reviewable:end -->
