### PR TITLE
makefile: package: use ZIPBIN instead of ZIP for path to zip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1008,7 +1008,7 @@ $(PACKAGE_TARGETS):
 package_flight: $(FLIGHTPKGNAME)
 
 $(FLIGHTPKGNAME): all_flight
-	$(ZIP) -j $@ $(FW_FILES) $^
+	$(ZIPBIN) -j $@ $(FW_FILES)
 
 ##############################
 #

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -530,9 +530,9 @@ else
 endif
 
 ifeq ($(shell [ -d "$(ZIP_DIR)" ] && echo "exists"), exists)
-  export ZIP := $(ZIP_DIR)/zip
+  export ZIPBIN := $(ZIP_DIR)/zip
 else
-  export ZIP := zip
+  export ZIPBIN := zip
 endif
 
 ifeq ($(shell [ -d "$(OPENOCD_DIR)" ] && echo "exists"), exists)

--- a/package/Makefile.osx
+++ b/package/Makefile.osx
@@ -35,11 +35,11 @@ ground_package_os_specific: | standalone
 .PHONY: gcs ground_package osx_package
 
 package_ground_compress: package_ground
-	$(V1)cd $(PACKAGE_DIR) && $(ZIP) -9 -r $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME) $(GCS_PACKAGE_NAME)
+	$(V1)cd $(PACKAGE_DIR) && $(ZIPBIN) -9 -r $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME) $(GCS_PACKAGE_NAME)
 package_matlab_compress: package_matlab
-	$(V1)cd $(PACKAGE_DIR) && $(ZIP) -9 -r $(PACKAGE_DIR)/matlab-$(PACKAGE_LBL) $(ML_DIR)
+	$(V1)cd $(PACKAGE_DIR) && $(ZIPBIN) -9 -r $(PACKAGE_DIR)/matlab-$(PACKAGE_LBL) $(ML_DIR)
 package_all_compress: package_all
-	$(V1)cd $(PACKAGE_DIR)/../ && $(ZIP)  -9 -r --exclude=*.zip $(BUILD_DIR)/$(PACKAGE_LBL) $(PACKAGE_DIR)
+	$(V1)cd $(PACKAGE_DIR)/../ && $(ZIPBIN)  -9 -r --exclude=*.zip $(BUILD_DIR)/$(PACKAGE_LBL) $(PACKAGE_DIR)
 
 .PHONY: standalone installer_package
 .PHONY: package_ground_compress package_matlab_compress

--- a/package/Makefile.winx86
+++ b/package/Makefile.winx86
@@ -34,11 +34,11 @@ endif
 	$(V1)find $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME) -type f -name "*.exp" -exec rm -f {} \;
 
 package_ground_compress: package_ground
-	$(V1)cd $(PACKAGE_DIR) && $(ZIP) -r $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME) $(GCS_PACKAGE_NAME)
+	$(V1)cd $(PACKAGE_DIR) && $(ZIPBIN) -r $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME) $(GCS_PACKAGE_NAME)
 package_matlab_compress: package_matlab
-	$(V1)cd $(PACKAGE_DIR) && $(ZIP) -r $(PACKAGE_DIR)/matlab-$(PACKAGE_LBL) $(ML_DIR)
+	$(V1)cd $(PACKAGE_DIR) && $(ZIPBIN) -r $(PACKAGE_DIR)/matlab-$(PACKAGE_LBL) $(ML_DIR)
 package_all_compress: package_all
-	$(V1)cd $(PACKAGE_DIR)/../ && $(ZIP) -r --exclude=*.zip $(BUILD_DIR)/$(PACKAGE_LBL) $(PACKAGE_DIR)
+	$(V1)cd $(PACKAGE_DIR)/../ && $(ZIPBIN) -r --exclude=*.zip $(BUILD_DIR)/$(PACKAGE_LBL) $(PACKAGE_DIR)
 
 .PHONY: standalone
 .PHONY: package_ground_compress package_matlab_compress


### PR DESCRIPTION
Turns out some versions of info-zip use the environment variable "ZIP"
to determine where to store the archive.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/257)

<!-- Reviewable:end -->
