### PR TITLE
Fix Sparky2 EF size, fix Makefile typo in EF deps

### DIFF
--- a/flight/targets/sparky2/board-info/board-info.mk
+++ b/flight/targets/sparky2/board-info/board-info.mk
@@ -27,7 +27,7 @@ EE_BANK_BASE        := 0x00000000
 EE_BANK_SIZE        := 0x00000000
 
 EF_BANK_BASE        := 0x08000000  # Start of entire flash image (usually start of bootloader as well)
-EF_BANK_SIZE        := 0x00060000  # Size of the entire flash image (from bootloader until end of firmware)
+EF_BANK_SIZE        := 0x00080000  # Size of the entire flash image (from bootloader until end of firmware)
 
 OSCILLATOR_FREQ     :=   8000000
 SYSCLK_FREQ         := 168000000


### PR DESCRIPTION
- Sparky2 entire flash size was wrong (TauLabs/TauLabs#2056), increased it to 512 kb (128 kb bootloader, 384 kb firmware).
- There was a mistake in my PR the other day that caused missing dependencies for ef_<board> targets.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/259)

<!-- Reviewable:end -->
