### PR TITLE
gcs: configinputwidget: small cleanup/correctness

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.h
+++ b/ground/gcs/src/plugins/config/configinputwidget.h
@@ -33,6 +33,7 @@
 #include <QRadioButton>
 #include <QWidget>
 #include <QSvgRenderer>
+#include <QTime>
 #include <QGraphicsSvgItem>
 
 #include "ui_input.h"
@@ -92,6 +93,8 @@ private:
         QList<QPointer<QWidget> > extraWidgets;
         txMode transmitterMode;
         txType transmitterType;
+        QTime intervalTimer;
+        bool manualControlDataDirty;
 
         enum failsafeDetection failsafeDetection;
         struct channelsStruct
@@ -102,12 +105,10 @@ private:
             }
             int group;
             int number;
-        }lastChannel;
+        } lastChannel;
         channelsStruct currentChannel;
         QList<channelsStruct> usedChannels;
         bool channelDetected;
-        QEventLoop * loop;
-        bool skipflag;
 
         int currentChannelNum;
         QList<int> heliChannelOrder;


### PR DESCRIPTION
Perhaps relates to #227.  There were some unused variables that were
removed.  But also, we'd tend to update manualcontrolsettings at a very
high rate during the wizard.

Still need to look at doing the same for the manual input limit
configuration (as part of this PR, but not done yet).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/263)

<!-- Reviewable:end -->
