### PR TITLE
packaging: flight: for EF images package hex not bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -737,7 +737,7 @@ define EF_TEMPLATE
 .PHONY: ef_$(1)
 ef_$(1): ef_$(1)_bin ef_$(1)_hex
 
-FW_FILES += $(BUILD_DIR)/ef_$(1)/ef_$(1).bin
+FW_FILES += $(BUILD_DIR)/ef_$(1)/ef_$(1).hex
 
 ef_$(1)_%: TARGET=ef_$(1)
 ef_$(1)_%: OUTDIR=$(BUILD_DIR)/$$(TARGET)


### PR DESCRIPTION
fixes issue #224 / simplifies Naze32 use cases by including a .hex
that cleanflight configurator will be happy to flash.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/266)

<!-- Reviewable:end -->
