### PR TITLE
flight: run config_check asynchronously

### DIFF
--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -110,6 +110,8 @@ static uint32_t idleCounterClear;
 static struct pios_thread *systemTaskHandle;
 static struct pios_queue *objectPersistenceQueue;
 
+static volatile bool config_check_needed;
+
 // Private functions
 static void systemPeriodicCb(UAVObjEvent *ev, void *ctx, void *obj_data, int len);
 static void objectUpdatedCb(UAVObjEvent * ev, void *ctx, void *obj, int len);
@@ -280,6 +282,13 @@ static void systemPeriodicCb(UAVObjEvent *ev, void *ctx, void *obj_data, int len
 	// Update the modem status, if present
 	updateRfm22bStats();
 
+#ifndef NO_SENSORS
+	if (config_check_needed) {
+		configuration_check();
+		config_check_needed = false;
+	}
+#endif
+
 #ifndef PIPXTREME
 	// Update the system statistics
 	updateStats();
@@ -434,7 +443,7 @@ static void objectUpdatedCb(UAVObjEvent * ev, void *ctx, void *obj_data, int len
 static void configurationUpdatedCb(UAVObjEvent * ev, void *ctx, void *obj, int len)
 {
 	(void) ev; (void) ctx; (void) obj; (void) len;
-	configuration_check();
+	config_check_needed = true;
 }
 #endif
 


### PR DESCRIPTION
This is just too expensive.  Input wizard can create wildly toggling
modes-- both from transmitter and GCS object changes-- that back up the
event system.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/273)

<!-- Reviewable:end -->
