### PR TITLE
attitude: increase stack size to 2504 from 2200

### DIFF
--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -80,7 +80,7 @@
 #include "velocityactual.h"
 
 // Private constants
-#define STACK_SIZE_BYTES 2200
+#define STACK_SIZE_BYTES 2504
 #define TASK_PRIORITY PIOS_THREAD_PRIO_HIGH
 #define FAILSAFE_TIMEOUT_MS 10
 


### PR DESCRIPTION
Static stack analysis indicates function will use 2440 at peak,
primarily through world magnetic model.  This is a nasty one, because
most attempts to dynamically measure stack won't cause home position
update.  Hence only at the beginning of real navigation flights have
we been blowing stack for quite some time! Eek!

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/275)

<!-- Reviewable:end -->
