### PR TITLE
gcs: work around different paths in build tree vs. pkg

### DIFF
--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -154,7 +154,16 @@ static inline QStringList getPluginPaths()
     pluginPath += QLatin1Char('/');
     pluginPath += QLatin1String("plugins");
     rc.push_back(pluginPath);
-    // 2) "PlugIns" (OS X)
+    // 2) "plugins" in build tree (Win/Linux)
+    pluginPath = rootDirPath;
+    pluginPath += QLatin1Char('/');
+    pluginPath += QLatin1String(GCS_LIBRARY_BASENAME);
+    pluginPath += QLatin1Char('/');
+    pluginPath += QLatin1String(GCS_PROJECT_BRANDING);
+    pluginPath += QLatin1Char('/');
+    pluginPath += QLatin1String("plugins");
+    rc.push_back(pluginPath);
+    // 3) "PlugIns" (OS X)
     pluginPath = rootDirPath;
     pluginPath += QLatin1Char('/');
     pluginPath += QLatin1String("Plugins");


### PR DESCRIPTION
Without this, Linux and Windows executables work in a package but not directly run from the build tree.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/282)

<!-- Reviewable:end -->
