### PR TITLE
gcs: hide splash when asking what config to use

### DIFF
--- a/ground/gcs/src/app/customsplash.cpp
+++ b/ground/gcs/src/app/customsplash.cpp
@@ -30,6 +30,7 @@
 #include <QPainter>
 #include <QCoreApplication>
 #include <QDebug>
+#include <stdio.h>
 
 #define PROGRESS_BAR_WIDTH  150
 #define PROGRESS_BAR_HEIGHT 12
@@ -110,6 +111,17 @@ void CustomSplash::showMessage(const QString &message, int alignment, const QCol
 
     QCoreApplication::processEvents();
 }
+
+void CustomSplash::hide()
+{
+    QSplashScreen::hide();
+}
+
+void CustomSplash::show()
+{
+    QSplashScreen::show();
+}
+
 /**
  * @brief Closes the splashscreen
  */

--- a/ground/gcs/src/app/customsplash.h
+++ b/ground/gcs/src/app/customsplash.h
@@ -44,6 +44,9 @@ public:
     void setprogressBarColor(const QColor &progressBarColor);
     int message_number;
     QSettings settings;
+
+    void hide();
+    void show();
 private:
     int progress() {return m_progress;}
     void setProgress(int value)

--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -361,6 +361,9 @@ int main(int argc, char **argv)
     }
 
     QObject::connect(&pluginManager,SIGNAL(splashMessages(QString)),&splash,SLOT(showMessage(const QString)));
+    QObject::connect(&pluginManager,SIGNAL(hideSplash()),&splash,SLOT(hide()));
+    QObject::connect(&pluginManager,SIGNAL(showSplash()),&splash,SLOT(show()));
+
     pluginManager.loadPlugins();
     {
         QStringList errors;

--- a/ground/gcs/src/libs/extensionsystem/pluginmanager.cpp
+++ b/ground/gcs/src/libs/extensionsystem/pluginmanager.cpp
@@ -549,8 +549,11 @@ void PluginManagerPrivate::loadPlugins()
     foreach (PluginSpec *spec, queue) {
         emit q->splashMessages(QString(QObject::tr("Loading %1 plugin")).arg(spec->name()));
         loadPlugin(spec, PluginSpec::Loaded);
-        if(spec->name() == "Core")
+        if(spec->name() == "Core") {
             QObject::connect(spec->plugin(),SIGNAL(splashMessages(QString)), q, SIGNAL(splashMessages(QString)));
+            QObject::connect(spec->plugin(),SIGNAL(showSplash()), q, SIGNAL(showSplash()));
+            QObject::connect(spec->plugin(),SIGNAL(hideSplash()), q, SIGNAL(hideSplash()));
+	}
     }
 
     foreach (PluginSpec *spec, queue) {

--- a/ground/gcs/src/libs/extensionsystem/pluginmanager.h
+++ b/ground/gcs/src/libs/extensionsystem/pluginmanager.h
@@ -115,6 +115,9 @@ signals:
     void pluginsChanged();
     void pluginsLoadEnded();
     void splashMessages(QString);
+
+    void hideSplash();
+    void showSplash();
 private slots:
     void startTests();
 

--- a/ground/gcs/src/plugins/coreplugin/coreplugin.cpp
+++ b/ground/gcs/src/plugins/coreplugin/coreplugin.cpp
@@ -41,6 +41,8 @@ CorePlugin::CorePlugin() :
     m_mainWindow(new MainWindow)
 {
     connect(m_mainWindow,SIGNAL(splashMessages(QString)),this,SIGNAL(splashMessages(QString)));
+    connect(m_mainWindow,SIGNAL(hideSplash()),this,SIGNAL(hideSplash()));
+    connect(m_mainWindow,SIGNAL(showSplash()),this,SIGNAL(showSplash()));
 }
 
 CorePlugin::~CorePlugin()

--- a/ground/gcs/src/plugins/coreplugin/coreplugin.h
+++ b/ground/gcs/src/plugins/coreplugin/coreplugin.h
@@ -54,6 +54,9 @@ public slots:
     void remoteArgument(const QString&);
 signals:
     void splashMessages(QString);
+    void hideSplash();
+    void showSplash();
+
 private:
     MainWindow *m_mainWindow;
 };

--- a/ground/gcs/src/plugins/coreplugin/mainwindow.cpp
+++ b/ground/gcs/src/plugins/coreplugin/mainwindow.cpp
@@ -344,10 +344,17 @@ void MainWindow::extensionsInitialized()
         }
         if(showDialog)
         {
+            // This has often ended up behind the splash screen, which looks
+            // bad.
+            emit hideSplash();
+
             importSettings * dialog=new importSettings(this);
             dialog->loadFiles(directory.absolutePath());
             dialog->exec();
             filename=dialog->choosenConfig();
+
+            emit showSplash();
+
             settings=new QSettings(filename, XmlConfig::XmlSettingsFormat);
             delete dialog;
         }

--- a/ground/gcs/src/plugins/coreplugin/mainwindow.h
+++ b/ground/gcs/src/plugins/coreplugin/mainwindow.h
@@ -129,6 +129,8 @@ public:
 signals:
     void windowActivated();
     void splashMessages(QString);
+    void hideSplash();
+    void showSplash();
 public slots:
     void newFile();
     void openFileWith();


### PR DESCRIPTION
Otherwise the splash screen can be in front, preventing interaction with the dialog.

Fixes #237 

This required a lot of plumbing.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/286)

<!-- Reviewable:end -->
