### PR TITLE
sysalarms: only look at correct uavo field

### DIFF
--- a/ground/gcs/src/plugins/sysalarmsmessaging/sysalarmsmessagingplugin.cpp
+++ b/ground/gcs/src/plugins/sysalarmsmessaging/sysalarmsmessagingplugin.cpp
@@ -89,42 +89,38 @@ bool SysAlarmsMessagingPlugin::initialize(const QStringList &arguments, QString 
  */
 void SysAlarmsMessagingPlugin::updateAlarms(UAVObject* systemAlarm)
 {
-    Q_ASSERT(systemAlarm->getObjID() == SystemAlarms::OBJID);
+    UAVObjectField *field = systemAlarm->getField(QString("Alarm"));
 
-    foreach (UAVObjectField *field, systemAlarm->getFields()) {
-        for (uint i = 0; i < field->getNumElements(); ++i) {
-            QString element = field->getElementNames()[i];
-            QString value = field->getValue(i).toString();
-            {
-                if(value==field->getOptions().at(SystemAlarms::ALARM_ERROR))
-                {
-                    errorMessages.value(element)->setActive(true);
-                    errorMessages.value(element)->setDescription(element+" module is in error state");
-                    warningMessages.value(element)->setActive(false);
-                }
-                else if(value==field->getOptions().at(SystemAlarms::ALARM_CRITICAL))
-                {
-                    errorMessages.value(element)->setActive(true);
-                    errorMessages.value(element)->setDescription(element+" module is in CRITICAL state");
-                    warningMessages.value(element)->setActive(false);
-                }
-                else if(value==field->getOptions().at(SystemAlarms::ALARM_WARNING))
-                {
-                    warningMessages.value(element)->setActive(true);
-                    warningMessages.value(element)->setDescription(element+" module is in warning state");
-                    errorMessages.value(element)->setActive(false);
-                }
-                else if(value==field->getOptions().at(SystemAlarms::ALARM_UNINITIALISED))
-                {
-                    warningMessages.value(element)->setActive(false);
-                    errorMessages.value(element)->setActive(false);
-                }
-                else if(value==field->getOptions().at(SystemAlarms::ALARM_OK))
-                {
-                    warningMessages.value(element)->setActive(false);
-                    errorMessages.value(element)->setActive(false);
-                }
-            }
+    for (uint i = 0; i < field->getNumElements(); ++i) {
+        const QString element = field->getElementNames()[i];
+        const QString value = field->getValue(i).toString();
+        if(value==field->getOptions().at(SystemAlarms::ALARM_ERROR))
+        {
+            errorMessages.value(element)->setActive(true);
+            errorMessages.value(element)->setDescription(element+" module is in error state");
+            warningMessages.value(element)->setActive(false);
+        }
+        else if(value==field->getOptions().at(SystemAlarms::ALARM_CRITICAL))
+        {
+            errorMessages.value(element)->setActive(true);
+            errorMessages.value(element)->setDescription(element+" module is in CRITICAL state");
+            warningMessages.value(element)->setActive(false);
+        }
+        else if(value==field->getOptions().at(SystemAlarms::ALARM_WARNING))
+        {
+            warningMessages.value(element)->setActive(true);
+            warningMessages.value(element)->setDescription(element+" module is in warning state");
+            errorMessages.value(element)->setActive(false);
+        }
+        else if(value==field->getOptions().at(SystemAlarms::ALARM_UNINITIALISED))
+        {
+            warningMessages.value(element)->setActive(false);
+            errorMessages.value(element)->setActive(false);
+        }
+        else if(value==field->getOptions().at(SystemAlarms::ALARM_OK))
+        {
+            warningMessages.value(element)->setActive(false);
+            errorMessages.value(element)->setActive(false);
         }
     }
 }


### PR DESCRIPTION
Fixes #296 

Previously we'd iterate over all the stuff in SystemAlarms instead of just the stuff that represents alarms.

This would trigger on various configuration errors and other things "0 module in warning state".  With Kenn's change to report reset reason, it would always fire on normal powerup.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/310)

<!-- Reviewable:end -->
