### PR TITLE
configgadgetwidget: defer creating subwidgets for 0.5s

### DIFF
--- a/ground/gcs/src/plugins/config/configgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.cpp
@@ -66,7 +66,7 @@ ConfigGadgetWidget::ConfigGadgetWidget(QWidget *parent) : QWidget(parent)
     help = 0;
     chunk = 0;
 
-    QTimer::singleShot(3000, this, SLOT(deferredLoader()));
+    QTimer::singleShot(500, this, SLOT(deferredLoader()));
 }
 
 void ConfigGadgetWidget::deferredLoader()
@@ -96,7 +96,7 @@ void ConfigGadgetWidget::deferredLoader()
     ftw->insertTab(ConfigGadgetWidget::aircraft, qwd, *icon, QString("Vehicle"));
     break;
 
-    	case 3:
+        case 3:
     icon = new QIcon();
     icon->addFile(":/configgadget/images/input_normal.png", QSize(), QIcon::Normal, QIcon::Off);
     icon->addFile(":/configgadget/images/input_selected.png", QSize(), QIcon::Selected, QIcon::Off);

--- a/ground/gcs/src/plugins/config/configgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.cpp
@@ -48,7 +48,7 @@
 #include <QTextEdit>
 #include <QVBoxLayout>
 #include <QPushButton>
-
+#include <QTimer>
 
 
 ConfigGadgetWidget::ConfigGadgetWidget(QWidget *parent) : QWidget(parent)
@@ -63,76 +63,113 @@ ConfigGadgetWidget::ConfigGadgetWidget(QWidget *parent) : QWidget(parent)
     layout->addWidget(ftw);
     setLayout(layout);
 
-    // *********************
+    help = 0;
+    chunk = 0;
+
+    QTimer::singleShot(3000, this, SLOT(deferredLoader()));
+}
+
+void ConfigGadgetWidget::deferredLoader()
+{
+    QIcon *icon;
     QWidget *qwd;
 
-    QIcon *icon = new QIcon();
+    switch (chunk) {
+	case 0:
+    // *********************
+    icon = new QIcon();
     icon->addFile(":/configgadget/images/hardware_normal.png", QSize(), QIcon::Normal, QIcon::Off);
     icon->addFile(":/configgadget/images/hardware_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new DefaultHwSettingsWidget(this, false);
     ftw->insertTab(ConfigGadgetWidget::hardware, qwd, *icon, QString("Board"));
+    break;
 
+	case 1:
+    ftw->setCurrentIndex(ConfigGadgetWidget::hardware);
+    break;
+
+	case 2:
     icon = new QIcon();
     icon->addFile(":/configgadget/images/vehicle_normal.png", QSize(), QIcon::Normal, QIcon::Off);
     icon->addFile(":/configgadget/images/vehicle_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new ConfigVehicleTypeWidget(this);
     ftw->insertTab(ConfigGadgetWidget::aircraft, qwd, *icon, QString("Vehicle"));
+    break;
 
+    	case 3:
     icon = new QIcon();
     icon->addFile(":/configgadget/images/input_normal.png", QSize(), QIcon::Normal, QIcon::Off);
     icon->addFile(":/configgadget/images/input_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new ConfigInputWidget(this);
     ftw->insertTab(ConfigGadgetWidget::input, qwd, *icon, QString("Input"));
+    break;
 
+	case 4:
     icon = new QIcon();
     icon->addFile(":/configgadget/images/output_normal.png", QSize(), QIcon::Normal, QIcon::Off);
     icon->addFile(":/configgadget/images/output_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new ConfigOutputWidget(this);
     ftw->insertTab(ConfigGadgetWidget::output, qwd, *icon, QString("Output"));
+    break;
 
+	case 5:
     icon = new QIcon();
     icon->addFile(":/configgadget/images/ins_normal.png", QSize(), QIcon::Normal, QIcon::Off);
     icon->addFile(":/configgadget/images/ins_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new ConfigAttitudeWidget(this);
     ftw->insertTab(ConfigGadgetWidget::sensors, qwd, *icon, QString("Attitude"));
+    break;
 
+	case 6:
     icon = new QIcon();
     icon->addFile(":/configgadget/images/stabilization_normal.png", QSize(), QIcon::Normal, QIcon::Off);
     icon->addFile(":/configgadget/images/stabilization_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new ConfigStabilizationWidget(this);
     ftw->insertTab(ConfigGadgetWidget::stabilization, qwd, *icon, QString("Stabilization"));
+    break;
 
+	case 7:
     icon = new QIcon();
     icon->addFile(":/configgadget/images/modules_normal.png", QSize(), QIcon::Normal, QIcon::Off);
     icon->addFile(":/configgadget/images/modules_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new ConfigModuleWidget(this);
     ftw->insertTab(ConfigGadgetWidget::modules, qwd, *icon, QString("Modules"));
+    break;
 
+	case 8:
     icon = new QIcon();
     icon->addFile(":/configgadget/images/autotune_normal.png", QSize(), QIcon::Normal, QIcon::Off);
     icon->addFile(":/configgadget/images/autotune_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new ConfigAutotuneWidget(this);
     ftw->insertTab(ConfigGadgetWidget::autotune, qwd, *icon, QString("Autotune"));
+    break;
 
+	case 9:
     icon = new QIcon();
     icon->addFile(":/configgadget/images/camstab_normal.png", QSize(), QIcon::Normal, QIcon::Off);
     icon->addFile(":/configgadget/images/camstab_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new ConfigCameraStabilizationWidget(this);
     ftw->insertTab(ConfigGadgetWidget::camerastabilization, qwd, *icon, QString("Camera Stab"));
+    break;
 
+	case 10:
     icon = new QIcon();
     icon->addFile(":/configgadget/images/txpid_normal.png", QSize(), QIcon::Normal, QIcon::Off);
     icon->addFile(":/configgadget/images/txpid_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new ConfigTxPIDWidget(this);
     ftw->insertTab(ConfigGadgetWidget::txpid, qwd, *icon, QString("TxPID"));
+    break;
 
+	case 11:
     icon = new QIcon();
     icon->addFile(":/configgadget/images/osd_normal.png", QSize(), QIcon::Normal, QIcon::Off);
     icon->addFile(":/configgadget/images/osd_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new ConfigOsdWidget(this);
     ftw->insertTab(ConfigGadgetWidget::osd, qwd, *icon, QString("OSD"));
+    break;
 
-    ftw->setCurrentIndex(ConfigGadgetWidget::hardware);
+        case 12:
+	default:
     // *********************
     // Listen to autopilot connection events
 
@@ -146,8 +183,22 @@ ConfigGadgetWidget::ConfigGadgetWidget(QWidget *parent) : QWidget(parent)
         onAutopilotConnect();    
     }
 
-    help = 0;
     connect(ftw,SIGNAL(currentAboutToShow(int,bool*)),this,SLOT(tabAboutToChange(int,bool*)));//,Qt::BlockingQueuedConnection);
+    return;
+    }
+
+    chunk++;
+
+    QTimer::singleShot(0, this, SLOT(deferredLoader()));
+}
+
+void ConfigGadgetWidget::paintEvent(QPaintEvent *event)
+{
+    if (chunk < 12) {
+	// jumpstart loading.
+        deferredLoader();
+        deferredLoader();
+    }
 }
 
 ConfigGadgetWidget::~ConfigGadgetWidget()

--- a/ground/gcs/src/plugins/config/configgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.cpp
@@ -194,6 +194,8 @@ void ConfigGadgetWidget::deferredLoader()
 
 void ConfigGadgetWidget::paintEvent(QPaintEvent *event)
 {
+    (void) event;
+
     if (chunk < 12) {
 	// jumpstart loading.
         deferredLoader();

--- a/ground/gcs/src/plugins/config/configgadgetwidget.h
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.h
@@ -45,6 +45,7 @@ class ConfigGadgetWidget: public QWidget
 {
     Q_OBJECT
     QTextBrowser* help;
+    int chunk;
 
 public:
     ConfigGadgetWidget(QWidget *parent = 0);
@@ -56,6 +57,7 @@ public slots:
     void onAutopilotConnect();
     void onAutopilotDisconnect();
     void tabAboutToChange(int i,bool *);
+    void deferredLoader();
 
 signals:
     void autopilotConnected();
@@ -63,6 +65,7 @@ signals:
 
 protected:
         void resizeEvent(QResizeEvent * event);
+        void paintEvent(QPaintEvent * event);
         MyTabbedStackWidget *ftw;
 };
 

--- a/ground/gcs/src/plugins/uavobjects/uavobjectmanager.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectmanager.cpp
@@ -136,6 +136,9 @@ void UAVObjectManager::addObject(UAVObject* obj)
     QMap<quint32,UAVObject*> list;
     list.insert(obj->getInstID(),obj);
     objects.insert(obj->getObjID(),list);
+
+    objectsByName.insert(obj->getName(), list);
+
     emit newObject(obj);
 }
 
@@ -216,7 +219,7 @@ QVector <QVector<UAVMetaObject*> > UAVObjectManager::getMetaObjectsVector()
  */
 UAVObject* UAVObjectManager::getObject(const QString& name, quint32 instId)
 {
-    return getObject(&name, 0, instId);
+    return getObject(name, 0, instId);
 }
 
 /**
@@ -231,16 +234,16 @@ UAVObject* UAVObjectManager::getObject(quint32 objId, quint32 instId)
 /**
  * Helper function for the public getObject() functions.
  */
-UAVObject* UAVObjectManager::getObject(const QString* name, quint32 objId, quint32 instId)
+UAVObject* UAVObjectManager::getObject(const QString& name, quint32 objId, quint32 instId)
 {
     QMutexLocker locker(mutex);
     if(name != NULL)
     {
-        foreach(const ObjectMap &map, objects)
-        {
-            if(map.first()->getName().compare(name) == 0)
-                return map.value(instId,NULL);
+        if (objectsByName.contains(name)) {
+            return objectsByName.value(name).value(instId);
         }
+
+        return NULL;
     }
     else if(objects.contains(objId))
         return objects.value(objId).value(instId);

--- a/ground/gcs/src/plugins/uavobjects/uavobjectmanager.h
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectmanager.h
@@ -65,10 +65,11 @@ signals:
 private:
     static const quint32 MAX_INSTANCES = 1000;
     QHash<quint32, QMap<quint32,UAVObject*> > objects;
+    QHash<QString, QMap<quint32,UAVObject*> > objectsByName;
     QMutex* mutex;
 
     void addObject(UAVObject* obj);
-    UAVObject* getObject(const QString* name, quint32 objId, quint32 instId);
+    UAVObject* getObject(const QString& name, quint32 objId, quint32 instId);
     QVector<UAVObject*> getObjectInstancesVector(const QString* name, quint32 objId);
     qint32 getNumInstances(const QString* name, quint32 objId);
 };


### PR DESCRIPTION
This allows the app to open a couple seconds quicker.  The trade off is,
if you try to go to config gadget widget too fast, you encounter a
couple second delay while we catch up and instantiate all the widgets.
But not everyone will go to config gadget first, and not all will go
there extremely quickly after loading.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/312)

<!-- Reviewable:end -->
