### PR TITLE
GCS:Config: Fix broken signal in autotune share

### DIFF
--- a/ground/gcs/src/plugins/config/configautotunewidget.cpp
+++ b/ground/gcs/src/plugins/config/configautotunewidget.cpp
@@ -117,7 +117,7 @@ void ConfigAutotuneWidget::saveStabilization()
 void ConfigAutotuneWidget::onShareData()
 {
     autotuneShareForm = new AutotuneShareForm();
-    connect(autotuneShareForm, SIGNAL(finished()), this, SLOT(onShareFinished()));
+    autotuneShareForm->setAttribute(Qt::WA_DeleteOnClose, true);
     connect(autotuneShareForm, SIGNAL(ClipboardRequest()), this, SLOT(onShareToClipboard()));
     connect(autotuneShareForm, SIGNAL(DatabaseRequest()), this, SLOT(onShareToDatabase()));
 
@@ -149,11 +149,6 @@ void ConfigAutotuneWidget::onShareData()
     autotuneShareForm->show();
     autotuneShareForm->raise();
     autotuneShareForm->activateWindow();
-}
-
-void ConfigAutotuneWidget::onShareFinished()
-{
-    autotuneShareForm->deleteLater();
 }
 
 void ConfigAutotuneWidget::onShareToDatabase()

--- a/ground/gcs/src/plugins/config/configautotunewidget.h
+++ b/ground/gcs/src/plugins/config/configautotunewidget.h
@@ -71,7 +71,6 @@ private slots:
     void onShareData();
     void onShareToDatabase();
     void onShareToClipboard();
-    void onShareFinished();
     void onShareToDatabaseComplete(QNetworkReply *reply);
 };
 


### PR DESCRIPTION
Oops, mistake from AT sharing work. This was generating a warning about invalid signal, and not cleaning up properly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/331)
<!-- Reviewable:end -->
