### PR TITLE
pios_servo/oneshot: Ensure dead time.

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -562,15 +562,16 @@ static bool set_channel(uint8_t mixer_channel, float value)
 			}
 		}
 		PIOS_Servo_Set(mixer_channel,
-					buzzOn ? actuatorSettings.ChannelMax[mixer_channel] : actuatorSettings.ChannelMin[mixer_channel]);
+					buzzOn ? actuatorSettings.ChannelMax[mixer_channel] : actuatorSettings.ChannelMin[mixer_channel],
+					actuatorSettings.ChannelMax[mixer_channel]);
 		return true;
 	}
 	case ACTUATORSETTINGS_CHANNELTYPE_PWM:
 #if defined(PIOS_INCLUDE_HPWM)
 		// The HPWM method will convert from us to the appropriate settings
-		PIOS_Servo_Set(mixer_channel, value);
+		PIOS_Servo_Set(mixer_channel, value, actuatorSettings.ChannelMax[mixer_channel]);
 #else
-		PIOS_Servo_Set(mixer_channel, value);
+		PIOS_Servo_Set(mixer_channel, value, actuatorSettings.ChannelMax[mixer_channel]);
 #endif
 		return true;
 	default:

--- a/flight/PiOS/STM32F10x/pios_servo.c
+++ b/flight/PiOS/STM32F10x/pios_servo.c
@@ -213,7 +213,7 @@ void PIOS_Servo_SetMode(const uint16_t * speeds, const enum pwm_mode *pwm_mode, 
 * \param[in] Position Servo position in microseconds
 */
 #if defined(PIOS_INCLUDE_HPWM)
-void PIOS_Servo_Set(uint8_t servo, float position)
+void PIOS_Servo_Set(uint8_t servo, float position, float max)
 {
 	/* Make sure servo exists */
 	if (!servo_cfg || servo >= servo_cfg->num_channels) {
@@ -239,7 +239,18 @@ void PIOS_Servo_Set(uint8_t servo, float position)
 
 	/* stop the timer in OneShot (Synchronous) mode */
 	if (output_channel_mode[servo] == SYNC_PWM_TRUE) {
-		TIM_Cmd(chan->timer, DISABLE);
+		/* But only if we have counted sufficiently high.
+		 * Ensure a dead time of 2% + 10 us, e.g. 15us for 250us
+		 * long pulses, 50 us for 2000us long pulses
+		 */
+		max = max * 1.02f + 10;
+
+		// Convert to timer counts.
+		max *= us_to_count;
+
+		if (TIM_GetCounter(chan->timer) > max) {
+			TIM_Cmd(chan->timer, DISABLE);
+		}
 	}
 
 	/* Update the position */

--- a/flight/PiOS/STM32F10x/pios_servo.c
+++ b/flight/PiOS/STM32F10x/pios_servo.c
@@ -211,6 +211,7 @@ void PIOS_Servo_SetMode(const uint16_t * speeds, const enum pwm_mode *pwm_mode, 
 * Set servo position for HPWM
 * \param[in] Servo Servo number (0-num_channels)
 * \param[in] Position Servo position in microseconds
+* \param[in] max Maximum pulse length in us for oneshot
 */
 #if defined(PIOS_INCLUDE_HPWM)
 void PIOS_Servo_Set(uint8_t servo, float position, float max)
@@ -250,6 +251,8 @@ void PIOS_Servo_Set(uint8_t servo, float position, float max)
 
 		if (TIM_GetCounter(chan->timer) > max) {
 			TIM_Cmd(chan->timer, DISABLE);
+		} else {
+			return;
 		}
 	}
 

--- a/flight/PiOS/STM32F30x/pios_servo.c
+++ b/flight/PiOS/STM32F30x/pios_servo.c
@@ -198,6 +198,7 @@ void PIOS_Servo_SetMode(const uint16_t * speeds, const enum pwm_mode *pwm_mode, 
 * Set servo position for HPWM
 * \param[in] Servo Servo number (0-num_channels)
 * \param[in] Position Servo position in microseconds
+* \param[in] max Maximum pulse length in us for oneshot
 */
 #if defined(PIOS_INCLUDE_HPWM)
 void PIOS_Servo_Set(uint8_t servo, float position, float max)
@@ -237,6 +238,8 @@ void PIOS_Servo_Set(uint8_t servo, float position, float max)
 
 		if (TIM_GetCounter(chan->timer) > max) {
 			TIM_Cmd(chan->timer, DISABLE);
+		} else {
+			return;
 		}
 	}
 

--- a/flight/PiOS/STM32F4xx/pios_servo.c
+++ b/flight/PiOS/STM32F4xx/pios_servo.c
@@ -197,6 +197,7 @@ void PIOS_Servo_SetMode(const uint16_t * speeds, const enum pwm_mode *pwm_mode, 
 * Set servo position for HPWM
 * \param[in] Servo Servo number (0-num_channels)
 * \param[in] Position Servo position in microseconds
+* \param[in] max Maximum pulse length in us for oneshot
 */
 #if defined(PIOS_INCLUDE_HPWM)
 void PIOS_Servo_Set(uint8_t servo, float position, float max)
@@ -236,6 +237,8 @@ void PIOS_Servo_Set(uint8_t servo, float position, float max)
 
 		if (TIM_GetCounter(chan->timer) > max) {
 			TIM_Cmd(chan->timer, DISABLE);
+		} else {
+			return;
 		}
 	}
 

--- a/flight/PiOS/STM32F4xx/pios_servo.c
+++ b/flight/PiOS/STM32F4xx/pios_servo.c
@@ -199,7 +199,7 @@ void PIOS_Servo_SetMode(const uint16_t * speeds, const enum pwm_mode *pwm_mode, 
 * \param[in] Position Servo position in microseconds
 */
 #if defined(PIOS_INCLUDE_HPWM)
-void PIOS_Servo_Set(uint8_t servo, float position)
+void PIOS_Servo_Set(uint8_t servo, float position, float max)
 {
 	/* Make sure servo exists */
 	if (!servo_cfg || servo >= servo_cfg->num_channels) {
@@ -225,7 +225,18 @@ void PIOS_Servo_Set(uint8_t servo, float position)
 
 	/* stop the timer in OneShot (Synchronous) mode */
 	if (output_channel_mode[servo] == SYNC_PWM_TRUE) {
-		TIM_Cmd(chan->timer, DISABLE);
+		/* But only if we have counted sufficiently high.
+		 * Ensure a dead time of 2% + 10 us, e.g. 15us for 250us
+		 * long pulses, 50 us for 2000us long pulses
+		 */
+		max = max * 1.02f + 10;
+
+		// Convert to timer counts.
+		max *= us_to_count;
+
+		if (TIM_GetCounter(chan->timer) > max) {
+			TIM_Cmd(chan->timer, DISABLE);
+		}
 	}
 
 	/* Update the position */

--- a/flight/PiOS/inc/pios_servo.h
+++ b/flight/PiOS/inc/pios_servo.h
@@ -36,7 +36,7 @@ enum pwm_mode {PWM_MODE_1MHZ, PWM_MODE_12MHZ};
 /* Public Functions */
 extern void PIOS_Servo_SetMode(const uint16_t * update_rates, const enum pwm_mode *pwm_mdoe, uint8_t banks);
 #if defined(PIOS_INCLUDE_HPWM)
-extern void PIOS_Servo_Set(uint8_t servo, float position);
+extern void PIOS_Servo_Set(uint8_t servo, float position, float max);
 extern void PIOS_Servo_Update();
 #else
 extern void PIOS_Servo_Set(uint8_t Servo, uint16_t Position);


### PR DESCRIPTION
Now max pulse length is passed into pios_servo, and we make sure we're
"past" that point by a defined margin before we'll disable the timer.

pios_servo should get factored common in the future and non-HPWM
variants of the code should get removed in that refactor.

This depends on all channels in a oneshot bank being defined with the
same "max" time to be fully protective.

Fixes #337

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/342)
<!-- Reviewable:end -->
