### PR TITLE
naze32: Add two ADC pins when using serial rcvrport

### DIFF
--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -512,6 +512,7 @@ void PIOS_Board_Init(void) {
 		switch(hw_rcvrport) {
 		case HWNAZE_RCVRPORT_PPM:
 		case HWNAZE_RCVRPORT_PPMSERIAL:
+		case HWNAZE_RCVRPORT_SERIAL:
 			number_of_adc_pins += 2; // rcvr port pins also available
 			break;
 		default:


### PR DESCRIPTION
Hat to to @ernieift who noticed that in #145 this was missed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/346)

<!-- Reviewable:end -->
