### PR TITLE
Package/OSX strip binaries to decrease size

### DIFF
--- a/package/osx/libraries
+++ b/package/osx/libraries
@@ -12,7 +12,7 @@ QMLDIR="${APP}/Contents/Resources/welcome"
 
 pushd "${QT_SDK_BIN_PATH}"
 
-./macdeployqt "${APP}" -verbose=2 -no-strip -always-overwrite -qmldir="$QMLDIR"
+./macdeployqt "${APP}" -verbose=2 -always-overwrite -qmldir="$QMLDIR"
 
 popd
 


### PR DESCRIPTION
For consideration.  Not having symbols could be annoying at times.  But it shrinks down the package size by a few megs, which is fairly large.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/349)

<!-- Reviewable:end -->
