### PR TITLE
simulator: improve display of LEDs

### DIFF
--- a/flight/PiOS.posix/posix/pios_heap.c
+++ b/flight/PiOS.posix/posix/pios_heap.c
@@ -85,7 +85,7 @@ void PIOS_heap_initialize_blocks(void)
 
 size_t PIOS_heap_get_free_size(void)
 {
-	return 1024;
+	return 4096;
 }
 
 size_t PIOS_fastheap_get_free_size(void)

--- a/flight/PiOS.posix/posix/pios_led.c
+++ b/flight/PiOS.posix/posix/pios_led.c
@@ -44,7 +44,7 @@ static inline void PIOS_SetLED(uint32_t led, uint8_t stat) {
 
 	PIOS_Assert(led < PIOS_LED_NUM);
 
-	uint8_t mask = 1<<led;
+	uint8_t mask = 1 << led;
 
 	if (stat) {
 		newStatus |= mask;
@@ -91,7 +91,7 @@ void PIOS_LED_Init(void)
 */
 void PIOS_LED_On(uint32_t led)
 {
-	PIOS_SetLED(led,1);
+	PIOS_SetLED(led, 1);
 }
 
 
@@ -101,7 +101,7 @@ void PIOS_LED_On(uint32_t led)
 */
 void PIOS_LED_Off(uint32_t led)
 {
-	PIOS_SetLED(led,0);
+	PIOS_SetLED(led, 0);
 }
 
 
@@ -111,7 +111,7 @@ void PIOS_LED_Off(uint32_t led)
 */
 void PIOS_LED_Toggle(uint32_t led)
 {
-	PIOS_SetLED(led,((ledStatus >> led) & 1)?0:1);
+	PIOS_SetLED(led, ((ledStatus >> led) & 1) ? 0 : 1);
 }
 
 #endif


### PR DESCRIPTION
This squashes the output from the simulator some, and makes it really clear there are very short lived transient alarms that should be investigated on the sim.

Also set the simulator "Fake free heap size" to be above where you get a warning.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/353)

<!-- Reviewable:end -->
