### PR TITLE
manualcontrol: prevent spurious disarms in altitude hold mode

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -671,6 +671,7 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 		                       flight_mode == FLIGHTSTATUS_FLIGHTMODE_POSITIONHOLD ||
 		                       flight_mode == FLIGHTSTATUS_FLIGHTMODE_RETURNTOHOME ||
 		                       flight_mode == FLIGHTSTATUS_FLIGHTMODE_PATHPLANNER  ||
+		                       flight_mode == FLIGHTSTATUS_FLIGHTMODE_ALTITUDEHOLD  ||
 		                       flight_mode == FLIGHTSTATUS_FLIGHTMODE_TABLETCONTROL;
 		bool check_throttle = settings->ArmTimeoutAutonomous == MANUALCONTROLSETTINGS_ARMTIMEOUTAUTONOMOUS_ENABLED ||
 			!autonomous_mode;


### PR DESCRIPTION
Altitude hold mode is an "autonomous flight mode" for the purpose of the
test in transmitter_control.  That is, low throttle values for extended
times can be legal.  If the "don't disarm on low throttle when
autonomous" is set, don't disarm under these circumstances in altitude
hold mode.  Else, in a prolonged descent, copter may drop out of the
sky.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/358)

<!-- Reviewable:end -->
