### PR TITLE
gcs: settings: increase size to 780x525

### DIFF
--- a/ground/gcs/src/plugins/coreplugin/dialogs/settingsdialog.ui
+++ b/ground/gcs/src/plugins/coreplugin/dialogs/settingsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>697</width>
-    <height>476</height>
+    <width>780</width>
+    <height>525</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/ground/gcs/src/plugins/scope/scopegadgetoptionspage.ui
+++ b/ground/gcs/src/plugins/scope/scopegadgetoptionspage.ui
@@ -233,7 +233,7 @@
               <item row="2" column="0">
                <widget class="QLabel" name="label_6">
                 <property name="text">
-                 <string>UAVO data multiplier:</string>
+                 <string>Data multiplier:</string>
                 </property>
                </widget>
               </item>
@@ -637,7 +637,7 @@
                   <item row="2" column="0">
                    <widget class="QLabel" name="label_21">
                     <property name="text">
-                     <string>UAVO data multiplier:</string>
+                     <string>Data multiplier:</string>
                     </property>
                    </widget>
                   </item>

--- a/ground/gcs/src/plugins/scope/scopegadgetoptionspage.ui
+++ b/ground/gcs/src/plugins/scope/scopegadgetoptionspage.ui
@@ -742,7 +742,7 @@
                   <item row="0" column="0">
                    <widget class="QLabel" name="label_24">
                     <property name="text">
-                     <string>Sampling frequency:</string>
+                     <string>Sampling rate:</string>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
Previous size was 697x496.  It's still a little cramped.

Rationale for this size was:  fit in 800x600 with margin at the bottom.
At 1024x768, be small-ish compared to screen.

Sort-of fixes #351

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/359)

<!-- Reviewable:end -->
