### PR TITLE
uavomspbridge: add "const" to msp_boxes struct def

### DIFF
--- a/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
+++ b/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
@@ -98,7 +98,7 @@ typedef enum {
 	MSP_BOX_LAST,
 } msp_box_t;
 
-static struct {
+const static struct {
 	msp_box_t mode;
 	uint8_t mwboxid;
 	FlightStatusFlightModeOptions tlmode;


### PR DESCRIPTION
Right now the compiler correctly infers the struct is const, but better
safe than sorry.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/372)

<!-- Reviewable:end -->
