### PR TITLE
TxPID stack and Init fix

### DIFF
--- a/flight/Modules/TxPID/txpid.c
+++ b/flight/Modules/TxPID/txpid.c
@@ -96,14 +96,19 @@ static float scale(float val, float inMin, float inMax, float outMin, float outM
  */
 int32_t TxPIDInitialize(void)
 {
+	bool module_enabled = false;
+
 #ifdef MODULE_TxPID_BUILTIN
-	if 1 {
+	module_enabled = true;
 #else
 	uint8_t module_state[MODULESETTINGS_ADMINSTATE_NUMELEM];
 	ModuleSettingsAdminStateGet(module_state);
 	if (module_state[MODULESETTINGS_ADMINSTATE_TXPID] == MODULESETTINGS_ADMINSTATE_ENABLED) {
+		module_enabled = true;
+	}
 #endif
 
+	if (module_enabled) {
 		txpid_data = PIOS_malloc(sizeof(*txpid_data));
 
 		if (txpid_data != NULL) {

--- a/flight/Modules/TxPID/txpid.c
+++ b/flight/Modules/TxPID/txpid.c
@@ -84,7 +84,6 @@ struct txpid_struct {
 
 // Private variables
 static struct txpid_struct *txpid_data;
-static bool module_enabled;
 
 // Private functions
 static void updatePIDs(UAVObjEvent* ev, void *ctx, void *obj, int len);
@@ -98,31 +97,26 @@ static float scale(float val, float inMin, float inMax, float outMin, float outM
 int32_t TxPIDInitialize(void)
 {
 #ifdef MODULE_TxPID_BUILTIN
-	module_enabled = true;
+	if 1 {
 #else
 	uint8_t module_state[MODULESETTINGS_ADMINSTATE_NUMELEM];
 	ModuleSettingsAdminStateGet(module_state);
 	if (module_state[MODULESETTINGS_ADMINSTATE_TXPID] == MODULESETTINGS_ADMINSTATE_ENABLED) {
-		module_enabled = true;
-	} else {
-		module_enabled = false;
-		return -1;
-	}
 #endif
 
-	txpid_data = PIOS_malloc(sizeof(*txpid_data));
+		txpid_data = PIOS_malloc(sizeof(*txpid_data));
 
-	if (txpid_data != NULL) {
-		memset(txpid_data, 0x00, sizeof(*txpid_data));
+		if (txpid_data != NULL) {
+			memset(txpid_data, 0x00, sizeof(*txpid_data));
+
+			TxPIDSettingsInitialize();
+			AccessoryDesiredInitialize();
+
+			return 0;
+		}
 	}
-	else {
-		return -1;
-	}
 
-	TxPIDSettingsInitialize();
-	AccessoryDesiredInitialize();
-
-	return 0;
+	return -1;
 }
 
 /**
@@ -131,7 +125,7 @@ int32_t TxPIDInitialize(void)
  */
 static int32_t TxPIDStart(void)
 {
-	if (!module_enabled) {
+	if (txpid_data == NULL) {
 		return -1;
 	}
 


### PR DESCRIPTION
This PR dynamically allocates memory for the large memory variables used in the code, preventing the stack from being depleted. Also fixes a problem where the Init function could try to construct a periodic callback before that system was running.

Tested on Sparky2 with TxPID on and off, also tested functionality of TxPID with FrSky S.PORT X4R-SB RX.

Fixes #370

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/374)
<!-- Reviewable:end -->
