### PR TITLE
GCS: Remove 50Hz PWM defaults

### DIFF
--- a/ground/gcs/src/plugins/setupwizard/pages/outputpage.cpp
+++ b/ground/gcs/src/plugins/setupwizard/pages/outputpage.cpp
@@ -65,10 +65,8 @@ bool OutputPage::validatePage()
         // This is safe to do even if they are wrong. Normal ESCS
         // ignore oneshot.
         setOneshotTimings();
-    } else if (ui->rapidESCButton->isChecked()) {
-        getWizard()->setESCType(SetupWizard::ESC_RAPID);
     } else {
-        getWizard()->setESCType(SetupWizard::ESC_LEGACY);
+        getWizard()->setESCType(SetupWizard::ESC_RAPID);
     }
 
     return true;

--- a/ground/gcs/src/plugins/setupwizard/pages/outputpage.ui
+++ b/ground/gcs/src/plugins/setupwizard/pages/outputpage.ui
@@ -56,50 +56,6 @@ p, li { white-space: pre-wrap; }
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QToolButton" name="defaultESCButton">
-       <property name="font">
-        <font>
-         <pointsize>10</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string>Standard ESC 50Hz</string>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">QToolButton { border: none }</string>
-       </property>
-       <property name="text">
-        <string>Standard ESC</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../wizardResources.qrc">
-         <normaloff>:/setupwizard/resources/bttn-ESC-up.png</normaloff>
-         <normalon>:/setupwizard/resources/bttn-ESC-down.png</normalon>:/setupwizard/resources/bttn-ESC-up.png</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>200</width>
-         <height>100</height>
-        </size>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-       <property name="autoExclusive">
-        <bool>true</bool>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextUnderIcon</enum>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QToolButton" name="rapidESCButton">
        <property name="font">
         <font>
@@ -107,13 +63,13 @@ p, li { white-space: pre-wrap; }
         </font>
        </property>
        <property name="toolTip">
-        <string>Turbo PWM ESC 400Hz</string>
+        <string>Modern ESC 400Hz PWM</string>
        </property>
        <property name="styleSheet">
         <string notr="true">QToolButton { border: none }</string>
        </property>
        <property name="text">
-        <string>Turbo PWM</string>
+        <string>400Hz PWM</string>
        </property>
        <property name="icon">
         <iconset resource="../wizardResources.qrc">
@@ -154,7 +110,7 @@ p, li { white-space: pre-wrap; }
         </font>
        </property>
        <property name="toolTip">
-        <string>Turbo PWM ESC 400Hz</string>
+        <string>OneShot Synchronous PWM</string>
        </property>
        <property name="styleSheet">
         <string notr="true">QToolButton { border: none }</string>

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -1,7 +1,7 @@
 <xml>
     <object name="ActuatorSettings" singleinstance="true" settings="true">
         <description>Settings for the @ref ActuatorModule that controls the channel assignments for the mixer based on AircraftType</description>
-        <field name="TimerUpdateFreq" units="Hz" type="uint16" elements="6" defaultvalue="50">
+        <field name="TimerUpdateFreq" units="Hz" type="uint16" elements="6" defaultvalue="400">
             <description>The frequency of the PWM signal output to the actuator. 0 specifies synchronous PWM.</description>
         </field>
         <field name="TimerPwmResolution" units="" type="enum" elements="6" options="1MHz,12MHz" defaultvalue="1MHz">


### PR DESCRIPTION
This is not a configuration that we ever want someone to use, and it's been pretty much the "default".  Hence it's something a lot of users trip over.  Fix that.

Fixes #383 

Note that the default is now "400" on all channels, but the GCS sets unused banks in the wizard to 50 to better support analog servos.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/384)

<!-- Reviewable:end -->
