### PR TITLE
flight: sbus: don't attempt to use time to synchronize

### DIFF
--- a/flight/PiOS/Common/pios_sbus.c
+++ b/flight/PiOS/Common/pios_sbus.c
@@ -286,7 +286,7 @@ static uint16_t PIOS_SBus_RxInCallback(uintptr_t context,
  * RTC timer is running at 625Hz (1.6ms).
  *
  * Data receive function must clear the receive_timer to confirm new
- * data reception. If no new data received in 100ms, we must call the
+ * data reception. If no new data received in 48ms, we must call the
  * failsafe function which clears all channels.
  */
 static void PIOS_SBus_Supervisor(uintptr_t sbus_id)
@@ -305,8 +305,8 @@ static void PIOS_SBus_Supervisor(uintptr_t sbus_id)
 		state->receive_timer = 0;
 	}
 
-	/* activate failsafe if no frames have arrived in 102.4ms */
-	if (++state->failsafe_timer > 64) {
+	/* activate failsafe if no frames have arrived in 48ms */
+	if (++state->failsafe_timer > 30) {
 		PIOS_SBus_ResetChannels(state);
 		state->failsafe_timer = 0;
 	}

--- a/flight/PiOS/Common/pios_sbus.c
+++ b/flight/PiOS/Common/pios_sbus.c
@@ -57,9 +57,7 @@ enum pios_sbus_dev_magic {
 struct pios_sbus_state {
 	uint16_t channel_data[PIOS_SBUS_NUM_INPUTS];
 	uint8_t received_data[SBUS_FRAME_LENGTH - 2];
-	uint8_t receive_timer;
 	uint8_t failsafe_timer;
-	uint8_t frame_found;
 	uint8_t byte_count;
 };
 
@@ -98,9 +96,8 @@ static void PIOS_SBus_ResetChannels(struct pios_sbus_state *state)
 /* Reset S.Bus receiver state */
 static void PIOS_SBus_ResetState(struct pios_sbus_state *state)
 {
-	state->receive_timer = 0;
 	state->failsafe_timer = 0;
-	state->frame_found = 0;
+	state->byte_count = 0;
 	PIOS_SBus_ResetChannels(state);
 }
 
@@ -210,18 +207,12 @@ static void PIOS_SBus_UnrollChannels(struct pios_sbus_state *state)
 /* Update decoder state processing input byte from the S.Bus stream */
 static void PIOS_SBus_UpdateState(struct pios_sbus_state *state, uint8_t b)
 {
-	/* should not process any data until new frame is found */
-	if (!state->frame_found)
-		return;
-
 	if (state->byte_count == 0) {
-		if (b != SBUS_SOF_BYTE) {
-			/* discard the whole frame if the 1st byte is not correct */
-			state->frame_found = 0;
-		} else {
+		if (b == SBUS_SOF_BYTE) {
 			/* do not store the SOF byte */
 			state->byte_count++;
 		}
+		/* Otherwise discard this byte. */
 		return;
 	}
 
@@ -249,7 +240,7 @@ static void PIOS_SBus_UpdateState(struct pios_sbus_state *state, uint8_t b)
 		}
 
 		/* prepare for the next frame */
-		state->frame_found = 0;
+		state->byte_count = 0;
 	}
 }
 
@@ -270,10 +261,9 @@ static uint16_t PIOS_SBus_RxInCallback(uintptr_t context,
 	/* process byte(s) and clear receive timer */
 	for (uint8_t i = 0; i < buf_len; i++) {
 		PIOS_SBus_UpdateState(state, buf[i]);
-		state->receive_timer = 0;
 	}
 
-	/* Always signal that we can accept another byte */
+	/* Always signal that we can accept another frame */
 	if (headroom)
 		*headroom = SBUS_FRAME_LENGTH;
 
@@ -286,11 +276,10 @@ static uint16_t PIOS_SBus_RxInCallback(uintptr_t context,
 
 /**
  * Input data supervisor is called periodically and provides
- * two functions: frame syncing and failsafe triggering.
+ * failsafe triggering.
  *
  * S.Bus frames come at 7ms (HS) or 14ms (FS) rate at 100000bps.
- * RTC timer is running at 625Hz (1.6ms). So with divider 2 it gives
- * 3.2ms pause between frames which is good for both S.Bus frame rates.
+ * RTC timer is running at 625Hz (1.6ms).
  *
  * Data receive function must clear the receive_timer to confirm new
  * data reception. If no new data received in 100ms, we must call the
@@ -304,13 +293,6 @@ static void PIOS_SBus_Supervisor(uintptr_t sbus_id)
 	PIOS_Assert(valid);
 
 	struct pios_sbus_state *state = &(sbus_dev->state);
-
-	/* waiting for new frame if no bytes were received in 3.2ms */
-	if (++state->receive_timer > 2) {
-		state->frame_found = 1;
-		state->byte_count = 0;
-		state->receive_timer = 0;
-	}
 
 	/* activate failsafe if no frames have arrived in 102.4ms */
 	if (++state->failsafe_timer > 64) {


### PR DESCRIPTION
Connects to #425 

Background:  We now have 2 users that have had significant anomalies with sbus + brain + arming switch.  Neither is at a rate that's conclusive.  The known switch arming issues mentioned in #357 are a significant confound.

However, in auditing the sbus code I noticed that we rely on pretty specific timing that relates to the Futaba air-interface that third party RX firmwares may not always try so hard to comply with.  This seems bad-- while this timing is probably considerably helpful in ensuring synchronization with genuine Futaba stuff and rejecting illegitimate data, it may work against us in other cases.

Non-openpilot ecosystem sbus decoders do not have this check.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/428)

<!-- Reviewable:end -->
