### PR TITLE
flight: fixed switch arming bugs

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -619,7 +619,7 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 
 	valid &= cmd->Connected == MANUALCONTROLCOMMAND_CONNECTED_TRUE;
 
-  	switch(arm_state) {
+	switch(arm_state) {
 	case ARM_STATE_DISARMED:
 	{
 		set_armed_if_changed(FLIGHTSTATUS_ARMED_DISARMED);
@@ -633,6 +633,12 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 			if (!last_arm) {
 				armedDisarmStart = lastSysTime;
 				arm_state = ARM_STATE_ARMED;
+			}
+		} else if (arm && (settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLEDELAY ||
+				settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHDELAY)) {
+			if (!last_arm) {
+				armedDisarmStart = lastSysTime;
+				arm_state = ARM_STATE_ARMING;
 			}
 		} else if (arm) {
 			armedDisarmStart = lastSysTime;
@@ -653,7 +659,12 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 			(settings->ArmTime == MANUALCONTROLSETTINGS_ARMTIME_1000) ? 1000 : \
 			(settings->ArmTime == MANUALCONTROLSETTINGS_ARMTIME_2000) ? 2000 : 1000;
 		if (arm && timeDifferenceMs(armedDisarmStart, lastSysTime) > arm_time) {
-			arm_state = ARM_STATE_ARMED_STILL_HOLDING;
+			if (settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLEDELAY ||
+					settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHDELAY) {
+				arm_state = ARM_STATE_ARMED;
+			} else {
+				arm_state = ARM_STATE_ARMED_STILL_HOLDING;
+			}
 		} else if (!arm) {
 			arm_state = ARM_STATE_DISARMED;
 		}


### PR DESCRIPTION
1: SWITCHDELAY got stuck in ARM_STATE_ARMED_STILL_HOLDING which prevented it from auto disarming from low throttle etc. 

2: SWITCHDELAY & SWITCHTHROTTLEDELAY would rearm themselves after a low throttle disarm event. The rising edge detection prevents that.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/434)

<!-- Reviewable:end -->
