### PR TITLE
GCS:Config:Input: Add description of arming timeout

### DIFF
--- a/ground/gcs/src/plugins/config/input.ui
+++ b/ground/gcs/src/plugins/config/input.ui
@@ -29,7 +29,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="RCInput">
       <attribute name="title">
@@ -1484,8 +1484,7 @@ channel value for each flight mode.</string>
                    <enum>Qt::StrongFocus</enum>
                   </property>
                   <property name="toolTip">
-                   <string>After the time indicated here, the frame go back to disarmed state.
-Set to 0 to disable (recommended for soaring fixed wings).</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;After the time indicated here, the vehicle will go back to disarmed state.&lt;/p&gt;&lt;p&gt;Set to 0 to disable (recommended for soaring fixed wings).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                   <property name="maximum">
                    <number>64</number>
@@ -1517,8 +1516,7 @@ Set to 0 to disable (recommended for soaring fixed wings).</string>
               <item>
                <widget class="QLabel" name="label_3">
                 <property name="text">
-                 <string>Airframe disarm is done by throttle off and opposite of above combination, except in the case of the switch option. For switch only the throttle is ignored.
-Note: In switch configuration without delay, zeroing the gyros while arming is not possible.</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Airframe disarm is done by throttle off and opposite of above combination, except in the case of the switch option. For switch only the throttle is ignored. Note: In switch configuration without delay, zeroing the gyros while arming is not possible. &lt;/p&gt;&lt;p&gt;The arming timeout applies when the vehicle is armed but at minimum throttle. The vehicle will be automatically disarmed if left at minimum throttle longer than the duration of this timeout. The timeout may be disabled by setting it to zero, but this is &lt;span style=&quot; font-weight:600;&quot;&gt;not recommended&lt;/span&gt; for multirotors.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="wordWrap">
                  <bool>true</bool>

--- a/ground/gcs/src/plugins/config/input.ui
+++ b/ground/gcs/src/plugins/config/input.ui
@@ -1470,6 +1470,26 @@ channel value for each flight mode.</string>
                </layout>
               </item>
               <item>
+               <widget class="QLabel" name="label_3">
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Airframe disarm is done by throttle off and opposite of above combination, except in the case of the switch option. For switch only the throttle is ignored. Note: In switch configuration without delay, zeroing the gyros while arming is not possible.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="lblThrottleCheckWarn">
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:14pt; font-weight:600; color:#ff0000;&quot;&gt;WARNING: This arming configuration ignores the throttle position!&lt;/span&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt; It will be possible to arm at full throttle. If this is not your intention please select an option containing &amp;quot;+Throttle&amp;quot;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
                <layout class="QHBoxLayout" name="horizontalLayout_2">
                 <item>
                  <widget class="QLabel" name="label_18">
@@ -1514,19 +1534,9 @@ channel value for each flight mode.</string>
                </layout>
               </item>
               <item>
-               <widget class="QLabel" name="label_3">
+               <widget class="QLabel" name="label_4">
                 <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Airframe disarm is done by throttle off and opposite of above combination, except in the case of the switch option. For switch only the throttle is ignored. Note: In switch configuration without delay, zeroing the gyros while arming is not possible. &lt;/p&gt;&lt;p&gt;The arming timeout applies when the vehicle is armed but at minimum throttle. The vehicle will be automatically disarmed if left at minimum throttle longer than the duration of this timeout. The timeout may be disabled by setting it to zero, but this is &lt;span style=&quot; font-weight:600;&quot;&gt;not recommended&lt;/span&gt; for multirotors.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="wordWrap">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="lblThrottleCheckWarn">
-                <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:14pt; font-weight:600; color:#ff0000;&quot;&gt;WARNING: This arming configuration ignores the throttle position!&lt;/span&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt; It will be possible to arm at full throttle. If this is not your intention please select an option containing &amp;quot;+Throttle&amp;quot;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The arming timeout applies when the vehicle is armed but at minimum throttle. The vehicle will be automatically disarmed if left at minimum throttle longer than the duration of this timeout. The timeout may be disabled by setting it to zero, but this is &lt;span style=&quot; font-weight:600;&quot;&gt;not recommended&lt;/span&gt; for multirotors.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="wordWrap">
                  <bool>true</bool>


### PR DESCRIPTION
Fixes #427 

Also changes default input tab to be RC input.

![screenshot from 2016-01-15 16 01 38](https://cloud.githubusercontent.com/assets/9995998/12344380/49282a5c-bba1-11e5-9fd0-27bf324b64e6.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/446)
<!-- Reviewable:end -->
