### PR TITLE
gcs/config: outputwidget: disable test-in-progress under bad circumstances

### DIFF
--- a/ground/gcs/src/plugins/config/configgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.cpp
@@ -293,6 +293,8 @@ void ConfigGadgetWidget::tabAboutToChange(int i, bool * proceed)
         return;
     }
 
+    wid->tabSwitchingAway();
+
     // Check if widget is dirty (i.e. has unsaved changes)
     if(wid->isDirty() && wid->isAutopilotConnected())
     {

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -623,6 +623,11 @@ void ConfigOutputWidget::openHelp()
     QDesktopServices::openUrl( QUrl("https://github.com/d-ronin/dRonin/wiki/OnlineHelp:-Output-Configuration", QUrl::StrictMode) );
 }
 
+void ConfigOutputWidget::tabSwitchingAway()
+{
+    stopTests();
+}
+
 void ConfigOutputWidget::stopTests()
 {
     if (m_config->channelOutTest->isChecked()) {

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -49,6 +49,7 @@
 #include "uavsettingsimportexport/uavsettingsimportexportfactory.h"
 #include <extensionsystem/pluginmanager.h>
 #include <coreplugin/generalsettings.h>
+#include <coreplugin/modemanager.h>
 
 ConfigOutputWidget::ConfigOutputWidget(QWidget *parent) : ConfigTaskWidget(parent)
 {
@@ -60,8 +61,23 @@ ConfigOutputWidget::ConfigOutputWidget(QWidget *parent) : ConfigTaskWidget(paren
     if(!settings->useExpertMode())
         m_config->saveRCOutputToRAM->setVisible(false);
 
+    /* There's lots of situations where it's unsafe to run tests.
+     * Import/export:
+     */
     UAVSettingsImportExportFactory * importexportplugin =  pm->getObject<UAVSettingsImportExportFactory>();
     connect(importexportplugin,SIGNAL(importAboutToBegin()),this,SLOT(stopTests()));
+
+    /* Board connection/disconnection: */
+    TelemetryManager* telMngr = pm->getObject<TelemetryManager>();
+    connect(telMngr, SIGNAL(connected()), this, SLOT(stopTests()));
+    connect(telMngr, SIGNAL(disconnected()), this, SLOT(stopTests()));
+
+    /* When we go into wizards, etc.. time to stop this too. */
+    Core::ModeManager *modeMngr = Core::ModeManager::instance();
+    connect(modeMngr, SIGNAL(currentModeAboutToChange(Core::IMode *)), this,
+		SLOT(stopTests()));
+    connect(modeMngr, SIGNAL(currentModeChanged(Core::IMode *)), this,
+		SLOT(stopTests()));
 
     // NOTE: we have channel indices from 0 to 9, but the convention for OP is Channel 1 to Channel 10.
     // Register for ActuatorSettings changes:
@@ -609,18 +625,11 @@ void ConfigOutputWidget::openHelp()
 
 void ConfigOutputWidget::stopTests()
 {
-    m_config->channelOutTest->setChecked(false);
-}
-
-void ConfigOutputWidget::disableIfNotMe(UAVObject* obj)
-{
-    if(UAVObject::GetGcsTelemetryUpdateMode(obj->getMetadata()) == UAVObject::UPDATEMODE_ONCHANGE)
-    {
-        if(!wasItMe)
-            this->setEnabled(false);
+    if (m_config->channelOutTest->isChecked()) {
+        qDebug() << "Output testing stopped by signal of incompatible mode";
     }
-    else
-        this->setEnabled(true);
+
+    m_config->channelOutTest->setChecked(false);
 }
 
 /**

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -50,7 +50,7 @@
 #include <extensionsystem/pluginmanager.h>
 #include <coreplugin/generalsettings.h>
 
-ConfigOutputWidget::ConfigOutputWidget(QWidget *parent) : ConfigTaskWidget(parent),wasItMe(false)
+ConfigOutputWidget::ConfigOutputWidget(QWidget *parent) : ConfigTaskWidget(parent)
 {
     m_config = new Ui_OutputWidget();
     m_config->setupUi(this);
@@ -108,7 +108,6 @@ ConfigOutputWidget::ConfigOutputWidget(QWidget *parent) : ConfigTaskWidget(paren
     resList << m_config->cb_outputResolution1 << m_config->cb_outputResolution2 << m_config->cb_outputResolution3
                << m_config->cb_outputResolution4 << m_config->cb_outputResolution5 << m_config->cb_outputResolution6;
 
-
     // Get the list of output resolutions and assign to the resolution dropdowns
     ActuatorSettings *actuatorSettings = ActuatorSettings::GetInstance(getObjectManager());
     Q_ASSERT(actuatorSettings);
@@ -137,12 +136,12 @@ ConfigOutputWidget::ConfigOutputWidget(QWidget *parent) : ConfigTaskWidget(paren
     UAVObject* obj = objManager->getObject(QString("ActuatorCommand"));
     if(UAVObject::GetGcsTelemetryUpdateMode(obj->getMetadata()) == UAVObject::UPDATEMODE_ONCHANGE)
         this->setEnabled(false);
-    connect(obj,SIGNAL(objectUpdated(UAVObject*)),this,SLOT(disableIfNotMe(UAVObject*)));
     connect(SystemSettings::GetInstance(objManager), SIGNAL(objectUpdated(UAVObject*)),this,SLOT(assignOutputChannels(UAVObject*)));
 
 
     refreshWidgetsValues();
 }
+
 void ConfigOutputWidget::enableControls(bool enable)
 {
     ConfigTaskWidget::enableControls(enable);
@@ -156,7 +155,6 @@ ConfigOutputWidget::~ConfigOutputWidget()
 {
    // Do nothing
 }
-
 
 // ************************************
 
@@ -190,7 +188,6 @@ void ConfigOutputWidget::runChannelTests(bool state)
         int retval = mbox.exec();
         if(retval != QMessageBox::Yes) {
             state = false;
-            qDebug() << "Cancelled";
             m_config->channelOutTest->setChecked(false);
             return;
         }
@@ -200,7 +197,6 @@ void ConfigOutputWidget::runChannelTests(bool state)
     UAVObject::Metadata mdata = obj->getMetadata();
     if (state)
     {
-        wasItMe=true;
         accInitialData = mdata;
         UAVObject::SetFlightAccess(mdata, UAVObject::ACCESS_READONLY);
         UAVObject::SetFlightTelemetryUpdateMode(mdata, UAVObject::UPDATEMODE_ONCHANGE);
@@ -210,7 +206,6 @@ void ConfigOutputWidget::runChannelTests(bool state)
     }
     else
     {
-        wasItMe=false;
         mdata = accInitialData; // Restore metadata
     }
     obj->setMetadata(mdata);

--- a/ground/gcs/src/plugins/config/configoutputwidget.h
+++ b/ground/gcs/src/plugins/config/configoutputwidget.h
@@ -72,11 +72,8 @@ private:
 
     UAVObject::Metadata accInitialData;
 
-    bool wasItMe;
-
 private slots:
     void stopTests();
-    void disableIfNotMe(UAVObject *obj);
     virtual void refreshWidgetsValues(UAVObject * obj=NULL);
     void updateObjectsFromWidgets();
     void runChannelTests(bool state);

--- a/ground/gcs/src/plugins/config/configoutputwidget.h
+++ b/ground/gcs/src/plugins/config/configoutputwidget.h
@@ -72,6 +72,8 @@ private:
 
     UAVObject::Metadata accInitialData;
 
+    virtual void tabSwitchingAway();
+
 private slots:
     void stopTests();
     virtual void refreshWidgetsValues(UAVObject * obj=NULL);

--- a/ground/gcs/src/plugins/setupwizard/setupwizardplugin.cpp
+++ b/ground/gcs/src/plugins/setupwizard/setupwizardplugin.cpp
@@ -79,6 +79,8 @@ void SetupWizardPlugin::shutdown()
 void SetupWizardPlugin::showSetupWizard()
 {
     if (!wizardRunning) {
+        Core::ModeManager::instance()->activateModeByWorkspaceName(Core::Constants::MODE_WELCOME);
+
         wizardRunning = true;
         SetupWizard *m_wiz = new SetupWizard();
         connect(m_wiz, SIGNAL(finished(int)), this, SLOT(wizardTerminated()));

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.h
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.h
@@ -148,6 +148,9 @@ public:
     void forceConnectedState();
 
     void setNotMandatory(QString object);
+
+    virtual void tabSwitchingAway() {}
+
 public slots:
     void onAutopilotDisconnect();
     void onAutopilotConnect();


### PR DESCRIPTION
Like tab change or autopilot disconnection.

Also remove some legacy logic to gray things in the config output widget when underlying changes happen.

Finally, tell setup wizard to toggle the UI away from config.

Fixes #452

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/453)

<!-- Reviewable:end -->
