### PR TITLE
Autotune improvements

### DIFF
--- a/flight/Libraries/math/misc_math.h
+++ b/flight/Libraries/math/misc_math.h
@@ -78,6 +78,94 @@ static inline bool IS_NOT_FINITE(float x) {
 	return (!isfinite(x));
 }
 
+/* Following functions from fastapprox https://code.google.com/p/fastapprox/
+ * are governed by this license agreement: */
+
+/*=====================================================================*
+ *                   Copyright (C) 2011 Paul Mineiro                   *
+ * All rights reserved.                                                *
+ *                                                                     *
+ * Redistribution and use in source and binary forms, with             *
+ * or without modification, are permitted provided that the            *
+ * following conditions are met:                                       *
+ *                                                                     *
+ *     * Redistributions of source code must retain the                *
+ *     above copyright notice, this list of conditions and             *
+ *     the following disclaimer.                                       *
+ *                                                                     *
+ *     * Redistributions in binary form must reproduce the             *
+ *     above copyright notice, this list of conditions and             *
+ *     the following disclaimer in the documentation and/or            *
+ *     other materials provided with the distribution.                 *
+ *                                                                     *
+ *     * Neither the name of Paul Mineiro nor the names                *
+ *     of other contributors may be used to endorse or promote         *
+ *     products derived from this software without specific            *
+ *     prior written permission.                                       *
+ *                                                                     *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND              *
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,         *
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES               *
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE             *
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER               *
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                 *
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES            *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE           *
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR                *
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF          *
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT           *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY              *
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE             *
+ * POSSIBILITY OF SUCH DAMAGE.                                         *
+ *                                                                     *
+ * Contact: Paul Mineiro <paul@mineiro.com>                            *
+ *=====================================================================*/
+
+static inline float 
+fastlog2 (float x)
+{
+	union { float f; uint32_t i; } vx = { x };
+	union { uint32_t i; float f; } mx = { (vx.i & 0x007FFFFF) | (0x7e << 23) };
+	float y = vx.i;
+	y *= 1.0f / (1 << 23);
+
+	return y - 124.22551499f
+		- 1.498030302f * mx.f 
+		- 1.72587999f / (0.3520887068f + mx.f);
+}
+
+static inline float
+fastpow2 (float p)
+{
+	float offset = (p < 0) ? 1.0f : 0.0f;
+	int w = p;
+	float z = p - w + offset;
+	union { uint32_t i; float f; } v = { (1 << 23) * (p + 121.2740838f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z) };
+
+	return v.f;
+}
+
+
+static inline float
+fastpow (float x, float p)
+{
+	return fastpow2 (p * fastlog2 (x));
+}
+
+static inline float
+fastexp (float p)
+{
+	  return fastpow2 (1.442695040f * p);
+}
+
+#ifdef SMALLF1
+#define powapprox fastpow
+#define expapprox fastexp
+#else
+#define powapprox powf
+#define expapprox expf
+#endif
+
 #endif /* MISC_MATH_H */
 
 /**

--- a/flight/Libraries/math/misc_math.h
+++ b/flight/Libraries/math/misc_math.h
@@ -121,6 +121,12 @@ static inline bool IS_NOT_FINITE(float x) {
  * Contact: Paul Mineiro <paul@mineiro.com>                            *
  *=====================================================================*/
 
+#ifdef __cplusplus
+#define cast_uint32_t static_cast<uint32_t>
+#else
+#define cast_uint32_t (uint32_t)
+#endif
+
 static inline float 
 fastlog2 (float x)
 {
@@ -140,7 +146,7 @@ fastpow2 (float p)
 	float offset = (p < 0) ? 1.0f : 0.0f;
 	int w = p;
 	float z = p - w + offset;
-	union { uint32_t i; float f; } v = { (1 << 23) * (p + 121.2740838f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z) };
+	union { uint32_t i; float f; } v = { cast_uint32_t ((1 << 23) * (p + 121.2740838f + 27.7280233f / (4.84252568f - z) - 1.49012907f * z)) };
 
 	return v.f;
 }

--- a/flight/Libraries/math/misc_math.h
+++ b/flight/Libraries/math/misc_math.h
@@ -127,7 +127,7 @@ static inline bool IS_NOT_FINITE(float x) {
 #define cast_uint32_t (uint32_t)
 #endif
 
-static inline float 
+static inline float
 fastlog2 (float x)
 {
 	union { float f; uint32_t i; } vx = { x };
@@ -136,7 +136,7 @@ fastlog2 (float x)
 	y *= 1.0f / (1 << 23);
 
 	return y - 124.22551499f
-		- 1.498030302f * mx.f 
+		- 1.498030302f * mx.f
 		- 1.72587999f / (0.3520887068f + mx.f);
 }
 

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -353,7 +353,7 @@ static void actuator_task(void* parameters)
 				if (status[ct] > 0) {
 					// Apply curve fitting, mapping the input to the propeller output.
 					status[ct] = actuatorSettings.MotorInputOutputCurveFit[ACTUATORSETTINGS_MOTORINPUTOUTPUTCURVEFIT_A] *
-						powf(status[ct], actuatorSettings.MotorInputOutputCurveFit[ACTUATORSETTINGS_MOTORINPUTOUTPUTCURVEFIT_B]);
+						powapprox(status[ct], actuatorSettings.MotorInputOutputCurveFit[ACTUATORSETTINGS_MOTORINPUTOUTPUTCURVEFIT_B]);
 				} else {
 					status[ct] = 0;
 				}

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -352,8 +352,7 @@ static void actuator_task(void* parameters)
 
 				if (status[ct] > 0) {
 					// Apply curve fitting, mapping the input to the propeller output.
-					status[ct] = actuatorSettings.MotorInputOutputCurveFit[ACTUATORSETTINGS_MOTORINPUTOUTPUTCURVEFIT_A] *
-						powapprox(status[ct], actuatorSettings.MotorInputOutputCurveFit[ACTUATORSETTINGS_MOTORINPUTOUTPUTCURVEFIT_B]);
+					status[ct] = powapprox(status[ct], actuatorSettings.MotorInputOutputCurveFit);
 				} else {
 					status[ct] = 0;
 				}

--- a/flight/Modules/Attitude/acro/attitude.c
+++ b/flight/Modules/Attitude/acro/attitude.c
@@ -581,19 +581,26 @@ static void updateTemperatureComp(float temperature, float *temp_bias)
 		temp_accum = 0;
 		temp_counter = 0;
 
-		// Compute a third order polynomial for each chanel after each 500 samples
-		temp_bias[0] = sensorSettings.XGyroTempCoeff[0] + 
-		               sensorSettings.XGyroTempCoeff[1] * t + 
-		               sensorSettings.XGyroTempCoeff[2] * powf(t,2) + 
-		               sensorSettings.XGyroTempCoeff[3] * powf(t,3);
-		temp_bias[1] = sensorSettings.YGyroTempCoeff[0] + 
-		               sensorSettings.YGyroTempCoeff[1] * t + 
-		               sensorSettings.YGyroTempCoeff[2] * powf(t,2) + 
-		               sensorSettings.YGyroTempCoeff[3] * powf(t,3);
+		// Compute a third order polynomial for each channel after each 500 samples
+#if 0
+		for reference :
 		temp_bias[2] = sensorSettings.ZGyroTempCoeff[0] + 
 		               sensorSettings.ZGyroTempCoeff[1] * t + 
 		               sensorSettings.ZGyroTempCoeff[2] * powf(t,2) + 
 		               sensorSettings.ZGyroTempCoeff[3] * powf(t,3);
+#endif
+		temp_bias[0] = sensorSettings.XGyroTempCoeff[0] + 
+		               t * (sensorSettings.XGyroTempCoeff[1] + 
+		               t * (sensorSettings.XGyroTempCoeff[2] + 
+		               t * sensorSettings.XGyroTempCoeff[3]));
+		temp_bias[1] = sensorSettings.YGyroTempCoeff[0] + 
+		               t * (sensorSettings.YGyroTempCoeff[1] + 
+		               t * (sensorSettings.YGyroTempCoeff[2] + 
+		               t * sensorSettings.YGyroTempCoeff[3]));
+		temp_bias[2] = sensorSettings.ZGyroTempCoeff[0] + 
+		               t * (sensorSettings.ZGyroTempCoeff[1] + 
+		               t * (sensorSettings.ZGyroTempCoeff[2] + 
+		               t * sensorSettings.ZGyroTempCoeff[3]));
 	}
 }
 

--- a/flight/Modules/Attitude/acro/attitude.c
+++ b/flight/Modules/Attitude/acro/attitude.c
@@ -582,24 +582,18 @@ static void updateTemperatureComp(float temperature, float *temp_bias)
 		temp_counter = 0;
 
 		// Compute a third order polynomial for each channel after each 500 samples
-#if 0
-		for reference :
-		temp_bias[2] = sensorSettings.ZGyroTempCoeff[0] + 
-		               sensorSettings.ZGyroTempCoeff[1] * t + 
-		               sensorSettings.ZGyroTempCoeff[2] * powf(t,2) + 
-		               sensorSettings.ZGyroTempCoeff[3] * powf(t,3);
-#endif
-		temp_bias[0] = sensorSettings.XGyroTempCoeff[0] + 
-		               t * (sensorSettings.XGyroTempCoeff[1] + 
-		               t * (sensorSettings.XGyroTempCoeff[2] + 
+		// a + t * (b + t * (c + t * d)) = a + b*t + c*t^2 + d*t^3
+		temp_bias[0] = sensorSettings.XGyroTempCoeff[0] +
+		               t * (sensorSettings.XGyroTempCoeff[1] +
+		               t * (sensorSettings.XGyroTempCoeff[2] +
 		               t * sensorSettings.XGyroTempCoeff[3]));
-		temp_bias[1] = sensorSettings.YGyroTempCoeff[0] + 
-		               t * (sensorSettings.YGyroTempCoeff[1] + 
-		               t * (sensorSettings.YGyroTempCoeff[2] + 
+		temp_bias[1] = sensorSettings.YGyroTempCoeff[0] +
+		               t * (sensorSettings.YGyroTempCoeff[1] +
+		               t * (sensorSettings.YGyroTempCoeff[2] +
 		               t * sensorSettings.YGyroTempCoeff[3]));
-		temp_bias[2] = sensorSettings.ZGyroTempCoeff[0] + 
-		               t * (sensorSettings.ZGyroTempCoeff[1] + 
-		               t * (sensorSettings.ZGyroTempCoeff[2] + 
+		temp_bias[2] = sensorSettings.ZGyroTempCoeff[0] +
+		               t * (sensorSettings.ZGyroTempCoeff[1] +
+		               t * (sensorSettings.ZGyroTempCoeff[2] +
 		               t * sensorSettings.ZGyroTempCoeff[3]));
 	}
 }

--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -52,6 +52,7 @@
 #include "systemsettings.h"
 
 #include "circqueue.h"
+#include "misc_math.h"
 
 // Private constants
 #define STACK_SIZE_BYTES 1340
@@ -457,13 +458,13 @@ __attribute__((always_inline)) static inline void af_predict(float X[AF_NUMX], f
 	float u1 = X[3];           // scaled roll torque
 	float u2 = X[4];           // scaled pitch torque
 	float u3 = X[5];           // scaled yaw torque
-	const float e_b1 = expf(X[6]);   // roll torque scale
+	const float e_b1 = expapprox(X[6]);   // roll torque scale
 	const float b1 = X[6];
-	const float e_b2 = expf(X[7]);   // pitch torque scale
+	const float e_b2 = expapprox(X[7]);   // pitch torque scale
 	const float b2 = X[7];
-	const float e_b3 = expf(X[8]);   // yaw torque scale
+	const float e_b3 = expapprox(X[8]);   // yaw torque scale
 	const float b3 = X[8];
-	const float e_tau = expf(X[9]); // time response of the motors
+	const float e_tau = expapprox(X[9]); // time response of the motors
 	const float tau = X[9];
 	const float bias1 = X[10];        // bias in the roll torque
 	const float bias2 = X[11];       // bias in the pitch torque

--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -54,7 +54,7 @@
 #include "circqueue.h"
 
 // Private constants
-#define STACK_SIZE_BYTES 1504
+#define STACK_SIZE_BYTES 1340
 #define TASK_PRIORITY PIOS_THREAD_PRIO_NORMAL
 
 #define AF_NUMX 13
@@ -84,7 +84,7 @@ static void af_predict(float X[AF_NUMX], float P[AF_NUMP], const float u_in[3], 
 static void af_init(float X[AF_NUMX], float P[AF_NUMP]);
 
 #ifndef AT_QUEUE_NUMELEM
-#define AT_QUEUE_NUMELEM 14
+#define AT_QUEUE_NUMELEM 18
 #endif
 
 /**
@@ -513,43 +513,43 @@ __attribute__((always_inline)) static inline void af_predict(float X[AF_NUMX], f
 	P[0] = D[0] + Q[0] + 2*Ts*e_b1*(D[3] - D[28] - D[9]*bias1 + D[9]*u1) + Tsq*(e_b1*e_b1)*(D[4] - 2*D[29] + D[32] - 2*D[10]*bias1 + 2*D[30]*bias1 + 2*D[10]*u1 - 2*D[30]*u1 + D[11]*(bias1*bias1) + D[11]*(u1*u1) - 2*D[11]*bias1*u1);
 	P[1] = D[1] + Q[1] + 2*Ts*e_b2*(D[5] - D[33] - D[12]*bias2 + D[12]*u2) + Tsq*(e_b2*e_b2)*(D[6] - 2*D[34] + D[37] - 2*D[13]*bias2 + 2*D[35]*bias2 + 2*D[13]*u2 - 2*D[35]*u2 + D[14]*(bias2*bias2) + D[14]*(u2*u2) - 2*D[14]*bias2*u2);
 	P[2] = D[2] + Q[2] + 2*Ts*e_b3*(D[7] - D[38] - D[15]*bias3 + D[15]*u3) + Tsq*(e_b3*e_b3)*(D[8] - 2*D[39] + D[42] - 2*D[16]*bias3 + 2*D[40]*bias3 + 2*D[16]*u3 - 2*D[40]*u3 + D[17]*(bias3*bias3) + D[17]*(u3*u3) - 2*D[17]*bias3*u3);
-	P[3] = (D[3]*e_tau2 + D[3]*Ts*e_tau + D[4]*Ts*(e_b1*e_tau2) - D[29]*Ts*(e_b1*e_tau2) + D[4]*Tsq*(e_b1*e_tau) - D[29]*Tsq*(e_b1*e_tau) + D[18]*Ts*u1*e_tau - D[18]*Ts*u1_in*e_tau - D[10]*Ts*bias1*(e_b1*e_tau2) - D[10]*Tsq*bias1*(e_b1*e_tau) + D[10]*Ts*u1*(e_b1*e_tau2) + D[10]*Tsq*u1*(e_b1*e_tau) + D[21]*Tsq*u1*(e_b1*e_tau) - D[31]*Tsq*u1*(e_b1*e_tau) - D[21]*Tsq*u1_in*(e_b1*e_tau) + D[31]*Tsq*u1_in*(e_b1*e_tau) + D[24]*Tsq*(u1*u1)*(e_b1*e_tau) - D[24]*Tsq*bias1*u1*(e_b1*e_tau) + D[24]*Tsq*bias1*u1_in*(e_b1*e_tau) - D[24]*Tsq*u1*u1_in*(e_b1*e_tau))/Ts_e_tau2;
-	P[4] = (Q[3]*Tsq4 + D[4]*e_tau4 + Q[3]*e_tau4 + 2*D[4]*Ts*e_tau3 + 4*Q[3]*Ts*e_tau3 + 4*Q[3]*Tsq3*e_tau + D[4]*Tsq*e_tau2 + 6*Q[3]*Tsq*e_tau2 + 2*D[21]*Tsq*u1*e_tau2 - 2*D[21]*Tsq*u1_in*e_tau2 + D[27]*Tsq*(u1*u1)*e_tau2 + D[27]*Tsq*(u1_in*u1_in)*e_tau2 + 2*D[21]*Ts*u1*e_tau3 - 2*D[21]*Ts*u1_in*e_tau3 - 2*D[27]*Tsq*u1*u1_in*e_tau2)/Ts_e_tau4;
-	P[5] = (D[5]*e_tau2 + D[5]*Ts*e_tau + D[6]*Ts*(e_b2*e_tau2) - D[34]*Ts*(e_b2*e_tau2) + D[6]*Tsq*(e_b2*e_tau) - D[34]*Tsq*(e_b2*e_tau) + D[19]*Ts*u2*e_tau - D[19]*Ts*u2_in*e_tau - D[13]*Ts*bias2*(e_b2*e_tau2) - D[13]*Tsq*bias2*(e_b2*e_tau) + D[13]*Ts*u2*(e_b2*e_tau2) + D[13]*Tsq*u2*(e_b2*e_tau) + D[22]*Tsq*u2*(e_b2*e_tau) - D[36]*Tsq*u2*(e_b2*e_tau) - D[22]*Tsq*u2_in*(e_b2*e_tau) + D[36]*Tsq*u2_in*(e_b2*e_tau) + D[25]*Tsq*(u2*u2)*(e_b2*e_tau) - D[25]*Tsq*bias2*u2*(e_b2*e_tau) + D[25]*Tsq*bias2*u2_in*(e_b2*e_tau) - D[25]*Tsq*u2*u2_in*(e_b2*e_tau))/Ts_e_tau2;
-	P[6] = (Q[4]*Tsq4 + D[6]*e_tau4 + Q[4]*e_tau4 + 2*D[6]*Ts*e_tau3 + 4*Q[4]*Ts*e_tau3 + 4*Q[4]*Tsq3*e_tau + D[6]*Tsq*e_tau2 + 6*Q[4]*Tsq*e_tau2 + 2*D[22]*Tsq*u2*e_tau2 - 2*D[22]*Tsq*u2_in*e_tau2 + D[27]*Tsq*(u2*u2)*e_tau2 + D[27]*Tsq*(u2_in*u2_in)*e_tau2 + 2*D[22]*Ts*u2*e_tau3 - 2*D[22]*Ts*u2_in*e_tau3 - 2*D[27]*Tsq*u2*u2_in*e_tau2)/Ts_e_tau4;
-	P[7] = (D[7]*e_tau2 + D[7]*Ts*e_tau + D[8]*Ts*(e_b3*e_tau2) - D[39]*Ts*(e_b3*e_tau2) + D[8]*Tsq*(e_b3*e_tau) - D[39]*Tsq*(e_b3*e_tau) + D[20]*Ts*u3*e_tau - D[20]*Ts*u3_in*e_tau - D[16]*Ts*bias3*(e_b3*e_tau2) - D[16]*Tsq*bias3*(e_b3*e_tau) + D[16]*Ts*u3*(e_b3*e_tau2) + D[16]*Tsq*u3*(e_b3*e_tau) + D[23]*Tsq*u3*(e_b3*e_tau) - D[41]*Tsq*u3*(e_b3*e_tau) - D[23]*Tsq*u3_in*(e_b3*e_tau) + D[41]*Tsq*u3_in*(e_b3*e_tau) + D[26]*Tsq*(u3*u3)*(e_b3*e_tau) - D[26]*Tsq*bias3*u3*(e_b3*e_tau) + D[26]*Tsq*bias3*u3_in*(e_b3*e_tau) - D[26]*Tsq*u3*u3_in*(e_b3*e_tau))/Ts_e_tau2;
-	P[8] = (Q[5]*Tsq4 + D[8]*e_tau4 + Q[5]*e_tau4 + 2*D[8]*Ts*e_tau3 + 4*Q[5]*Ts*e_tau3 + 4*Q[5]*Tsq3*e_tau + D[8]*Tsq*e_tau2 + 6*Q[5]*Tsq*e_tau2 + 2*D[23]*Tsq*u3*e_tau2 - 2*D[23]*Tsq*u3_in*e_tau2 + D[27]*Tsq*(u3*u3)*e_tau2 + D[27]*Tsq*(u3_in*u3_in)*e_tau2 + 2*D[23]*Ts*u3*e_tau3 - 2*D[23]*Ts*u3_in*e_tau3 - 2*D[27]*Tsq*u3*u3_in*e_tau2)/Ts_e_tau4;
-	P[9] = D[9] - Ts*(D[30]*e_b1 - D[10]*e_b1 + D[11]*e_b1*(bias1 - u1));
-	P[10] = (e_tau*(D[10]*Ts + D[10]*e_tau + D[24]*Ts*u1 - D[24]*Ts*u1_in))/Ts_e_tau2;
+	P[3] = (D[3]*(e_tau2 + Ts*e_tau) + Ts*e_b1*e_tau2*(D[4] - D[29]) + Tsq*e_b1*e_tau*(D[4] - D[29]) + D[18]*Ts*e_tau*(u1 - u1_in) + D[10]*e_b1*(u1*(Ts*e_tau2 + Tsq*e_tau) - bias1*(Ts*e_tau2 + Tsq*e_tau)) + D[21]*Tsq*e_b1*e_tau*(u1 - u1_in) + D[31]*Tsq*e_b1*e_tau*(u1_in - u1) + D[24]*Tsq*e_b1*e_tau*(u1*(u1 - bias1) + u1_in*(bias1 - u1)))/Ts_e_tau2;
+	P[4] = (Q[3]*Tsq4 + e_tau4*(D[4] + Q[3]) + 2*Ts*e_tau3*(D[4] + 2*Q[3]) + 4*Q[3]*Tsq3*e_tau + Tsq*e_tau2*(D[4] + 6*Q[3] + u1*(D[27]*u1 + 2*D[21]) + u1_in*(D[27]*u1_in - 2*D[21])) + 2*D[21]*Ts*e_tau3*(u1 - u1_in) - 2*D[27]*Tsq*u1*u1_in*e_tau2)/Ts_e_tau4;
+	P[5] = (D[5]*(e_tau2 + Ts*e_tau) + Ts*e_b2*e_tau2*(D[6] - D[34]) + Tsq*e_b2*e_tau*(D[6] - D[34]) + D[19]*Ts*e_tau*(u2 - u2_in) + D[13]*e_b2*(u2*(Ts*e_tau2 + Tsq*e_tau) - bias2*(Ts*e_tau2 + Tsq*e_tau)) + D[22]*Tsq*e_b2*e_tau*(u2 - u2_in) + D[36]*Tsq*e_b2*e_tau*(u2_in - u2) + D[25]*Tsq*e_b2*e_tau*(u2*(u2 - bias2) + u2_in*(bias2 - u2)))/Ts_e_tau2;
+	P[6] = (Q[4]*Tsq4 + e_tau4*(D[6] + Q[4]) + 2*Ts*e_tau3*(D[6] + 2*Q[4]) + 4*Q[4]*Tsq3*e_tau + Tsq*e_tau2*(D[6] + 6*Q[4] + u2*(D[27]*u2 + 2*D[22]) + u2_in*(D[27]*u2_in - 2*D[22])) + 2*D[22]*Ts*e_tau3*(u2 - u2_in) - 2*D[27]*Tsq*u2*u2_in*e_tau2)/Ts_e_tau4;
+	P[7] = (D[7]*(e_tau2 + Ts*e_tau) + Ts*e_b3*e_tau2*(D[8] - D[39]) + Tsq*e_b3*e_tau*(D[8] - D[39]) + D[20]*Ts*e_tau*(u3 - u3_in) + D[16]*e_b3*(u3*(Ts*e_tau2 + Tsq*e_tau) - bias3*(Ts*e_tau2 + Tsq*e_tau)) + D[23]*Tsq*e_b3*e_tau*(u3 - u3_in) + D[41]*Tsq*e_b3*e_tau*(u3_in - u3) + D[26]*Tsq*e_b3*e_tau*(u3*(u3 - bias3) + u3_in*(bias3 - u3)))/Ts_e_tau2;
+	P[8] = (Q[5]*Tsq4 + e_tau4*(D[8] + Q[5]) + 2*Ts*e_tau3*(D[8] + 2*Q[5]) + 4*Q[5]*Tsq3*e_tau + Tsq*e_tau2*(D[8] + 6*Q[5] + u3*(D[27]*u3 + 2*D[23]) + u3_in*(D[27]*u3_in - 2*D[23])) + 2*D[23]*Ts*e_tau3*(u3 - u3_in) - 2*D[27]*Tsq*u3*u3_in*e_tau2)/Ts_e_tau4;
+	P[9] = D[9] - Ts*e_b1*(D[30] - D[10] + D[11]*(bias1 - u1));
+	P[10] = (D[10]*(Ts + e_tau) + D[24]*Ts*(u1 - u1_in))*(e_tau/Ts_e_tau2);
 	P[11] = D[11] + Q[6];
-	P[12] = D[12] - Ts*(D[35]*e_b2 - D[13]*e_b2 + D[14]*e_b2*(bias2 - u2));
-	P[13] = (e_tau*(D[13]*Ts + D[13]*e_tau + D[25]*Ts*u2 - D[25]*Ts*u2_in))/Ts_e_tau2;
+	P[12] = D[12] - Ts*e_b2*(D[35] - D[13] + D[14]*(bias2 - u2));
+	P[13] = (D[13]*(Ts + e_tau) + D[25]*Ts*(u2 - u2_in))*(e_tau/Ts_e_tau2);
 	P[14] = D[14] + Q[7];
-	P[15] = D[15] - Ts*(D[40]*e_b3 - D[16]*e_b3 + D[17]*e_b3*(bias3 - u3));
-	P[16] = (e_tau*(D[16]*Ts + D[16]*e_tau + D[26]*Ts*u3 - D[26]*Ts*u3_in))/Ts_e_tau2;
+	P[15] = D[15] - Ts*e_b3*(D[40] - D[16] + D[17]*(bias3 - u3));
+	P[16] = (D[16]*(Ts + e_tau) + D[26]*Ts*(u3 - u3_in))*(e_tau/Ts_e_tau2);
 	P[17] = D[17] + Q[8];
-	P[18] = D[18] - Ts*(D[31]*e_b1 - D[21]*e_b1 + D[24]*e_b1*(bias1 - u1));
-	P[19] = D[19] - Ts*(D[36]*e_b2 - D[22]*e_b2 + D[25]*e_b2*(bias2 - u2));
-	P[20] = D[20] - Ts*(D[41]*e_b3 - D[23]*e_b3 + D[26]*e_b3*(bias3 - u3));
-	P[21] = (e_tau*(D[21]*Ts + D[21]*e_tau + D[27]*Ts*u1 - D[27]*Ts*u1_in))/Ts_e_tau2;
-	P[22] = (e_tau*(D[22]*Ts + D[22]*e_tau + D[27]*Ts*u2 - D[27]*Ts*u2_in))/Ts_e_tau2;
-	P[23] = (e_tau*(D[23]*Ts + D[23]*e_tau + D[27]*Ts*u3 - D[27]*Ts*u3_in))/Ts_e_tau2;
+	P[18] = D[18] - Ts*e_b1*(D[31] - D[21] + D[24]*(bias1 - u1));
+	P[19] = D[19] - Ts*e_b2*(D[36] - D[22] + D[25]*(bias2 - u2));
+	P[20] = D[20] - Ts*e_b3*(D[41] - D[23] + D[26]*(bias3 - u3));
+	P[21] = (D[21]*(Ts + e_tau) + D[27]*Ts*(u1 - u1_in))*(e_tau/Ts_e_tau2);
+	P[22] = (D[22]*(Ts + e_tau) + D[27]*Ts*(u2 - u2_in))*(e_tau/Ts_e_tau2);
+	P[23] = (D[23]*(Ts + e_tau) + D[27]*Ts*(u3 - u3_in))*(e_tau/Ts_e_tau2);
 	P[24] = D[24];
 	P[25] = D[25];
 	P[26] = D[26];
 	P[27] = D[27] + Q[9];
-	P[28] = D[28] - Ts*(D[32]*e_b1 - D[29]*e_b1 + D[30]*e_b1*(bias1 - u1));
-	P[29] = (e_tau*(D[29]*Ts + D[29]*e_tau + D[31]*Ts*u1 - D[31]*Ts*u1_in))/Ts_e_tau2;
+	P[28] = D[28] - Ts*e_b1*(D[32] - D[29] + D[30]*(bias1 - u1));
+	P[29] = (D[29]*(Ts + e_tau) + D[31]*Ts*(u1 - u1_in))*(e_tau/Ts_e_tau2);
 	P[30] = D[30];
 	P[31] = D[31];
 	P[32] = D[32] + Q[10];
-	P[33] = D[33] - Ts*(D[37]*e_b2 - D[34]*e_b2 + D[35]*e_b2*(bias2 - u2));
-	P[34] = (e_tau*(D[34]*Ts + D[34]*e_tau + D[36]*Ts*u2 - D[36]*Ts*u2_in))/Ts_e_tau2;
+	P[33] = D[33] - Ts*e_b2*(D[37] - D[34] + D[35]*(bias2 - u2));
+	P[34] = (D[34]*(Ts + e_tau) + D[36]*Ts*(u2 - u2_in))*(e_tau/Ts_e_tau2);
 	P[35] = D[35];
 	P[36] = D[36];
 	P[37] = D[37] + Q[11];
-	P[38] = D[38] - Ts*(D[42]*e_b3 - D[39]*e_b3 + D[40]*e_b3*(bias3 - u3));
-	P[39] = (e_tau*(D[39]*Ts + D[39]*e_tau + D[41]*Ts*u3 - D[41]*Ts*u3_in))/Ts_e_tau2;
+	P[38] = D[38] - Ts*e_b3*(D[42] - D[39] + D[40]*(bias3 - u3));
+	P[39] = (D[39]*(Ts + e_tau) + D[41]*Ts*(u3 - u3_in))*(e_tau/Ts_e_tau2);
 	P[40] = D[40];
 	P[41] = D[41];
 	P[42] = D[42] + Q[12];
@@ -559,19 +559,19 @@ __attribute__((always_inline)) static inline void af_predict(float X[AF_NUMX], f
 
     float S[3] = {P[0] + s_a, P[1] + s_a, P[2] + s_a};
 
-	X[0] = w1 + (P[0]*(gyro_x - w1))/S[0];
-	X[1] = w2 + (P[1]*(gyro_y - w2))/S[1];
-	X[2] = w3 + (P[2]*(gyro_z - w3))/S[2];
-	X[3] = u1 + (P[3]*(gyro_x - w1))/S[0];
-	X[4] = u2 + (P[5]*(gyro_y - w2))/S[1];
-	X[5] = u3 + (P[7]*(gyro_z - w3))/S[2];
-	X[6] = b1 + (P[9]*(gyro_x - w1))/S[0];
-	X[7] = b2 + (P[12]*(gyro_y - w2))/S[1];
-	X[8] = b3 + (P[15]*(gyro_z - w3))/S[2];
-	X[9] = tau + (P[18]*(gyro_x - w1))/S[0] + (P[19]*(gyro_y - w2))/S[1] + (P[20]*(gyro_z - w3))/S[2];
-	X[10] = bias1 + (P[28]*(gyro_x - w1))/S[0];
-	X[11] = bias2 + (P[33]*(gyro_y - w2))/S[1];
-	X[12] = bias3 + (P[38]*(gyro_z - w3))/S[2];
+	X[0] = w1 + P[0]*((gyro_x - w1)/S[0]);
+	X[1] = w2 + P[1]*((gyro_y - w2)/S[1]);
+	X[2] = w3 + P[2]*((gyro_z - w3)/S[2]);
+	X[3] = u1 + P[3]*((gyro_x - w1)/S[0]);
+	X[4] = u2 + P[5]*((gyro_y - w2)/S[1]);
+	X[5] = u3 + P[7]*((gyro_z - w3)/S[2]);
+	X[6] = b1 + P[9]*((gyro_x - w1)/S[0]);
+	X[7] = b2 + P[12]*((gyro_y - w2)/S[1]);
+	X[8] = b3 + P[15]*((gyro_z - w3)/S[2]);
+	X[9] = tau + P[18]*((gyro_x - w1)/S[0]) + P[19]*((gyro_y - w2)/S[1]) + P[20]*((gyro_z - w3)/S[2]);
+	X[10] = bias1 + P[28]*((gyro_x - w1)/S[0]);
+	X[11] = bias2 + P[33]*((gyro_y - w2)/S[1]);
+	X[12] = bias3 + P[38]*((gyro_z - w3)/S[2]);
 
 	// update the duplicate cache
 	for (uint32_t i = 0; i < AF_NUMP; i++)
@@ -589,40 +589,39 @@ __attribute__((always_inline)) static inline void af_predict(float X[AF_NUMX], f
 	P[7] = -D[7]*(D[2]/S[2] - 1);
 	P[8] = D[8] - D[7]*D[7]/S[2];
 	P[9] = -D[9]*(D[0]/S[0] - 1);
-	P[10] = D[10] - (D[3]*D[9])/S[0];
-	P[11] = D[11] - D[9]*D[9]/S[0];
+	P[10] = D[10] - D[3]*(D[9]/S[0]);
+	P[11] = D[11] - D[9]*(D[9]/S[0]);
 	P[12] = -D[12]*(D[1]/S[1] - 1);
-	P[13] = D[13] - (D[5]*D[12])/S[1];
-	P[14] = D[14] - D[12]*D[12]/S[1];
+	P[13] = D[13] - D[5]*(D[12]/S[1]);
+	P[14] = D[14] - D[12]*(D[12]/S[1]);
 	P[15] = -D[15]*(D[2]/S[2] - 1);
-	P[16] = D[16] - (D[7]*D[15])/S[2];
-	P[17] = D[17] - D[15]*D[15]/S[2];
+	P[16] = D[16] - D[7]*(D[15]/S[2]);
+	P[17] = D[17] - D[15]*(D[15]/S[2]);
 	P[18] = -D[18]*(D[0]/S[0] - 1);
 	P[19] = -D[19]*(D[1]/S[1] - 1);
 	P[20] = -D[20]*(D[2]/S[2] - 1);
-	P[21] = D[21] - (D[3]*D[18])/S[0];
-	P[22] = D[22] - (D[5]*D[19])/S[1];
-	P[23] = D[23] - (D[7]*D[20])/S[2];
-	P[24] = D[24] - (D[9]*D[18])/S[0];
-	P[25] = D[25] - (D[12]*D[19])/S[1];
-	P[26] = D[26] - (D[15]*D[20])/S[2];
-	P[27] = D[27] - D[18]*D[18]/S[0] - D[19]*D[19]/S[1] - D[20]*D[20]/S[2];
+	P[21] = D[21] - D[3]*(D[18]/S[0]);
+	P[22] = D[22] - D[5]*(D[19]/S[1]);
+	P[23] = D[23] - D[7]*(D[20]/S[2]);
+	P[24] = D[24] - D[9]*(D[18]/S[0]);
+	P[25] = D[25] - D[12]*(D[19]/S[1]);
+	P[26] = D[26] - D[15]*(D[20]/S[2]);
+	P[27] = D[27] - D[18]*(D[18]/S[0]) - D[19]*(D[19]/S[1]) - D[20]*(D[20]/S[2]);
 	P[28] = -D[28]*(D[0]/S[0] - 1);
-	P[29] = D[29] - (D[3]*D[28])/S[0];
-	P[30] = D[30] - (D[9]*D[28])/S[0];
-	P[31] = D[31] - (D[18]*D[28])/S[0];
-	P[32] = D[32] - D[28]*D[28]/S[0];
+	P[29] = D[29] - D[3]*(D[28]/S[0]);
+	P[30] = D[30] - D[9]*(D[28]/S[0]);
+	P[31] = D[31] - D[18]*(D[28]/S[0]);
+	P[32] = D[32] - D[28]*(D[28]/S[0]);
 	P[33] = -D[33]*(D[1]/S[1] - 1);
-	P[34] = D[34] - (D[5]*D[33])/S[1];
-	P[35] = D[35] - (D[12]*D[33])/S[1];
-	P[36] = D[36] - (D[19]*D[33])/S[1];
-	P[37] = D[37] - D[33]*D[33]/S[1];
+	P[34] = D[34] - D[5]*(D[33]/S[1]);
+	P[35] = D[35] - D[12]*(D[33]/S[1]);
+	P[36] = D[36] - D[19]*(D[33]/S[1]);
+	P[37] = D[37] - D[33]*(D[33]/S[1]);
 	P[38] = -D[38]*(D[2]/S[2] - 1);
-	P[39] = D[39] - (D[7]*D[38])/S[2];
-	P[40] = D[40] - (D[15]*D[38])/S[2];
-	P[41] = D[41] - (D[20]*D[38])/S[2];
-	P[42] = D[42] - D[38]*D[38]/S[2];
-
+	P[39] = D[39] - D[7]*(D[38]/S[2]);
+	P[40] = D[40] - D[15]*(D[38]/S[2]);
+	P[41] = D[41] - D[20]*(D[38]/S[2]);
+	P[42] = D[42] - D[38]*(D[38]/S[2]);
 
 	// apply limits to some of the state variables
 	if (X[9] > -1.5f)

--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -80,7 +80,7 @@ static uint32_t throttle_accumulator;
 
 // Private functions
 static void AutotuneTask(void *parameters);
-static void af_predict(float X[AF_NUMX], float P[AF_NUMP], const float u_in[3], const float gyro[3], const float dT_s);
+static void af_predict(float X[AF_NUMX], float P[AF_NUMP], const float u_in[3], const float gyro[3], const float dT_s, const float t_in);
 static void af_init(float X[AF_NUMX], float P[AF_NUMP]);
 
 #ifndef AT_QUEUE_NUMELEM
@@ -379,7 +379,7 @@ static void AutotuneTask(void *parameters)
 
 					last_time = pt->raw_time;
 
-					af_predict(X, P, pt->u, pt->y, dT_s);
+					af_predict(X, P, pt->u, pt->y, dT_s, pt->t);
 
 					for (uint32_t i = 0; i < 3; i++) {
 						const float NOISE_ALPHA = 0.9997f;  // 10 second time constant at 300 Hz
@@ -442,7 +442,7 @@ static void AutotuneTask(void *parameters)
  * @param[in] the current control inputs (roll, pitch, yaw)
  * @param[in] the gyro measurements
  */
-__attribute__((always_inline)) static inline void af_predict(float X[AF_NUMX], float P[AF_NUMP], const float u_in[3], const float gyro[3], const float dT_s)
+__attribute__((always_inline)) static inline void af_predict(float X[AF_NUMX], float P[AF_NUMP], const float u_in[3], const float gyro[3], const float dT_s, const float t_in)
 {
 	const float Ts = dT_s;
 	const float Tsq = Ts * Ts;
@@ -470,9 +470,9 @@ __attribute__((always_inline)) static inline void af_predict(float X[AF_NUMX], f
 	const float bias3 = X[12];       // bias in the yaw torque
 
 	// inputs to the system (roll, pitch, yaw)
-	const float u1_in = u_in[0];
-	const float u2_in = u_in[1];
-	const float u3_in = u_in[2];
+	const float u1_in = 4*t_in*u_in[0];
+	const float u2_in = 4*t_in*u_in[1];
+	const float u3_in = 4*t_in*u_in[2];
 
 	// measurements from gyro
 	const float gyro_x = gyro[0];
@@ -490,12 +490,12 @@ __attribute__((always_inline)) static inline void af_predict(float X[AF_NUMX], f
     // X[6] to X[12] unchanged
 
 	/**** filter parameters ****/
-	const float q_w = 1e-4f;
-	const float q_ud = 1e-4f;
-	const float q_B = 1e-5f;
-	const float q_tau = 1e-5f;
+	const float q_w = 1e-3f;
+	const float q_ud = 1e-3f;
+	const float q_B = 1e-6f;
+	const float q_tau = 1e-6f;
 	const float q_bias = 1e-19f;
-	const float s_a = 3000.0f;  // expected gyro noise
+	const float s_a = 150.0f; // expected gyro measurment noise
 
 	const float Q[AF_NUMX] = {q_w, q_w, q_w, q_ud, q_ud, q_ud, q_B, q_B, q_B, q_tau, q_bias, q_bias, q_bias};
 

--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -380,7 +380,7 @@ static void AutotuneTask(void *parameters)
 
 					last_time = pt->raw_time;
 
-					af_predict(X, P, pt->u, pt->y, dT_s, pt->t);
+					af_predict(X, P, pt->u, pt->y, dT_s, pt->throttle);
 
 					for (uint32_t i = 0; i < 3; i++) {
 						const float NOISE_ALPHA = 0.9997f;  // 10 second time constant at 300 Hz

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -156,7 +156,7 @@ int32_t StabilizationStart()
 	// Listen for updates.
 	//	AttitudeActualConnectQueue(queue);
 	GyrosConnectQueue(queue);
-	
+
 	// Connect settings callback
 	MWRateSettingsConnectCallback(SettingsUpdatedCb);
 	StabilizationSettingsConnectCallback(SettingsUpdatedCb);
@@ -197,9 +197,9 @@ MODULE_INITCALL(StabilizationInitialize, StabilizationStart);
 static void stabilizationTask(void* parameters)
 {
 	UAVObjEvent ev;
-	
+
 	uint32_t timeval = PIOS_DELAY_GetRaw();
-	
+
 	ActuatorDesiredData actuatorDesired;
 	StabilizationDesiredData stabDesired;
 	RateDesiredData rateDesired;
@@ -215,7 +215,7 @@ static void stabilizationTask(void* parameters)
 
 	// Force refresh of all settings immediately before entering main task loop
 	SettingsUpdatedCb(NULL, NULL, NULL, 0);
-	
+
 	// Settings for system identification
 	uint32_t iteration = 0;
 	const uint32_t SYSTEM_IDENT_PERIOD = 75;
@@ -229,19 +229,19 @@ static void stabilizationTask(void* parameters)
 		iteration++;
 
 		PIOS_WDG_UpdateFlag(PIOS_WDG_STABILIZATION);
-		
+
 		// Wait until the AttitudeRaw object is updated, if a timeout then go to failsafe
 		if (PIOS_Queue_Receive(queue, &ev, FAILSAFE_TIMEOUT_MS) != true)
 		{
 			AlarmsSet(SYSTEMALARMS_ALARM_STABILIZATION,SYSTEMALARMS_ALARM_WARNING);
 			continue;
 		}
-		
+
 		calculate_pids();
 
 		float dT = PIOS_DELAY_DiffuS(timeval) * 1.0e-6f;
 		timeval = PIOS_DELAY_GetRaw();
-		
+
 		// exponential moving averaging (EMA) of dT to reduce jitter; ~200points
 		// to have more or less equivalent noise reduction to a normal N point moving averaging:  alpha = 2 / (N + 1)
 		// run it only at the beginning for the first samples, to reduce CPU load, and the value should converge to a constant value
@@ -289,7 +289,7 @@ static void stabilizationTask(void* parameters)
 			float Pitch;
 			float Yaw;
 		} trimmedAttitudeSetpoint;
-		
+
 		// Mux in level trim values, and saturate the trimmed attitude setpoint.
 		trimmedAttitudeSetpoint.Roll = bound_min_max(
 			stabDesired.Roll + subTrim.Roll,
@@ -344,7 +344,7 @@ static void stabilizationTask(void* parameters)
 		local_attitude_error[0] = trimmedAttitudeSetpoint.Roll - attitudeActual.Roll;
 		local_attitude_error[1] = trimmedAttitudeSetpoint.Pitch - attitudeActual.Pitch;
 		local_attitude_error[2] = trimmedAttitudeSetpoint.Yaw - attitudeActual.Yaw;
-		
+
 		// Wrap yaw error to [-180,180]
 		local_attitude_error[2] = circular_modulus_deg(local_attitude_error[2]);
 
@@ -361,7 +361,7 @@ static void stabilizationTask(void* parameters)
 		for(uint8_t i=0; i< MAX_AXES; i++)
 		{
 			// XXX TODO: Factor this body out into function.
-			
+
 			uint8_t mode = stabDesired.StabilizationMode[i];
 			float raw_input = (&stabDesired.Roll)[i];
 
@@ -418,7 +418,7 @@ static void stabilizationTask(void* parameters)
 				case STABILIZATIONDESIRED_STABILIZATIONMODE_FAILSAFE:
 					PIOS_Assert(0); /* Shouldn't happen, per above */
 					break;
-					
+
 				case STABILIZATIONDESIRED_STABILIZATIONMODE_RATE:
 					if(reinit)
 						pids[PID_GROUP_RATE + i].iAccumulator = 0;
@@ -570,7 +570,7 @@ static void stabilizationTask(void* parameters)
 					float dynP8 = pids[PID_GROUP_MWR + i].p * pid_scale;
 					float dynD8 = pids[PID_GROUP_MWR + i].d * pid_scale;
 					// these terms are used by the integral loop this proportional term is scaled by thrust (this is different than MW
-					// that does not apply scale 
+					// that does not apply scale
 					float cfgP8 = pids[PID_GROUP_MWR + i].p;
 					float cfgI8 = pids[PID_GROUP_MWR + i].i;
 
@@ -620,9 +620,9 @@ static void stabilizationTask(void* parameters)
 						SystemIdentGet(&systemIdent);
 
 						const float SCALE_BIAS = 7.1f;
-						float roll_scale = expf(SCALE_BIAS - systemIdent.Beta[SYSTEMIDENT_BETA_ROLL]);
-						float pitch_scale = expf(SCALE_BIAS - systemIdent.Beta[SYSTEMIDENT_BETA_PITCH]);
-						float yaw_scale = expf(SCALE_BIAS - systemIdent.Beta[SYSTEMIDENT_BETA_YAW]);
+						float roll_scale = expapprox(SCALE_BIAS - systemIdent.Beta[SYSTEMIDENT_BETA_ROLL]);
+						float pitch_scale = expapprox(SCALE_BIAS - systemIdent.Beta[SYSTEMIDENT_BETA_PITCH]);
+						float yaw_scale = expapprox(SCALE_BIAS - systemIdent.Beta[SYSTEMIDENT_BETA_YAW]);
 
 						if (roll_scale > 0.25f)
 							roll_scale = 0.25f;
@@ -691,7 +691,7 @@ static void stabilizationTask(void* parameters)
 						// Compute the inner loop only for yaw
 						actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i],  rateDesiredAxis[i],  gyro_filtered[i], dT);
 						actuatorDesiredAxis[i] += ident_offsets[i];
-						actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);						
+						actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 					}
 
 					break;
@@ -1075,4 +1075,3 @@ static void SettingsUpdatedCb(UAVObjEvent * ev, void *ctx, void *obj, int len)
  * @}
  * @}
  */
-

--- a/matlab/system_ident/ProcessAutotuneLog.m
+++ b/matlab/system_ident/ProcessAutotuneLog.m
@@ -1,58 +1,59 @@
 function [] = ProcessAutotuneLog(fileStr, makeGraphs)
-%/**
-% ******************************************************************************
-% * @file       ProcessAutotuneLog.m
-% * @author     dRonin, http://dRonin.org/, Copyright (C) 2015
-% * @addtogroup [Group]
-% * @{
-% * @addtogroup %CLASS%
-% * @{
-% * @brief [Brief]
-% *****************************************************************************/
-%/*
-% * This program is free software; you can redistribute it and/or modify
-% * it under the terms of the GNU General Public License as published by
-% * the Free Software Foundation; either version 3 of the License, or
-% * (at your option) any later version.
-% *
-% * This program is distributed in the hope that it will be useful, but
-% * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-% * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
-% * for more details.
-% *
-% * You should have received a copy of the GNU General Public License along
-% * with this program; if not, write to the Free Software Foundation, Inc.,
-% * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-% */
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% @file       ProcessAutotuneLog.m
+% @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
+% @addtogroup [Group]
+% @{
+% @addtogroup %CLASS%
+% @{
+% @brief [Brief]
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% This program is free software; you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation; either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful, but
+% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+% or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+% for more details.
+%
+% You should have received a copy of the GNU General Public License along
+% with this program; if not, write to the Free Software Foundation, Inc.,
+% 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+%
 
   close all;
   Roll = 1;
   Pitch = 2;
   Yaw = 3;
-  
-  %get data from log file
+
+  % get data from log file
   LogConvert(fileStr, true);
-  LogData = load([fileStr(1:end-3) 'mat']);
-  
+  LogData = load([fileStr(1:end-5) 'mat']);
+
   if makeGraphs
-    %make some pretty pictures
-%    figure; plot(LogData.SystemIdent.NumAfPredicts(10:end-1), [LogData.SystemIdent.Noise(:,10:end-1)]);
-%    legend('Roll', 'Pitch', 'Yaw');
-%    title('Noise');
-%    figure; plot(LogData.SystemIdent.NumAfPredicts(10:end-1), [LogData.SystemIdent.Bias(:,10:end-1)]);
-%    legend('Roll', 'Pitch', 'Yaw');
-%    title('Bias');
+    % make some pretty pictures
+    if false
+      figure; plot(LogData.SystemIdent.NumAfPredicts(10:end-1), [LogData.SystemIdent.Noise(:,10:end-1)]);
+      legend('Roll', 'Pitch', 'Yaw');
+      title('Noise');
+      figure; plot(LogData.SystemIdent.NumAfPredicts(10:end-1), [LogData.SystemIdent.Bias(:,10:end-1)]);
+      legend('Roll', 'Pitch', 'Yaw');
+      title('Bias');
+    end
     figure; plot(LogData.SystemIdent.NumAfPredicts(10:end-1), [LogData.SystemIdent.Beta(:,10:end-1)]);
     legend('Roll', 'Pitch', 'Yaw');
     title('Beta');
     figure; plot(LogData.SystemIdent.NumAfPredicts(10:end-1), 1000*exp(LogData.SystemIdent.Tau(10:end-1)));
     title('Tau (ms)');
   end
-  
-  %default values
-  ghf = 0.01;%m_autotune->rateNoise->value() / 1000.0;
-  damp = 1.1;%m_autotune->rateDamp->value() / 100.0;
-  
+
+  % default values
+  ghf = 0.01;
+  damp = 1.1;
+
   numSIPoints = size(LogData.SystemIdent.NumAfPredicts,2);
   Rollki = zeros(1,numSIPoints);
   Rollkp = zeros(1,numSIPoints);
@@ -62,12 +63,12 @@ function [] = ProcessAutotuneLog(fileStr, makeGraphs)
   Pitchkd = zeros(1,numSIPoints);
   DerivativeCutoff = zeros(1,numSIPoints);
   NaturalFrequency = zeros(1,numSIPoints);
-  
-  % get resulting PID values at each point in the logged data
+
+  % get resulting PID values at each point in the logged data, adapted from the GCS code that does the same
   for ii=1:numSIPoints
-    tau = exp(LogData.SystemIdent.Tau(ii)); %exp(systemIdentData.Tau(ii));
-    beta_roll = LogData.SystemIdent.Beta(Roll,ii); %systemIdentData.Beta[SystemIdent::BETA_ROLL];
-    beta_pitch = LogData.SystemIdent.Beta(Pitch,ii); %systemIdentData.Beta[SystemIdent::BETA_PITCH];
+    tau = exp(LogData.SystemIdent.Tau(ii));
+    beta_roll = LogData.SystemIdent.Beta(Roll,ii);
+    beta_pitch = LogData.SystemIdent.Beta(Pitch,ii);
 
     wn = 1/tau;
     tau_d = 0;
@@ -75,25 +76,25 @@ function [] = ProcessAutotuneLog(fileStr, makeGraphs)
       tau_d_roll = (2*damp*tau*wn - 1)/(4*tau*damp*damp*wn*wn - 2*damp*wn - tau*wn*wn + exp(beta_roll)*ghf);
       tau_d_pitch = (2*damp*tau*wn - 1)/(4*tau*damp*damp*wn*wn - 2*damp*wn - tau*wn*wn + exp(beta_pitch)*ghf);
 
-%      // Select the slowest filter property
+      % Select the slowest filter property
       if (tau_d_roll > tau_d_pitch)
         tau_d = tau_d_roll;
       else
         tau_d = tau_d_pitch;
       end
-        
+
       wn = (tau + tau_d) / (tau*tau_d) / (2 * damp + 2);
     end
 
-%    // Set the real pole position. The first pole is quite slow, which
-%    // prevents the integral being too snappy and driving too much
-%    // overshoot.
+    % Set the real pole position. The first pole is quite slow, which
+    % prevents the integral being too snappy and driving too much
+    % overshoot.
     a = ((tau+tau_d) / tau / tau_d - 2 * damp * wn) / 20.0;
     b = ((tau+tau_d) / tau / tau_d - 2 * damp * wn - a);
 
-%    // Calculate the gain for the outer loop by approximating the
-%    // inner loop as a single order lpf. Set the outer loop to be
-%    // critically damped;
+    % Calculate the gain for the outer loop by approximating the
+    % inner loop as a single order lpf. Set the outer loop to be
+    % critically damped;
     zeta_o = 1.3;
     kp_o(ii) = 1 / 4.0 / (zeta_o * zeta_o) / (1/wn);
 
@@ -107,14 +108,26 @@ function [] = ProcessAutotuneLog(fileStr, makeGraphs)
     Pitchkp(ii) = (tau * tau_d * ((a+b)*wn*wn + 2*a*b*damp*wn) / beta) - (Pitchki(ii)*tau_d);
     Pitchkd(ii) = (tau * tau_d * (a*b + wn*wn + (a+b)*2*damp*wn) - 1) / beta - (Pitchkp(ii) * tau_d);
 
+    beta = exp(LogData.SystemIdent.Beta(Roll, ii));
+    Rollki(ii) = a * b * wn * wn * tau * tau_d / beta;
+    Rollkp(ii) = (tau * tau_d * ((a+b)*wn*wn + 2*a*b*damp*wn) / beta) - (Rollki(ii)*tau_d);
+    Rollkd(ii) = (tau * tau_d * (a*b + wn*wn + (a+b)*2*damp*wn) - 1) / beta - (Rollkp(ii) * tau_d);
+
+    beta = exp(LogData.SystemIdent.Beta(Yaw, ii));
+    Yawki(ii) = a * b * wn * wn * tau * tau_d / beta;
+    Yawkp(ii) = (tau * tau_d * ((a+b)*wn*wn + 2*a*b*damp*wn) / beta) - (Yawki(ii)*tau_d);
+    Yawkd(ii) = (tau * tau_d * (a*b + wn*wn + (a+b)*2*damp*wn) - 1) / beta - (Yawkp(ii) * tau_d);
+
     DerivativeCutoff(ii) = 1 / (2*pi*tau_d);
     NaturalFrequency(ii) = wn / 2 / pi;
   end
-  
+
   if makeGraphs
-    %make more pretty pictures
-%    figure; plot(LogData.SystemIdent.NumAfPredicts(1:end-1), DerivativeCutoff(1:end-1));
-%    title('DerivativeCutoff');
+    % make more pretty pictures
+    if false
+      figure; plot(LogData.SystemIdent.NumAfPredicts(1:end-1), DerivativeCutoff(1:end-1));
+      title('DerivativeCutoff');
+    end
     figure; plot(LogData.SystemIdent.NumAfPredicts(1:end-1), NaturalFrequency(1:end-1));
     title('NaturalFrequency');
     figure; plot(LogData.SystemIdent.NumAfPredicts(1:end-1), kp_o(1:end-1));
@@ -125,33 +138,64 @@ function [] = ProcessAutotuneLog(fileStr, makeGraphs)
     figure; plot(LogData.SystemIdent.NumAfPredicts(1:end-1), [Pitchki(1:end-1); Pitchkp(1:end-1); Pitchkd(1:end-1)]');
     title('Pitch PID Values');
     legend('Pitchki', 'Pitchkp', 'Pitchkd');
+    figure; plot(LogData.SystemIdent.NumAfPredicts(1:end-1), [Yawki(1:end-1); Yawkp(1:end-1); Yawkd(1:end-1)]');
+    title('Yaw PID Values');
+    legend('Yawki', 'Yawkp', 'Yawkd');
   end
-  
-  % Covariance trace figure of merrit
-  traceFOM = sum(LogData.SystemIdent.CovarianceMatrix,1);
-  if makeGraphs
-    figure; plot(LogData.SystemIdent.NumAfPredicts(10:end-1), traceFOM(10:end-1));
-    title('tr(P)');
-  end
-  
+
+%  % Recreate the X vector
+%  X = [LogData.SystemIdent.X; LogData.SystemIdent.Beta; LogData.SystemIdent.Tau; LogData.SystemIdent.Bias];
+%
+%  % Covariance trace figure of merrit
+%  traceFOMRaw = sum(LogData.SystemIdent.CovarianceMatrix,1);
+%  % Covariance trace with each element scaled by the value of the variences at 30seconds in
+%  traceFOMScaled = sum(LogData.SystemIdent.CovarianceMatrix ./ LogData.SystemIdent.CovarianceMatrix(:,round(end/2)),1);
+%  %
+%  traceFOMIndexOfDispersion = sum(LogData.SystemIdent.CovarianceMatrix ./ mean(abs(X),2),1);
+%  %
+%  traceFOMCoefficientOfVariation = sum(sqrt(LogData.SystemIdent.CovarianceMatrix) ./ mean(abs(X),2),1);
+%  % select which FOM to use
+%  traceFOM = traceFOMRaw;
+%
+%  if makeGraphs
+%    figure; plot(LogData.SystemIdent.NumAfPredicts(10:end-1), traceFOM(10:end-1));
+%    title('tr(P)');
+%  end
+
   % find the best trace in the second half of the tuning run, exclude any data points where NumAfPredicts is zero (invalid data)
-  [convValue convPoint] = min(traceFOM(end/2:end) + 1000*(!LogData.SystemIdent.NumAfPredicts(end/2:end)));
-  convPoint = round(convPoint + size(traceFOM,2)/2 - 1);
-  
-  printf('\nMinimum Tr(P) value in last half: %f\n', convValue);
-  printf('Minimum Tr(P) location in last half: %f\n', convPoint);
-  printf('Minimum Tr(P) NumAfPredicts in last half: %f\n', LogData.SystemIdent.NumAfPredicts(convPoint));
-  
-  % print data and converged PID values
-  printf('Achieved Tau (ms): %f\n', 1000*exp(LogData.SystemIdent.Tau(convPoint)));
-  
-  printf('\nOptimal Roll Kp: %f\n', Rollkp(convPoint));
-  printf('Optimal Roll Ki: %f\n', Rollki(convPoint));
-  printf('Optimal Roll Kd: %f\n', Rollkd(convPoint));
-  
-  printf('\nOptimal Pitch Kp: %f\n', Pitchkp(convPoint));
-  printf('Optimal Pitch Ki: %f\n', Pitchki(convPoint));
-  printf('Optimal Pitch Kd: %f\n', Pitchkd(convPoint));
-  
-  printf('\nOuter Kp: %f\n', kp_o(convPoint));
-  
+%  [convValue convPoint] = min(traceFOM(end/2:end) + 1000*(!LogData.SystemIdent.NumAfPredicts(end/2:end)));
+%  convPoint = round(convPoint + size(traceFOM,2)/2 - 1);
+  [tmp lastValid] = max(LogData.SystemIdent.NumAfPredicts(round(end/2):end));
+  lastValid = lastValid + round(numel(LogData.SystemIdent.NumAfPredicts)/2 - 1);
+
+  printf('\n\n**********************************************\n');
+  printf('*************** Output Results ***************\n');
+  printf('**********************************************\n');
+
+%  printf('\nMinimum Tr(P) value in last half: %f\n', convValue);
+%  printf('Minimum Tr(P) location in last half: %f\n', convPoint);
+%  printf('Minimum Tr(P) NumAfPredicts in last half: %f\n', LogData.SystemIdent.NumAfPredicts(convPoint));
+
+  printf('Last Valid location in last half: %f\n', lastValid);
+  printf('Last Valid NumAfPredicts in last half: %f\n', LogData.SystemIdent.NumAfPredicts(lastValid));
+
+  % print data and calculated PID values
+  printf('Achieved Tau (ms): %f\n', 1000*exp(LogData.SystemIdent.Tau(lastValid)));
+
+  printf('\nCalculated Roll Kp: %f\n', Rollkp(lastValid));
+  printf('Calculated Roll Ki: %f\n', Rollki(lastValid));
+  printf('Calculated Roll Kd: %f\n', Rollkd(lastValid));
+
+  printf('\nCalculated Pitch Kp: %f\n', Pitchkp(lastValid));
+  printf('Calculated Pitch Ki: %f\n', Pitchki(lastValid));
+  printf('Calculated Pitch Kd: %f\n', Pitchkd(lastValid));
+
+  % Results for the yaw PID values are not proven yet
+  printf('\nvvv DONT USE THESE YAW VALUES UNLESS YOU KNOW YOU WANT TO!! vvv');
+  printf('\nCalculated Yaw Kp: %f\n', Yawkp(lastValid));
+  printf('Calculated Yaw Ki: %f\n', Yawki(lastValid));
+  printf('Calculated Yaw Kd: %f\n', Yawkd(lastValid));
+  printf('^^^ DONT USE THESE YAW VALUES UNLESS YOU KNOW YOU WANT TO!! ^^^\n');
+  % Results for the yaw PID values are not proven yet
+
+  printf('\nOuter Kp: %f\n', kp_o(lastValid));

--- a/matlab/system_ident/ProcessAutotuneLog.m
+++ b/matlab/system_ident/ProcessAutotuneLog.m
@@ -1,0 +1,157 @@
+function [] = ProcessAutotuneLog(fileStr, makeGraphs)
+%/**
+% ******************************************************************************
+% * @file       ProcessAutotuneLog.m
+% * @author     dRonin, http://dRonin.org/, Copyright (C) 2015
+% * @addtogroup [Group]
+% * @{
+% * @addtogroup %CLASS%
+% * @{
+% * @brief [Brief]
+% *****************************************************************************/
+%/*
+% * This program is free software; you can redistribute it and/or modify
+% * it under the terms of the GNU General Public License as published by
+% * the Free Software Foundation; either version 3 of the License, or
+% * (at your option) any later version.
+% *
+% * This program is distributed in the hope that it will be useful, but
+% * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+% * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+% * for more details.
+% *
+% * You should have received a copy of the GNU General Public License along
+% * with this program; if not, write to the Free Software Foundation, Inc.,
+% * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+% */
+
+  close all;
+  Roll = 1;
+  Pitch = 2;
+  Yaw = 3;
+  
+  %get data from log file
+  LogConvert(fileStr, true);
+  LogData = load([fileStr(1:end-3) 'mat']);
+  
+  if makeGraphs
+    %make some pretty pictures
+%    figure; plot(LogData.SystemIdent.NumAfPredicts(10:end-1), [LogData.SystemIdent.Noise(:,10:end-1)]);
+%    legend('Roll', 'Pitch', 'Yaw');
+%    title('Noise');
+%    figure; plot(LogData.SystemIdent.NumAfPredicts(10:end-1), [LogData.SystemIdent.Bias(:,10:end-1)]);
+%    legend('Roll', 'Pitch', 'Yaw');
+%    title('Bias');
+    figure; plot(LogData.SystemIdent.NumAfPredicts(10:end-1), [LogData.SystemIdent.Beta(:,10:end-1)]);
+    legend('Roll', 'Pitch', 'Yaw');
+    title('Beta');
+    figure; plot(LogData.SystemIdent.NumAfPredicts(10:end-1), 1000*exp(LogData.SystemIdent.Tau(10:end-1)));
+    title('Tau (ms)');
+  end
+  
+  %default values
+  ghf = 0.01;%m_autotune->rateNoise->value() / 1000.0;
+  damp = 1.1;%m_autotune->rateDamp->value() / 100.0;
+  
+  numSIPoints = size(LogData.SystemIdent.NumAfPredicts,2);
+  Rollki = zeros(1,numSIPoints);
+  Rollkp = zeros(1,numSIPoints);
+  Rollkd = zeros(1,numSIPoints);
+  Pitchki = zeros(1,numSIPoints);
+  Pitchkp = zeros(1,numSIPoints);
+  Pitchkd = zeros(1,numSIPoints);
+  DerivativeCutoff = zeros(1,numSIPoints);
+  NaturalFrequency = zeros(1,numSIPoints);
+  
+  % get resulting PID values at each point in the logged data
+  for ii=1:numSIPoints
+    tau = exp(LogData.SystemIdent.Tau(ii)); %exp(systemIdentData.Tau(ii));
+    beta_roll = LogData.SystemIdent.Beta(Roll,ii); %systemIdentData.Beta[SystemIdent::BETA_ROLL];
+    beta_pitch = LogData.SystemIdent.Beta(Pitch,ii); %systemIdentData.Beta[SystemIdent::BETA_PITCH];
+
+    wn = 1/tau;
+    tau_d = 0;
+    for jj=1:30
+      tau_d_roll = (2*damp*tau*wn - 1)/(4*tau*damp*damp*wn*wn - 2*damp*wn - tau*wn*wn + exp(beta_roll)*ghf);
+      tau_d_pitch = (2*damp*tau*wn - 1)/(4*tau*damp*damp*wn*wn - 2*damp*wn - tau*wn*wn + exp(beta_pitch)*ghf);
+
+%      // Select the slowest filter property
+      if (tau_d_roll > tau_d_pitch)
+        tau_d = tau_d_roll;
+      else
+        tau_d = tau_d_pitch;
+      end
+        
+      wn = (tau + tau_d) / (tau*tau_d) / (2 * damp + 2);
+    end
+
+%    // Set the real pole position. The first pole is quite slow, which
+%    // prevents the integral being too snappy and driving too much
+%    // overshoot.
+    a = ((tau+tau_d) / tau / tau_d - 2 * damp * wn) / 20.0;
+    b = ((tau+tau_d) / tau / tau_d - 2 * damp * wn - a);
+
+%    // Calculate the gain for the outer loop by approximating the
+%    // inner loop as a single order lpf. Set the outer loop to be
+%    // critically damped;
+    zeta_o = 1.3;
+    kp_o(ii) = 1 / 4.0 / (zeta_o * zeta_o) / (1/wn);
+
+    beta = exp(LogData.SystemIdent.Beta(Roll, ii));
+    Rollki(ii) = a * b * wn * wn * tau * tau_d / beta;
+    Rollkp(ii) = (tau * tau_d * ((a+b)*wn*wn + 2*a*b*damp*wn) / beta) - (Rollki(ii)*tau_d);
+    Rollkd(ii) = (tau * tau_d * (a*b + wn*wn + (a+b)*2*damp*wn) - 1) / beta - (Rollkp(ii) * tau_d);
+
+    beta = exp(LogData.SystemIdent.Beta(Pitch, ii));
+    Pitchki(ii) = a * b * wn * wn * tau * tau_d / beta;
+    Pitchkp(ii) = (tau * tau_d * ((a+b)*wn*wn + 2*a*b*damp*wn) / beta) - (Pitchki(ii)*tau_d);
+    Pitchkd(ii) = (tau * tau_d * (a*b + wn*wn + (a+b)*2*damp*wn) - 1) / beta - (Pitchkp(ii) * tau_d);
+
+    DerivativeCutoff(ii) = 1 / (2*pi*tau_d);
+    NaturalFrequency(ii) = wn / 2 / pi;
+  end
+  
+  if makeGraphs
+    %make more pretty pictures
+%    figure; plot(LogData.SystemIdent.NumAfPredicts(1:end-1), DerivativeCutoff(1:end-1));
+%    title('DerivativeCutoff');
+    figure; plot(LogData.SystemIdent.NumAfPredicts(1:end-1), NaturalFrequency(1:end-1));
+    title('NaturalFrequency');
+    figure; plot(LogData.SystemIdent.NumAfPredicts(1:end-1), kp_o(1:end-1));
+    title('Outer Kp');
+    figure; plot(LogData.SystemIdent.NumAfPredicts(1:end-1), [Rollki(1:end-1); Rollkp(1:end-1); Rollkd(1:end-1)]');
+    title('Roll PID Values');
+    legend('Rollki', 'Rollkp', 'Rollkd');
+    figure; plot(LogData.SystemIdent.NumAfPredicts(1:end-1), [Pitchki(1:end-1); Pitchkp(1:end-1); Pitchkd(1:end-1)]');
+    title('Pitch PID Values');
+    legend('Pitchki', 'Pitchkp', 'Pitchkd');
+  end
+  
+  % Covariance trace figure of merrit
+  traceFOM = sum(LogData.SystemIdent.CovarianceMatrix,1);
+  if makeGraphs
+    figure; plot(LogData.SystemIdent.NumAfPredicts(10:end-1), traceFOM(10:end-1));
+    title('tr(P)');
+  end
+  
+  % find the best trace in the second half of the tuning run, exclude any data points where NumAfPredicts is zero (invalid data)
+  [convValue convPoint] = min(traceFOM(end/2:end) + 1000*(!LogData.SystemIdent.NumAfPredicts(end/2:end)));
+  convPoint = round(convPoint + size(traceFOM,2)/2 - 1);
+  
+  printf('\nMinimum Tr(P) value in last half: %f\n', convValue);
+  printf('Minimum Tr(P) location in last half: %f\n', convPoint);
+  printf('Minimum Tr(P) NumAfPredicts in last half: %f\n', LogData.SystemIdent.NumAfPredicts(convPoint));
+  
+  % print data and converged PID values
+  printf('Achieved Tau (ms): %f\n', 1000*exp(LogData.SystemIdent.Tau(convPoint)));
+  
+  printf('\nOptimal Roll Kp: %f\n', Rollkp(convPoint));
+  printf('Optimal Roll Ki: %f\n', Rollki(convPoint));
+  printf('Optimal Roll Kd: %f\n', Rollkd(convPoint));
+  
+  printf('\nOptimal Pitch Kp: %f\n', Pitchkp(convPoint));
+  printf('Optimal Pitch Ki: %f\n', Pitchki(convPoint));
+  printf('Optimal Pitch Kd: %f\n', Pitchkd(convPoint));
+  
+  printf('\nOuter Kp: %f\n', kp_o(convPoint));
+  

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -23,8 +23,8 @@
             <description>When enabled, the motors will spin at the ChannelNeutral command when armed with zero throttle.</description>
         </field>
 
-        <field name="MotorInputOutputCurveFit" units="-" type="float" elementnames="A,B" defaultvalue="1,1">
-            <description>Actuator mapping of input in [-1,1] to output on [-1,1], using power equation of type a*x^b.</description>
+        <field name="MotorInputOutputCurveFit" units="-" type="float" elements="1" defaultvalue="1">
+            <description>Actuator mapping of input in [-1,1] to output on [-1,1], using power equation of type x^value.</description>
         </field>
 
         <access gcs="readwrite" flight="readwrite"/>


### PR DESCRIPTION
This is a PR to improve autotune performance. Changes include the following:
- Change kalman inputs to use '4_u_t' instead of just 'u' (as suggested in the original autotune derivation by korken)
- Reduce the R-matrix expected measurement noise to more closely match the measured value on a real system
- Added a matlab script to help analyze autotune measurement progress from a flash log

edit by MPL:

Required flights and observations:
- [x] Flight F1 brushless; compared vs. baseline:
- [x] Flight F1 small quad; compared vs baseline:
- [ ] Flight F4 small quad; compared vs baseline:
- [x] Flight F4 large quad; compared vs baseline:
- [ ] Sure would be nice to tune one of these generic 250s we have showing up in great numbers

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/457)

<!-- Reviewable:end -->

edit by MPL: fixes #112, fixes #170
