### PR TITLE
GCS: Obfuscate chip serial # in AT results

### DIFF
--- a/ground/gcs/src/plugins/config/configautotunewidget.cpp
+++ b/ground/gcs/src/plugins/config/configautotunewidget.cpp
@@ -28,6 +28,7 @@
 
 #include "configautotunewidget.h"
 
+#include <QCryptographicHash>
 #include <QDebug>
 #include <QStringList>
 #include <QWidget>
@@ -506,7 +507,7 @@ QJsonDocument ConfigAutotuneWidget::getResultsJson()
 
     QJsonObject json;
     json["dataVersion"] = 1;
-    json["uniqueId"] = QString(utilMngr->getBoardCPUSerial().toHex());
+    json["uniqueId"] = QString(QCryptographicHash::hash(utilMngr->getBoardCPUSerial(), QCryptographicHash::Sha256).toHex());
 
     QJsonObject vehicle, fw;
     fw["board"] = autotuneShareForm->getBoardType();

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.cpp
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.cpp
@@ -25,6 +25,7 @@
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 #include "usagestatsplugin.h"
+#include <QCryptographicHash>
 #include <QDebug>
 #include <QtPlugin>
 #include <QStringList>
@@ -245,7 +246,7 @@ QByteArray UsageStatsPlugin::processJson() {
         b["gitHash"] = board.device.gitHash;
         b["gitTag"] = board.device.gitTag;
         if(sendPrivateData)
-            b["CPU"] = board.board.cpu_serial;
+            b["UUID"] = QString(QCryptographicHash::hash(QByteArray::fromHex(board.board.cpu_serial.toUtf8()), QCryptographicHash::Sha256).toHex());
         boardArray.append(b);
     }
     json["boardsSeen"] = boardArray;


### PR DESCRIPTION
Use a cryptographic hash to obfuscate the chip serial number in the shared autotune results. 

The rationale for doing this is that the serial number may be used for other things, like warranty claims or registering the controller with a manufacturer, so the serial number should be kept private. While this is not 100% secure (it may be possible to guess a valid serial # due to limited entropy), this is IMO better than not obfuscating the number at all.

Compile but not tested. This should go into the Renatus release, otherwise we will not be able to associate boards with each other in the future.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/469)
<!-- Reviewable:end -->
