### PR TITLE
flight: don't traverse STILL_HOLDING for switches

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -731,7 +731,14 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 		}
 
   		if (disarm && timeDifferenceMs(armedDisarmStart, lastSysTime) > disarm_time) {
-			arm_state = ARM_STATE_DISARMED_STILL_HOLDING;
+			if (settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCH ||
+					settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHDELAY ||
+					settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLE ||
+					settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCHTHROTTLEDELAY) {
+				arm_state = ARM_STATE_DISARMED;
+			} else {
+				arm_state = ARM_STATE_DISARMED_STILL_HOLDING;
+			}
   		} else if (!disarm) {
   			arm_state = ARM_STATE_ARMED;
   		}


### PR DESCRIPTION
This is necessary so that with switch modes you don't need to toggle
twice to rearm.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/474)

<!-- Reviewable:end -->
