### PR TITLE
PiOS: Remove unused PIOS_SYS_getCPUFlashSize

### DIFF
--- a/flight/PiOS.posix/inc/pios_sys.h
+++ b/flight/PiOS.posix/inc/pios_sys.h
@@ -38,7 +38,6 @@
 /* Public Functions */
 extern void PIOS_SYS_Init(void);
 extern int32_t PIOS_SYS_Reset(void);
-extern uint32_t PIOS_SYS_getCPUFlashSize(void);
 extern int32_t PIOS_SYS_SerialNumberGetBinary(uint8_t array[PIOS_SYS_SERIAL_NUM_BINARY_LEN]);
 extern int32_t PIOS_SYS_SerialNumberGet(char str[PIOS_SYS_SERIAL_NUM_ASCII_LEN+1]);
 

--- a/flight/PiOS.posix/posix/pios_sys.c
+++ b/flight/PiOS.posix/posix/pios_sys.c
@@ -136,14 +136,6 @@ int32_t PIOS_SYS_Reset(void)
 }
 
 /**
-* Returns the CPU's flash size (in bytes)
-*/
-uint32_t PIOS_SYS_getCPUFlashSize(void)
-{
-	return 1024000;
-}
-
-/**
 * Returns the serial number as a string
 * param[out] uint8_t pointer to a string which can store at least 12 bytes
 * (12 bytes returned for STM32)

--- a/flight/PiOS/STM32F10x/pios_sys.c
+++ b/flight/PiOS/STM32F10x/pios_sys.c
@@ -103,14 +103,6 @@ int32_t PIOS_SYS_Reset(void)
 }
 
 /**
-* Returns the CPU's flash size (in bytes)
-*/
-uint32_t PIOS_SYS_getCPUFlashSize(void)
-{
-	return ((uint32_t) MEM16(0x1FFFF7E0) * 1000);
-}
-
-/**
  * Returns the serial number as byte array
  * param[out] pointer to a byte array which can store at least 12 bytes
  * (12 bytes returned for STM32)

--- a/flight/PiOS/STM32F30x/pios_sys.c
+++ b/flight/PiOS/STM32F30x/pios_sys.c
@@ -176,14 +176,6 @@ int32_t PIOS_SYS_Reset(void)
 }
 
 /**
-* Returns the CPU's flash size (in bytes)
-*/
-uint32_t PIOS_SYS_getCPUFlashSize(void)
-{
-	return ((uint32_t) MEM_SIZE);	// FIXME: it might be possible to locate in the OTP area, but haven't looked and not documented
-}
-
-/**
  * Returns the serial number as byte array
  * param[out] pointer to a byte array which can store at least 12 bytes
  * (12 bytes returned for STM32)

--- a/flight/PiOS/STM32F4xx/pios_sys.c
+++ b/flight/PiOS/STM32F4xx/pios_sys.c
@@ -211,14 +211,6 @@ int32_t PIOS_SYS_Reset(void)
 }
 
 /**
-* Returns the CPU's flash size (in bytes)
-*/
-uint32_t PIOS_SYS_getCPUFlashSize(void)
-{
-	return ((uint32_t) MEM16(0x1fff7a22) * 1024);
-}
-
-/**
  * Returns the serial number as byte array
  * param[out] pointer to a byte array which can store at least 12 bytes
  * (12 bytes returned for STM32)

--- a/flight/PiOS/inc/pios_sys.h
+++ b/flight/PiOS/inc/pios_sys.h
@@ -38,7 +38,6 @@
 /* Public Functions */
 extern void PIOS_SYS_Init(void);
 extern int32_t PIOS_SYS_Reset(void);
-extern uint32_t PIOS_SYS_getCPUFlashSize(void);
 extern int32_t PIOS_SYS_SerialNumberGetBinary(uint8_t array[PIOS_SYS_SERIAL_NUM_BINARY_LEN]);
 extern int32_t PIOS_SYS_SerialNumberGet(char str[PIOS_SYS_SERIAL_NUM_ASCII_LEN+1]);
 


### PR DESCRIPTION
After:

```
mike@mike-desktop:~/Dev/dronin/flight$ grep -r PIOS_SYS_getCPUFlashSize
mike@mike-desktop:~/Dev/dronin/flight$ 
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/484)

<!-- Reviewable:end -->
