### PR TITLE
Config:CCPM: Fix broken CSS, eliminates warning

### DIFF
--- a/ground/gcs/src/plugins/config/ccpm.ui
+++ b/ground/gcs/src/plugins/config/ccpm.ui
@@ -82,7 +82,7 @@ QGroupBox::title {
      subcontrol-position: top center; /* position at the top center */
      padding: 0 3px;
      background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                                       stop: 0 #FFOECE, stop: 1 #FFFFFF);
+                                       stop: 0 #FF0ECE, stop: 1 #FFFFFF);
 	top: 5px;
  }</string>
        </property>


### PR DESCRIPTION
Qt generates a runtime warning for this.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/485)

<!-- Reviewable:end -->
