### PR TITLE
GCS:Uploader: Fix scaling of status icon on OS X

### DIFF
--- a/ground/gcs/src/plugins/uploader/uploader.ui
+++ b/ground/gcs/src/plugins/uploader/uploader.ui
@@ -149,11 +149,14 @@ Rescue is possible in USB mode only.</string>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QLabel" name="statusPic">
+       <property name="maximumSize">
+        <size>
+         <width>48</width>
+         <height>48</height>
+        </size>
+       </property>
        <property name="text">
         <string/>
-       </property>
-       <property name="scaledContents">
-        <bool>true</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
<img width="312" alt="untitled 2" src="https://cloud.githubusercontent.com/assets/9995998/12479339/5645b0b2-c09f-11e5-9725-d5f718710058.png">
<img width="311" alt="untitled" src="https://cloud.githubusercontent.com/assets/9995998/12479341/56f2c39c-c09f-11e5-8340-60d0878b9352.png">

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/490)

<!-- Reviewable:end -->
