### PR TITLE
mailmap for attribution fixup

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,26 @@
+dankers <david@openpilot.org>   <dankers>
+dankers <david@openpilot.org>   <David@OpenPilot.org>
+dankers <david@openpilot.org>   <GoogleMap,GoogleSatellite,GoogleLabels,GoogleTerrain,GoogleHybrid,GoogleMapChina,GoogleSatelliteChina,GoogleLabelsChina,GoogleTerrainChina,GoogleHybridChina, OpenStreetMap,OpenStreetOsm,OpenStreetMapSurfer,OpenStreetMapSurferTerrain,YahooMap,YahooSatellite,YahooLabels,YahooHybrid,BingMap,BingSatellite,BingHybrid, ArcGIS_Map,ArcGIS_Satellite,ArcGIS_ShadedRelief,ArcGIS_Terrain,ArcGIS_MapsLT_Map>
+Stacey Sheldon <stac@solidgoldbomb.org> <stac>
+Pip <cmoss296@blueyonder.co.uk> <pip>
+James Cotton <peabody124@gmail.com> <peabody124>
+James Cotton <peabody124@gmail.com> <rcotton@cns.bcm.edu>
+PT_Dreamer <josemanuelbarros@gmail.com> <josembarros@hotmail.com>
+Edouard Lafargue <edouard@lafargue.name> <edouard>
+Edouard Lafargue <edouard@lafargue.name> <edouard@lafargue.name>
+Edouard Lafargue <edouard@lafargue.name> <edouard@openpilot.org>
+Kenn Sebesta <kenn@eissq.com> <kenn@eissq.com>
+Kenn Sebesta <kenn@eissq.com> <kenz@Kenns-MacBook-Pro.local>
+Kenn Sebesta <kenn@eissq.com> <kenn@bu.edu>
+Kenn Sebesta <kenn@eissq.com> <kenz@Kenz-Dales-iMac.local>
+Martin Luessi <mluessi@gmail.com> <martin>
+Martin Luessi <mluessi@gmail.com> <mluessi@gmail.com>
+Martin Luessi <mluessi@gmail.com> <brainfpv@gmail.com>
+Oleg Semyonov <os@openpilot.org> <os-openpilot-org@os-propo.info>
+Alessio Morale <alessiomorale@gmail.com> <alessiomorale@gmail.com>
+Michael Corcoran <mrc93@uclive.ac.nz> <tracer@outlook.co.nz>
+Michael Lyle <mlyle@lyle.org> <mlyle@sharpie.lan>
+PT_Dreamer <josemanuelbarros@gmail.com> <jose@Latitude-E6400.(none)>
+Thomas Greer <UKTamo@gmail.com> <UKTamo@gmail.com>
+Thomas Greer <UKTamo@gmail.com> <tgreer@tsone.net.uk>
+DTF UHF <dtfuhf@gmail.com> <dtfuhf@gmail.com>


### PR DESCRIPTION
There are a lot of garbage author records in here.  This cleans up some
of them, but there are a lot more to go.  It'd be really nice if we stopped letting this happen.

see also:

git shorlog -sne

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/491)

<!-- Reviewable:end -->
