### PR TITLE
Lux: New board config plugin, Config UAVO tweaks, Board reboot button

### DIFF
--- a/ground/gcs/src/plugins/boards_brotronics/Brotronics.pluginspec
+++ b/ground/gcs/src/plugins/boards_brotronics/Brotronics.pluginspec
@@ -7,6 +7,8 @@
     <dependencyList>
         <dependency name="Core" version="1.0.0"/>
         <dependency name="UAVObjects" version="1.0.0"/>
+        <dependency name="UAVObjectUtil" version="1.0.0"/>
+        <dependency name="UAVObjectWidgetUtils" version="1.0.0"/>
     </dependencyList>
 </plugin>
 

--- a/ground/gcs/src/plugins/boards_brotronics/boards_brotronics.pro
+++ b/ground/gcs/src/plugins/boards_brotronics/boards_brotronics.pro
@@ -3,16 +3,23 @@ TARGET = Brotronics
 include(../../taulabsgcsplugin.pri)
 include(../../plugins/uavobjects/uavobjects.pri)
 include(../../plugins/coreplugin/coreplugin.pri)
+include(../../plugins/uavobjectutil/uavobjectutil.pri)
+include(../../plugins/uavobjectwidgetutils/uavobjectwidgetutils.pri)
 
 OTHER_FILES += Brotronics.pluginspec
 
 HEADERS += \
     brotronicsplugin.h \
-    lux.h
+    lux.h \
+    luxconfiguration.h
 
 SOURCES += \
     brotronicsplugin.cpp \
-    lux.cpp
+    lux.cpp \
+    luxconfiguration.cpp
 
 RESOURCES += \
     brotronics.qrc
+
+FORMS += \
+	luxconfiguration.ui

--- a/ground/gcs/src/plugins/boards_brotronics/lux.cpp
+++ b/ground/gcs/src/plugins/boards_brotronics/lux.cpp
@@ -34,6 +34,7 @@
 #include <extensionsystem/pluginmanager.h>
 
 #include "hwlux.h"
+#include "luxconfiguration.h"
 
 /**
  * @brief Lux:Lux
@@ -221,4 +222,10 @@ int Lux::queryMaxGyroRate()
 QStringList Lux::getAdcNames()
 {
     return QStringList() << "VBAT" << "Current" << "RSSI";
+}
+
+QWidget *Lux::getBoardConfiguration(QWidget *parent, bool connected)
+{
+    Q_UNUSED(connected);
+    return new LuxConfiguration(parent);
 }

--- a/ground/gcs/src/plugins/boards_brotronics/lux.h
+++ b/ground/gcs/src/plugins/boards_brotronics/lux.h
@@ -71,6 +71,14 @@ public:
 
     virtual QStringList getAdcNames();
 
+    /**
+     * @brief getBoardConfiguration
+     * @param parent Parent object
+     * @param connected Unused
+     * @return Configuration widget handle or NULL on failure
+     */
+    QWidget *getBoardConfiguration(QWidget *parent, bool connected);
+
 };
 
 

--- a/ground/gcs/src/plugins/boards_brotronics/luxconfiguration.cpp
+++ b/ground/gcs/src/plugins/boards_brotronics/luxconfiguration.cpp
@@ -1,0 +1,52 @@
+/**
+ ******************************************************************************
+ * @file       luxconfiguration.cpp
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
+ * @addtogroup GCSPlugins GCS Plugins
+ * @{
+ * @addtogroup Boards_Brotronics Brotronics boards support Plugin
+ * @{
+ * @brief Plugin to support Brotronics boards
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "smartsavebutton.h"
+#include "luxconfiguration.h"
+#include "ui_luxconfiguration.h"
+
+#include "hwlux.h"
+
+LuxConfiguration::LuxConfiguration(QWidget *parent) :
+    ConfigTaskWidget(parent),
+    ui(new Ui::LuxConfiguration)
+{
+    ui->setupUi(this);
+    
+    // Load UAVObjects to widget relations from UI file
+    // using objrelation dynamic property
+    autoLoadWidgets();
+
+    enableControls(true);
+    populateWidgets();
+    refreshWidgetsValues();
+    forceConnectedState();
+}
+
+LuxConfiguration::~LuxConfiguration()
+{
+    delete ui;
+}

--- a/ground/gcs/src/plugins/boards_brotronics/luxconfiguration.h
+++ b/ground/gcs/src/plugins/boards_brotronics/luxconfiguration.h
@@ -1,0 +1,52 @@
+/**
+ ******************************************************************************
+ * @file       luxconfiguration.h
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
+ * @addtogroup GCSPlugins GCS Plugins
+ * @{
+ * @addtogroup Boards_Brotronics Brotronics boards support Plugin
+ * @{
+ * @brief Plugin to support Brotronics boards
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+
+#ifndef LUXCONFIGURATION_H
+#define LUXCONFIGURATION_H
+
+#include <QPixmap>
+#include "configtaskwidget.h"
+
+namespace Ui {
+class LuxConfiguration;
+}
+
+class LuxConfiguration : public ConfigTaskWidget
+{
+    Q_OBJECT
+    
+public:
+    explicit LuxConfiguration(QWidget *parent = 0);
+    ~LuxConfiguration();
+
+private:
+    Ui::LuxConfiguration *ui;
+
+    QPixmap img;
+};
+
+#endif // LUXCONFIGURATION_H

--- a/ground/gcs/src/plugins/boards_brotronics/luxconfiguration.ui
+++ b/ground/gcs/src/plugins/boards_brotronics/luxconfiguration.ui
@@ -1,0 +1,768 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LuxConfiguration</class>
+ <widget class="QWidget" name="LuxConfiguration">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>959</width>
+    <height>678</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="font">
+   <font>
+    <weight>50</weight>
+    <bold>false</bold>
+    <kerning>true</kerning>
+   </font>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Lumenier Lux Flight Controller Board Configuration</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <spacer name="horizontalSpacer_5">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QFrame" name="frame">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>770</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Plain</enum>
+          </property>
+          <property name="lineWidth">
+           <number>0</number>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_7">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <property name="sizeConstraint">
+              <enum>QLayout::SetFixedSize</enum>
+             </property>
+             <item>
+              <layout class="QVBoxLayout" name="verticalLayout_5"/>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="verticalLayout_3">
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_8">
+                 <item>
+                  <spacer name="horizontalSpacer_8">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="lblMainPort">
+                   <property name="text">
+                    <string>Main Port (UART2)</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="cmbMainPort">
+                   <property name="objrelation" stdset="0">
+                    <stringlist notr="true">
+                     <string>objname:HwLux</string>
+                     <string>fieldname:MainPort</string>
+                     <string>buttongroup:1</string>
+                    </stringlist>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="lblFlexiPort">
+                   <property name="text">
+                    <string>Flexi Port (UART3)</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="cmbFlexiPort">
+                   <property name="objrelation" stdset="0">
+                    <stringlist>
+                     <string>objname:HwLux</string>
+                     <string>fieldname:FlexiPort</string>
+                     <string>buttongroup:1</string>
+                    </stringlist>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_9">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_10">
+                 <item>
+                  <spacer name="horizontalSpacer_10">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="imgLabel">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>300</width>
+                     <height>291</height>
+                    </size>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>300</width>
+                     <height>291</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="pixmap">
+                    <pixmap resource="brotronics.qrc">:/brotronics/images/lux.png</pixmap>
+                   </property>
+                   <property name="scaledContents">
+                    <bool>true</bool>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_11">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_4">
+                 <item>
+                  <spacer name="horizontalSpacer_7">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="lblRxPort">
+                   <property name="text">
+                    <string>Receiver Port (UART1)</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="cmbRxPort">
+                   <property name="objrelation" stdset="0">
+                    <stringlist>
+                     <string>objname:HwLux</string>
+                     <string>fieldname:RcvrPort</string>
+                     <string>buttongroup:1</string>
+                    </stringlist>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_2">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="Line" name="line">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <spacer name="horizontalSpacer_6">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0">
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>USB HID Port</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="3">
+           <widget class="QComboBox" name="cmbAccelLpf">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Low-pass filter (LPF) cutoff frequency for the accelerometer signals. Generally, the cutoff frequency should be as high as possible. Lowering the cutoff helps reducing noise caused by motor vibrations, but it can possibly decrease the responsiveness of the UAV. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:HwLux</string>
+              <string>fieldname:MPU9250AccelLPF</string>
+              <string>buttongroup:1</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_15">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Gyro LPF</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QComboBox" name="cmbAccelRange">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:HwLux</string>
+              <string>fieldname:AccelRange</string>
+              <string>buttongroup:1</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QLabel" name="label_7">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>USB VCP Port</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Gyro Range</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_12">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>DSMX Mode</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QComboBox" name="cmbGyroLpf">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Low-pass filter (LPF) cutoff frequency for gyro signals. Generally, the cutoff frequency should be as high as possible. Lowering the cutoff helps reducing noise caused by motor vibrations, but it can possibly decrease the responsiveness of the UAV. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:HwLux</string>
+              <string>fieldname:MPU9250GyroLPF</string>
+              <string>buttongroup:1</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="cmbUsbHidPort">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:HwLux</string>
+              <string>fieldname:USB_HIDPort</string>
+              <string>buttongroup:1</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QComboBox" name="cmbDsmxMode">
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:HwLux</string>
+              <string>fieldname:DSMxMode</string>
+              <string>buttongroup:1</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="cmbGyroRange">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:HwLux</string>
+              <string>fieldname:GyroRange</string>
+              <string>buttongroup:1</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QComboBox" name="cmbUsbVcpPort">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:HwLux</string>
+              <string>fieldname:USB_VCPPort</string>
+              <string>buttongroup:1</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QLabel" name="label_11">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Accel Range</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="2">
+           <widget class="QLabel" name="label_16">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Accel LPF</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_14">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>MPU Rate</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QComboBox" name="cmbMpuRate">
+            <property name="font">
+             <font>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sampling frequency for the gyros and accelerometers in Hz. A higher frequency is better, but will increase the CPU utilization. When SyncPWM is used, this is the frequency with which the ESCs are updated.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:HwLux</string>
+              <string>fieldname:MPU9250Rate</string>
+              <string>buttongroup:1</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="spacing">
+      <number>4</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_13">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Note: Flight controller needs to be rebooted for changes to take effect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="help">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>25</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>25</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Takes you to the wiki page</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../coreplugin/core.qrc">
+         <normaloff>:/core/images/helpicon.svg</normaloff>:/core/images/helpicon.svg</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>25</width>
+         <height>25</height>
+        </size>
+       </property>
+       <property name="flat">
+        <bool>true</bool>
+       </property>
+       <property name="objrelation" stdset="0">
+        <stringlist>
+         <string>button:help</string>
+         <string>url:http://www.getfpv.com/flight-controllers/lumenier-lux-flight-controller.html</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="reloadSettings">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reload previously saved settings from board.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Reload Board Data</string>
+       </property>
+       <property name="objrelation" stdset="0">
+        <stringlist>
+         <string>button:reload</string>
+         <string>buttongroup:1</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="defaultSettings">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset all settings to defaults.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Reset Defaults</string>
+       </property>
+       <property name="objrelation" stdset="0">
+        <stringlist>
+         <string>button:default</string>
+         <string>buttongroup:1</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveSettings">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Applies and saves all settings to persistent storage.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Save</string>
+       </property>
+       <property name="objrelation" stdset="0">
+        <stringlist>
+         <string>button:save</string>
+         <string>buttongroup:1</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="rebootBoard">
+       <property name="text">
+        <string>Reboot</string>
+       </property>
+       <property name="objrelation" stdset="0">
+        <stringlist>
+         <string>button:reboot</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>cmbMainPort</tabstop>
+  <tabstop>cmbFlexiPort</tabstop>
+  <tabstop>cmbRxPort</tabstop>
+  <tabstop>cmbUsbHidPort</tabstop>
+  <tabstop>cmbUsbVcpPort</tabstop>
+  <tabstop>cmbGyroRange</tabstop>
+  <tabstop>cmbAccelRange</tabstop>
+  <tabstop>cmbGyroLpf</tabstop>
+  <tabstop>cmbAccelLpf</tabstop>
+  <tabstop>cmbMpuRate</tabstop>
+  <tabstop>cmbDsmxMode</tabstop>
+  <tabstop>help</tabstop>
+  <tabstop>reloadSettings</tabstop>
+  <tabstop>defaultSettings</tabstop>
+  <tabstop>saveSettings</tabstop>
+  <tabstop>rebootBoard</tabstop>
+ </tabstops>
+ <resources>
+  <include location="brotronics.qrc"/>
+  <include location="../coreplugin/core.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/ground/gcs/src/plugins/plugins.pro
+++ b/ground/gcs/src/plugins/plugins.pro
@@ -353,4 +353,6 @@ SUBDIRS += plugin_boards_aeroquad
 plugin_boards_brotronics.subdir = boards_brotronics
 plugin_boards_brotronics.depends = plugin_coreplugin
 plugin_boards_brotronics.depends = plugin_uavobjects
+plugin_boards_brotronics.depends += plugin_uavobjectutil
+plugin_boards_brotronics.depends += plugin_uavobjectwidgetutils
 SUBDIRS += plugin_boards_brotronics

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.h
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.h
@@ -83,7 +83,7 @@ public:
         }
     };
 
-    enum buttonTypeEnum {none,save_button,apply_button,reload_button,default_button,help_button};
+    enum buttonTypeEnum {none,save_button,apply_button,reload_button,default_button,help_button,reboot_button};
     enum metadataSetEnum {ALL_METADATA, SETTINGS_METADATA_ONLY, NONSETTINGS_METADATA_ONLY};
 
     struct uiRelationAutomation
@@ -128,6 +128,7 @@ public:
     void addApplySaveButtons(QPushButton * update,QPushButton * save);
     void addReloadButton(QPushButton * button,int buttonGroup);
     void addDefaultButton(QPushButton * button,int buttonGroup);
+    void addRebootButton(QPushButton * button);
     //////////
 
     void addWidgetToDefaultReloadGroups(QWidget * widget, QList<int> *groups);
@@ -176,6 +177,7 @@ private slots:
     void objectUpdated(UAVObject*);
     void defaultButtonClicked();
     void reloadButtonClicked();
+    void rebootButtonClicked();
     void doRefreshHiddenObjects(UAVDataObject*);
 private:
     int currentBoard;
@@ -191,6 +193,7 @@ private:
     QMap<QWidget *,objectToWidget*> shadowsList;
     QMap<QPushButton *,QString> helpButtonList;
     QList<QPushButton *> reloadButtonList;
+    QList<QPushButton *> rebootButtonList;
     bool dirty;
     bool setFieldFromWidget(QWidget *widget, UAVObjectField *field, int index, double scale);
     bool setWidgetFromField(QWidget *widget, UAVObjectField *field, int index, double scale, bool hasLimits);

--- a/shared/uavobjectdefinition/hwlux.xml
+++ b/shared/uavobjectdefinition/hwlux.xml
@@ -2,7 +2,7 @@
 	<object name="HwLux" singleinstance="true" settings="true" category="HardwareSettings">
 		<description>Selection of optional hardware configurations.</description>
 
-		<field name="RcvrPort" units="function" type="enum" elements="1" parent="HwShared.PortTypes" defaultvalue="Disabled">
+		<field name="RcvrPort" units="function" type="enum" elements="1" parent="HwShared.PortTypes" defaultvalue="PPM">
 			<options>
 				<option>Disabled</option>
 				<option>PPM</option>
@@ -53,7 +53,14 @@
 		</field>
 
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" parent="HwShared.USB_HIDPort" defaultvalue="USBTelemetry"/>
-		<field name="USB_VCPPort" units="function" type="enum" elements="1" parent="HwShared.USB_VCPPort" defaultvalue="Disabled"/>
+		<field name="USB_VCPPort" units="function" type="enum" elements="1" parent="HwShared.USB_VCPPort" defaultvalue="Disabled">
+			<options>
+				<option>Disabled</option>
+				<option>USBTelemetry</option>
+				<option>ComBridge</option>
+				<option>DebugConsole</option>
+			</options>
+		</field>
 
 		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 


### PR DESCRIPTION
- Board config plugin for Lux
- Reboot button function in ConfigTaskWidget allows reboots from the board config plugin (or anywhere for that matter, although it will return to the board config tab after reboot).
- Removed PicoC option from Lux VCP
- Set a default RxPort type (PPM), was there any reason this wasn't done before?

![screenshot from 2016-01-23 13 46 43](https://cloud.githubusercontent.com/assets/9995998/12526905/c2ece2d8-c1d7-11e5-969e-75f461d037b8.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/500)

<!-- Reviewable:end -->
