### PR TITLE
gcs: simplify ccache usage

### DIFF
--- a/ground/gcs/gcs.pri
+++ b/ground/gcs/gcs.pri
@@ -121,16 +121,18 @@ unix {
     CONFIG(debug, debug|release):MOC_DIR = $${OUT_PWD}/.moc/debug-shared
     CONFIG(release, debug|release):MOC_DIR = $${OUT_PWD}/.moc/release-shared
 
-    CONFIG(debug, debug|release) {
-# Unfortunately this is ineffective on OSX, due to
-# https://bugreports.qt.io/browse/QTBUG-39417
-# Should probe paths once upstream defect resolved
-        exists(/usr/bin/ccache):QMAKE_CXX="ccache g++"
-    }
-
     RCC_DIR = $${OUT_PWD}/.rcc
     UI_DIR = $${OUT_PWD}/.uic
 }
+
+
+CONFIG(debug, debug|release) {
+    # Unfortunately this is ineffective on OSX, due to
+    # https://bugreports.qt.io/browse/QTBUG-39417
+    # Should use it once upstream defect resolved
+    QMAKE_CXX=$(CCACHE_BIN) g++
+}
+
 
 linux-g++* {
     # Bail out on non-selfcontained libraries. Just a security measure

--- a/ground/uavobjgenerator/uavobjgenerator.pro
+++ b/ground/uavobjgenerator/uavobjgenerator.pro
@@ -1,6 +1,3 @@
-# -------------------------------------------------
-# Project created by QtCreator 2010-03-21T20:44:17
-# -------------------------------------------------
 QT += xml
 QT -= gui
 
@@ -9,6 +6,11 @@ macx {
 }
 
 cache()
+
+# Unfortunately this is ineffective on OSX, due to
+# https://bugreports.qt.io/browse/QTBUG-39417
+# Should use it once upstream defect resolved
+QMAKE_CXX=$(CCACHE_BIN) g++
 
 TARGET = uavobjgenerator
 CONFIG += console


### PR DESCRIPTION
This formula works on Windows, too... lets the toplevel makefile to decide whether to ccache and where to find it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/504)

<!-- Reviewable:end -->
