### PR TITLE
OSD: Fix alarm display

### DIFF
--- a/flight/Modules/OnScreenDisplay/onscreendisplay.c
+++ b/flight/Modules/OnScreenDisplay/onscreendisplay.c
@@ -722,10 +722,10 @@ void draw_alarms(int x, int y, int xs, int ys, int va, int ha, int flags, int fo
 	}
 
 	uint8_t state;
-	int32_t len = AlarmString(&alarm, &buf[pos], sizeof(buf) - pos, blink, &state);
+	int32_t len = AlarmString(&alarm, buf, sizeof(buf) - 1, blink, &state);
 
 	if (len > 0) {
-		buf[pos] = '\0';
+		buf[len] = '\0';
 		write_string(buf, x, y, xs, ys, va, ha, flags, font);
 	}
 }


### PR DESCRIPTION
Alarms were not being displayed in the Brain OSD. Not sure how this wasn't noticed before the release.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/509)

<!-- Reviewable:end -->
