### PR TITLE
gcs: Set default heli swashplate config to CCPM 3-servo 120-degree

### DIFF
--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configccpmwidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configccpmwidget.cpp
@@ -159,7 +159,13 @@ ConfigCcpmWidget::ConfigCcpmWidget(QWidget *parent) : VehicleConfig(parent)
              QString::fromUtf8("Coax 2 Servo 90º")  <<
              QString::fromUtf8("Custom - User Angles") << QString::fromUtf8("Custom - Advanced Settings");
     m_ccpm->ccpmType->addItems(Types);
-    m_ccpm->ccpmType->setCurrentIndex(m_ccpm->ccpmType->count() - 1);
+
+    // set default swashplate config to CCPM 3 Servo 120 degrees
+    // need to set the index for the dropdown list and update the UI config using that index
+    m_ccpm->ccpmType->setCurrentIndex(m_ccpm->ccpmType->findText(QString::fromUtf8("CCPM 3 Servo 120º")));
+    GUIConfigDataUnion config = GetConfigData();
+    config.heli.SwashplateType = m_ccpm->ccpmType->count() - m_ccpm->ccpmType->currentIndex()-1;
+    SetConfigData(config);
 
     refreshAirframeWidgetsValues(SystemSettings::AIRFRAMETYPE_HELICP);
 


### PR DESCRIPTION
Sets default swashplate config selection box to ccpm 3-servo 120-degree

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/517)

<!-- Reviewable:end -->
