### PR TITLE
Flight: Erase old settings UAVOs on boot

### DIFF
--- a/flight/PiOS.posix/posix/sections_chibios.ld
+++ b/flight/PiOS.posix/posix/sections_chibios.ld
@@ -133,16 +133,16 @@ SECTIONS
   }
 
   /* 
-   * Init section for UAVObjects.
+   * Register of settings UAVObjects. 
    */
-  .initcalluavobj.init :
+  .settingsuavobjs :
   {
     . = ALIGN(4);
-    __uavobj_initcall_start = .;
-    KEEP(*(.initcalluavobj.init))
+    __uavobj_settings_register_start = .;
+    KEEP(*(.settingsuavobjs))
     . = ALIGN(4);
-    __uavobj_initcall_end   = .;
-  }
+    __uavobj_settings_register_end   = .;
+  } > flash
 
   /* 
   * Module init section section

--- a/flight/PiOS/STM32F10x/link_STM32103CB_CC_Rev1_sections.ld
+++ b/flight/PiOS/STM32F10x/link_STM32103CB_CC_Rev1_sections.ld
@@ -24,6 +24,18 @@ SECTIONS
         *(.rodata .rodata* .gnu.linkonce.r.*)
     } > FLASH
 
+    /* 
+     * Register of settings UAVObjects. 
+     */
+    .settingsuavobjs :
+    {
+        . = ALIGN(4);
+        __uavobj_settings_register_start = .;
+        KEEP(*(.settingsuavobjs))
+        . = ALIGN(4);
+        __uavobj_settings_register_end   = .;
+    } >FLASH
+
     /* module sections */
     .initcallmodule.init :
     {

--- a/flight/PiOS/STM32F10x/link_STM32103CB_PIPXTREME_sections.ld
+++ b/flight/PiOS/STM32F10x/link_STM32103CB_PIPXTREME_sections.ld
@@ -24,6 +24,18 @@ SECTIONS
         *(.rodata .rodata* .gnu.linkonce.r.*)
     } > FLASH
 
+    /* 
+     * Register of settings UAVObjects. 
+     */
+    .settingsuavobjs :
+    {
+        . = ALIGN(4);
+        __uavobj_settings_register_start = .;
+        KEEP(*(.settingsuavobjs))
+        . = ALIGN(4);
+        __uavobj_settings_register_end   = .;
+    } >FLASH
+
     /* module sections */
     .initcallmodule.init :
     {

--- a/flight/PiOS/STM32F30x/link_STM32F30x_sections.ld
+++ b/flight/PiOS/STM32F30x/link_STM32F30x_sections.ld
@@ -16,15 +16,15 @@ SECTIONS
     } > FLASH
 
     /* 
-     * Init section for UAVObjects. 
+     * Register of settings UAVObjects. 
      */
-    .initcalluavobj.init :
+    .settingsuavobjs :
     {
         . = ALIGN(4);
-        __uavobj_initcall_start = .;
-        KEEP(*(.initcalluavobj.init))
+        __uavobj_settings_register_start = .;
+        KEEP(*(.settingsuavobjs))
         . = ALIGN(4);
-        __uavobj_initcall_end   = .;
+        __uavobj_settings_register_end   = .;
     } >FLASH
 
     /* 

--- a/flight/PiOS/STM32F30x/sections_chibios.ld
+++ b/flight/PiOS/STM32F30x/sections_chibios.ld
@@ -71,15 +71,15 @@ SECTIONS
     } > flash
 
     /* 
-     * Init section for UAVObjects.
+     * Register of settings UAVObjects. 
      */
-    .initcalluavobj.init :
+    .settingsuavobjs :
     {
         . = ALIGN(4);
-        __uavobj_initcall_start = .;
-        KEEP(*(.initcalluavobj.init))
+        __uavobj_settings_register_start = .;
+        KEEP(*(.settingsuavobjs))
         . = ALIGN(4);
-        __uavobj_initcall_end   = .;
+        __uavobj_settings_register_end   = .;
     } > flash
 
     /* 

--- a/flight/PiOS/STM32F4xx/link_STM32F4xx_sections.ld
+++ b/flight/PiOS/STM32F4xx/link_STM32F4xx_sections.ld
@@ -16,15 +16,15 @@ SECTIONS
     } > FLASH
 
     /* 
-     * Init section for UAVObjects. 
+     * Register of settings UAVObjects. 
      */
-    .initcalluavobj.init :
+    .settingsuavobjs :
     {
         . = ALIGN(4);
-        __uavobj_initcall_start = .;
-        KEEP(*(.initcalluavobj.init))
+        __uavobj_settings_register_start = .;
+        KEEP(*(.settingsuavobjs))
         . = ALIGN(4);
-        __uavobj_initcall_end   = .;
+        __uavobj_settings_register_end   = .;
     } >FLASH
 
     /* 

--- a/flight/PiOS/STM32F4xx/sections_chibios.ld
+++ b/flight/PiOS/STM32F4xx/sections_chibios.ld
@@ -71,15 +71,15 @@ SECTIONS
     } > flash
 
     /* 
-     * Init section for UAVObjects.
+     * Register of settings UAVObjects. 
      */
-    .initcalluavobj.init :
+    .settingsuavobjs :
     {
         . = ALIGN(4);
-        __uavobj_initcall_start = .;
-        KEEP(*(.initcalluavobj.init))
+        __uavobj_settings_register_start = .;
+        KEEP(*(.settingsuavobjs))
         . = ALIGN(4);
-        __uavobj_initcall_end   = .;
+        __uavobj_settings_register_end   = .;
     } > flash
 
     /* 

--- a/flight/PiOS/inc/pios_flashfs.h
+++ b/flight/PiOS/inc/pios_flashfs.h
@@ -33,5 +33,6 @@ int32_t PIOS_FLASHFS_Format(uintptr_t fs_id);
 int32_t PIOS_FLASHFS_ObjSave(uintptr_t fs_id, uint32_t obj_id, uint16_t obj_inst_id, uint8_t * obj_data, uint16_t obj_size);
 int32_t PIOS_FLASHFS_ObjLoad(uintptr_t fs_id, uint32_t obj_id, uint16_t obj_inst_id, uint8_t * obj_data, uint16_t obj_size);
 int32_t PIOS_FLASHFS_ObjDelete(uintptr_t fs_id, uint32_t obj_id, uint16_t obj_inst_id);
+int32_t PIOS_FLASHFS_ObjIdAtSlot(uintptr_t fs_id, uint16_t slot, uint32_t *obj_id, uint32_t *obj_inst_id);
 
 #endif	/* PIOS_FLASHFS_H_ */

--- a/flight/UAVObjects/inc/uavobjectmanager.h
+++ b/flight/UAVObjects/inc/uavobjectmanager.h
@@ -37,6 +37,10 @@
 #define UAVOBJ_ALL_INSTANCES 0xFFFF
 #define UAVOBJ_MAX_INSTANCES 1000
 
+#define UAVOBJ_SETTINGS_REGISTER(uavoid) \
+	static uint32_t __settings_uavobj_##uavoid __attribute__((__used__)) \
+	__attribute__((section(".settingsuavobjs"))) = uavoid;
+
 /*
  * Shifts and masks used to read/write metadata flags.
  */

--- a/flight/UAVObjects/uavobjectmanager.c
+++ b/flight/UAVObjects/uavobjectmanager.c
@@ -178,6 +178,7 @@ static int32_t connectObj(UAVObjHandle obj_handle, struct pios_queue *queue,
 			uint16_t interval);
 static int32_t disconnectObj(UAVObjHandle obj_handle, struct pios_queue *queue,
 			UAVObjEventCallback cb, void *cbCtx);
+static int32_t cleanupSettingsObjs(void);
 
 // Private variables
 static struct UAVOData * uavo_list;
@@ -229,6 +230,10 @@ int32_t UAVObjInitialize()
 	mutex = PIOS_Recursive_Mutex_Create();
 	if (mutex == NULL)
 		return -1;
+
+	// Clean up old settings objects
+	cleanupSettingsObjs();
+
 	// Done
 	return 0;
 }
@@ -2177,6 +2182,44 @@ void UAVObjRegisterNewInstanceCB(new_uavo_instance_cb_t callback)
 {
 	newUavObjInstanceCB = callback;
 }
+
+static int32_t cleanupSettingsObjs(void)
+{
+	extern uint32_t __uavobj_settings_register_start[], __uavobj_settings_register_end[];
+	uint32_t slot = 1;
+	uint32_t curr_obj_id, curr_obj_inst_id;
+	int32_t res = 0;
+	do {
+		res = PIOS_FLASHFS_ObjIdAtSlot(pios_uavo_settings_fs_id, slot++, 
+					&curr_obj_id, &curr_obj_inst_id) == 0;
+
+		if (res == -3) {
+			// empty slot, ignore it
+			res = 0;
+			continue;
+		} else if (res != 0) {
+			return -1;
+		}
+		
+		bool found = false;
+		for (uint32_t *obj_id = __uavobj_settings_register_start; 
+					obj_id < __uavobj_settings_register_end; obj_id++) {
+			if (*obj_id == curr_obj_id) {
+				found = true;
+				break;
+			}
+		}
+
+		if (!found) {
+			// didn't find it, old object
+			PIOS_FLASHFS_ObjDelete(pios_uavo_settings_fs_id, curr_obj_id, curr_obj_inst_id);
+		}
+	} while (res == 0);
+
+	return 0;
+}
+
+
 /**
  * @}
  * @}

--- a/flight/UAVObjects/uavobjecttemplate.c
+++ b/flight/UAVObjects/uavobjecttemplate.c
@@ -39,6 +39,8 @@
 #include "uavobjectmanager.h"
 #include "$(NAMELC).h"
 
+UAVOBJ_SETTINGS_REGISTER($(NAMEUC)_OBJID)
+
 // Private variables
 static UAVObjHandle handle = NULL;
 

--- a/flight/targets/naze32/link_STM32103CB_Naze32_sections.ld
+++ b/flight/targets/naze32/link_STM32103CB_Naze32_sections.ld
@@ -22,6 +22,18 @@ SECTIONS
         *(.rodata .rodata* .gnu.linkonce.r.*)
     } > FLASH
 
+    /* 
+     * Register of settings UAVObjects. 
+     */
+    .settingsuavobjs :
+    {
+        . = ALIGN(4);
+        __uavobj_settings_register_start = .;
+        KEEP(*(.settingsuavobjs))
+        . = ALIGN(4);
+        __uavobj_settings_register_end   = .;
+    } >FLASH
+
     /* module sections */
     .initcallmodule.init :
     {


### PR DESCRIPTION
Previously settings UAVOs left over from old firmware versions would be left after an upgrade, taking up slots in the filesystem. It is suspected that the the cause of problems seen where the board fails to boot after an upgrade unless the settings partition is erased, is due to the partition becoming full. The UAVO manager now cycles through each slot in the settings partition, and if an unknown UAVO ID is found it is deleted.

It would be great to find some test cases where we failed to boot before to verify that this fixes it.

Connects to #83

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/521)

<!-- Reviewable:end -->
