### PR TITLE
gcs: Fix default collective curve being ignored on initial setup

### DIFF
--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configccpmwidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configccpmwidget.cpp
@@ -130,13 +130,9 @@ ConfigCcpmWidget::ConfigCcpmWidget(QWidget *parent) : VehicleConfig(parent)
 
     }
 
-    //initialize our two mixer curves
+    //initialize our throttle mixer curve
     // mixercurve defaults to mixercurve_throttle
     m_ccpm->ThrottleCurve->initLinearCurve(5, 1.0, 0.0);
-
-    // tell mixercurve this is a pitch curve
-    m_ccpm->PitchCurve->setMixerType(MixerCurve::MIXERCURVE_OTHER);
-    m_ccpm->PitchCurve->initLinearCurve(5, 1.0, -1.0);
 
     //initialize channel names
     m_ccpm->ccpmEngineChannel->addItems(channelNames);
@@ -162,6 +158,13 @@ ConfigCcpmWidget::ConfigCcpmWidget(QWidget *parent) : VehicleConfig(parent)
     m_ccpm->ccpmType->setCurrentIndex(m_ccpm->ccpmType->count() - 1);
 
     refreshAirframeWidgetsValues(SystemSettings::AIRFRAMETYPE_HELICP);
+
+    //initialize our collective mixer curve
+    // refreshAirframeWidgetsValues triggers a whole cascade of curve-related calls
+    // need set the collective curve info after this point to make it stick
+    // tell mixercurve this is a pitch curve
+    m_ccpm->PitchCurve->setMixerType(MixerCurve::MIXERCURVE_OTHER);
+    m_ccpm->PitchCurve->initLinearCurve(5, 1.0, -1.0);
 
     UpdateType();
 


### PR DESCRIPTION
When changing vehicle type to helicopter, the collective curve has its range on [0,1] even though the code clearly tries to have it default to [-1,1]. It seems as though refreshAirframeWidgetsValues() triggers some complex behavior that resets the the collective curve range to [0,1] regardless of the desired value. 

Thus, the simple fix presented here configures the collective curve range after the call to refreshAirframeWidgetsValues().

Resolves #401.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/522)

<!-- Reviewable:end -->
