### PR TITLE
Uploader: Tell the user if a file was loaded successfully

### DIFF
--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -268,6 +268,7 @@ void UploaderGadgetWidget::FirmwareLoadedUpdate(QByteArray firmwareArray)
         m_widget->userDefined_LD_lbl->setVisible(false);
         return;
     }
+    setStatusInfo(tr("File loaded successfully"), uploader::STATUSICON_INFO);
     m_widget->builtForLD_lbl->setText(Core::IBoardType::getBoardNameFromID(firmware.boardID()));
     bool ok;
     currentBoard.max_code_size.toLong(&ok);


### PR DESCRIPTION
Previously we told them if a file was loaded unsuccessfully but then never overwrote that message when they sucessfully loaded on a subsequent attempt. Had a user come to me confused about it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/525)

<!-- Reviewable:end -->
