### PR TITLE
Flying F3: added ADC on Port PC0 to PC3 support to BMP85 shield

### DIFF
--- a/flight/targets/flyingf3/board-info/board_hw_defs.c
+++ b/flight/targets/flyingf3/board-info/board_hw_defs.c
@@ -2751,6 +2751,37 @@ static const struct pios_internal_adc_cfg internal_adc_cfg_rcflyer_shield = {
 		{GPIOC,GPIO_Pin_4,ADC_Channel_5,false},
 	},
 };
+
+static const struct pios_internal_adc_cfg internal_adc_cfg_bmp85 = {
+	.dma = {
+		.irq = {
+			.flags   = (DMA1_FLAG_TC1 | DMA1_FLAG_TE1 | DMA1_FLAG_HT1 | DMA1_FLAG_GL1),
+			.init    = {
+				.NVIC_IRQChannel                   = DMA1_Channel1_IRQn,
+				.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_HIGH,
+				.NVIC_IRQChannelSubPriority        = 0,
+				.NVIC_IRQChannelCmd                = ENABLE,
+			},
+		},
+		.rx = {
+			.channel = DMA1_Channel1,
+			.init    = {
+				.DMA_Priority           = DMA_Priority_High,
+			},
+		}
+	},
+	.half_flag = DMA1_IT_HT1,
+	.full_flag = DMA1_IT_TC1,
+	.oversampling = 32,
+	.adc_pin_count = 3,
+	.adc_pins = {
+		{GPIOC,GPIO_Pin_0,ADC_Channel_6,true},
+		{GPIOC,GPIO_Pin_1,ADC_Channel_7,false},
+		{GPIOC,GPIO_Pin_2,ADC_Channel_8,false},
+	},
+	.adc_dev_master = ADC1,
+	.adc_dev_slave = ADC2,
+};
 #endif //PIOS_INCLUDE_ADC
 
 /**

--- a/flight/targets/flyingf3/board-info/board_hw_defs.c
+++ b/flight/targets/flyingf3/board-info/board_hw_defs.c
@@ -2773,11 +2773,12 @@ static const struct pios_internal_adc_cfg internal_adc_cfg_bmp85 = {
 	.half_flag = DMA1_IT_HT1,
 	.full_flag = DMA1_IT_TC1,
 	.oversampling = 32,
-	.adc_pin_count = 3,
+	.adc_pin_count = 4,
 	.adc_pins = {
 		{GPIOC,GPIO_Pin_0,ADC_Channel_6,true},
 		{GPIOC,GPIO_Pin_1,ADC_Channel_7,false},
 		{GPIOC,GPIO_Pin_2,ADC_Channel_8,false},
+		{GPIOC,GPIO_Pin_3,ADC_Channel_9,false},
 	},
 	.adc_dev_master = ADC1,
 	.adc_dev_slave = ADC2,

--- a/flight/targets/flyingf3/fw/pios_board.c
+++ b/flight/targets/flyingf3/fw/pios_board.c
@@ -709,20 +709,17 @@ void PIOS_Board_Init(void) {
 		panic(5);
 	if (PIOS_BMP085_Test() != 0)
 		panic(5);
-
-
+#endif /* PIOS_INCLUDE_BMP085 && PIOS_INCLUDE_I2C */
 #if defined(PIOS_INCLUDE_ADC)
 		//Sanity check, this is to ensure that no one changes the adc_pins array without changing the defines
-		//PIOS_Assert(internal_adc_cfg_rcflyer_shield.adc_pins[PIOS_ADC_RCFLYER_SHIELD_BARO_PIN].pin == GPIO_Pin_3);
-		//PIOS_Assert(internal_adc_cfg_rcflyer_shield.adc_pins[PIOS_ADC_RCFLYER_SHIELD_BAT_VOLTAGE_PIN].pin == GPIO_Pin_4);
+		PIOS_Assert(internal_adc_cfg_bmp85.adc_pins[0].pin == GPIO_Pin_0);
+		PIOS_Assert(internal_adc_cfg_bmp85.adc_pins[1].pin == GPIO_Pin_1);
+		PIOS_Assert(internal_adc_cfg_bmp85.adc_pins[2].pin == GPIO_Pin_2);
+		PIOS_Assert(internal_adc_cfg_bmp85.adc_pins[3].pin == GPIO_Pin_3);
 		if (PIOS_INTERNAL_ADC_Init(&internal_adc_id, &internal_adc_cfg_bmp85) < 0)
 			PIOS_Assert(0);
 		PIOS_ADC_Init(&pios_internal_adc_id, &pios_internal_adc_driver, internal_adc_id);
-#endif
-
-
-
-#endif /* PIOS_INCLUDE_BMP085 && PIOS_INCLUDE_I2C */
+#endif /* PIOS_INCLUDE_ADC */
 		break;
 	case HWFLYINGF3_SHIELD_NONE:
 		break;

--- a/flight/targets/flyingf3/fw/pios_board.c
+++ b/flight/targets/flyingf3/fw/pios_board.c
@@ -709,6 +709,19 @@ void PIOS_Board_Init(void) {
 		panic(5);
 	if (PIOS_BMP085_Test() != 0)
 		panic(5);
+
+
+#if defined(PIOS_INCLUDE_ADC)
+		//Sanity check, this is to ensure that no one changes the adc_pins array without changing the defines
+		//PIOS_Assert(internal_adc_cfg_rcflyer_shield.adc_pins[PIOS_ADC_RCFLYER_SHIELD_BARO_PIN].pin == GPIO_Pin_3);
+		//PIOS_Assert(internal_adc_cfg_rcflyer_shield.adc_pins[PIOS_ADC_RCFLYER_SHIELD_BAT_VOLTAGE_PIN].pin == GPIO_Pin_4);
+		if (PIOS_INTERNAL_ADC_Init(&internal_adc_id, &internal_adc_cfg_bmp85) < 0)
+			PIOS_Assert(0);
+		PIOS_ADC_Init(&pios_internal_adc_id, &pios_internal_adc_driver, internal_adc_id);
+#endif
+
+
+
 #endif /* PIOS_INCLUDE_BMP085 && PIOS_INCLUDE_I2C */
 		break;
 	case HWFLYINGF3_SHIELD_NONE:


### PR DESCRIPTION
Pinout in HW description flight/targets/flyingf3/hw/pinout.txt mention ADC functionality on PC0 to PC3. However this did not seem to be implemented. So I copied the rcflyer shield example and adjusted the adc channels for PC0-PC3. I added this just for the BMP85 shield. I am not sure if this approach is ok or if it is better to use PC0-PC3 for all shields as default.
I verified this in on my f3 and it works in hardware.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/534)

<!-- Reviewable:end -->
