### PR TITLE
FirmwareIAP: Plumb runtime detected hardware rev

### DIFF
--- a/flight/Modules/FirmwareIAP/firmwareiap.c
+++ b/flight/Modules/FirmwareIAP/firmwareiap.c
@@ -67,6 +67,7 @@ const uint32_t    iap_time_3_high_end = 5000;
 // Private variables
 static uint8_t reset_count = 0;
 static uint32_t lastResetSysTime;
+static uint8_t board_rev = 0;
 
 // Private functions
 static void FirmwareIAPCallback(UAVObjEvent* ev, void *ctx, void *obj, int len);
@@ -96,13 +97,16 @@ int32_t FirmwareIAPInitialize()
 	
 	const struct pios_board_info * bdinfo = &pios_board_info_blob;
 
+	if (!board_rev)
+		board_rev = bdinfo->board_rev;
+
 	FirmwareIAPObjData data;
 	FirmwareIAPObjGet(&data);
 
 	data.BoardType= bdinfo->board_type;
 	PIOS_BL_HELPER_FLASH_Read_Description(data.Description,FIRMWAREIAPOBJ_DESCRIPTION_NUMELEM);
 	PIOS_SYS_SerialNumberGetBinary(data.CPUSerial);
-	data.BoardRevision= bdinfo->board_rev;
+	data.BoardRevision = board_rev;
 	data.crc = PIOS_BL_HELPER_CRC_Memory_Calc();
 	FirmwareIAPObjSet( &data );
 	if(bdinfo->magic==PIOS_BOARD_INFO_BLOB_MAGIC) FirmwareIAPObjConnectCallback( &FirmwareIAPCallback );
@@ -244,6 +248,16 @@ static void resetTask(UAVObjEvent * ev, void *ctx, void *obj, int len)
 		lastResetSysTime = PIOS_Thread_Systime();
 			PIOS_SYS_Reset();
 	}
+}
+
+int32_t FirmwareIAPStart()
+{
+	return 0;
+};
+
+void FirmwareIAPSetBoardRev(uint8_t rev)
+{
+	board_rev = rev;
 }
 
 /**

--- a/flight/Modules/FirmwareIAP/inc/firmwareiap.h
+++ b/flight/Modules/FirmwareIAP/inc/firmwareiap.h
@@ -31,7 +31,8 @@
 #define FIRMWAREIAP_H
 
 int32_t FirmwareIAPInitialize();
-int32_t FirmwareIAPStart() {return 0;};
+int32_t FirmwareIAPStart();
+void FirmwareIAPSetBoardRev(uint8_t rev);
 
 #endif // FIRMWAREIAP_H
 


### PR DESCRIPTION
Allows us to have a meaningful revision on targets that use runtime detection, like the Naze32. I will use this on Naze32 in a subsequent PR if merged (I already had the code working in my one-true-mpu branch).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/537)

<!-- Reviewable:end -->
