### PR TITLE
GCS: Quieten down a lot of debug warnings

### DIFF
--- a/ground/gcs/src/plugins/config/configautotunewidget.cpp
+++ b/ground/gcs/src/plugins/config/configautotunewidget.cpp
@@ -53,6 +53,14 @@
 #include "coreplugin/iboardtype.h"
 
 
+//#define CONF_ATUNE_DEBUG
+#ifdef CONF_ATUNE_DEBUG
+#define CONF_ATUNE_QXTLOG_DEBUG(...) qDebug()<<__VA_ARGS__
+#else  // CONF_ATUNE_DEBUG
+#define CONF_ATUNE_QXTLOG_DEBUG(...)
+#endif	// CONF_ATUNE_DEBUG
+
+
 const QString ConfigAutotuneWidget::databaseUrl = QString("http://dronin-autotown.appspot.com/storeTune");
 
 ConfigAutotuneWidget::ConfigAutotuneWidget(QWidget *parent) :
@@ -334,9 +342,9 @@ void ConfigAutotuneWidget::recomputeStabilization()
     const double a = ((tau+tau_d) / tau / tau_d - 2 * damp * wn) / 20.0;
     const double b = ((tau+tau_d) / tau / tau_d - 2 * damp * wn - a);
 
-    qDebug() << "ghf: " << ghf;
-    qDebug() << "wn: " << wn << "tau_d: " << tau_d;
-    qDebug() << "a: " << a << " b: " << b;
+    CONF_ATUNE_QXTLOG_DEBUG("ghf: ", ghf);
+    CONF_ATUNE_QXTLOG_DEBUG("wn: ", wn, "tau_d: ", tau_d);
+    CONF_ATUNE_QXTLOG_DEBUG("a: ", a, " b: ", b);
 
     // Calculate the gain for the outer loop by approximating the
     // inner loop as a single order lpf. Set the outer loop to be

--- a/ground/gcs/src/plugins/rawhid/rawhid.cpp
+++ b/ground/gcs/src/plugins/rawhid/rawhid.cpp
@@ -141,7 +141,7 @@ RawHIDReadThread::~RawHIDReadThread()
     m_running = false;
     //wait for the thread to terminate
     if(wait(10000) == false)
-        qDebug() << "Cannot terminate RawHIDReadThread";
+        qWarning() << "Cannot terminate RawHIDReadThread";
 }
 
 void RawHIDReadThread::run()
@@ -211,7 +211,7 @@ RawHIDWriteThread::~RawHIDWriteThread()
     m_running = false;
     //wait for the thread to terminate
     if(wait(10000) == false)
-        qDebug() << "Cannot terminate RawHIDWriteThread";
+        qWarning() << "Cannot terminate RawHIDWriteThread";
 }
 
 void RawHIDWriteThread::run()
@@ -259,7 +259,7 @@ void RawHIDWriteThread::run()
         else if(ret == -110) // timeout
         {
             // timeout occured
-            qDebug() << "Send Timeout: No data written to device.";
+            RAW_HID_QXTLOG_DEBUG("Send Timeout: No data written to device.");
         }
         else if(ret < 0) // < 0 => error
         {
@@ -268,7 +268,7 @@ void RawHIDWriteThread::run()
             {
                 retry = 0;
                 m_running = false; //TODO! make proper error handling, this only quick hack for unplug freeze
-                qDebug() << "Error writing to device";
+                qWarning() << "[RawHID] Error writing to device";
             }
             else
             {
@@ -277,7 +277,7 @@ void RawHIDWriteThread::run()
         }
         else
         {
-            qDebug() << "No data written to device ??";
+            RAW_HID_QXTLOG_DEBUG("No data written to device ??");
         }
     }
 }
@@ -344,7 +344,7 @@ bool RawHID::open(OpenMode mode)
         m_readThread->start();
         m_writeThread->start();
     } else {
-        qDebug() << "Failed to open USB device";
+        qWarning() << "[RawHID] Failed to open USB device";
         return false;
     }
 
@@ -356,7 +356,7 @@ void RawHID::close()
     if (!isOpen())
         return;
 
-    qDebug() << "RawHID: close()";
+    RAW_HID_QXTLOG_DEBUG("RawHID: close()");
 
     m_writeThread->stop();
     m_readThread->stop();

--- a/ground/gcs/src/plugins/rawhid/rawhid.h
+++ b/ground/gcs/src/plugins/rawhid/rawhid.h
@@ -41,6 +41,13 @@
 #include "usbmonitor.h"
 #include "usbdevice.h"
 
+//#define RAW_HID_DEBUG
+#ifdef RAW_HID_DEBUG
+#define RAW_HID_QXTLOG_DEBUG(...) qDebug()<<__VA_ARGS__
+#else  // RAW_HID_DEBUG
+#define RAW_HID_QXTLOG_DEBUG(...)
+#endif	// RAW_HID_DEBUG
+
 //helper classes
 class RawHIDReadThread;
 class RawHIDWriteThread;

--- a/ground/gcs/src/plugins/rawhid/rawhidplugin.cpp
+++ b/ground/gcs/src/plugins/rawhid/rawhidplugin.cpp
@@ -72,7 +72,7 @@ void RawHIDConnection::onDeviceConnected()
   */
 void RawHIDConnection::onDeviceDisconnected()
 {
-    qDebug() << "onDeviceDisconnected()";
+    RAW_HID_QXTLOG_DEBUG("onDeviceDisconnected()");
     if (enablePolling)
         emit availableDevChanged(this);
 }
@@ -90,7 +90,7 @@ QList < Core::IDevice*> RawHIDConnection::availableDevices()
     Core::BoardManager* brdMgr = Core::ICore::instance()->boardManager();
     QList<int> brdVID = brdMgr->getKnownVendorIDs();
     foreach(int vendorID, brdVID) {
-        qDebug() << "[rawhidplugin] VendorID type known: " << vendorID;
+        RAW_HID_QXTLOG_DEBUG("[rawhidplugin] VendorID type known: ", vendorID);
         portsList = m_usbMonitor->availableDevices(vendorID, -1, -1,USBMonitor::Running);
         // We currently list devices by their serial number        
         USBDevice* dev = new USBDevice();
@@ -126,7 +126,7 @@ void RawHIDConnection::closeDevice(const QString &deviceName)
     Q_UNUSED(deviceName);
 	if (RawHidHandle)
 	{
-        qDebug() << "Closing the device here";
+        RAW_HID_QXTLOG_DEBUG("Closing the device here");
         RawHidHandle->close();
 		delete RawHidHandle;
 		RawHidHandle = NULL;

--- a/ground/gcs/src/plugins/rawhid/usbmonitor_linux.cpp
+++ b/ground/gcs/src/plugins/rawhid/usbmonitor_linux.cpp
@@ -33,11 +33,19 @@
 #include "usbmonitor.h"
 #include <QDebug>
 
-#define printf qDebug
+//#define USB_MON_DEBUG
+#ifdef USB_MON_DEBUG
+#define USB_MON_QXTLOG_DEBUG(...) qDebug()<<__VA_ARGS__
+#else  // USB_MON_DEBUG
+#define USB_MON_QXTLOG_DEBUG(...)
+#endif	// USB_MON_DEBUG
+
+#define printf USB_MON_QXTLOG_DEBUG
 
 
 void printPortInfo(struct udev_device *dev)
 {
+    Q_UNUSED(dev);
     printf("   Node: %s", udev_device_get_devnode(dev));
     printf("   Subsystem: %s", udev_device_get_subsystem(dev));
     printf("   Devtype: %s", udev_device_get_devtype(dev));

--- a/ground/gcs/src/plugins/rawhid/usbmonitor_linux.cpp
+++ b/ground/gcs/src/plugins/rawhid/usbmonitor_linux.cpp
@@ -72,7 +72,7 @@ void printPortInfo(struct udev_device *dev)
 
 void USBMonitor::deviceEventReceived() {
 
-    qDebug() << "Device event";
+    USB_MON_QXTLOG_DEBUG("Device event");
     struct udev_device *dev;
 
     dev = udev_monitor_receive_device(this->monitor);

--- a/ground/gcs/src/plugins/rawhid/usbmonitor_mac.cpp
+++ b/ground/gcs/src/plugins/rawhid/usbmonitor_mac.cpp
@@ -34,7 +34,16 @@
 #include <QMutexLocker>
 #include <QDebug>
 
-#define printf qDebug
+
+//#define USB_MON_DEBUG
+#ifdef USB_MON_DEBUG
+#define USB_MON_QXTLOG_DEBUG(...) qDebug()<<__VA_ARGS__
+#else  // USB_MON_DEBUG
+#define USB_MON_QXTLOG_DEBUG(...)
+#endif	// USB_MON_DEBUG
+
+#define printf USB_MON_QXTLOG_DEBUG
+
 
 //! Local helper functions
 static bool HID_GetIntProperty(IOHIDDeviceRef dev, CFStringRef property, int * value);
@@ -85,7 +94,7 @@ USBMonitor::~USBMonitor()
 
 void USBMonitor::deviceEventReceived() {
 
-    qDebug() << "Device event";
+    USB_MON_QXTLOG_DEBUG("Device event");
 }
 
 USBMonitor* USBMonitor::instance()
@@ -119,7 +128,7 @@ void USBMonitor::detach_callback(void *context, IOReturn r, void *hid_mgr, IOHID
     Q_UNUSED(r);
     Q_UNUSED(hid_mgr);
 
-    qDebug() << "USBMonitor: Device detached event";
+    USB_MON_QXTLOG_DEBUG("USBMonitor: Device detached event");
     instance()->removeDevice(dev);
 }
 
@@ -141,7 +150,7 @@ void USBMonitor::attach_callback(void *context, IOReturn r, void *hid_mgr, IOHID
 
     deviceInfo.dev_handle = dev;
 
-    qDebug() << "USBMonitor: Device attached event";
+    USB_MON_QXTLOG_DEBUG("USBMonitor: Device attached event");
 
     // Populate the device info structure
     got_properties &= HID_GetIntProperty(dev, CFSTR( kIOHIDVendorIDKey ), &deviceInfo.vendorID);
@@ -156,7 +165,7 @@ void USBMonitor::attach_callback(void *context, IOReturn r, void *hid_mgr, IOHID
 
     // Currently only enumerating objects that have the complete list of properties
     if(got_properties) {
-        qDebug() << "USBMonitor: Adding device";
+        USB_MON_QXTLOG_DEBUG("USBMonitor: Adding device");
         instance()->addDevice(deviceInfo);
     }
 }

--- a/ground/gcs/src/plugins/rawhid/usbmonitor_win.cpp
+++ b/ground/gcs/src/plugins/rawhid/usbmonitor_win.cpp
@@ -32,11 +32,20 @@
 #include <QTimer>
 #include "usbmonitor.h"
 #include <QDebug>
-#define printf qDebug
+
+
+//#define USB_MON_DEBUG
+#ifdef USB_MON_DEBUG
+#define USB_MON_QXTLOG_DEBUG(...) qDebug()<<__VA_ARGS__
+#else  // USB_MON_DEBUG
+#define USB_MON_QXTLOG_DEBUG(...)
+#endif	// USB_MON_DEBUG
+
+#define printf USB_MON_QXTLOG_DEBUG
 
 void USBMonitor::deviceEventReceived() {
 
-    qDebug() << "Device event";
+    USB_MON_QXTLOG_DEBUG("Device event");
     // Dispatch and emit the signals here...
 
 }
@@ -78,32 +87,32 @@ USBMonitor::~USBMonitor()
 QList<USBPortInfo> USBMonitor::availableDevices(int vid, int pid, int bcdDeviceMSB, int bcdDeviceLSB)
 {
     QList<USBPortInfo> allPorts = availableDevices();
-    qDebug()<<"USBMonitor::availableDevices list off all ports:";
-    qDebug()<<"USBMonitor::availableDevices total ports:"<<allPorts.length();
+    USB_MON_QXTLOG_DEBUG("USBMonitor::availableDevices list off all ports:");
+    USB_MON_QXTLOG_DEBUG("USBMonitor::availableDevices total ports:", allPorts.length());
     foreach (USBPortInfo info, allPorts) {
-        qDebug()<<"----------";
-        qDebug()<<"bcdDevice:"<<info.bcdDevice;
-        qDebug()<<"devicePath:"<<info.devicePath;
-        qDebug()<<"product:"<<info.product;
+        USB_MON_QXTLOG_DEBUG("----------");
+        USB_MON_QXTLOG_DEBUG("bcdDevice:", info.bcdDevice);
+        USB_MON_QXTLOG_DEBUG("devicePath:", info.devicePath);
+        USB_MON_QXTLOG_DEBUG("product:", info.product);
     }
-    qDebug()<<"END OF LIST";
+    USB_MON_QXTLOG_DEBUG("END OF LIST");
     QList<USBPortInfo> thePortsWeWant;
-    qDebug()<<"USBMonitor::availableDevices bcdLSB="<<bcdDeviceLSB;
+    USB_MON_QXTLOG_DEBUG("USBMonitor::availableDevices bcdLSB=", bcdDeviceLSB);
     foreach (USBPortInfo port, allPorts) {
-        qDebug()<<"USBMonitorWin:Port VID="<<port.vendorID<<"PID="<<port.productID<<"bcddevice="<<port.bcdDevice;
+        USB_MON_QXTLOG_DEBUG("USBMonitorWin:Port VID=", port.vendorID, "PID=", port.productID, "bcddevice=", port.bcdDevice);
         if((port.vendorID==vid || vid==-1) && (port.productID==pid || pid==-1) && ((port.bcdDevice>>8)==bcdDeviceMSB || bcdDeviceMSB==-1) &&
                 ( (port.bcdDevice&0x00ff) ==bcdDeviceLSB || bcdDeviceLSB==-1))
             thePortsWeWant.append(port);
     }
-    qDebug()<<"USBMonitor::availableDevices list off matching ports vid pid bcdMSD bcdLSD:"<<vid<<pid<<bcdDeviceMSB<<bcdDeviceLSB;
-    qDebug()<<"USBMonitor::availableDevices total matching ports:"<<thePortsWeWant.length();
+    USB_MON_QXTLOG_DEBUG("USBMonitor::availableDevices list off matching ports vid pid bcdMSD bcdLSD:", vid, pid, bcdDeviceMSB, bcdDeviceLSB);
+    USB_MON_QXTLOG_DEBUG("USBMonitor::availableDevices total matching ports:", thePortsWeWant.length());
     foreach (USBPortInfo info, thePortsWeWant) {
-        qDebug()<<"----------";
-        qDebug()<<"bcdDevice:"<<info.bcdDevice;
-        qDebug()<<"devicePath:"<<info.devicePath;
-        qDebug()<<"product:"<<info.product;
+        USB_MON_QXTLOG_DEBUG(<<"----------");
+        USB_MON_QXTLOG_DEBUG("bcdDevice:", info.bcdDevice);
+        USB_MON_QXTLOG_DEBUG("devicePath:", info.devicePath);
+        USB_MON_QXTLOG_DEBUG("product:", info.product);
     }
-    qDebug()<<"END OF LIST";
+    USB_MON_QXTLOG_DEBUG("END OF LIST");
     return thePortsWeWant;
 }
 
@@ -179,7 +188,7 @@ bool USBRegistrationWidget::nativeEvent(const QByteArray & /*eventType*/, void *
 #endif
 bool USBMonitor::matchAndDispatchChangedDevice(const QString & deviceID, const GUID & guid, WPARAM wParam)
 {
-    qDebug()<<"USB_MONITOR matchAndDispatchChangedDevice deviceID="<<deviceID;
+    USB_MON_QXTLOG_DEBUG("USB_MONITOR matchAndDispatchChangedDevice deviceID=", deviceID);
     bool rv = false;
     DWORD dwFlag = (DBT_DEVICEARRIVAL == wParam) ? DIGCF_PRESENT : DIGCF_ALLCLASSES;
     HDEVINFO devInfo;
@@ -198,7 +207,7 @@ bool USBMonitor::matchAndDispatchChangedDevice(const QString & deviceID, const G
                 info.devicePath=deviceID;
                 if( wParam == DBT_DEVICEARRIVAL )
                 {
-                    qDebug()<<"USB_MONITOR INSERTION";
+                    USB_MON_QXTLOG_DEBUG("USB_MONITOR INSERTION");
                     if(infoFromHandle(guid,info,devInfo,i)!=1)
                     {
                         qDebug()<<"USB_MONITOR infoFromHandle failed on matchAndDispatchChangedDevice";
@@ -208,7 +217,7 @@ bool USBMonitor::matchAndDispatchChangedDevice(const QString & deviceID, const G
                     foreach (USBPortInfo m_info, knowndevices) {
                         if(m_info.serialNumber==info.serialNumber && m_info.productID==info.productID && m_info.bcdDevice==info.bcdDevice && m_info.devicePath==info.devicePath)
                         {
-                            qDebug()<<"USB_MONITOR device already present don't emit signal";
+                            USB_MON_QXTLOG_DEBUG("USB_MONITOR device already present don't emit signal");
                             m_break=true;
                         }
 
@@ -217,11 +226,11 @@ bool USBMonitor::matchAndDispatchChangedDevice(const QString & deviceID, const G
                         break;
                     if(info.bcdDevice==0 || info.product.isEmpty())
                     {
-                        qDebug()<<"USB_MONITOR empty information on device not emiting signal";
+                        USB_MON_QXTLOG_DEBUG("USB_MONITOR empty information on device not emiting signal");
                         break;
                     }
                     knowndevices.append(info);
-                    qDebug()<<"USB_MONITOR emit device discovered on device:"<<info.product<<info.bcdDevice;
+                    USB_MON_QXTLOG_DEBUG("USB_MONITOR emit device discovered on device:", info.product, info.bcdDevice);
                     emit deviceDiscovered(info);
                     break;
 
@@ -235,7 +244,7 @@ bool USBMonitor::matchAndDispatchChangedDevice(const QString & deviceID, const G
                         {
                             USBPortInfo temp=knowndevices.at(x);
                             knowndevices.removeAt(x);
-                            qDebug()<<"USB_MONITOR emit device removed on device:"<<temp.product<<temp.bcdDevice;
+                            USB_MON_QXTLOG_DEBUG("USB_MONITOR emit device removed on device:", temp.product, temp.bcdDevice);
                             emit deviceRemoved(temp);
                             found=true;
                             break;
@@ -273,7 +282,7 @@ QList<USBPortInfo> USBMonitor::availableDevices()
 {
     QList<USBPortInfo> ports;
     enumerateDevicesWin(guid_hid, &ports);
-    //qDebug()<<"USBMonitorWin availabledevices="<<ports.count();
+    //USB_MON_QXTLOG_DEBUG("USBMonitorWin availabledevices=", ports.count());
     return ports;
 }
 
@@ -281,10 +290,10 @@ void USBMonitor::enumerateDevicesWin( const GUID & guid, QList<USBPortInfo>* inf
 {
     HDEVINFO devInfo;
     USBPortInfo info;
-    //qDebug()<<"enumerateDevicesWin1";
+    //USB_MON_QXTLOG_DEBUG("enumerateDevicesWin1");
     if( (devInfo = SetupDiGetClassDevs(&guid, NULL, NULL, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE)) != INVALID_HANDLE_VALUE)
     {
-        //qDebug()<<"enumerateDevicesWin2";
+        //USB_MON_QXTLOG_DEBUG("enumerateDevicesWin2");
         SP_DEVINFO_DATA devInfoData;
         devInfoData.cbSize = sizeof(SP_DEVINFO_DATA);
         for(DWORD i = 0; SetupDiEnumDeviceInfo(devInfo, i, &devInfoData); i++)
@@ -302,7 +311,7 @@ void USBMonitor::enumerateDevicesWin( const GUID & guid, QList<USBPortInfo>* inf
 
 int USBMonitor::infoFromHandle(const GUID & guid,USBPortInfo & info,HDEVINFO & devInfo,DWORD & index)
 {
-    //qDebug()<<"index0="<<index;
+    //USB_MON_QXTLOG_DEBUG("index0=", index);
     bool ret;
     HANDLE h;
     SP_DEVICE_INTERFACE_DATA iface;
@@ -316,11 +325,11 @@ int USBMonitor::infoFromHandle(const GUID & guid,USBPortInfo & info,HDEVINFO & d
 
     ret = SetupDiEnumDeviceInterfaces(devInfo, NULL, &guid, index, &iface);
     if (!ret) return 0;
-    //qDebug()<<"index1="<<index;
+    //USB_MON_QXTLOG_DEBUG("index1=", index);
     SetupDiGetInterfaceDeviceDetail(devInfo, &iface, NULL, 0, &reqd_size, NULL);
     details = (SP_DEVICE_INTERFACE_DETAIL_DATA *)malloc(reqd_size);
     if (details == NULL) return 2;
-    //qDebug()<<"index2="<<index;
+    //USB_MON_QXTLOG_DEBUG("index2=", index);
     memset(details, 0, reqd_size);
     details->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
     ret = SetupDiGetDeviceInterfaceDetail(devInfo, &iface, details, reqd_size, NULL, NULL);
@@ -329,7 +338,7 @@ int USBMonitor::infoFromHandle(const GUID & guid,USBPortInfo & info,HDEVINFO & d
             free(details);
             return 2;
     }
-    //qDebug()<<"index3="<<index;
+    //USB_MON_QXTLOG_DEBUG("index3=", index);
     h = CreateFile(details->DevicePath, GENERIC_READ|GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
 
     if (h == INVALID_HANDLE_VALUE)
@@ -349,9 +358,9 @@ int USBMonitor::infoFromHandle(const GUID & guid,USBPortInfo & info,HDEVINFO & d
             free(details);
             return 2;
     }
-    //qDebug()<<"index4="<<index;
+    //USB_MON_QXTLOG_DEBUG("index4=", index);
     free(details);
-    //qDebug()<<"DETAILS???"<<QString().fromWCharArray(details->DevicePath).toUpper().replace("#", "\\");
+    //USB_MON_QXTLOG_DEBUG("DETAILS???", QString().fromWCharArray(details->DevicePath).toUpper().replace("#", "\\"));
     attrib.Size = sizeof(HIDD_ATTRIBUTES);
     ret = HidD_GetAttributes(h, &attrib);
     info.vendorID=attrib.VendorID;
@@ -364,14 +373,14 @@ int USBMonitor::infoFromHandle(const GUID & guid,USBPortInfo & info,HDEVINFO & d
             CloseHandle(h);
             return 2;
     }
-    //qDebug()<<"index5="<<index;
+    //USB_MON_QXTLOG_DEBUG("index5=", index);
     if (!HidP_GetCaps(hid_data, &capabilities))
     {
             HidD_FreePreparsedData(hid_data);
             CloseHandle(h);
             return 2;
     }
-    //qDebug()<<"index6="<<index;
+    //USB_MON_QXTLOG_DEBUG("index6=", index);
     info.UsagePage=capabilities.UsagePage;
     info.Usage=capabilities.Usage;
     HidD_FreePreparsedData(hid_data);
@@ -382,7 +391,7 @@ int USBMonitor::infoFromHandle(const GUID & guid,USBPortInfo & info,HDEVINFO & d
     info.manufacturer= QString().fromUtf16((ushort*)temp,-1);
     HidD_GetProductString(h, temp, sizeof(temp));
     info.product= QString().fromUtf16((ushort*)temp,-1);
-    //qDebug()<<"index="<<index<<"ProductID="<<info.product;
+    //USB_MON_QXTLOG_DEBUG("index=", index, "ProductID=", info.product);
     CloseHandle(h);
     h = NULL;
     return 1;

--- a/ground/gcs/src/plugins/rawhid/usbsignalfilter.cpp
+++ b/ground/gcs/src/plugins/rawhid/usbsignalfilter.cpp
@@ -1,12 +1,20 @@
 #include "usbsignalfilter.h"
 #include <QDebug>
+
+//#define USB_FILTER_DEBUG
+#ifdef USB_FILTER_DEBUG
+#define USB_FILTER_QXTLOG_DEBUG(...) qDebug()<<__VA_ARGS__
+#else  // USB_FILTER_DEBUG
+#define USB_FILTER_QXTLOG_DEBUG(...)
+#endif	// USB_FILTER_DEBUG
+
 void USBSignalFilter::m_deviceDiscovered(USBPortInfo port)
 {
     availableDevices = USBMonitor::instance()->availableDevices();
     if((m_vid.contains(port.vendorID) || m_vid.isEmpty()) && (port.productID==m_pid || m_pid==-1) && ((port.bcdDevice>>8)==m_boardModel || m_boardModel==-1) &&
             ( (port.bcdDevice&0x00ff) ==m_runState || m_runState==-1))
     {
-        qDebug()<<"USBSignalFilter emit device discovered";
+        USB_FILTER_QXTLOG_DEBUG("USBSignalFilter emit device discovered");
         emit deviceDiscovered();
     }
 }
@@ -20,7 +28,7 @@ void USBSignalFilter::m_deviceRemoved(USBPortInfo port)
             if((m_vid.contains(port.vendorID) || m_vid.isEmpty()) && (port.productID==m_pid || m_pid==-1) && ((port.bcdDevice>>8)==m_boardModel || m_boardModel==-1) &&
                     ( (port.bcdDevice&0x00ff) ==m_runState || m_runState==-1))
             {
-                qDebug()<<"USBSignalFilter emit device removed";
+                USB_FILTER_QXTLOG_DEBUG("USBSignalFilter emit device removed");
                 emit deviceRemoved();
             }
         }

--- a/ground/gcs/src/plugins/uploader/uploader.pro
+++ b/ground/gcs/src/plugins/uploader/uploader.pro
@@ -29,10 +29,3 @@ FORMS += \
 
 RESOURCES += \
     uploader.qrc
-
-exists(../../../../../build/ground/tlfw_resource/tlfw_resource.qrc ) {
-    RESOURCES += ../../../../../build/ground/tlfw_resource/tlfw_resource.qrc
-} else {
-    message("tlfw_resource.qrc not found.  Automatically firmware updates disabled.")
-}
-

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -1277,7 +1277,6 @@ uploader::UploaderStatus UploaderGadgetWidget::getUploaderStatus() const
  */
 void UploaderGadgetWidget::setUploaderStatus(const uploader::UploaderStatus &value)
 {
-    qDebug()<< "STATUS="<<value;
     uploaderStatus = value;
     switch (uploaderStatus) {
     case uploader::DISCONNECTED:


### PR DESCRIPTION
This disables a lot of (imo unncecessary) debug warnings with defines to re-enabled them on a per-module level as required (following existing GCS code with this). The debug console is now usable for debugging. Also removed the last of the tlfw_resource.qrc stuff.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/540)

<!-- Reviewable:end -->
