### PR TITLE
Sparky2: Allow DAC pin to be used as ADC, cleanup GPIO

### DIFF
--- a/flight/targets/sparky2/board-info/board_hw_defs.c
+++ b/flight/targets/sparky2/board-info/board_hw_defs.c
@@ -1815,19 +1815,6 @@ struct pios_internal_adc_cfg pios_adc_cfg = {
 		{NULL,  0,              ADC_Channel_Vrefint},           /* Voltage reference */         \
 		{NULL,  0,              ADC_Channel_TempSensor}         /* Temperature sensor */        \
 	},
-	.adc_pin_count = 4
-};
-
-struct stm32_gpio pios_current_sonar_pin ={
-    .gpio = GPIOA,
-			.init = {
-				.GPIO_Pin = GPIO_Pin_8,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_IN,
-				.GPIO_OType = GPIO_OType_OD,
-				.GPIO_PuPd  = GPIO_PuPd_NOPULL
-			},
-			.pin_source = GPIO_PinSource8,
 };
 
 static void PIOS_ADC_DMA_irq_handler(void)

--- a/flight/targets/sparky2/board-info/board_hw_defs.c
+++ b/flight/targets/sparky2/board-info/board_hw_defs.c
@@ -1812,9 +1812,11 @@ struct pios_internal_adc_cfg pios_adc_cfg = {
 	.adc_pins = {                                                                               \
 		{GPIOC, GPIO_Pin_3,     ADC_Channel_13},                /* Current sensor */            \
 		{GPIOC, GPIO_Pin_2,     ADC_Channel_12},                /* Voltage sensor */            \
+		{GPIOA, GPIO_Pin_4,     ADC_Channel_4},                 /* DAC pin        */            \
 		{NULL,  0,              ADC_Channel_Vrefint},           /* Voltage reference */         \
 		{NULL,  0,              ADC_Channel_TempSensor}         /* Temperature sensor */        \
 	},
+	.adc_pin_count = 5
 };
 
 static void PIOS_ADC_DMA_irq_handler(void)

--- a/flight/targets/sparky2/fw/pios_board.c
+++ b/flight/targets/sparky2/fw/pios_board.c
@@ -683,9 +683,6 @@ void PIOS_Board_Init(void) {
 	uint32_t internal_adc_id;
 	PIOS_INTERNAL_ADC_Init(&internal_adc_id, &pios_adc_cfg);
 	PIOS_ADC_Init(&pios_internal_adc_id, &pios_internal_adc_driver, internal_adc_id);
- 
-        // configure the pullup for PA8 (inhibit pullups from current/sonar shared pin)
-        GPIO_Init(pios_current_sonar_pin.gpio, &pios_current_sonar_pin.init);
 #endif
 
 #if defined(PIOS_INCLUDE_MS5611)

--- a/ground/gcs/src/plugins/boards_taulabs/sparky2.cpp
+++ b/ground/gcs/src/plugins/boards_taulabs/sparky2.cpp
@@ -350,5 +350,5 @@ bool Sparky2::bindRadio(quint32 id, quint32 baud_rate, float rf_power,
 
 QStringList Sparky2::getAdcNames()
 {
-    return QStringList() << "Analog CUR" << "Analog VOLT";
+    return QStringList() << "Analog CUR" << "Analog VOLT" << "DAC";
 }


### PR DESCRIPTION
Firstly, cleans up a pointless GPIO (as far as I can tell). We were initialising the USB Vsense pin as an input and calling it the current/sonar pin for reasons I do not know.

Mostly, adds the (currently unused) DAC out pin to the list of available ADC inputs. This allows three ADCs for setups like Volt/Current/RSSI. The only other choice would be to use PWM output 5 and/or 6. The DAC pin is the best choice because:
- It's unused
- It's on the same connector as the other ADC pins
- It has a 10 k series resistor on-board (the PWM outs would require this to be done externally)

We can add a configuration option to select whether this should be used as a DAC or ADC later if we do end up adding DAC functionality.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/543)

<!-- Reviewable:end -->
