### PR TITLE
Revo/CC3D: Fix PPM on revo connection diagram, remove OP branding

### DIFF
--- a/ground/gcs/src/plugins/boards_openpilot/images/connection-diagrams.svg
+++ b/ground/gcs/src/plugins/boards_openpilot/images/connection-diagrams.svg
@@ -14,7 +14,7 @@
    height="525.51001"
    width="1078.6002"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="connection-diagrams.svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -25,17 +25,17 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1440"
-     inkscape:window-height="803"
+     inkscape:window-width="2495"
+     inkscape:window-height="1416"
      id="namedview4616"
      showgrid="false"
      inkscape:zoom="2.21"
-     inkscape:cx="152.22499"
-     inkscape:cy="346.37639"
-     inkscape:window-x="17"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="background"
+     inkscape:cx="664.81167"
+     inkscape:cy="293.55445"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g8076"
      fit-margin-top="15"
      fit-margin-left="15"
      fit-margin-right="15"
@@ -2727,7 +2727,8986 @@
   </metadata>
   <g
      id="background"
-     transform="translate(0,5.995598)">
+     transform="translate(0,5.995598)"
+     style="display:inline">
+    <g
+       inkscape:groupmode="layer"
+       id="layer1"
+       inkscape:label="cc3d"
+       style="display:inline">
+      <g
+         id="controller-coptercontrol"
+         inkscape:label="#controller"
+         transform="translate(-16.970563,-13.803392)">
+        <rect
+           id="rect9798"
+           rx="14.194314"
+           ry="10.835353"
+           height="227.54242"
+           width="227.54243"
+           stroke-miterlimit="4"
+           y="99.148933"
+           x="438.74414"
+           style="fill:#171717;stroke:#000000;stroke-width:2.16707063;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+        <rect
+           style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
+           x="507.61179"
+           y="244.72189"
+           width="7.064651"
+           height="5.5151949"
+           id="rect4320" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="515.19653"
+           y="244.72189"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect4322" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="504.36118"
+           y="244.72189"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect4324" />
+        <rect
+           style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
+           x="-279.05756"
+           y="612.47388"
+           width="7.0646501"
+           height="5.5151954"
+           id="rect4408"
+           transform="matrix(0,-1,1,0,0,0)" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="-271.47281"
+           y="612.47388"
+           width="3.868221"
+           height="5.5151954"
+           id="rect4410"
+           transform="matrix(0,-1,1,0,0,0)" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="-282.30814"
+           y="612.47388"
+           width="3.868221"
+           height="5.5151954"
+           id="rect4412"
+           transform="matrix(0,-1,1,0,0,0)" />
+        <rect
+           style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
+           x="587.396"
+           y="149.71573"
+           width="7.064651"
+           height="5.5151949"
+           id="rect10507" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="594.98071"
+           y="149.71573"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect10509" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="584.14539"
+           y="149.71573"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect10511" />
+        <rect
+           style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
+           x="523.35864"
+           y="259.94388"
+           width="7.064651"
+           height="5.5151949"
+           id="rect10515" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="530.94342"
+           y="259.94388"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect10517" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="520.10803"
+           y="259.94388"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect10519" />
+        <rect
+           style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
+           x="494.18936"
+           y="256.50372"
+           width="7.064651"
+           height="5.5151949"
+           id="rect4219" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="501.77411"
+           y="256.50372"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect4221" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="490.93878"
+           y="256.50372"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect4223" />
+        <rect
+           style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
+           x="596.80658"
+           y="266.47675"
+           width="7.064651"
+           height="5.5151949"
+           id="rect10550" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="604.3913"
+           y="266.47675"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect10552" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="593.55597"
+           y="266.47675"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect10554" />
+        <rect
+           style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
+           x="596.01923"
+           y="279.3367"
+           width="7.064651"
+           height="5.5151949"
+           id="rect10558" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="603.60394"
+           y="279.3367"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect10560" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="592.76862"
+           y="279.3367"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect10562" />
+        <rect
+           style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
+           x="590.50781"
+           y="185.90521"
+           width="7.064651"
+           height="5.5151949"
+           id="rect10566" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="598.09253"
+           y="185.90521"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect10568" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="587.2572"
+           y="185.90521"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect10570" />
+        <rect
+           style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
+           x="613.34076"
+           y="105.85859"
+           width="7.064651"
+           height="5.5151949"
+           id="rect10574" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="620.92554"
+           y="105.85859"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect10576" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="610.09015"
+           y="105.85859"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect10578" />
+        <rect
+           style="fill:#0052ff;stroke-width:0;stroke-miterlimit:4"
+           x="449.0675"
+           y="148.40121"
+           width="7.064651"
+           height="5.5151949"
+           id="rect4416" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="456.65225"
+           y="148.40121"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect4418" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="445.81689"
+           y="148.40121"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect4420" />
+        <rect
+           style="fill:#ff7900;stroke-width:0;stroke-miterlimit:4"
+           x="448.71127"
+           y="161.59825"
+           width="7.064651"
+           height="5.5151949"
+           id="rect4432" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="456.29602"
+           y="161.59825"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect4434" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="445.46066"
+           y="161.59825"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect4436" />
+        <rect
+           style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
+           x="117.81582"
+           y="-508.21155"
+           width="7.0646501"
+           height="5.5151954"
+           id="rect4280"
+           transform="matrix(0,1,-1,0,0,0)" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="125.40057"
+           y="-508.21155"
+           width="3.868221"
+           height="5.5151954"
+           id="rect4282"
+           transform="matrix(0,1,-1,0,0,0)" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="114.56521"
+           y="-508.21155"
+           width="3.868221"
+           height="5.5151954"
+           id="rect4284"
+           transform="matrix(0,1,-1,0,0,0)" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
+           x="152.48895"
+           y="-508.21155"
+           width="7.0646501"
+           height="5.5151954"
+           id="rect10763" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="160.0737"
+           y="-508.21155"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10765" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="149.23834"
+           y="-508.21155"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10767" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
+           x="161.61464"
+           y="-567.24731"
+           width="7.0646501"
+           height="5.5151954"
+           id="rect10771" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="169.19939"
+           y="-567.24731"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10773" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="158.36404"
+           y="-567.24731"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10775" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
+           x="266.85629"
+           y="-482.47665"
+           width="7.0646501"
+           height="5.5151954"
+           id="rect10779" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="274.44104"
+           y="-482.47665"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10781" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="263.60568"
+           y="-482.47665"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10783" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
+           x="289.68927"
+           y="-482.47665"
+           width="7.0646501"
+           height="5.5151954"
+           id="rect10787" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="297.27402"
+           y="-482.47665"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10789" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="286.43866"
+           y="-482.47665"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10791" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
+           x="280.24115"
+           y="-530.76709"
+           width="7.0646501"
+           height="5.5151954"
+           id="rect10795" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="287.8259"
+           y="-530.76709"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10797" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="276.99054"
+           y="-530.76709"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10799" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
+           x="-234.70383"
+           y="511.16895"
+           width="7.0646501"
+           height="5.5151954"
+           id="rect10803" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="-227.11908"
+           y="511.16895"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10805" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="-237.95442"
+           y="511.16895"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10807" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
+           x="-234.96628"
+           y="499.62125"
+           width="7.0646501"
+           height="5.5151954"
+           id="rect10811" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="-227.38153"
+           y="499.62125"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10813" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="-238.21687"
+           y="499.62125"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10815" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
+           x="-235.75362"
+           y="488.336"
+           width="7.0646501"
+           height="5.5151954"
+           id="rect10819" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="-228.16887"
+           y="488.336"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10821" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="-239.00423"
+           y="488.336"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10823" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
+           x="-198.74844"
+           y="489.38577"
+           width="7.0646501"
+           height="5.5151954"
+           id="rect10827" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="-191.1637"
+           y="489.38577"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10829" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="-201.99905"
+           y="489.38577"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10831" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
+           x="-199.01088"
+           y="506.18246"
+           width="7.0646501"
+           height="5.5151954"
+           id="rect10835" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="-191.42613"
+           y="506.18246"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10837" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="-202.26149"
+           y="506.18246"
+           width="3.868221"
+           height="5.5151954"
+           id="rect10839" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 660.83109,147.16536 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
+           id="path4550"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 643.49452,147.16536 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
+           id="path4554"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <rect
+           x="616.76898"
+           y="141.73187"
+           width="10.445282"
+           height="9.2858973"
+           id="rect4556"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 660.83109,162.33485 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
+           id="path10894"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 643.49452,162.33485 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
+           id="path10896"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <rect
+           x="616.76898"
+           y="156.90137"
+           width="10.445282"
+           height="9.2858973"
+           id="rect10898"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 660.83109,179.67142 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
+           id="path10902"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 643.49452,179.67142 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
+           id="path10904"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <rect
+           x="616.76898"
+           y="174.23793"
+           width="10.445282"
+           height="9.2858973"
+           id="rect10906"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 660.83109,197.00798 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
+           id="path10910"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 643.49452,197.00798 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
+           id="path10912"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <rect
+           x="616.76898"
+           y="191.57449"
+           width="10.445282"
+           height="9.2858973"
+           id="rect10914"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 660.83109,214.34455 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
+           id="path10918"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 643.49452,214.34455 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
+           id="path10920"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <rect
+           x="616.76898"
+           y="208.91106"
+           width="10.445282"
+           height="9.2858973"
+           id="rect10922"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 660.83109,229.51404 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
+           id="path10926"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 643.49452,229.51404 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
+           id="path10928"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <rect
+           x="616.76898"
+           y="224.08055"
+           width="10.445282"
+           height="9.2858973"
+           id="rect10930"
+           style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#a9814d;stroke-width:0;stroke-miterlimit:4"
+           x="151.32674"
+           y="-495.40668"
+           width="8.7648525"
+           height="9.8560762"
+           id="rect4790" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="160.73685"
+           y="-495.40668"
+           width="4.79916"
+           height="9.8560762"
+           id="rect4792" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="147.29382"
+           y="-495.40668"
+           width="4.79916"
+           height="9.8560762"
+           id="rect4794" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#a9814d;stroke-width:0;stroke-miterlimit:4"
+           x="116.6536"
+           y="-495.40668"
+           width="8.7648525"
+           height="9.8560762"
+           id="rect12056" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="126.06372"
+           y="-495.40668"
+           width="4.79916"
+           height="9.8560762"
+           id="rect12058" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="112.6207"
+           y="-495.40668"
+           width="4.79916"
+           height="9.8560762"
+           id="rect12060" />
+        <rect
+           style="fill:#a9814d;stroke-width:0;stroke-miterlimit:4"
+           x="456.07767"
+           y="277.10086"
+           width="8.7648525"
+           height="9.8560753"
+           id="rect12064" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="465.48776"
+           y="277.10086"
+           width="4.79916"
+           height="9.8560753"
+           id="rect12066" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="452.04474"
+           y="277.10086"
+           width="4.79916"
+           height="9.8560753"
+           id="rect12068" />
+        <rect
+           style="fill:#a9814d;stroke-width:0;stroke-miterlimit:4"
+           x="492.91785"
+           y="277.10086"
+           width="8.7648525"
+           height="9.8560753"
+           id="rect12072" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="502.32797"
+           y="277.10086"
+           width="4.79916"
+           height="9.8560753"
+           id="rect12074" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="488.88495"
+           y="277.10086"
+           width="4.79916"
+           height="9.8560753"
+           id="rect12076" />
+        <path
+           id="path5376"
+           d="m 532.94311,107.25258 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5378"
+           d="m 529.69251,107.25258 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5386"
+           d="m 545.94554,107.25258 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5388"
+           d="m 542.69493,107.25258 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5390"
+           d="m 539.44433,107.25258 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5454"
+           d="m 529.69251,139.75864 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5456"
+           d="m 532.94311,139.75864 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5466"
+           d="m 539.44433,139.75864 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5468"
+           d="m 542.69493,139.75864 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5470"
+           d="m 545.94554,139.75864 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5612"
+           d="m 523.19129,126.75621 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5614"
+           d="m 523.19129,129.79011 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5616"
+           d="m 523.19129,133.04072 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5618"
+           d="m 549.19614,133.04072 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5620"
+           d="m 549.19614,129.79011 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5622"
+           d="m 549.19614,126.75621 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5624"
+           d="m 523.19129,113.9705 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5626"
+           d="m 523.19129,117.2211 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5628"
+           d="m 523.19129,120.255 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5630"
+           d="m 549.19614,120.255 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5632"
+           d="m 549.19614,117.2211 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5634"
+           d="m 549.19614,113.9705 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5636"
+           d="m 536.19372,107.25258 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5726"
+           d="m 523.19129,123.50561 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5728"
+           d="m 536.19372,139.75864 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5730"
+           d="m 549.19614,123.50561 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5738"
+           d="m 523.19129,110.71989 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path5740"
+           d="m 549.19614,110.71989 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <rect
+           style="fill:#6a6a6a;stroke:#000000;stroke-width:0.75847471;stroke-miterlimit:4;stroke-dasharray:none"
+           x="524.66852"
+           y="105.10838"
+           stroke-miterlimit="4"
+           width="26.32991"
+           height="33.806301"
+           id="rect4974" />
+        <path
+           id="path12832"
+           d="m 532.94311,107.25258 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12834"
+           d="m 529.69251,107.25258 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12836"
+           d="m 545.94554,107.25258 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12838"
+           d="m 542.69493,107.25258 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12840"
+           d="m 539.44433,107.25258 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12842"
+           d="m 529.69251,139.75864 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path13512"
+           d="m 532.94311,139.75864 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12846"
+           d="m 539.44433,139.75864 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path13515"
+           d="m 542.69493,139.75864 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12850"
+           d="m 545.94554,139.75864 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12852"
+           d="m 523.19129,126.75621 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12854"
+           d="m 523.19129,129.79011 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12856"
+           d="m 523.19129,133.04072 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12858"
+           d="m 549.19614,133.04072 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12860"
+           d="m 549.19614,129.79011 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12862"
+           d="m 549.19614,126.75621 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12864"
+           d="m 523.19129,113.9705 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12866"
+           d="m 523.19129,117.2211 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12868"
+           d="m 523.19129,120.255 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12870"
+           d="m 549.19614,120.255 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12872"
+           d="m 549.19614,117.2211 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12874"
+           d="m 549.19614,113.9705 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12876"
+           d="m 536.19372,107.25258 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12878"
+           d="m 523.19129,123.50561 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12880"
+           d="m 536.19372,139.75864 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12882"
+           d="m 549.19614,123.50561 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12884"
+           d="m 523.19129,110.71989 2.91472,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12886"
+           d="m 549.19614,110.71989 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <rect
+           style="fill:#6a6a6a;stroke:#000000;stroke-width:0.75847471;stroke-miterlimit:4;stroke-dasharray:none"
+           x="524.66852"
+           y="105.10838"
+           stroke-miterlimit="4"
+           width="26.32991"
+           height="33.806301"
+           id="rect12888" />
+        <path
+           id="path12894"
+           d="m 533.68543,149.16923 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12896"
+           d="m 530.43483,149.16923 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12898"
+           d="m 546.68786,149.16923 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12900"
+           d="m 543.43725,149.16923 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12902"
+           d="m 540.18665,149.16923 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12904"
+           d="m 530.43483,181.67529 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12906"
+           d="m 533.68543,181.67529 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12908"
+           d="m 540.18665,181.67529 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12910"
+           d="m 543.43725,181.67529 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12912"
+           d="m 546.68786,181.67529 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12914"
+           d="m 523.93362,168.67287 2.91471,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12916"
+           d="m 523.93362,171.70677 2.91471,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12918"
+           d="m 523.93362,174.95738 2.91471,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12920"
+           d="m 549.93846,174.95738 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12922"
+           d="m 549.93846,171.70677 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12924"
+           d="m 549.93846,168.67287 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12926"
+           d="m 523.93362,155.88715 2.91471,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12928"
+           d="m 523.93362,159.13776 2.91471,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12930"
+           d="m 523.93362,162.17166 2.91471,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12932"
+           d="m 549.93846,162.17166 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12934"
+           d="m 549.93846,159.13776 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12936"
+           d="m 549.93846,155.88715 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12938"
+           d="m 536.93604,149.16923 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12940"
+           d="m 523.93362,165.42226 2.91471,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12942"
+           d="m 536.93604,181.67529 0,-2.91471"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12944"
+           d="m 549.93846,165.42226 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12946"
+           d="m 523.93362,152.63655 2.91471,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <path
+           id="path12948"
+           d="m 549.93846,152.63655 2.75218,0"
+           inkscape:connector-curvature="0"
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
+        <rect
+           style="fill:#6a6a6a;stroke:#000000;stroke-width:0.75847471;stroke-miterlimit:4;stroke-dasharray:none"
+           x="525.41083"
+           y="147.02502"
+           stroke-miterlimit="4"
+           width="26.32991"
+           height="33.806301"
+           id="rect12950" />
+        <rect
+           style="fill:#6a6a6a;stroke:#000000;stroke-width:2.16960835;stroke-miterlimit:4;stroke-dasharray:none"
+           x="544.84949"
+           y="207.27293"
+           stroke-miterlimit="4"
+           width="45.789528"
+           height="46.029259"
+           ry="1.4983482"
+           id="rect3773" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 549.32105,206.71507 0,-4.7108"
+           id="path3777" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 549.32105,205.51639 0.12203,0"
+           id="path3779" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 551.7184,206.71507 0,-4.7108"
+           id="path3787" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 551.7184,205.51639 0.12203,0"
+           id="path3789" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 554.11576,206.71507 0,-4.7108"
+           id="path3793" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 554.11576,205.51639 0.12203,0"
+           id="path3795" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 556.51312,206.71507 0,-4.7108"
+           id="path3799" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 556.51312,205.51639 0.12203,0"
+           id="path3801" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 558.91048,206.71507 0,-4.7108"
+           id="path3805" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 558.91048,205.51639 0.12203,0"
+           id="path3807" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 561.30783,206.71507 0,-4.7108"
+           id="path3811" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 561.30783,205.51639 0.12203,0"
+           id="path3813" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 563.70519,206.71507 0,-4.7108"
+           id="path3817" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 563.70519,205.51639 0.12203,0"
+           id="path3819" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 566.10255,206.71507 0,-4.7108"
+           id="path3823" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 566.10255,205.51639 0.12203,0"
+           id="path3825" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 568.49991,206.71507 0,-4.7108"
+           id="path3829" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 568.49991,205.51639 0.12203,0"
+           id="path3831" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 570.89726,206.71507 0,-4.7108"
+           id="path3835" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 570.89726,205.51639 0.12203,0"
+           id="path3837" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 573.29462,206.71507 0,-4.7108"
+           id="path3841" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 573.29462,205.51639 0.12203,0"
+           id="path3843" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 575.69198,206.71507 0,-4.7108"
+           id="path3847" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 575.69198,205.51639 0.12203,0"
+           id="path3849" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 578.08934,206.71507 0,-4.7108"
+           id="path3853" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 578.08934,205.51639 0.12203,0"
+           id="path3855" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 580.48669,206.71507 0,-4.7108"
+           id="path3859" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 580.48669,205.51639 0.12203,0"
+           id="path3861" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 582.88405,206.71507 0,-4.7108"
+           id="path3865" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 582.88405,205.51639 0.12203,0"
+           id="path3867" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 585.28141,206.71507 0,-4.7108"
+           id="path3871" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 585.28141,205.51639 0.12203,0"
+           id="path3873" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,213.54644 4.71081,0"
+           id="path3929" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,213.54644 0,0.12202"
+           id="path3931" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,215.9438 4.71081,0"
+           id="path3935" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,215.9438 0,0.12202"
+           id="path3937" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,218.34116 4.71081,0"
+           id="path3941" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,218.34116 0,0.12202"
+           id="path3943" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,220.73851 4.71081,0"
+           id="path3947" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,220.73851 0,0.12202"
+           id="path3949" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,223.13587 4.71081,0"
+           id="path3953" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,223.13587 0,0.12202"
+           id="path3955" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,225.53323 4.71081,0"
+           id="path3959" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,225.53323 0,0.12202"
+           id="path3961" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,227.93058 4.71081,0"
+           id="path3965" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,227.93058 0,0.12202"
+           id="path3967" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,230.32794 4.71081,0"
+           id="path3971" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,230.32794 0,0.12202"
+           id="path3973" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,232.7253 4.71081,0"
+           id="path3977" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,232.7253 0,0.12202"
+           id="path3979" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,235.12266 4.71081,0"
+           id="path3983" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,235.12266 0,0.12202"
+           id="path3985" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,237.52001 4.71081,0"
+           id="path3989" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,237.52001 0,0.12202"
+           id="path3991" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,239.91737 4.71081,0"
+           id="path3995" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,239.91737 0,0.12202"
+           id="path3997" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,242.31473 4.71081,0"
+           id="path4001" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,242.31473 0,0.12202"
+           id="path4003" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,244.71208 4.71081,0"
+           id="path4007" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,244.71208 0,0.12202"
+           id="path4009" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,247.10944 4.71081,0"
+           id="path4013" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,247.10944 0,0.12202"
+           id="path4015" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 591.43136,249.5068 4.71081,0"
+           id="path4019" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 592.63004,249.5068 0,0.12202"
+           id="path4021" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,213.54644 -4.71081,0"
+           id="path4027" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,213.54644 0,0.12202"
+           id="path4029" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,215.9438 -4.71081,0"
+           id="path4033" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,215.9438 0,0.12202"
+           id="path4035" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,218.34116 -4.71081,0"
+           id="path4039" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,218.34116 0,0.12202"
+           id="path4041" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,220.73851 -4.71081,0"
+           id="path4045" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,220.73851 0,0.12202"
+           id="path4047" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,223.13587 -4.71081,0"
+           id="path4051" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,223.13587 0,0.12202"
+           id="path4053" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,225.53323 -4.71081,0"
+           id="path4057" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,225.53323 0,0.12202"
+           id="path4059" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,227.93058 -4.71081,0"
+           id="path4063" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,227.93058 0,0.12202"
+           id="path4065" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,230.32794 -4.71081,0"
+           id="path4069" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,230.32794 0,0.12202"
+           id="path4071" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,232.7253 -4.71081,0"
+           id="path4075" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,232.7253 0,0.12202"
+           id="path4077" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,235.12266 -4.71081,0"
+           id="path4081" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,235.12266 0,0.12202"
+           id="path4083" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,237.52001 -4.71081,0"
+           id="path4087" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,237.52001 0,0.12202"
+           id="path4089" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,239.91737 -4.71081,0"
+           id="path4093" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,239.91737 0,0.12202"
+           id="path4095" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,242.31473 -4.71081,0"
+           id="path4099" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,242.31473 0,0.12202"
+           id="path4101" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,244.71208 -4.71081,0"
+           id="path4105" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,244.71208 0,0.12202"
+           id="path4107" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,247.10944 -4.71081,0"
+           id="path4111" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,247.10944 0,0.12202"
+           id="path4113" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 543.76405,249.5068 -4.71081,0"
+           id="path4117" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 542.56537,249.5068 0,0.12202"
+           id="path4119" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 549.32105,253.94049 0,4.7108"
+           id="path4125" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 549.32105,255.13916 0.12203,0"
+           id="path4127" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 551.7184,253.94049 0,4.7108"
+           id="path4131" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 551.7184,255.13916 0.12203,0"
+           id="path4133" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 554.11576,253.94049 0,4.7108"
+           id="path4137" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 554.11576,255.13916 0.12203,0"
+           id="path4139" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 556.51312,253.94049 0,4.7108"
+           id="path4143" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 556.51312,255.13916 0.12203,0"
+           id="path4145" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 558.91048,253.94049 0,4.7108"
+           id="path4149" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 558.91048,255.13916 0.12203,0"
+           id="path4151" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 561.30783,253.94049 0,4.7108"
+           id="path4155" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 561.30783,255.13916 0.12203,0"
+           id="path4157" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 563.70519,253.94049 0,4.7108"
+           id="path4161" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 563.70519,255.13916 0.12203,0"
+           id="path4163" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 566.10255,253.94049 0,4.7108"
+           id="path4167" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 566.10255,255.13916 0.12203,0"
+           id="path4169" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 568.49991,253.94049 0,4.7108"
+           id="path4173" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 568.49991,255.13916 0.12203,0"
+           id="path4175" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 570.89726,253.94049 0,4.7108"
+           id="path4179" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 570.89726,255.13916 0.12203,0"
+           id="path4181" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 573.29462,253.94049 0,4.7108"
+           id="path4185" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 573.29462,255.13916 0.12203,0"
+           id="path4187" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 575.69198,253.94049 0,4.7108"
+           id="path4191" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 575.69198,255.13916 0.12203,0"
+           id="path4193" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 578.08934,253.94049 0,4.7108"
+           id="path4197" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 578.08934,255.13916 0.12203,0"
+           id="path4199" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 580.48669,253.94049 0,4.7108"
+           id="path4203-8" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 580.48669,255.13916 0.12203,0"
+           id="path4205" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 582.88405,253.94049 0,4.7108"
+           id="path4209" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 582.88405,255.13916 0.12203,0"
+           id="path4211-8" />
+        <path
+           style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 585.28141,253.94049 0,4.7108"
+           id="path4215-2" />
+        <path
+           style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
+           inkscape:connector-curvature="0"
+           d="m 585.28141,255.13916 0.12203,0"
+           id="path4217" />
+        <rect
+           id="rect4867"
+           height="2.7210622"
+           width="4.9367957"
+           y="274.48654"
+           x="584.37372"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect4869"
+           height="2.7210622"
+           width="1.135463"
+           y="274.48654"
+           x="586.16888"
+           style="fill:#8c8989" />
+        <rect
+           id="rect4877"
+           height="2.7210622"
+           width="4.9367957"
+           y="278.97452"
+           x="584.37372"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect4879"
+           height="2.7210622"
+           width="1.135463"
+           y="278.97452"
+           x="586.16888"
+           style="fill:#8c8989" />
+        <rect
+           id="rect4883"
+           height="2.7210622"
+           width="4.9367957"
+           y="283.46252"
+           x="584.37372"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect4885"
+           height="2.7210622"
+           width="1.135463"
+           y="283.46252"
+           x="586.16888"
+           style="fill:#8c8989" />
+        <rect
+           id="rect4889"
+           transform="scale(-1,1)"
+           height="2.7210622"
+           width="4.9367957"
+           y="283.46252"
+           x="-575.68927"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect4891"
+           transform="scale(-1,1)"
+           height="2.7210622"
+           width="1.135463"
+           y="283.46252"
+           x="-573.89404"
+           style="fill:#8c8989" />
+        <rect
+           id="rect4901"
+           transform="scale(-1,1)"
+           height="2.7210622"
+           width="4.9367957"
+           y="274.48654"
+           x="-575.68927"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect4903"
+           transform="scale(-1,1)"
+           height="2.7210622"
+           width="1.135463"
+           y="274.48654"
+           x="-573.89404"
+           style="fill:#8c8989" />
+        <rect
+           style="fill:#6a6a6a;stroke:#000000;stroke-width:1.08160698;stroke-miterlimit:4;stroke-dasharray:none"
+           x="575.72699"
+           y="273.93018"
+           stroke-miterlimit="4"
+           width="8.3925524"
+           height="14.271826"
+           ry="0.6731993"
+           id="rect4841" />
+        <rect
+           id="rect13881"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="2.7210624"
+           width="4.9367952"
+           y="-623.52423"
+           x="127.2851"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect13883"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="2.7210624"
+           width="1.1354629"
+           y="-623.52423"
+           x="129.08029"
+           style="fill:#8c8989" />
+        <rect
+           id="rect13887"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="2.7210624"
+           width="4.9367952"
+           y="-619.03619"
+           x="127.2851"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect13889"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="2.7210624"
+           width="1.1354629"
+           y="-619.03619"
+           x="129.08029"
+           style="fill:#8c8989" />
+        <rect
+           id="rect13893"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="2.7210624"
+           width="4.9367952"
+           y="-614.54822"
+           x="127.2851"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect13895"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="2.7210624"
+           width="1.1354629"
+           y="-614.54822"
+           x="129.08029"
+           style="fill:#8c8989" />
+        <rect
+           id="rect13899"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="2.7210624"
+           width="4.9367952"
+           y="-614.54822"
+           x="-118.60066"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect13901"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="2.7210624"
+           width="1.1354629"
+           y="-614.54822"
+           x="-116.80547"
+           style="fill:#8c8989" />
+        <rect
+           id="rect13905"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="2.7210624"
+           width="4.9367952"
+           y="-623.52423"
+           x="-118.60066"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect13907"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="2.7210624"
+           width="1.1354629"
+           y="-623.52423"
+           x="-116.80547"
+           style="fill:#8c8989" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#6a6a6a;stroke:#000000;stroke-width:1.08160698;stroke-miterlimit:4;stroke-dasharray:none"
+           x="118.63837"
+           y="-624.08057"
+           stroke-miterlimit="4"
+           width="8.3925524"
+           height="14.271827"
+           ry="0.67319936"
+           id="rect13909" />
+        <rect
+           style="fill:#fffcfc;stroke:#828282;stroke-width:2.17025805;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+           x="179.77756"
+           y="-467.97284"
+           stroke-miterlimit="4"
+           width="59.816059"
+           height="34.898285"
+           transform="matrix(0,1,-1,0,0,0)"
+           id="rect5020" />
+        <rect
+           id="rect4966-2"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="7.3681602"
+           y="-191.53841"
+           x="468.33835"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect4968-1"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="1.6946768"
+           y="-191.53841"
+           x="471.01767"
+           style="fill:#8c8989" />
+        <rect
+           id="rect5048"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="7.3681602"
+           y="-198.23674"
+           x="468.33835"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect5050"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="1.6946768"
+           y="-198.23674"
+           x="471.01767"
+           style="fill:#8c8989" />
+        <rect
+           id="rect5054"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="7.3681602"
+           y="-204.93506"
+           x="468.33835"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect5056"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="1.6946768"
+           y="-204.93506"
+           x="471.01767"
+           style="fill:#8c8989" />
+        <rect
+           id="rect5060"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="7.3681602"
+           y="-211.63339"
+           x="468.33835"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect5062"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="1.6946768"
+           y="-211.63339"
+           x="471.01767"
+           style="fill:#8c8989" />
+        <rect
+           id="rect5066"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="7.3681602"
+           y="-218.33173"
+           x="468.33835"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect5068"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="1.6946768"
+           y="-218.33173"
+           x="471.01767"
+           style="fill:#8c8989" />
+        <rect
+           id="rect5072"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="7.3681602"
+           y="-225.03006"
+           x="468.33835"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect5074"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="1.6946768"
+           y="-225.03006"
+           x="471.01767"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14000"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="7.3681602"
+           y="-231.53119"
+           x="468.33835"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14002"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="1.6946768"
+           y="-231.53119"
+           x="471.01767"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14006"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="7.3681602"
+           y="-238.0323"
+           x="468.33835"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14008"
+           transform="scale(1,-1)"
+           height="4.0611815"
+           width="1.6946768"
+           y="-238.0323"
+           x="471.01767"
+           style="fill:#8c8989" />
+        <rect
+           id="rect4867-0"
+           transform="scale(-1,-1)"
+           height="3.9238191"
+           width="5.7475319"
+           y="-273.86774"
+           x="-456.31073"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect4869-4"
+           transform="scale(-1,-1)"
+           height="3.9238191"
+           width="1.3219323"
+           y="-273.86774"
+           x="-454.2207"
+           style="fill:#8c8989" />
+        <rect
+           id="rect4877-3"
+           transform="scale(-1,-1)"
+           height="3.9238191"
+           width="5.7475319"
+           y="-267.39597"
+           x="-456.31073"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect4879-4"
+           transform="scale(-1,-1)"
+           height="3.9238191"
+           width="1.3219323"
+           y="-267.39597"
+           x="-454.2207"
+           style="fill:#8c8989" />
+        <rect
+           id="rect4883-6"
+           transform="scale(-1,-1)"
+           height="3.9238191"
+           width="5.7475319"
+           y="-260.92419"
+           x="-456.31073"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect4885-2"
+           transform="scale(-1,-1)"
+           height="3.9238191"
+           width="1.3219323"
+           y="-260.92419"
+           x="-454.2207"
+           style="fill:#8c8989" />
+        <rect
+           id="rect4889-3"
+           transform="scale(1,-1)"
+           height="3.9238191"
+           width="5.7475319"
+           y="-260.92419"
+           x="466.42136"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect4891-3"
+           transform="scale(1,-1)"
+           height="3.9238191"
+           width="1.3219323"
+           y="-260.92419"
+           x="468.51135"
+           style="fill:#8c8989" />
+        <rect
+           id="rect4901-7"
+           transform="scale(1,-1)"
+           height="3.9238191"
+           width="5.7475319"
+           y="-273.86774"
+           x="466.42136"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect4903-8"
+           transform="scale(1,-1)"
+           height="3.9238191"
+           width="1.3219323"
+           y="-273.86774"
+           x="468.51135"
+           style="fill:#8c8989" />
+        <rect
+           transform="scale(-1,-1)"
+           style="fill:#6a6a6a;stroke:#000000;stroke-width:1.0816052;stroke-miterlimit:4;stroke-dasharray:none"
+           x="-466.37744"
+           y="-274.67001"
+           stroke-miterlimit="4"
+           width="9.7708044"
+           height="20.580219"
+           ry="0.97076511"
+           id="rect4841-1" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           x="-308.31299"
+           y="621.14215"
+           width="3.868221"
+           height="5.5151954"
+           id="rect14080"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4" />
+        <rect
+           transform="matrix(0,-1,1,0,0,0)"
+           x="-316.98129"
+           y="621.14215"
+           width="3.868221"
+           height="5.5151954"
+           id="rect14082"
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4" />
+        <rect
+           style="fill:#fffcfc;stroke:#828282;stroke-width:2.1680696;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+           x="490.68149"
+           y="296.49902"
+           stroke-miterlimit="4"
+           width="35.702084"
+           height="27.293268"
+           id="rect14086" />
+        <rect
+           id="rect14090"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="5.7624946"
+           y="-502.82507"
+           x="-295.9913"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14092"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="1.3253738"
+           y="-502.82507"
+           x="-293.89584"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14096"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="5.7624946"
+           y="-509.52341"
+           x="-295.9913"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14098"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="1.3253738"
+           y="-509.52341"
+           x="-293.89584"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14102"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="5.7624946"
+           y="-516.22174"
+           x="-295.9913"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14104"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="1.3253738"
+           y="-516.22174"
+           x="-293.89584"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14108"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="5.7624946"
+           y="-522.9201"
+           x="-295.9913"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14110"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="1.3253738"
+           y="-522.9201"
+           x="-293.89584"
+           style="fill:#8c8989" />
+        <rect
+           style="fill:#fffcfc;stroke:#828282;stroke-width:2.1680696;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+           x="575.19727"
+           y="296.49902"
+           stroke-miterlimit="4"
+           width="35.702084"
+           height="27.293268"
+           id="rect14138" />
+        <rect
+           id="rect14142"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="5.7624946"
+           y="-587.34082"
+           x="-295.9913"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14144"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="1.3253738"
+           y="-587.34082"
+           x="-293.89584"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14148"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="5.7624946"
+           y="-594.03918"
+           x="-295.9913"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14150"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="1.3253738"
+           y="-594.03918"
+           x="-293.89584"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14154"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="5.7624946"
+           y="-600.73749"
+           x="-295.9913"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14156"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="1.3253738"
+           y="-600.73749"
+           x="-293.89584"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14160"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="5.7624946"
+           y="-607.43579"
+           x="-295.9913"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14162"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.061182"
+           width="1.3253738"
+           y="-607.43579"
+           x="-293.89584"
+           style="fill:#8c8989" />
+        <rect
+           style="fill:#00440d;stroke-width:0;stroke-miterlimit:4"
+           x="631.93884"
+           y="249.09335"
+           width="16.967201"
+           height="21.734783"
+           id="rect14166" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="650.15515"
+           y="249.09335"
+           width="9.2903233"
+           height="21.734783"
+           id="rect14168" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="624.13184"
+           y="249.09335"
+           width="9.2903233"
+           height="21.734783"
+           id="rect14170" />
+        <rect
+           id="rect14172"
+           height="30.880756"
+           width="20.045404"
+           stroke-miterlimit="4"
+           y="112.47642"
+           x="577.76172"
+           style="fill:#6a6a6a;stroke:#000000;stroke-width:0.75847471;stroke-miterlimit:4;stroke-dasharray:none" />
+        <rect
+           style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
+           x="474.20758"
+           y="135.60159"
+           width="7.064651"
+           height="5.5151949"
+           id="rect14194" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="481.79233"
+           y="135.60159"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect14196" />
+        <rect
+           style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
+           x="470.957"
+           y="135.60159"
+           width="3.8682213"
+           height="5.5151949"
+           id="rect14198" />
+        <rect
+           id="rect14204"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="4.0624456"
+           width="7.6110497"
+           y="-563.91339"
+           x="308.06442"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14206"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="4.0624456"
+           width="1.7505414"
+           y="-563.91339"
+           x="310.83209"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14210"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="4.0624456"
+           width="7.6110497"
+           y="-557.21295"
+           x="308.06442"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14212"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="4.0624456"
+           width="1.7505414"
+           y="-557.21295"
+           x="310.83209"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14216"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="4.0624456"
+           width="7.6110497"
+           y="-550.51251"
+           x="308.06442"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14218"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="4.0624456"
+           width="1.7505414"
+           y="-550.51251"
+           x="310.83209"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14222"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.0624456"
+           width="7.6110497"
+           y="-550.51251"
+           x="-286.00735"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14224"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.0624456"
+           width="1.7505414"
+           y="-550.51251"
+           x="-283.23969"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14228"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.0624456"
+           width="7.6110497"
+           y="-563.91339"
+           x="-286.00735"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14230"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.0624456"
+           width="1.7505414"
+           y="-563.91339"
+           x="-283.23969"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14242"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.0624456"
+           width="7.6110497"
+           y="-556.98328"
+           x="-286.00735"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14244"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.0624456"
+           width="1.7505414"
+           y="-556.98328"
+           x="-283.23969"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14248"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.0624456"
+           width="7.6110497"
+           y="-544.04181"
+           x="-286.00735"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14250"
+           transform="matrix(0,-1,-1,0,0,0)"
+           height="4.0624456"
+           width="1.7505414"
+           y="-544.04181"
+           x="-283.23969"
+           style="fill:#8c8989" />
+        <rect
+           id="rect14254"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="4.0624456"
+           width="7.6110497"
+           y="-544.04181"
+           x="308.06442"
+           style="fill:#e9dcdc" />
+        <rect
+           id="rect14256"
+           transform="matrix(0,1,-1,0,0,0)"
+           height="4.0624456"
+           width="1.7505414"
+           y="-544.04181"
+           x="310.83209"
+           style="fill:#8c8989" />
+        <rect
+           transform="matrix(0,1,-1,0,0,0)"
+           style="fill:#6a6a6a;stroke:#000000;stroke-width:1.08261442;stroke-miterlimit:4;stroke-dasharray:none"
+           x="284.95566"
+           y="-564.74396"
+           stroke-miterlimit="4"
+           width="24.216976"
+           height="27.404684"
+           ry="1.2931794"
+           id="rect14232" />
+        <path
+           style="fill:url(#linearGradient8752)"
+           inkscape:connector-curvature="0"
+           d="m 530.25061,73.31614 9.00763,0 0,25.796734 22.41432,0 0,-25.796734 9.55228,0 -20.46617,-19.904887 z"
+           id="path10151-2" />
+        <image
+           xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAABcCAYAAABTEPRqAAAABHNCSVQICAgIfAhkiAAAAydJREFU SInN1kuIV3UUB/DPGf8jhmVYkxNRiwpbBGGSMSRGNW1CJdEw3NWmVYGFYVmLHsta9JpqUbkpmuiF aS8oJCMjDYUQQnSSiYIeOiTZa5z01+KeO3Pn//8PtQnmwuX+fud873n/zvkppahfnI+fUXBBKUWT 2cJHyZwOwI34usHsAOxL4gszAYawCr1dAQ07OgA9/uWZDYBW2/4UHsn1CYh073+04b8ZGRELcBeu xt/4AkOllHE4U2eqC3ZjDtyThFGswEr8mbSbW6oM7sGbpZTPUuXnGMRl09LdSPlYSljdzgxsTeZh zG0HPJ3McdzQXtX3JXMCayfpyVyP0ziJdU2pgSuwF/PwKl5uBHIEnuoSpPp9uIXzsGuGVIzOpnpY hDtxJX7CS6WUPTWoH0dMd28C19UObEnix7gcz+f+rRqwHPdjaRJuSsChbsd/Lb5MwJb2bM5v2LB9 WjYTsAgP4dME7ehQkcC5OJ6gZT0RsToiNkXEpVBKOYnvMwRXwXuJHsYZqpZY27IcrlHVYMEfDeZw s+QG8D6+w348gFYpZVb0hw5ARKyJiE8iYjM6ktVnaqBs7darn1Udg04VEXELbpX9cRogIvrwHH7A k01A3WmfUaV7LS6eJiEi1mEDXi+lbOvwCj+qKvuJ9GCFajztwxuRLs30lMDdbcTrsUbV+Ya7lVzd N7sGiqrcduEgs2terMK1XfiP167t0L0NLq6TtSS/j6lmRf2MwcJEH28PWh2o+u+JiPggIg5GxIsR cU4tZmND54nG+gB656gax++qQ7wer+A2XIjRDp3p1faUMtSKiKW4BF+VUkZSbW9+/6KaEUV1uudh MX5L2kpYampO/qKavJONrNa5DO/gW9X0edQs6g+Tl5yI6FeV/AJsK6UcxaQXg6YGelG5urF2YD6O JeM1bE7AGM5q4XaciyOllA2pbjzVL2zJfozdETGgmjo7SykHavs+TPEjDRtO4d7ahr0NwzbhDvya +yXwbgJ2N+rh7aQ92GNqNhxrxOeb/Pb3YGduBiPi7FzXh2iE6jJ1OEUeNXWFPoa+WudFqpvX6WQe wkApxT8athIE2BWsmgAAAABJRU5ErkJggg== "
+           width="8"
+           height="92"
+           transform="translate(671,142.51434)"
+           id="image10745" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer2"
+       inkscape:label="revo"
+       style="display:inline">
+      <g
+         transform="translate(-17.131942,-13.548786)"
+         id="controller-revomini"
+         inkscape:label="#controller">
+        <image
+           xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAABcCAYAAABTEPRqAAAABHNCSVQICAgIfAhkiAAAAydJREFU SInN1kuIV3UUB/DPGf8jhmVYkxNRiwpbBGGSMSRGNW1CJdEw3NWmVYGFYVmLHsta9JpqUbkpmuiF aS8oJCMjDYUQQnSSiYIeOiTZa5z01+KeO3Pn//8PtQnmwuX+fud873n/zvkppahfnI+fUXBBKUWT 2cJHyZwOwI34usHsAOxL4gszAYawCr1dAQ07OgA9/uWZDYBW2/4UHsn1CYh073+04b8ZGRELcBeu xt/4AkOllHE4U2eqC3ZjDtyThFGswEr8mbSbW6oM7sGbpZTPUuXnGMRl09LdSPlYSljdzgxsTeZh zG0HPJ3McdzQXtX3JXMCayfpyVyP0ziJdU2pgSuwF/PwKl5uBHIEnuoSpPp9uIXzsGuGVIzOpnpY hDtxJX7CS6WUPTWoH0dMd28C19UObEnix7gcz+f+rRqwHPdjaRJuSsChbsd/Lb5MwJb2bM5v2LB9 WjYTsAgP4dME7ehQkcC5OJ6gZT0RsToiNkXEpVBKOYnvMwRXwXuJHsYZqpZY27IcrlHVYMEfDeZw s+QG8D6+w348gFYpZVb0hw5ARKyJiE8iYjM6ktVnaqBs7darn1Udg04VEXELbpX9cRogIvrwHH7A k01A3WmfUaV7LS6eJiEi1mEDXi+lbOvwCj+qKvuJ9GCFajztwxuRLs30lMDdbcTrsUbV+Ya7lVzd N7sGiqrcduEgs2terMK1XfiP167t0L0NLq6TtSS/j6lmRf2MwcJEH28PWh2o+u+JiPggIg5GxIsR cU4tZmND54nG+gB656gax++qQ7wer+A2XIjRDp3p1faUMtSKiKW4BF+VUkZSbW9+/6KaEUV1uudh MX5L2kpYampO/qKavJONrNa5DO/gW9X0edQs6g+Tl5yI6FeV/AJsK6UcxaQXg6YGelG5urF2YD6O JeM1bE7AGM5q4XaciyOllA2pbjzVL2zJfozdETGgmjo7SykHavs+TPEjDRtO4d7ahr0NwzbhDvya +yXwbgJ2N+rh7aQ92GNqNhxrxOeb/Pb3YGduBiPi7FzXh2iE6jJ1OEUeNXWFPoa+WudFqpvX6WQe wkApxT8athIE2BWsmgAAAABJRU5ErkJggg== "
+           width="8"
+           height="92"
+           transform="translate(671,142.51434)"
+           id="image10745-4" />
+        <g
+           id="g8076"
+           inkscape:label="#controller-revomini">
+          <path
+             id="path10151-2-3"
+             d="m 530.25061,73.31614 9.00763,0 0,25.796734 22.41432,0 0,-25.796734 9.55228,0 -20.46617,-19.904887 z"
+             inkscape:connector-curvature="0"
+             style="fill:url(#linearGradient8734)" />
+          <g
+             id="g8764"
+             transform="matrix(1.0887723,0,0,1.065281,432.61098,99.35125)">
+            <path
+               d="m 203.083,1.012 -183.511,0 c -7.224,0 -13.08,4.478 -13.08,10 l 0,190.038 c 0,5.522 5.855,10 13.08,10 l 183.512,0 c 7.223,0 13.079,-4.478 13.079,-10 l 0,-190.038 c 0,-5.523 -5.857,-10 -13.08,-10 z M 19.523,204.315 c -3.92,0 -7.098,-3.178 -7.098,-7.097 0,-3.92 3.178,-7.097 7.098,-7.097 3.918,0 7.096,3.177 7.096,7.097 0,3.92 -3.178,7.097 -7.096,7.097 z M 19.522,21.924 c -3.919,0 -7.097,-3.178 -7.097,-7.097 0,-3.919 3.178,-7.097 7.097,-7.097 3.919,0 7.097,3.177 7.097,7.097 0,3.919 -3.178,7.097 -7.097,7.097 z m 182.942,182.064 c -3.92,0 -7.098,-3.178 -7.098,-7.098 0,-3.919 3.178,-7.096 7.098,-7.096 3.918,0 7.096,3.177 7.096,7.096 0,3.921 -3.178,7.098 -7.096,7.098 z m 0.194,-183.487 c -3.92,0 -7.098,-3.178 -7.098,-7.097 0,-3.919 3.178,-7.097 7.098,-7.097 3.918,0 7.096,3.177 7.096,7.097 -0.001,3.92 -3.178,7.097 -7.096,7.097 z"
+               id="path8131"
+               inkscape:connector-curvature="0"
+               style="fill:#ffffff;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round" />
+            <rect
+               id="rect4320-3"
+               x="140.19701"
+               y="135.117"
+               width="6.5190001"
+               height="5.0900002"
+               style="fill:#312d29" />
+            <rect
+               id="rect4322-2"
+               x="146.67"
+               y="135.117"
+               width="3.5710001"
+               height="5.0900002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4324-1"
+               x="136.67"
+               y="135.117"
+               width="3.5710001"
+               height="5.0900002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4320_1_"
+               x="166.8"
+               y="24.256001"
+               width="5.0900002"
+               height="6.5190001"
+               style="fill:#312d29" />
+            <rect
+               id="rect4322_1_"
+               x="166.8"
+               y="30.73"
+               width="5.0900002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4324_1_"
+               x="166.8"
+               y="20.73"
+               width="5.0900002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4408-1"
+               x="164.828"
+               y="145.592"
+               width="6.5180001"
+               height="5.0879998"
+               style="fill:#312d29" />
+            <rect
+               id="rect4410-3"
+               x="161.3"
+               y="145.592"
+               width="3.572"
+               height="5.0879998"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4412-2"
+               x="171.3"
+               y="145.592"
+               width="3.572"
+               height="5.0879998"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4408_1_"
+               x="166.828"
+               y="138.592"
+               width="6.5180001"
+               height="5.0879998"
+               style="fill:#312d29" />
+            <rect
+               id="rect4410_1_"
+               x="163.3"
+               y="138.592"
+               width="3.572"
+               height="5.0879998"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4412_1_"
+               x="173.3"
+               y="138.592"
+               width="3.572"
+               height="5.0879998"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10515-5"
+               x="86.940002"
+               y="152.383"
+               width="5.0900002"
+               height="6.5180001"
+               style="fill:#312d29" />
+            <rect
+               id="rect10517-3"
+               x="86.940002"
+               y="158.856"
+               width="5.0900002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10519-5"
+               x="86.940002"
+               y="148.856"
+               width="5.0900002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10515_1_"
+               x="79.940002"
+               y="152.383"
+               width="5.0900002"
+               height="6.5180001"
+               style="fill:#312d29" />
+            <rect
+               id="rect10517_1_"
+               x="79.940002"
+               y="158.856"
+               width="5.0900002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10519_1_"
+               x="79.940002"
+               y="148.856"
+               width="5.0900002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4219-1"
+               x="57.810001"
+               y="145.991"
+               width="6.5180001"
+               height="5.0890002"
+               style="fill:#bc781e" />
+            <rect
+               id="rect4221-2"
+               x="64.282997"
+               y="145.991"
+               width="3.5710001"
+               height="5.0890002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4223-2"
+               x="54.283001"
+               y="145.991"
+               width="3.5710001"
+               height="5.0890002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10550-2"
+               x="127.165"
+               y="150.646"
+               width="5.0900002"
+               height="6.5180001"
+               style="fill:#bc781e" />
+            <rect
+               id="rect10552-6"
+               x="127.165"
+               y="157.121"
+               width="5.0900002"
+               height="3.5699999"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10554-4"
+               x="127.165"
+               y="147.121"
+               width="5.0900002"
+               height="3.5699999"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10558-0"
+               x="120.317"
+               y="156.90601"
+               width="5.0879998"
+               height="6.5180001"
+               style="fill:#bc781e" />
+            <rect
+               id="rect10560-7"
+               x="120.317"
+               y="163.381"
+               width="5.0879998"
+               height="3.5699999"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10562-0"
+               x="120.317"
+               y="153.381"
+               width="5.0890002"
+               height="3.5699999"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10566-3"
+               x="156.007"
+               y="96.193001"
+               width="5.0900002"
+               height="6.5180001"
+               style="fill:#bc781e" />
+            <rect
+               id="rect10568-4"
+               x="156.007"
+               y="102.666"
+               width="5.0900002"
+               height="3.572"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10570-0"
+               x="156.007"
+               y="92.666"
+               width="5.0900002"
+               height="3.572"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10566_1_"
+               x="148.007"
+               y="96.193001"
+               width="5.0900002"
+               height="6.5180001"
+               style="fill:#bc781e" />
+            <rect
+               id="rect10568_1_"
+               x="148.007"
+               y="102.666"
+               width="5.0900002"
+               height="3.572"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10570_1_"
+               x="148.007"
+               y="92.666"
+               width="5.0900002"
+               height="3.572"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10574-0"
+               x="167.77499"
+               y="6.96"
+               width="6.5180001"
+               height="5.0890002"
+               style="fill:#bc781e" />
+            <rect
+               id="rect10576-5"
+               x="174.24899"
+               y="6.96"
+               width="3.5710001"
+               height="5.0890002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10578-3"
+               x="164.24899"
+               y="6.96"
+               width="3.5710001"
+               height="5.0890002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4416-1"
+               x="16.167"
+               y="46.223"
+               width="6.5180001"
+               height="5.0890002"
+               style="fill:#42a839" />
+            <rect
+               id="rect4418-0"
+               x="22.639999"
+               y="46.223"
+               width="3.572"
+               height="5.0890002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4420-6"
+               x="12.64"
+               y="46.223"
+               width="3.572"
+               height="5.0890002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4416_1_"
+               x="43.869999"
+               y="172.005"
+               width="6.5180001"
+               height="5.0900002"
+               style="fill:#fbac0c" />
+            <rect
+               id="rect4418_1_"
+               x="50.342999"
+               y="172.005"
+               width="3.572"
+               height="5.0900002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4420_1_"
+               x="40.342999"
+               y="172.005"
+               width="3.572"
+               height="5.0900002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4416_2_"
+               x="43.869999"
+               y="162.005"
+               width="6.5180001"
+               height="5.0900002"
+               style="fill:#20abcc" />
+            <rect
+               id="rect4418_2_"
+               x="50.342999"
+               y="162.005"
+               width="3.572"
+               height="5.0900002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4420_2_"
+               x="40.342999"
+               y="162.005"
+               width="3.572"
+               height="5.0900002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4432-7"
+               x="15.838"
+               y="58.402"
+               width="6.5180001"
+               height="5.0890002"
+               style="fill:#ff7900" />
+            <rect
+               id="rect4434-5"
+               x="22.311001"
+               y="58.402"
+               width="3.5710001"
+               height="5.0890002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4436-0"
+               x="12.311"
+               y="58.402"
+               width="3.5710001"
+               height="5.0890002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4280-0"
+               x="69.966003"
+               y="20.334"
+               width="5.0890002"
+               height="6.5180001"
+               style="fill:#bc781e" />
+            <rect
+               id="rect4282-4"
+               x="69.966003"
+               y="26.808001"
+               width="5.0890002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4284-5"
+               x="69.966003"
+               y="16.808001"
+               width="5.0890002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10763-4"
+               x="75.407997"
+               y="56.049"
+               width="5.0890002"
+               height="6.5180001"
+               style="fill:#bc781e" />
+            <rect
+               id="rect10765-9"
+               x="75.407997"
+               y="62.521999"
+               width="5.0890002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10767-5"
+               x="75.407997"
+               y="52.521999"
+               width="5.0890002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10771-6"
+               x="91.143997"
+               y="52.145"
+               width="6.5180001"
+               height="5.0900002"
+               style="fill:#bc781e" />
+            <rect
+               id="rect10773-4"
+               x="87.615997"
+               y="52.145"
+               width="3.572"
+               height="5.0900002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10775-8"
+               x="97.615997"
+               y="52.145"
+               width="3.572"
+               height="5.0900002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10779-2"
+               x="57.523998"
+               y="131.85699"
+               width="5.0890002"
+               height="6.5180001"
+               style="fill:#bc781e" />
+            <rect
+               id="rect10781-1"
+               x="57.523998"
+               y="138.33099"
+               width="5.0890002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10783-6"
+               x="57.523998"
+               y="128.33099"
+               width="5.0890002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10795-8"
+               x="113.275"
+               y="151.013"
+               width="5.0900002"
+               height="6.5180001"
+               style="fill:#bc781e" />
+            <rect
+               id="rect10797-3"
+               x="113.275"
+               y="157.485"
+               width="5.0900002"
+               height="3.572"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10799-1"
+               x="113.275"
+               y="147.485"
+               width="5.0900002"
+               height="3.572"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10803-4"
+               x="73.119003"
+               y="119.482"
+               width="5.0890002"
+               height="6.5190001"
+               style="fill:#312d29" />
+            <rect
+               id="rect10805-8"
+               x="73.119003"
+               y="115.956"
+               width="5.0890002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10807-4"
+               x="73.119003"
+               y="125.956"
+               width="5.0890002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10819-9"
+               x="50.306999"
+               y="127.865"
+               width="5.0890002"
+               height="6.5190001"
+               style="fill:#312d29" />
+            <rect
+               id="rect10821-2"
+               x="50.306999"
+               y="124.339"
+               width="5.0890002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10823-0"
+               x="50.306999"
+               y="134.339"
+               width="5.0890002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10819_1_"
+               x="43.306999"
+               y="127.865"
+               width="5.0890002"
+               height="6.5190001"
+               style="fill:#312d29" />
+            <rect
+               id="rect10821_1_"
+               x="43.306999"
+               y="124.339"
+               width="5.0890002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10823_1_"
+               x="43.306999"
+               y="134.339"
+               width="5.0890002"
+               height="3.5710001"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10827-7"
+               x="45.959"
+               y="52.146999"
+               width="5.0890002"
+               height="6.5180001"
+               style="fill:#312d29" />
+            <rect
+               id="rect10829-0"
+               x="45.959"
+               y="48.620998"
+               width="5.0890002"
+               height="3.572"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10831-6"
+               x="45.959"
+               y="58.620998"
+               width="5.0890002"
+               height="3.572"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10827_1_"
+               x="52.959"
+               y="52.146999"
+               width="5.0890002"
+               height="6.5180001"
+               style="fill:#312d29" />
+            <rect
+               id="rect10829_1_"
+               x="52.959"
+               y="48.620998"
+               width="5.0890002"
+               height="3.572"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect10831_1_"
+               x="52.959"
+               y="58.620998"
+               width="5.0890002"
+               height="3.572"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4556-0"
+               x="170.64"
+               y="41.332001"
+               width="9.6429996"
+               height="8.5710001"
+               style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            <rect
+               id="rect10898-7"
+               x="170.64"
+               y="56.332001"
+               width="9.6429996"
+               height="8.5710001"
+               style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            <rect
+               id="rect10906-0"
+               x="170.64"
+               y="71.332001"
+               width="9.6429996"
+               height="8.5710001"
+               style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            <rect
+               id="rect10914-5"
+               x="170.64"
+               y="86.332001"
+               width="9.6429996"
+               height="8.5710001"
+               style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            <rect
+               id="rect10922-6"
+               x="170.64"
+               y="101.332"
+               width="9.6429996"
+               height="8.5710001"
+               style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            <rect
+               id="rect10930-7"
+               x="170.64"
+               y="116.332"
+               width="9.6429996"
+               height="8.5710001"
+               style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            <rect
+               id="rect4790-3"
+               x="36.320999"
+               y="30.511"
+               width="9.0950003"
+               height="8.0860004"
+               style="fill:#a9814d" />
+            <rect
+               id="rect4792-8"
+               x="36.320999"
+               y="38.542"
+               width="9.0950003"
+               height="4.4310002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect4794-4"
+               x="36.320999"
+               y="26.135"
+               width="9.0950003"
+               height="4.4310002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect12056-9"
+               x="50.665001"
+               y="16.808001"
+               width="8.0860004"
+               height="9.0950003"
+               style="fill:#a9814d" />
+            <rect
+               id="rect12058-2"
+               x="46.289001"
+               y="16.808001"
+               width="4.4310002"
+               height="9.0950003"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect12060-6"
+               x="58.695"
+               y="16.808001"
+               width="4.4320002"
+               height="9.0950003"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect12064-5"
+               x="150.177"
+               y="73.853996"
+               width="8.0860004"
+               height="9.0950003"
+               style="fill:#a9814d" />
+            <rect
+               id="rect12066-7"
+               x="158.20799"
+               y="73.853996"
+               width="4.4310002"
+               height="9.0950003"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect12068-7"
+               x="145.802"
+               y="73.853996"
+               width="4.4310002"
+               height="9.0950003"
+               style="fill:#d3d0ce" />
+            <path
+               id="path5376-4"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 97.239,22.516 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5378-5"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 94.402,22.516 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5386-7"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 109.033,22.516 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5388-9"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 106.047,22.516 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5390-8"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 103.21,22.516 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5454-3"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 94.402,47.442 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5456-0"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 97.239,47.442 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5466-2"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 103.21,47.442 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5468-2"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 106.047,47.442 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5470-3"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 109.033,47.442 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5612-6"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,37.521 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5614-7"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,39.877 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5616-1"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,42.357 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5618-5"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,42.357 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5620-5"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,39.877 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5622-4"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,37.521 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5624-0"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,27.724 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5626-2"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,30.204 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5628-6"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,32.561 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5630-0"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,32.561 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5632-6"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,30.204 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5634-1"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,27.724 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5636-1"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 100.225,22.516 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5726-1"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,35.041 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5728-7"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 100.225,47.442 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5730-3"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,35.041 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5738-0"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,25.244 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path5740-0"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,25.244 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <rect
+               id="rect4974-4"
+               x="89.485001"
+               y="20.92"
+               width="24.347"
+               height="25.917999"
+               style="fill:#6a6a6a;stroke:#000000;stroke-width:0.69999999" />
+            <path
+               id="path12832-8"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 97.239,22.516 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12834-3"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 94.402,22.516 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12836-0"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 109.033,22.516 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12838-1"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 106.047,22.516 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12840-2"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 103.21,22.516 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12842-9"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 94.402,47.442 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12844"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 97.239,47.442 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12846-0"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 103.21,47.442 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12848"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 106.047,47.442 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12850-3"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 109.033,47.442 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12852-8"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,37.521 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12854-8"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,39.877 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12856-5"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,42.357 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12858-7"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,42.357 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12860-7"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,39.877 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12862-0"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,37.521 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12864-8"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,27.724 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12866-9"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,30.204 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12868-3"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,32.561 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12870-0"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,32.561 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12872-7"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,30.204 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12874-4"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,27.724 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12876-7"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 100.225,22.516 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12878-8"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,35.041 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12880-3"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 100.225,47.442 0,-2.232"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12882-7"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,35.041 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12884-1"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 88.281,25.244 2.687,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12886-0"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 112.466,25.244 2.539,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <rect
+               id="rect12888-0"
+               x="89.485001"
+               y="20.92"
+               width="24.347"
+               height="25.917999"
+               style="fill:#3e3e3e;stroke:#000000;stroke-width:0.69999999" />
+            <path
+               id="path12832_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 142.249,51.205 0,-1.801"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12834_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 139.96,51.205 0,-1.801"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12836_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 151.763,51.205 0,-1.801"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12838_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 149.354,51.205 0,-1.801"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12840_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 147.066,51.205 0,-1.801"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12842_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 139.96,71.312 0,-1.801"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12844_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 142.249,71.312 0,-1.801"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12846_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 147.066,71.312 0,-1.801"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12848_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 149.354,71.312 0,-1.801"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12850_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 151.763,71.312 0,-1.801"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12852_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 135.023,63.309 2.168,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12854_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 135.023,65.209 2.168,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12856_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 135.023,67.21 2.168,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12858_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 154.533,67.21 2.047,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12860_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 154.533,65.209 2.047,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12862_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 154.533,63.309 2.047,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12864_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 135.023,55.406 2.168,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12866_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 135.023,57.407 2.168,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12868_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 135.023,59.308 2.168,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12870_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 154.533,59.308 2.047,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12872_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 154.533,57.407 2.047,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12874_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 154.533,55.406 2.047,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12876_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 144.658,51.205 0,-1.801"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12878_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 135.023,61.308 2.168,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12880_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 144.658,71.312 0,-1.801"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12882_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 154.533,61.308 2.047,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12884_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 135.023,53.405 2.168,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <path
+               id="path12886_1_"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="10"
+               d="m 154.533,53.405 2.047,0"
+               style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10" />
+            <rect
+               id="rect12888_1_"
+               x="135.994"
+               y="49.917"
+               width="19.639"
+               height="20.907"
+               style="fill:#4a4a4a;stroke:#000000;stroke-width:0.69999999" />
+            <path
+               id="rect3773-8"
+               d="m 75.291,79.213 53.691,0 c 1.039,0 1.879,0.841 1.879,1.879 l 0,53.959 c 0,1.039 -0.84,1.879 -1.879,1.879 l -53.691,0 c -1.038,0 -1.879,-0.84 -1.879,-1.879 l 0,-53.958 c 0,-1.038 0.841,-1.88 1.879,-1.88 z"
+               inkscape:connector-curvature="0"
+               style="fill:#434242;stroke:#000000;stroke-width:3.6157999" />
+            <g
+               id="g3781"
+               transform="matrix(1.4970318,0,0,1,-211.28069,0.21205357)">
+              <path
+                 id="path3777-3"
+                 inkscape:connector-curvature="0"
+                 d="m 193.993,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3779-4"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 193.941,76.477 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3785"
+               transform="matrix(1.4970318,0,0,1,-207.28069,0.21205357)">
+              <path
+                 id="path3787-5"
+                 inkscape:connector-curvature="0"
+                 d="m 193.329,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3789-0"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 193.278,76.477 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3791"
+               transform="matrix(1.4970318,0,0,1,-203.28069,0.21205357)">
+              <path
+                 id="path3793-1"
+                 inkscape:connector-curvature="0"
+                 d="m 192.665,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3795-4"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 192.614,76.477 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3797"
+               transform="matrix(1.4970318,0,0,1,-199.28069,0.21205357)">
+              <path
+                 id="path3799-5"
+                 inkscape:connector-curvature="0"
+                 d="m 192.001,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3801-6"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 191.95,76.477 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3803"
+               transform="matrix(1.4970318,0,0,1,-195.28069,0.21205357)">
+              <path
+                 id="path3805-2"
+                 inkscape:connector-curvature="0"
+                 d="m 191.338,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3807-0"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 191.286,76.477 0.103,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3809"
+               transform="matrix(1.4970318,0,0,1,-191.28069,0.21205357)">
+              <path
+                 id="path3811-3"
+                 inkscape:connector-curvature="0"
+                 d="m 190.674,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3813-5"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 190.623,76.477 0.103,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3815"
+               transform="matrix(1.4970318,0,0,1,-187.28069,0.21205357)">
+              <path
+                 id="path3817-6"
+                 inkscape:connector-curvature="0"
+                 d="m 190.011,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3819-6"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 189.96,76.477 0.103,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3821"
+               transform="matrix(1.4970318,0,0,1,-183.28069,0.21205357)">
+              <path
+                 id="path3823-6"
+                 inkscape:connector-curvature="0"
+                 d="m 189.348,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3825-7"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 189.297,76.477 0.101,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3827"
+               transform="matrix(1.4970318,0,0,1,-179.28069,0.21205357)">
+              <path
+                 id="path3829-6"
+                 inkscape:connector-curvature="0"
+                 d="m 188.684,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3831-7"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 188.633,76.477 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3833"
+               transform="matrix(1.4970318,0,0,1,-175.28069,0.21205357)">
+              <path
+                 id="path3835-7"
+                 inkscape:connector-curvature="0"
+                 d="m 188.02,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3837-1"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 187.97,76.477 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3839"
+               transform="matrix(1.4970318,0,0,1,-171.28069,0.21205357)">
+              <path
+                 id="path3841-9"
+                 inkscape:connector-curvature="0"
+                 d="m 187.357,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3843-1"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 187.305,76.477 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3845"
+               transform="matrix(1.4970318,0,0,1,-167.28069,0.21205357)">
+              <path
+                 id="path3847-6"
+                 inkscape:connector-curvature="0"
+                 d="m 186.693,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3849-2"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 186.643,76.477 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3851"
+               transform="matrix(1.4970318,0,0,1,-163.28069,0.21205357)">
+              <path
+                 id="path3853-7"
+                 inkscape:connector-curvature="0"
+                 d="m 186.03,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3855-2"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 185.979,76.477 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3857"
+               transform="matrix(1.4970318,0,0,1,-159.28069,0.21205357)">
+              <path
+                 id="path3859-7"
+                 inkscape:connector-curvature="0"
+                 d="m 185.366,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3861-6"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 185.316,76.477 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3863"
+               transform="matrix(1.4970318,0,0,1,-155.28069,0.21205357)">
+              <path
+                 id="path3865-5"
+                 inkscape:connector-curvature="0"
+                 d="m 184.702,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3867-1"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 184.652,76.477 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3869"
+               transform="matrix(1.4970318,0,0,1,-151.28069,0.21205357)">
+              <path
+                 id="path3871-3"
+                 inkscape:connector-curvature="0"
+                 d="m 184.039,78.221 0,-5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3873-9"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 183.988,76.477 0.103,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3927"
+               transform="matrix(1.4970318,0,0,1,-211.28069,0.21205357)">
+              <path
+                 id="path3929-9"
+                 inkscape:connector-curvature="0"
+                 d="m 229.176,86.44 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3931-5"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 230.34,86.364 0,0.153"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3933"
+               transform="matrix(1.4970318,0,0,1,-207.28069,0.21205357)">
+              <path
+                 id="path3935-9"
+                 inkscape:connector-curvature="0"
+                 d="m 226.504,89.448 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3937-2"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 227.668,89.37 0,0.153"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3939"
+               transform="matrix(1.4970318,0,0,1,-203.28069,0.21205357)">
+              <path
+                 id="path3941-6"
+                 inkscape:connector-curvature="0"
+                 d="m 223.832,92.453 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3943-5"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 224.996,92.378 0,0.153"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3945"
+               transform="matrix(1.4970318,0,0,1,-199.28069,0.21205357)">
+              <path
+                 id="path3947-3"
+                 inkscape:connector-curvature="0"
+                 d="m 221.16,95.461 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3949-2"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 222.324,95.384 0,0.153"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3951"
+               transform="matrix(1.4970318,0,0,1,-195.28069,0.21205357)">
+              <path
+                 id="path3953-4"
+                 inkscape:connector-curvature="0"
+                 d="m 218.488,98.468 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3955-4"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 219.652,98.391 0,0.154"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3957"
+               transform="matrix(1.4970318,0,0,1,-191.28069,0.21205357)">
+              <path
+                 id="path3959-4"
+                 inkscape:connector-curvature="0"
+                 d="m 215.816,101.475 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3961-2"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 216.98,101.398 0,0.152"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3963"
+               transform="matrix(1.4970318,0,0,1,-187.28069,0.21205357)">
+              <path
+                 id="path3965-7"
+                 inkscape:connector-curvature="0"
+                 d="m 213.144,104.48 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3967-9"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 214.308,104.405 0,0.152"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3969"
+               transform="matrix(1.4970318,0,0,1,-183.28069,0.21205357)">
+              <path
+                 id="path3971-2"
+                 inkscape:connector-curvature="0"
+                 d="m 210.472,107.488 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3973-3"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 211.636,107.411 0,0.152"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3975"
+               transform="matrix(1.4970318,0,0,1,-179.28069,0.21205357)">
+              <path
+                 id="path3977-7"
+                 inkscape:connector-curvature="0"
+                 d="m 207.8,110.493 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3979-3"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 208.964,110.417 0,0.154"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3981"
+               transform="matrix(1.4970318,0,0,1,-175.28069,0.21205357)">
+              <path
+                 id="path3983-1"
+                 inkscape:connector-curvature="0"
+                 d="m 205.128,113.501 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3985-5"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 206.292,113.424 0,0.154"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3987"
+               transform="matrix(1.4970318,0,0,1,-171.28069,0.21205357)">
+              <path
+                 id="path3989-7"
+                 inkscape:connector-curvature="0"
+                 d="m 202.457,116.508 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3991-8"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 203.62,116.431 0,0.153"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3993"
+               transform="matrix(1.4970318,0,0,1,-167.28069,0.21205357)">
+              <path
+                 id="path3995-5"
+                 inkscape:connector-curvature="0"
+                 d="m 199.785,119.514 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path3997-8"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 200.948,119.437 0,0.153"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g3999"
+               transform="matrix(1.4970318,0,0,1,-163.28069,0.21205357)">
+              <path
+                 id="path4001-3"
+                 inkscape:connector-curvature="0"
+                 d="m 197.113,122.52 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4003-2"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 198.276,122.444 0,0.152"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4005"
+               transform="matrix(1.4970318,0,0,1,-159.28069,0.21205357)">
+              <path
+                 id="path4007-4"
+                 inkscape:connector-curvature="0"
+                 d="m 194.441,125.527 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4009-1"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 195.604,125.452 0,0.151"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4011"
+               transform="matrix(1.4970318,0,0,1,-155.28069,0.21205357)">
+              <path
+                 id="path4013-1"
+                 inkscape:connector-curvature="0"
+                 d="m 191.769,128.534 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4015-5"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 192.932,128.457 0,0.154"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4017"
+               transform="matrix(1.4970318,0,0,1,-151.28069,0.21205357)">
+              <path
+                 id="path4019-9"
+                 inkscape:connector-curvature="0"
+                 d="m 189.097,131.541 3.945,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4021-5"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 190.261,131.464 0,0.154"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4025"
+               transform="matrix(1.4970318,0,0,1,-211.28069,0.21205357)">
+              <path
+                 id="path4027-1"
+                 inkscape:connector-curvature="0"
+                 d="m 189.569,86.44 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4029-0"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 188.405,86.364 0,0.153"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4031"
+               transform="matrix(1.4970318,0,0,1,-207.28069,0.21205357)">
+              <path
+                 id="path4033-6"
+                 inkscape:connector-curvature="0"
+                 d="m 186.897,89.448 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4035-4"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 185.733,89.37 0,0.153"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4037"
+               transform="matrix(1.4970318,0,0,1,-203.28069,0.21205357)">
+              <path
+                 id="path4039-5"
+                 inkscape:connector-curvature="0"
+                 d="m 184.225,92.453 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4041-3"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 183.061,92.378 0,0.153"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4043"
+               transform="matrix(1.4970318,0,0,1,-199.28069,0.21205357)">
+              <path
+                 id="path4045-0"
+                 inkscape:connector-curvature="0"
+                 d="m 181.554,95.461 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4047-8"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 180.389,95.384 0,0.153"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4049"
+               transform="matrix(1.4970318,0,0,1,-195.28069,0.21205357)">
+              <path
+                 id="path4051-9"
+                 inkscape:connector-curvature="0"
+                 d="m 178.882,98.468 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4053-1"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 177.717,98.391 0,0.154"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4055"
+               transform="matrix(1.4970318,0,0,1,-191.28069,0.21205357)">
+              <path
+                 id="path4057-3"
+                 inkscape:connector-curvature="0"
+                 d="m 176.21,101.475 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4059-4"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 175.045,101.398 0,0.152"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4061"
+               transform="matrix(1.4970318,0,0,1,-187.28069,0.21205357)">
+              <path
+                 id="path4063-7"
+                 inkscape:connector-curvature="0"
+                 d="m 173.538,104.48 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4065-4"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 172.373,104.405 0,0.152"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4067"
+               transform="matrix(1.4970318,0,0,1,-183.28069,0.21205357)">
+              <path
+                 id="path4069-6"
+                 inkscape:connector-curvature="0"
+                 d="m 170.866,107.488 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4071-3"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 169.701,107.411 0,0.152"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4073"
+               transform="matrix(1.4970318,0,0,1,-179.28069,0.21205357)">
+              <path
+                 id="path4075-6"
+                 inkscape:connector-curvature="0"
+                 d="m 168.194,110.493 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4077-5"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 167.029,110.417 0,0.154"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4079"
+               transform="matrix(1.4970318,0,0,1,-175.28069,0.21205357)">
+              <path
+                 id="path4081-2"
+                 inkscape:connector-curvature="0"
+                 d="m 165.522,113.501 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4083-8"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 164.357,113.424 0,0.154"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4085"
+               transform="matrix(1.4970318,0,0,1,-171.28069,0.21205357)">
+              <path
+                 id="path4087-1"
+                 inkscape:connector-curvature="0"
+                 d="m 162.85,116.508 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4089-0"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 161.685,116.431 0,0.153"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4091"
+               transform="matrix(1.4970318,0,0,1,-167.28069,0.21205357)">
+              <path
+                 id="path4093-3"
+                 inkscape:connector-curvature="0"
+                 d="m 160.178,119.514 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4095-1"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 159.013,119.437 0,0.153"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4097"
+               transform="matrix(1.4970318,0,0,1,-163.28069,0.21205357)">
+              <path
+                 id="path4099-5"
+                 inkscape:connector-curvature="0"
+                 d="m 157.506,122.52 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4101-5"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 156.341,122.444 0,0.152"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4103"
+               transform="matrix(1.4970318,0,0,1,-159.28069,0.21205357)">
+              <path
+                 id="path4105-2"
+                 inkscape:connector-curvature="0"
+                 d="m 154.834,125.527 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4107-2"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 153.669,125.452 0,0.151"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4109"
+               transform="matrix(1.4970318,0,0,1,-155.28069,0.21205357)">
+              <path
+                 id="path4111-1"
+                 inkscape:connector-curvature="0"
+                 d="m 152.162,128.534 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4113-7"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 150.997,128.457 0,0.154"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4115"
+               transform="matrix(1.4970318,0,0,1,-151.28069,0.21205357)">
+              <path
+                 id="path4117-4"
+                 inkscape:connector-curvature="0"
+                 d="m 149.49,131.541 -3.946,0"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4119-8"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 148.325,131.464 0,0.154"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4123"
+               transform="matrix(1.4970318,0,0,1,-211.28069,0.21205357)">
+              <path
+                 id="path4125-2"
+                 inkscape:connector-curvature="0"
+                 d="m 193.993,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4127-3"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 193.941,138.702 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4129"
+               transform="matrix(1.4970318,0,0,1,-207.28069,0.21205357)">
+              <path
+                 id="path4131-6"
+                 inkscape:connector-curvature="0"
+                 d="m 193.329,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4133-3"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 193.278,138.702 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4135"
+               transform="matrix(1.4970318,0,0,1,-203.28069,0.21205357)">
+              <path
+                 id="path4137-0"
+                 inkscape:connector-curvature="0"
+                 d="m 192.665,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4139-3"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 192.614,138.702 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4141"
+               transform="matrix(1.4970318,0,0,1,-199.28069,0.21205357)">
+              <path
+                 id="path4143-5"
+                 inkscape:connector-curvature="0"
+                 d="m 192.001,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4145-2"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 191.95,138.702 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4147"
+               transform="matrix(1.4970318,0,0,1,-195.28069,0.21205357)">
+              <path
+                 id="path4149-8"
+                 inkscape:connector-curvature="0"
+                 d="m 191.338,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4151-0"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 191.286,138.702 0.103,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4153"
+               transform="matrix(1.4970318,0,0,1,-191.28069,0.21205357)">
+              <path
+                 id="path4155-7"
+                 inkscape:connector-curvature="0"
+                 d="m 190.674,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4157-2"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 190.623,138.702 0.103,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4159"
+               transform="matrix(1.4970318,0,0,1,-187.28069,0.21205357)">
+              <path
+                 id="path4161-2"
+                 inkscape:connector-curvature="0"
+                 d="m 190.011,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4163-5"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 189.96,138.702 0.103,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4165"
+               transform="matrix(1.4970318,0,0,1,-183.28069,0.21205357)">
+              <path
+                 id="path4167-9"
+                 inkscape:connector-curvature="0"
+                 d="m 189.348,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4169-1"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 189.297,138.702 0.101,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4171"
+               transform="matrix(1.4970318,0,0,1,-179.28069,0.21205357)">
+              <path
+                 id="path4173-0"
+                 inkscape:connector-curvature="0"
+                 d="m 188.684,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4175-8"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 188.633,138.702 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4177"
+               transform="matrix(1.4970318,0,0,1,-175.28069,0.21205357)">
+              <path
+                 id="path4179-5"
+                 inkscape:connector-curvature="0"
+                 d="m 188.02,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4181-0"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 187.97,138.702 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4183"
+               transform="matrix(1.4970318,0,0,1,-171.28069,0.21205357)">
+              <path
+                 id="path4185-7"
+                 inkscape:connector-curvature="0"
+                 d="m 187.357,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4187-9"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 187.305,138.702 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4189"
+               transform="matrix(1.4970318,0,0,1,-167.28069,0.21205357)">
+              <path
+                 id="path4191-0"
+                 inkscape:connector-curvature="0"
+                 d="m 186.693,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4193-5"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 186.643,138.702 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4195"
+               transform="matrix(1.4970318,0,0,1,-163.28069,0.21205357)">
+              <path
+                 id="path4197-3"
+                 inkscape:connector-curvature="0"
+                 d="m 186.03,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4199-4"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 185.979,138.702 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4201"
+               transform="matrix(1.4970318,0,0,1,-159.28069,0.21205357)">
+              <path
+                 id="path4203-1"
+                 inkscape:connector-curvature="0"
+                 d="m 185.366,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4205-0"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 185.316,138.702 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4207"
+               transform="matrix(1.4970318,0,0,1,-155.28069,0.21205357)">
+              <path
+                 id="path4209-4"
+                 inkscape:connector-curvature="0"
+                 d="m 184.702,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4211"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 184.652,138.702 0.102,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <g
+               id="g4213"
+               transform="matrix(1.4970318,0,0,1,-151.28069,0.21205357)">
+              <path
+                 id="path4215"
+                 inkscape:connector-curvature="0"
+                 d="m 184.039,136.959 0,5.906"
+                 style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995" />
+              <path
+                 id="path4217-8"
+                 sodipodi:nodetypes="cc"
+                 inkscape:connector-curvature="0"
+                 d="m 183.988,138.702 0.103,0"
+                 style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square" />
+            </g>
+            <rect
+               id="rect4867-5"
+               x="164.326"
+               y="170.105"
+               width="2.5120001"
+               height="4.5489998"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4869-9"
+               x="164.326"
+               y="171.412"
+               width="2.5120001"
+               height="1.0470001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4877-2"
+               x="160.183"
+               y="170.105"
+               width="2.5120001"
+               height="4.5489998"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4879-5"
+               x="160.183"
+               y="171.412"
+               width="2.5120001"
+               height="1.0470001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4883-4"
+               x="156.04201"
+               y="170.105"
+               width="2.51"
+               height="4.5489998"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4885-1"
+               x="156.04201"
+               y="171.412"
+               width="2.51"
+               height="1.0470001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4889-39"
+               x="156.04201"
+               y="157.217"
+               width="2.51"
+               height="4.5489998"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4891-5"
+               x="156.04201"
+               y="159.412"
+               width="2.51"
+               height="1.0470001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4901-8"
+               x="164.326"
+               y="157.217"
+               width="2.5120001"
+               height="4.5489998"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4903-2"
+               x="164.326"
+               y="159.412"
+               width="2.5120001"
+               height="1.0470001"
+               style="fill:#8c8989" />
+            <path
+               id="rect4841-7"
+               d="m 167.542,162.639 0,6.498 c 0,0.342 -0.277,0.621 -0.621,0.621 l -11.936,0 c -0.344,0 -0.623,-0.279 -0.623,-0.621 l 0,-6.498 c 0,-0.344 0.279,-0.621 0.623,-0.621 l 11.936,0 c 0.344,0 0.621,0.277 0.621,0.621 z"
+               inkscape:connector-curvature="0"
+               style="fill:#6a6a6a;stroke:#000000;stroke-width:2.41429996" />
+            <rect
+               id="rect4867_1_"
+               x="147.20399"
+               y="166.33501"
+               width="2.5120001"
+               height="4.5489998"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4869_1_"
+               x="147.20399"
+               y="167.642"
+               width="2.5120001"
+               height="1.0470001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4877_1_"
+               x="143.061"
+               y="166.33501"
+               width="2.5120001"
+               height="4.5489998"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4879_1_"
+               x="143.061"
+               y="167.642"
+               width="2.5120001"
+               height="1.0470001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4883_1_"
+               x="138.92"
+               y="166.33501"
+               width="2.51"
+               height="4.5489998"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4885_1_"
+               x="138.92"
+               y="167.642"
+               width="2.51"
+               height="1.0470001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4889_1_"
+               x="138.92"
+               y="153.446"
+               width="2.51"
+               height="4.5489998"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4891_1_"
+               x="138.92"
+               y="155.642"
+               width="2.51"
+               height="1.0470001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4901_1_"
+               x="147.20399"
+               y="153.446"
+               width="2.5120001"
+               height="4.5489998"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4903_1_"
+               x="147.20399"
+               y="155.642"
+               width="2.5120001"
+               height="1.0470001"
+               style="fill:#8c8989" />
+            <path
+               id="rect4841_1_"
+               d="m 150.42,158.868 0,6.498 c 0,0.342 -0.277,0.621 -0.621,0.621 l -11.936,0 c -0.344,0 -0.623,-0.279 -0.623,-0.621 l 0,-6.498 c 0,-0.344 0.279,-0.621 0.623,-0.621 l 11.936,0 c 0.344,0 0.621,0.277 0.621,0.621 z"
+               inkscape:connector-curvature="0"
+               style="fill:#6a6a6a;stroke:#000000;stroke-width:2.41429996" />
+            <rect
+               id="rect4867_2_"
+               x="148.49001"
+               y="129.869"
+               width="4.5489998"
+               height="2.5120001"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4869_2_"
+               x="150.685"
+               y="129.869"
+               width="1.0470001"
+               height="2.5120001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4877_2_"
+               x="148.49001"
+               y="125.727"
+               width="4.5489998"
+               height="2.5120001"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4879_2_"
+               x="150.685"
+               y="125.727"
+               width="1.0470001"
+               height="2.5120001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4883_2_"
+               x="148.49001"
+               y="121.586"
+               width="4.5489998"
+               height="2.51"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4885_2_"
+               x="150.685"
+               y="121.586"
+               width="1.0470001"
+               height="2.51"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4889_2_"
+               x="161.37801"
+               y="121.586"
+               width="4.5489998"
+               height="2.51"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4891_2_"
+               x="162.685"
+               y="121.586"
+               width="1.0470001"
+               height="2.51"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4901_2_"
+               x="161.37801"
+               y="129.869"
+               width="4.5489998"
+               height="2.5120001"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4903_2_"
+               x="162.685"
+               y="129.869"
+               width="1.0470001"
+               height="2.5120001"
+               style="fill:#8c8989" />
+            <path
+               id="rect4841_2_"
+               d="m 160.505,133.086 -6.498,0 c -0.342,0 -0.621,-0.277 -0.621,-0.621 l 0,-11.936 c 0,-0.344 0.279,-0.623 0.621,-0.623 l 6.498,0 c 0.344,0 0.621,0.279 0.621,0.623 l 0,11.936 c 0,0.344 -0.277,0.621 -0.621,0.621 z"
+               inkscape:connector-curvature="0"
+               style="fill:#6a6a6a;stroke:#000000;stroke-width:2.41429996" />
+            <rect
+               id="rect4867_3_"
+               x="47.349998"
+               y="40.327"
+               width="4.5489998"
+               height="2.5120001"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4869_3_"
+               x="49.544998"
+               y="40.327"
+               width="1.0470001"
+               height="2.5120001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4877_3_"
+               x="47.349998"
+               y="36.185001"
+               width="4.5489998"
+               height="2.5120001"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4879_3_"
+               x="49.544998"
+               y="36.185001"
+               width="1.0470001"
+               height="2.5120001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4883_3_"
+               x="47.349998"
+               y="32.043999"
+               width="4.5489998"
+               height="2.51"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4885_3_"
+               x="49.544998"
+               y="32.043999"
+               width="1.0470001"
+               height="2.51"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4889_3_"
+               x="60.238998"
+               y="32.043999"
+               width="4.5489998"
+               height="2.51"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4891_3_"
+               x="61.544998"
+               y="32.043999"
+               width="1.0470001"
+               height="2.51"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4901_3_"
+               x="60.238998"
+               y="40.327"
+               width="4.5489998"
+               height="2.5120001"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4903_3_"
+               x="61.544998"
+               y="40.327"
+               width="1.0470001"
+               height="2.5120001"
+               style="fill:#8c8989" />
+            <path
+               id="rect4841_3_"
+               d="m 59.366,43.544 -6.498,0 c -0.342,0 -0.621,-0.277 -0.621,-0.621 l 0,-11.936 c 0,-0.344 0.279,-0.623 0.621,-0.623 l 6.498,0 c 0.344,0 0.621,0.279 0.621,0.623 l 0,11.936 c 0,0.344 -0.278,0.621 -0.621,0.621 z"
+               inkscape:connector-curvature="0"
+               style="fill:#6a6a6a;stroke:#000000;stroke-width:2.41429996" />
+            <rect
+               id="rect4867_4_"
+               x="46.395"
+               y="75.561996"
+               width="3.122"
+               height="1.723"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4869_4_"
+               x="47.901001"
+               y="75.561996"
+               width="0.71899998"
+               height="1.723"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4877_4_"
+               x="46.395"
+               y="72.719002"
+               width="3.122"
+               height="1.723"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4879_4_"
+               x="47.901001"
+               y="72.719002"
+               width="0.71899998"
+               height="1.723"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4883_4_"
+               x="46.395"
+               y="69.876999"
+               width="3.122"
+               height="1.722"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4885_4_"
+               x="47.901001"
+               y="69.876999"
+               width="0.71899998"
+               height="1.722"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4889_4_"
+               x="55.238998"
+               y="69.876999"
+               width="3.122"
+               height="1.722"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4891_4_"
+               x="56.136002"
+               y="69.876999"
+               width="0.71799999"
+               height="1.722"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4901_4_"
+               x="55.238998"
+               y="75.561996"
+               width="3.122"
+               height="1.723"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4903_4_"
+               x="56.136002"
+               y="75.561996"
+               width="0.71799999"
+               height="1.723"
+               style="fill:#8c8989" />
+            <path
+               id="rect4841_4_"
+               d="m 54.64,77.769 -4.459,0 c -0.234,0 -0.426,-0.19 -0.426,-0.426 l 0,-8.19 c 0,-0.236 0.192,-0.428 0.426,-0.428 l 4.459,0 c 0.236,0 0.426,0.192 0.426,0.428 l 0,8.19 c 0,0.236 -0.19,0.426 -0.426,0.426 z"
+               inkscape:connector-curvature="0"
+               style="fill:#6a6a6a;stroke:#000000;stroke-width:1.5" />
+            <rect
+               id="rect4867_5_"
+               x="46.395"
+               y="87.421997"
+               width="3.122"
+               height="1.723"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4869_5_"
+               x="47.901001"
+               y="87.421997"
+               width="0.71899998"
+               height="1.723"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4877_5_"
+               x="46.395"
+               y="84.579002"
+               width="3.122"
+               height="1.723"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4879_5_"
+               x="47.901001"
+               y="84.579002"
+               width="0.71899998"
+               height="1.723"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4883_5_"
+               x="46.395"
+               y="81.737"
+               width="3.122"
+               height="1.722"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4885_5_"
+               x="47.901001"
+               y="81.737"
+               width="0.71899998"
+               height="1.722"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4889_5_"
+               x="55.238998"
+               y="81.737"
+               width="3.122"
+               height="1.722"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4891_5_"
+               x="56.136002"
+               y="81.737"
+               width="0.71799999"
+               height="1.722"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4901_5_"
+               x="55.238998"
+               y="87.421997"
+               width="3.122"
+               height="1.723"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4903_5_"
+               x="56.136002"
+               y="87.421997"
+               width="0.71799999"
+               height="1.723"
+               style="fill:#8c8989" />
+            <path
+               id="rect4841_5_"
+               d="m 54.64,89.629 -4.459,0 c -0.234,0 -0.426,-0.19 -0.426,-0.426 l 0,-8.19 c 0,-0.236 0.192,-0.428 0.426,-0.428 l 4.459,0 c 0.236,0 0.426,0.192 0.426,0.428 l 0,8.19 c 0,0.236 -0.19,0.426 -0.426,0.426 z"
+               inkscape:connector-curvature="0"
+               style="fill:#6a6a6a;stroke:#000000;stroke-width:1.5" />
+            <rect
+               id="rect4867_6_"
+               x="46.395"
+               y="99.281998"
+               width="3.122"
+               height="1.723"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4869_6_"
+               x="47.901001"
+               y="99.281998"
+               width="0.71899998"
+               height="1.723"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4877_6_"
+               x="46.395"
+               y="96.439003"
+               width="3.122"
+               height="1.724"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4879_6_"
+               x="47.901001"
+               y="96.439003"
+               width="0.71899998"
+               height="1.724"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4883_6_"
+               x="46.395"
+               y="93.598"
+               width="3.122"
+               height="1.722"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4885_6_"
+               x="47.901001"
+               y="93.598"
+               width="0.71899998"
+               height="1.722"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4889_6_"
+               x="55.238998"
+               y="93.598"
+               width="3.122"
+               height="1.722"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4891_6_"
+               x="56.136002"
+               y="93.598"
+               width="0.71799999"
+               height="1.722"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4901_6_"
+               x="55.238998"
+               y="99.281998"
+               width="3.122"
+               height="1.723"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4903_6_"
+               x="56.136002"
+               y="99.281998"
+               width="0.71799999"
+               height="1.723"
+               style="fill:#8c8989" />
+            <path
+               id="rect4841_6_"
+               d="m 54.64,101.489 -4.459,0 c -0.234,0 -0.426,-0.19 -0.426,-0.426 l 0,-8.19 c 0,-0.236 0.192,-0.428 0.426,-0.428 l 4.459,0 c 0.236,0 0.426,0.192 0.426,0.428 l 0,8.19 c 0,0.236 -0.19,0.426 -0.426,0.426 z"
+               inkscape:connector-curvature="0"
+               style="fill:#6a6a6a;stroke:#000000;stroke-width:1.5" />
+            <rect
+               id="rect4867_7_"
+               x="46.395"
+               y="111.142"
+               width="3.122"
+               height="1.724"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4869_7_"
+               x="47.901001"
+               y="111.142"
+               width="0.71899998"
+               height="1.724"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4877_7_"
+               x="46.395"
+               y="108.3"
+               width="3.122"
+               height="1.724"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4879_7_"
+               x="47.901001"
+               y="108.3"
+               width="0.71899998"
+               height="1.724"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4883_7_"
+               x="46.395"
+               y="105.458"
+               width="3.122"
+               height="1.723"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4885_7_"
+               x="47.901001"
+               y="105.458"
+               width="0.71899998"
+               height="1.723"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4889_7_"
+               x="55.238998"
+               y="105.458"
+               width="3.122"
+               height="1.723"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4891_7_"
+               x="56.136002"
+               y="105.458"
+               width="0.71799999"
+               height="1.723"
+               style="fill:#8c8989" />
+            <rect
+               id="rect4901_7_"
+               x="55.238998"
+               y="111.142"
+               width="3.122"
+               height="1.724"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4903_7_"
+               x="56.136002"
+               y="111.142"
+               width="0.71799999"
+               height="1.724"
+               style="fill:#8c8989" />
+            <path
+               id="rect4841_7_"
+               d="m 54.64,113.35 -4.459,0 c -0.234,0 -0.426,-0.19 -0.426,-0.427 l 0,-8.19 c 0,-0.236 0.192,-0.428 0.426,-0.428 l 4.459,0 c 0.236,0 0.426,0.192 0.426,0.428 l 0,8.19 c 0,0.236 -0.19,0.427 -0.426,0.427 z"
+               inkscape:connector-curvature="0"
+               style="fill:#6a6a6a;stroke:#000000;stroke-width:1.5" />
+            <rect
+               id="rect5020-9"
+               x="0.99900001"
+               y="58.249001"
+               width="32.234001"
+               height="68.248001"
+               style="fill:#fffde9;stroke:#828282;stroke-width:3.23519993;stroke-linecap:round;stroke-linejoin:round" />
+            <rect
+               id="rect4966-2-6"
+               x="34.077"
+               y="62.148998"
+               width="6.7919998"
+               height="3.747"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect4968-1-1"
+               x="36.028"
+               y="62.148998"
+               width="1.561"
+               height="3.747"
+               style="fill:#8c8989" />
+            <rect
+               id="rect5048-7"
+               x="34.077"
+               y="68.331001"
+               width="6.7919998"
+               height="3.747"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect5050-7"
+               x="36.028"
+               y="68.331001"
+               width="1.561"
+               height="3.747"
+               style="fill:#8c8989" />
+            <rect
+               id="rect5054-1"
+               x="34.077"
+               y="74.513"
+               width="6.7919998"
+               height="3.747"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect5056-9"
+               x="36.028"
+               y="74.513"
+               width="1.561"
+               height="3.747"
+               style="fill:#8c8989" />
+            <rect
+               id="rect5060-0"
+               x="34.077"
+               y="80.695"
+               width="6.7919998"
+               height="3.747"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect5062-3"
+               x="36.028"
+               y="80.695"
+               width="1.561"
+               height="3.747"
+               style="fill:#8c8989" />
+            <rect
+               id="rect5066-4"
+               x="34.077"
+               y="86.876999"
+               width="6.7919998"
+               height="3.7460001"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect5068-1"
+               x="36.028"
+               y="86.876999"
+               width="1.561"
+               height="3.7460001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect5072-7"
+               x="34.077"
+               y="93.058998"
+               width="6.7919998"
+               height="3.747"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect5074-5"
+               x="36.028"
+               y="93.058998"
+               width="1.561"
+               height="3.747"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14000-3"
+               x="34.077"
+               y="99.058998"
+               width="6.7919998"
+               height="3.747"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14002-3"
+               x="36.028"
+               y="99.058998"
+               width="1.561"
+               height="3.747"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14006-2"
+               x="34.077"
+               y="105.059"
+               width="6.7919998"
+               height="3.747"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14008-4"
+               x="36.028"
+               y="105.059"
+               width="1.561"
+               height="3.747"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14000_1_"
+               x="34.077"
+               y="111.059"
+               width="6.7919998"
+               height="3.747"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14002_1_"
+               x="36.028"
+               y="111.059"
+               width="1.561"
+               height="3.747"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14006_1_"
+               x="34.077"
+               y="117.059"
+               width="6.7919998"
+               height="3.747"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14008_1_"
+               x="36.028"
+               y="117.059"
+               width="1.561"
+               height="3.747"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14086-1"
+               x="51.1222"
+               y="183.14999"
+               width="32.93"
+               height="25.209999"
+               style="fill:#fffde9;stroke:#828282;stroke-width:3.65829992;stroke-linecap:round;stroke-linejoin:round" />
+            <rect
+               id="rect14090-2"
+               x="58.023201"
+               y="177.17999"
+               width="3.747"
+               height="5.3109999"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14092-9"
+               x="58.023201"
+               y="179.743"
+               width="3.747"
+               height="1.222"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14096-0"
+               x="64.205215"
+               y="177.17999"
+               width="3.747"
+               height="5.3109999"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14098-8"
+               x="64.205215"
+               y="179.743"
+               width="3.747"
+               height="1.222"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14102-7"
+               x="70.386215"
+               y="177.17999"
+               width="3.747"
+               height="5.3109999"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14104-4"
+               x="70.386215"
+               y="179.743"
+               width="3.747"
+               height="1.222"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14108-5"
+               x="76.569214"
+               y="177.17999"
+               width="3.747"
+               height="5.3109999"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14110-6"
+               x="76.569214"
+               y="179.743"
+               width="3.747"
+               height="1.222"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14138-8"
+               x="139.632"
+               y="183.14999"
+               width="32.931"
+               height="25.209999"
+               style="fill:#fffde9;stroke:#828282;stroke-width:3.65829992;stroke-linecap:round;stroke-linejoin:round" />
+            <rect
+               id="rect14142-0"
+               x="146.534"
+               y="177.17999"
+               width="3.747"
+               height="5.3109999"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14144-7"
+               x="146.534"
+               y="179.743"
+               width="3.747"
+               height="1.222"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14148-7"
+               x="152.716"
+               y="177.17999"
+               width="3.7460001"
+               height="5.3109999"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14150-4"
+               x="152.716"
+               y="179.743"
+               width="3.7460001"
+               height="1.222"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14154-3"
+               x="158.89799"
+               y="177.17999"
+               width="3.7460001"
+               height="5.3109999"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14156-1"
+               x="158.89799"
+               y="179.743"
+               width="3.7460001"
+               height="1.222"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14160-3"
+               x="165.08"
+               y="177.17999"
+               width="3.7460001"
+               height="5.3109999"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14162-6"
+               x="165.08"
+               y="179.743"
+               width="3.7460001"
+               height="1.222"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14194-3"
+               x="62.810001"
+               y="5.4099998"
+               width="6.5180001"
+               height="5.0890002"
+               style="fill:#312d29" />
+            <rect
+               id="rect14196-0"
+               x="69.282997"
+               y="5.4099998"
+               width="3.5710001"
+               height="5.0890002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect14198-1"
+               x="59.283001"
+               y="5.4099998"
+               width="3.5710001"
+               height="5.0890002"
+               style="fill:#d3d0ce" />
+            <rect
+               id="rect14138_1_"
+               x="188.08299"
+               y="133.88499"
+               width="25.209999"
+               height="32.931"
+               style="fill:#fffde9;stroke:#828282;stroke-width:3.65829992;stroke-linecap:round;stroke-linejoin:round" />
+            <rect
+               id="rect14142_1_"
+               x="182.112"
+               y="156.16701"
+               width="5.3109999"
+               height="3.747"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14144_1_"
+               x="184.675"
+               y="156.16701"
+               width="1.222"
+               height="3.747"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14148_1_"
+               x="182.112"
+               y="149.985"
+               width="5.3109999"
+               height="3.7460001"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14150_1_"
+               x="184.675"
+               y="149.985"
+               width="1.222"
+               height="3.7460001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14154_1_"
+               x="182.112"
+               y="143.804"
+               width="5.3109999"
+               height="3.7460001"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14156_1_"
+               x="184.675"
+               y="143.804"
+               width="1.222"
+               height="3.7460001"
+               style="fill:#8c8989" />
+            <rect
+               id="rect14160_1_"
+               x="182.112"
+               y="137.62199"
+               width="5.3109999"
+               height="3.7460001"
+               style="fill:#e9dcdc" />
+            <rect
+               id="rect14162_1_"
+               x="184.675"
+               y="137.62199"
+               width="1.222"
+               height="3.7460001"
+               style="fill:#8c8989" />
+            <g
+               onmousemove="Antenna connector"
+               id="g12789">
+              <rect
+                 style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square"
+                 id="rect8636"
+                 height="27.461"
+                 width="28.195999"
+                 y="169.758"
+                 x="97.285141" />
+              <rect
+                 style="fill:url(#linearGradient8736)"
+                 id="rect8652"
+                 height="19.075001"
+                 width="19.502001"
+                 y="195.395"
+                 x="101.77314" />
+              <path
+                 style="fill:#dab452"
+                 inkscape:connector-curvature="0"
+                 id="path8654"
+                 d="m 124.36614,193.487 c 0,1.423 -1.302,2.575 -2.91,2.575 l -19.86,0 c -1.608001,0 -2.912001,-1.152 -2.912001,-2.575 l 0,-20.03 c 0,-1.422 1.303,-2.575 2.912001,-2.575 l 19.859,0 c 1.608,0 2.91,1.153 2.91,2.575 l 0,20.03 z" />
+            </g>
+            <rect
+               x="168.086"
+               y="38.695999"
+               width="45.997002"
+               height="13.826"
+               id="rect8656"
+               style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square" />
+            <rect
+               x="168.086"
+               y="53.695999"
+               width="45.997002"
+               height="13.826"
+               id="rect8658"
+               style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square" />
+            <rect
+               x="168.086"
+               y="68.695999"
+               width="45.997002"
+               height="13.826"
+               id="rect8660"
+               style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square" />
+            <rect
+               x="168.086"
+               y="83.695999"
+               width="45.997002"
+               height="13.826"
+               id="rect8662"
+               style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square" />
+            <rect
+               x="168.086"
+               y="98.695999"
+               width="45.997002"
+               height="13.825"
+               id="rect8664"
+               style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square" />
+            <rect
+               x="168.086"
+               y="113.696"
+               width="45.997002"
+               height="13.825"
+               id="rect8666"
+               style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square" />
+            <path
+               d="m 110.126,10.926 0.563,1.734 c 3.82,-1.425 2.62,-7.761 -2.074,-6.405 4.021,-0.446 4.084,4.377 1.511,4.671 z"
+               id="path8668"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m 108.854,7.167 -0.563,-1.734 c -3.82,1.425 -2.62,7.761 2.075,6.405 -4.021,0.446 -4.084,-4.377 -1.512,-4.671 z"
+               id="path8670"
+               inkscape:connector-curvature="0" />
+            <path
+               d="M 110.202,11.38"
+               id="path8672"
+               inkscape:connector-curvature="0" />
+            <path
+               d="m 98.619,13.405 -1.59,0 -1.481,-3.055 -0.158,0 0,2.083 -1.45,0 0,-6.761 c 0.381,-0.009 1.283,-0.148 1.711,-0.148 0.437,0 0.949,0.019 1.396,0.25 0.734,0.372 1.134,1.154 1.087,2.558 -0.093,1.144 -0.502,1.692 -1.125,1.916 l 1.61,3.157 z m -1.936,-5.39 c 0,-0.576 -0.205,-1.199 -0.819,-1.199 -0.158,0 -0.333,0.018 -0.474,0.046 l 0,2.38 c 0.892,0.336 1.293,-0.389 1.293,-1.227 z"
+               id="path8674"
+               inkscape:connector-curvature="0"
+               style="fill:#070606" />
+            <path
+               d="m 98.329,12.433 0,-6.761 3.05,0 0,1.274 -1.562,0 0,1.479 1.488,0 0,1.209 -1.488,0 0,1.479 1.562,0 0,1.32 -3.05,0 z"
+               id="path8676"
+               inkscape:connector-curvature="0"
+               style="fill:#070606" />
+            <path
+               d="m 103.88,10.359 0.707,-4.687 1.553,0 -1.404,6.761 -1.85,0 -1.414,-6.761 1.562,0 0.708,4.687 0.074,0.567 0.064,-0.567 z"
+               id="path8678"
+               inkscape:connector-curvature="0"
+               style="fill:#070606" />
+            <path
+               d="m 113.285,12.433 0,-6.761 1.469,0 0,5.44 1.646,0 0,1.32 -3.115,0 z"
+               id="path8680"
+               inkscape:connector-curvature="0"
+               style="fill:#070606" />
+            <path
+               d="m 116.558,10.573 0,-4.901 1.487,0 0,4.817 c 0.009,0.456 0.038,0.818 0.651,0.818 0.613,0 0.642,-0.362 0.651,-0.818 l 0,-4.817 1.487,0 0,4.901 c 0,1.376 -0.763,1.99 -2.139,1.99 -1.356,0 -2.137,-0.614 -2.137,-1.99 z"
+               id="path8682"
+               inkscape:connector-curvature="0"
+               style="fill:#070606" />
+            <path
+               d="m 121.022,6.946 0.102,-1.274 3.952,0 0.121,1.274 -1.292,0 0,5.487 -1.525,0 0,-5.487 -1.358,0 z"
+               id="path8684"
+               inkscape:connector-curvature="0"
+               style="fill:#070606" />
+            <path
+               d="m 125.41,5.672 1.517,0 0,6.761 -1.517,0 0,-6.761 z"
+               id="path8686"
+               inkscape:connector-curvature="0"
+               style="fill:#070606" />
+            <path
+               d="m 127.177,9.029 c 0,-1.692 0.633,-3.542 2.604,-3.533 1.962,-0.009 2.595,1.841 2.586,3.533 0,1.711 -0.595,3.543 -2.586,3.534 -1.999,0.009 -2.584,-1.823 -2.604,-3.534 z m 1.563,0.019 c 0,0.93 0.186,2.269 1.041,2.306 0.847,-0.038 1.032,-1.376 1.032,-2.306 0,-0.921 -0.186,-2.111 -1.032,-2.167 -0.856,0.056 -1.041,1.246 -1.041,2.167 z"
+               id="path8688"
+               inkscape:connector-curvature="0"
+               style="fill:#070606" />
+            <path
+               d="m 132.598,12.433 0,-6.761 1.256,0 1.423,3.32 0,-3.32 1.433,0 0,6.761 -1.19,0 -1.469,-3.311 0,3.311 -1.453,0 z"
+               id="path8690"
+               inkscape:connector-curvature="0"
+               style="fill:#070606" />
+            <circle
+               cx="109.494"
+               cy="9.1289997"
+               r="0.93800002"
+               id="circle8692"
+               style="fill:#070606" />
+            <path
+               d="m 35.028,179.497 c 0,1.104 -0.896,2 -2,2 l -26.944,0 c -1.104,0 -2,-0.896 -2,-2 l 2,-1.341 -2,-2.125 0,-31 2,-2.375 -2,-1.288 c 0,-1.104 0.896,-2 2,-2 l 26.945,0 c 1.104,0 2,0.896 2,2 l 0,38.129 z"
+               id="path8694"
+               inkscape:connector-curvature="0"
+               style="fill:#dbdbdb;stroke:#848484;stroke-width:2;stroke-linecap:round;stroke-linejoin:round" />
+            <rect
+               x="9.7510004"
+               y="143.804"
+               width="9.3459997"
+               height="3.7460001"
+               id="rect8696"
+               style="fill:#5a5a5a" />
+            <rect
+               x="9.7510004"
+               y="172.804"
+               width="9.3459997"
+               height="3.7460001"
+               id="rect8698"
+               style="fill:#5a5a5a" />
+            <rect
+               x="128.155"
+               y="17.379"
+               width="26.266001"
+               height="14.662"
+               id="rect8700"
+               style="fill:#c4c4c4;stroke:#6d6d6d;stroke-width:0.69999999" />
+            <circle
+               cx="131.185"
+               cy="20.466"
+               r="1.413"
+               id="circle8702"
+               style="fill:#2c2c2c" />
+            <circle
+               cx="151.73199"
+               cy="29.417"
+               r="1.413"
+               id="circle8704"
+               style="fill:#2c2c2c" />
+            <polygon
+               points="191.036,13.319 186.194,11.031 181.129,13.319 186.083,4.74 "
+               id="polygon8706" />
+            <polygon
+               points="41.036,13.319 36.194,11.031 31.129,13.319 36.083,4.74 "
+               id="polygon8708" />
+            <g
+               id="g8710">
+              <circle
+                 cx="190.63"
+                 cy="45.712002"
+                 r="4.9549999"
+                 id="circle8712"
+                 style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            </g>
+            <g
+               id="g8714">
+              <circle
+                 cx="205.63"
+                 cy="45.712002"
+                 r="4.9549999"
+                 id="circle8716"
+                 style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            </g>
+            <g
+               id="g8718">
+              <circle
+                 cx="190.63"
+                 cy="60.712002"
+                 r="4.9549999"
+                 id="circle8720"
+                 style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            </g>
+            <g
+               id="g8722">
+              <circle
+                 cx="205.63"
+                 cy="60.712002"
+                 r="4.9549999"
+                 id="circle8724"
+                 style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            </g>
+            <g
+               id="g8726">
+              <circle
+                 cx="190.63"
+                 cy="75.711998"
+                 r="4.9549999"
+                 id="circle8728"
+                 style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            </g>
+            <g
+               id="g8730">
+              <circle
+                 cx="205.63"
+                 cy="75.711998"
+                 r="4.9549999"
+                 id="circle8732"
+                 style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            </g>
+            <g
+               id="g8734">
+              <circle
+                 cx="190.63"
+                 cy="90.711998"
+                 r="4.9549999"
+                 id="circle8736"
+                 style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            </g>
+            <g
+               id="g8738">
+              <circle
+                 cx="205.63"
+                 cy="90.711998"
+                 r="4.9549999"
+                 id="circle8740"
+                 style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            </g>
+            <g
+               id="g8742">
+              <circle
+                 cx="190.63"
+                 cy="105.712"
+                 r="4.9549999"
+                 id="circle8744"
+                 style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            </g>
+            <g
+               id="g8746">
+              <circle
+                 cx="205.63"
+                 cy="105.712"
+                 r="4.9549999"
+                 id="circle8748"
+                 style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            </g>
+            <g
+               id="g8750">
+              <circle
+                 cx="190.63"
+                 cy="120.712"
+                 r="4.9549999"
+                 id="circle8752"
+                 style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            </g>
+            <g
+               id="g8754">
+              <circle
+                 cx="205.63"
+                 cy="120.712"
+                 r="4.9549999"
+                 id="circle8756"
+                 style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square" />
+            </g>
+          </g>
+          <rect
+             y="232.90596"
+             x="407.52969"
+             height="15.837104"
+             width="24.434389"
+             id="rect7306"
+             style="fill:#ffffff;fill-opacity:1;stroke:none" />
+        </g>
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer3"
+       inkscape:label="hex-h"
+       style="display:inline">
+      <g
+         transform="matrix(0.4,0,0,0.4,-56.741854,-148.46127)"
+         id="hexa-h">
+        <g
+           transform="matrix(1.25,0,0,-1.25,-575.71068,1844.8336)"
+           id="6165">
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2480,772 c 3.92,0 7.09,2.06 7.09,4.6 0,2.54 -3.17,4.6 -7.09,4.6 l -352,0 c -3.92,0 -7.09,-2.06 -7.09,-4.6 0,-2.54 3.17,-4.6 7.09,-4.6 l 352,0 z"
+             id="path4203" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 2480,772 c 3.92,0 7.09,2.06 7.09,4.6 0,2.54 -3.17,4.6 -7.09,4.6 l -352,0 c -3.92,0 -7.09,-2.06 -7.09,-4.6 0,-2.54 3.17,-4.6 7.09,-4.6 l 352,0 z"
+             id="path4207" />
+          <g
+             id="g7099">
+            <path
+               style="fill:url(#linearGradient8855)"
+               inkscape:connector-curvature="0"
+               d="m 2290,818 2.7,0 0,-16.7 16.7,0 0,16.7 2.99,0 -11.2,11.2 -11.2,-11.2 z"
+               id="path7107" />
+          </g>
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2470,595 c 3.95,-3.95 8.6,-5.69 10.4,-3.9 1.8,1.8 0.051,6.45 -3.9,10.4 l -355,355 c -3.95,3.95 -8.6,5.69 -10.4,3.9 -1.8,-1.8 -0.053,-6.45 3.9,-10.4 l 355,-355 z"
+             id="path7119" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 2470,595 c 3.95,-3.95 8.6,-5.69 10.4,-3.9 1.8,1.8 0.051,6.45 -3.9,10.4 l -355,355 c -3.95,3.95 -8.6,5.69 -10.4,3.9 -1.8,-1.8 -0.053,-6.45 3.9,-10.4 l 355,-355 z"
+             id="path7123" />
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2470,944 c 3.9,3.9 5.6,8.51 3.8,10.3 -1.8,1.8 -6.41,0.093 -10.3,-3.8 l -350,-350 c -3.9,-3.9 -5.6,-8.51 -3.8,-10.3 1.8,-1.8 6.41,-0.093 10.3,3.8 l 350,350 z"
+             id="path7127" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 2470,944 c 3.9,3.9 5.6,8.51 3.8,10.3 -1.8,1.8 -6.41,0.093 -10.3,-3.8 l -350,-350 c -3.9,-3.9 -5.6,-8.51 -3.8,-10.3 1.8,-1.8 6.41,-0.093 10.3,3.8 l 350,350 z"
+             id="path7131" />
+          <g
+             transform="matrix(82.988968,0,0,64.991364,2254.6221,743.15219)"
+             id="g7143">
+            <image
+               transform="matrix(1,0,0,-1,0,1)"
+               xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFMAAABBCAYAAACtrJiQAAAABHNCSVQICAgIfAhkiAAADhxJREFUeJztnGt0HOV5x38zs5fZ++rqi6z73RfJsiQjOxDbhdQ3TIAPLSTpCYXGQNKeHpKU0LRJOKXknPRDD5Rwjg9Q04T0cCnQNjUXAwZh2ZZtbMzFtizJ1gVZ1tpaSXuf3ZmdmX6QpeAaYwuvbalHvy+rM6PZeeY/z/M+z/u8MyvULVliMktGEK+1Af+fmBUzg8yKmUFmxcwgs2JmEMtUDzDN8eQvCMLk37OMM2UxYVzIz3/OMs6Uw3xWwAszZTFnQ/vCzCagDDIrZgb5SgnoWiOKIol4nHg8jtVqweX2YLFYrvkQNOM8U5IkQmOjOJxOrl+1hsrqhcRjUYLDZzBNE1G8dpc0ozxTEARGR0YoKinll48+QmlZGaGxMT49fIT/ePlV2nfvxCE78Pn96Lp+1e2bUZ5pGAaapnLnt+6kqXk5gydPomkaq9es4sknH+eBH/0IQRQ4HRhCEISrXsZJc+bMeXiqB12rWlNJJMjLn8Nd3/0zFEUhlUqh6zpjoyOkkilWr17DyhUrOHy4g96e48gOx1UdS2eMZwqCQCIRp7K6lsLCQmKx2OQ+UZRIJhW6Ojsor6jg2WefZt3GWwgOnyERjyNJ0lWxccaIOeFddXWLsdllDOPcMVEQRERRor+vl1RK5Z9+9Uv+4r7vE4tFGR0ZuSqCzpgwV1UVuyzzne98G7/XQ0JJAmCaBoIgMH/+PHLz8jEMg2AwiKqqrFu7lqKSItrb9zISHMblcl9R22eMZ8ZjMUrLK6mqrCQUDk1uFwQRn8/Lttff5LHHn2B0dJSq6moAOo8dZcOGjWzd+gwLF9dzOjBEMpm8Yl6aAc8UABNTTyMIIlzszgsCCCJ6YgRDiSBaZRAtwIWThCAIRKMR1m+8mdWrv04wGJy0IT8vj86ubh568EH272unrW0XsbjCyhUt+Hxejnd3U1RUxK23bkIzBA7s34eqqTidrownpsv3TFNHEG1YvQXoyRBaaAg9GQIjzbjQZxFEMHXSkdOoY4M4CprxLfk26cQo6WjgrKBffCPSmobT6WRp/WKSijJ+0xgPcZfHw4GDh9DTaRYsKCISCbPlySfYfN8P6OvrZ9HiJQSDZwiFw/z0oQd55NF/BNPkzOlAxj00A55pYKYVHHObKLzhYexzGtCi/aSjAfR4CDOtACbp2AimlsRZtJK5K3/O4q/fTvGyFYh5G0lGT5KODCCIX+zZsViU0rJKvnXnHSiKMlmQi6KILMu8+NLL9Pf14HA6kWUHLreb3p7jbH9zO4IksnLl17BZrfT29nLdihaamprYu28/gcAQHo/nK0p3PpcvpiCBaaIGj6JjoaZlHVU3/imuwk0IWXWYGBipMTxlaym96VFqv7aRuRXz0RQNNZxkwbIFGK4Ghg/+OxabzFgohJJQcDgck4V3JBKmsWk5N9+8kbHR0clTu9xugsFhXnzhRVQ1hc1mn9zn9XpREgnef7+VQx9/Sk1VBQsXLeHU4ElKSktZv24d+/cfpL+/F4/Hm5GQz0g2FyQLglUm/tkuTh54AYUmyprLKGlZRE5eEzkVN1O27Hqy5nhRYymSkSSmbmACkiTQ91E70RNvowk2Vq25kezcPLo7O1BTKRwOJ0oiwbr162lsXEY49Ifkk5uTw8FDH/Latm04nK5z5uWmaSI7HDidTo53dbJ9+9skVY1lDfXoaQ2Hw8natTfR2trGmdNDOF2XP4ZmtDSyOvxg6ox1vMzJj1sxLMvJKfRjEUXUhEYqlsI0zMmR0WIRSSsaPTt/TTISAIudR/7hF9x99914/T4GBgbpOdGN35/Nw7/4OQIQjUYQBBHTNMjNy2fHu63sa9+D231+uJqmiSAIeL0+kqkku9t2smvPXhobG3G5nPizsikomM87b7+NJEmX3STJaGlkGGkEuxtbdgHqaA9Hn7uFI7s+RLKKmLpxXnoRLRJKMo0eHyKVNigsLMHhcDJ8JsCdd97B009tYfP9f4nT6WTrvz0HQElp2eTNVNUUPT29F7VL13Xcbg9z582ns+MIP/27nxGPJxgdCbJsaT2L6pYSjUYu+/ozX2eaJpgGVt88JKuNwR0/JDSqYHfbz/tXTU3j8dqpumULaUOguDCfvPx8QqEwx7u6ME2Tnzz4Yx5//DH6+/u5+557eeHFF1lQWEhZeQVDp4Y43t2FLDsuwSwT0zSZM3cevT3Had3ZhtvjweFyU15RSTqdvuxLv2JFu2noSO48jFSSzzr3Y/Xaz6kkTUEAw8TilTGtEoKpU1VTg2QZL1dEUSIajdBx5DALCubz6yce47bbb+XNN95i873389GhQwwHgwSGBnE4Li7m5xEFkVgsjiiOn8vtcmXkmq9sP9M0Ea12wkefJ1m3AqtNIq3qk/sESUS0WRj85C1kSaCmZhFKLD55uCCICAKcGR5GCI5w+2238s1NN/Psb57jN797noH+PmLRKM6zyccwjEswyUSySHg8LgxDR5IsmObFj7sUrnBz2ERyZaOcOkLviR5qmxcTDUQRAJvdQkLR2P2vDxPofIfyqlpKy0oJR84fuyaK9M/6+7BYrGz+3j2MjY6yc9dutm9/i317dmG1WsnKzhk/65dkZdM0kSQJj9uNaRggfdnca2pc+bm5IIAoMnLkeXRFQ5JETMDmlRkZjRPu2IaaUiivbSAnJ5dUKnVhY0UJwzDo7+slHo/zzVs28S+P/zN/+/c/o6i4jEBgiHA4hCiKF6w4TMPAarXhcrkmi/9MTSuvvJimicWdQ7xvF4ODEXxVuTh9MoJVJDzQDqKAINmpriieHC8vhiCMh3Rfbw/B4SB33PEnPPPMFv7qrx8gOzuHoVODxGOxL5wu6oaBzWZDlmU0LT2emIyZIiYgSDZEi4UTr/+Qg6++zXAgih5XUc4cQDcF/D4fNTXVJKLRKX2vKEqoqsrxri60tM59927m6ae38N27v4dksTB0ahBVVc8t5g0Du92Oy+lA18czuDEzxsyzmAaSMxctMsDgjr/htNOHPLcBLdyLKtgoKiikvr4Ot8eLqmmEw5GzfcpLu9eiKBGLRuiKhMnOzuahhx5kw9obeWrrb9nT1ko4NIbPn4Usy+iGjs0uY7fLpPXMiDjB1WsOmwaiRUZy+AADbeQ4iCIWu4O0pnLg4EecGjpFTlYW5RUVeDxeVFVF09RLOt/4PF5EURSCw2dYUFjIhvXrWNrQgI5E97GjhCNhTMMkJyePTZvWI4giTqeL9r37OfzJRzgvs0S6+ku9poEg2ZDcuQDYJYlUKsXune/R1rqDl+YXsKz5Ola2NNPc3Ex5ZSWJWIzh4DBpLX1Rb50opwKBAKIoUV+3hOXLl9O+YS2//d3zvLdjOwWFheTlzyEwFBhPPhlKQNd83VzXdSRJIjcvH4BIOMy2/3qFN1/7PZWVNTQub2bFdc001Nfj9nkZDQYJhyMYhv6lwo7P300GBwcRRYmm5mYaGhrY9voaykqKz37HeJhnqs6cdmtAssOB3WZHSSQYHBzgw4Mf8H5rK4c+OUJobAyvx01xSQnZubmIgoCqqmeF/WKbJraHQmMkUwqNjcuQZZmxsTEkScLr89G+dx+HP/3kssN82okZjUQoLi3n/h98H5fbh9VqIxwK0dV5lLa2nezZs5cjHZ2EQiHsNgvFxcXk5OWhaSqapk0usJ1vs4hpmEQjUVRVnSybvD4fe/d9wOFPPp6BY+aXMLE2Xrd0Kfdu3syG9Ws5fTpAT08fe/d9wMEPDnBqcIB3tr/Bu29tx5+VxeK6paxZs4rGZfWUlJaiqilGgiMkk8olVwP/d9n4qzKtxEyn08iyTN2SWgYG+hk6NYTskFmxooXVq1cTj0Z54Mc/4dCBffizskkmk7S17mDX++9RVFJKY1MzK1uaqa+vZ35BAbFImODI6JeOr4ahMzYWyki0TSsxlUSCgsJiaqtrCIVCmKaJklBIxOO4PV4MQyc0OorFYgVAlmUcDgeGYRAYGuSVl46z7b9fpbyyhutaWlh1w0pqF9Zis9kZCQaJRqPn1K9Ol5NwOEJfTw82+/ktwqkyrcRMJhVqFi5ifkEBJwcGJrdPrI3v2PEu/X0ncH2uqz7RTfd4vPh8fjRNo7vzKEcPf8x/vvISi+saWLniOpoal1FeUQHAyMgIaU2jqrqWrVu30t11jOycnMu2f1qJCVBdVX72Yas/eJBpGthsdjqOdZNKpfD5s76wOWEYBpIkTXaPkskku3e+x+6d7zFvfgH1DY20tDRTv2QJebm5vLbtf3hqyxZsdhuiKF52w2PaiKlpKm6Pl4rycuJn13kmsNmshMZGOXL4MBaL9aIXPbHfbrcj58/BNE3CoRBvvPZ73tn+OkXFZfj8fjo7jmAYBllZ2RnptE8bMePxOLULF1NdVUU4cm7Dw+320tPTQ39fz5TLlwlhnS4XLrcbXdcZGjrJZ5/14nK5xufoGRASptGzRpqq8o1v3ERVTS3JpHLOrMTldtPT1084FMJms33lc0w8pu1yufH7s7BabZfUnb9UpoWYpmnicDjZt/8Ae3a1UVVdy7x58xAEAcPQsVgsnBoKkNbT0/qlrmkR5oIg4PP7ad+9k48OfsCmW2/jj2/6I5bU1WEYOkoizrGOY4iXWIRfK4Sp/qzERClyJZAkiXgsRjQaweVy03L9Ddy/+R5cLjd33fXnJOJx5CmuRF5NppWYE4jieF8yEg6Rm5dPWUUVJ7o7r+lrKZfCtBRzAlEUSSQSJJMKfn/WtH8te1qMmRfCMAxkWUaWZWD6vwQ7veNmhjErZgaZFTODzIqZQWbFzCBfKZtP96x6rZiymNN5bnytmQ3zDDIrZgaZFTOD/C9uew7sSK2nLAAAAABJRU5ErkJggg=="
+               width="1"
+               height="1"
+               id="image7145" />
+          </g>
+          <g
+             id="g7163">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath7159)"
+               id="g7165">
+              <g
+                 transform="translate(2538.3311,837.6123)"
+                 id="g7167">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path7169" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7189">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7175)"
+               id="g7191">
+              <g
+                 id="g7193">
+                <g
+                   id="g7195">
+                  <g
+                     id="g7197">
+                    <g
+                       id="g7199">
+                      <path
+                         style="fill:url(#radialGradient8857)"
+                         inkscape:connector-curvature="0"
+                         d="m 2460,771 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0.004 22.2,9.11 23.7,20.9 l -12,-10e-4 35.6,35.6 35.6,-35.6 -11.3,0 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 l 17.8,17.8 z"
+                         id="path7201" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7221">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7207)"
+               id="g7223">
+              <g
+                 id="g7225">
+                <g
+                   id="g7227">
+                  <g
+                     id="g7229">
+                    <g
+                       id="g7231">
+                      <path
+                         style="fill:url(#radialGradient8859)"
+                         inkscape:connector-curvature="0"
+                         d="m 2410,781 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.006 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.009 -22.1,-8.99 -23.7,-20.7 l 11.1,0.002 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path7233" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7243">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath7239)"
+               id="g7245">
+              <g
+                 transform="translate(2538.3311,657.5947)"
+                 id="g7247">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path7249" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7269">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7255)"
+               id="g7271">
+              <g
+                 id="g7273">
+                <g
+                   id="g7275">
+                  <g
+                     id="g7277">
+                    <g
+                       id="g7279">
+                      <path
+                         style="fill:url(#radialGradient8861)"
+                         inkscape:connector-curvature="0"
+                         d="m 2500,588 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0.004 -22.2,9.11 -23.7,20.9 l 12,-10e-4 -35.6,35.6 -35.6,-35.6 11.3,0 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.011 44,13.9 53.4,34 l -17.8,17.8 z"
+                         id="path7281" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7301">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7287)"
+               id="g7303">
+              <g
+                 id="g7305">
+                <g
+                   id="g7307">
+                  <g
+                     id="g7309">
+                    <g
+                       id="g7311">
+                      <path
+                         style="fill:url(#radialGradient8863)"
+                         inkscape:connector-curvature="0"
+                         d="m 2550,599 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.006 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.008 22.1,-8.99 23.7,-20.6 l -11.1,10e-4 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0 z"
+                         id="path7313" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7323">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath7319)"
+               id="g7325">
+              <g
+                 transform="translate(2538.3252,1017.5234)"
+                 id="g7327">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path7329" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7349">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7335)"
+               id="g7351">
+              <g
+                 id="g7353">
+                <g
+                   id="g7355">
+                  <g
+                     id="g7357">
+                    <g
+                       id="g7359">
+                      <path
+                         style="fill:url(#radialGradient8865)"
+                         inkscape:connector-curvature="0"
+                         d="m 2500,950 c -3.01,-9.78 -12.1,-16.9 -22.9,-16.9 -12.2,0.005 -22.2,9.11 -23.7,20.9 l 12,0 -35.6,35.6 -35.6,-35.6 11.3,0 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 2500,950 Z"
+                         id="path7361" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7381">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7367)"
+               id="g7383">
+              <g
+                 id="g7385">
+                <g
+                   id="g7387">
+                  <g
+                     id="g7389">
+                    <g
+                       id="g7391">
+                      <path
+                         style="fill:url(#radialGradient8867)"
+                         inkscape:connector-curvature="0"
+                         d="m 2550,961 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.009 22.1,-8.99 23.7,-20.6 l -11.1,10e-4 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0 z"
+                         id="path7393" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2500,974 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.4,9.41 24.7,9.41 34.1,0.008"
+             id="path7397" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2480,949 0,10.9 -2.77,-2.14 -1.83,2.5 4.89,3.59 3.23,0 0,-14.9 -3.53,0 z"
+             id="path7401" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2496,795 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
+             id="path7405" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2470,770 0,2.94 5.8,5.25 c 0.735,0.694 1.22,1.39 1.22,2.29 0,1.05 -0.735,1.78 -1.85,1.78 -1.18,0 -1.95,-0.924 -2.1,-2.25 l -3.38,0.463 c 0.336,3 2.77,4.79 5.67,4.79 2.73,0 5.38,-1.45 5.38,-4.56 0,-2.12 -1.24,-3.36 -2.6,-4.58 l -3.44,-3.07 6.07,0 0,-3.06 -10.8,0 z"
+             id="path7409" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2490,613 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
+             id="path7413" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2480,588 c -2.71,0 -5.16,1.18 -5.96,3.95 l 3.28,0.861 c 0.273,-0.987 1.18,-1.85 2.52,-1.85 1.01,0 2.16,0.504 2.16,1.89 0,1.51 -1.56,1.95 -3.02,1.95 l -0.946,0 0,2.58 1.03,0 c 1.32,0 2.6,0.336 2.6,1.76 0,1.07 -0.903,1.64 -1.87,1.64 -1.01,0 -1.81,-0.65 -2.04,-1.66 l -3.28,0.756 c 0.714,2.5 3.07,3.78 5.54,3.78 2.62,0 5.23,-1.34 5.23,-4.2 0,-1.64 -1.05,-2.86 -2.5,-3.23 l 0,-0.063 c 1.68,-0.398 2.86,-1.78 2.86,-3.44 0,-3.25 -2.88,-4.72 -5.61,-4.72"
+             id="path7417" />
+          <g
+             id="g7427">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath7423)"
+               id="g7429">
+              <g
+                 transform="translate(2056.7451,837.6123)"
+                 id="g7431">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c -33.2,-33.2 -33.2,-87.1 0.049,-120 33.2,-33.2 87.1,-33.2 120,0 33.2,33.2 33.2,87 -0.008,120 -32.9,33.2 -86.8,33.2 -120,0"
+                   id="path7433" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7453">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7439)"
+               id="g7455">
+              <g
+                 id="g7457">
+                <g
+                   id="g7459">
+                  <g
+                     id="g7461">
+                    <g
+                       id="g7463">
+                      <path
+                         style="fill:url(#radialGradient8869)"
+                         inkscape:connector-curvature="0"
+                         d="m 2140,771 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0.004 -22.2,9.11 -23.7,20.9 l 12,-10e-4 -35.6,35.6 -35.6,-35.6 11.3,0 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 l -17.8,17.8 z"
+                         id="path7465" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7485">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7471)"
+               id="g7487">
+              <g
+                 id="g7489">
+                <g
+                   id="g7491">
+                  <g
+                     id="g7493">
+                    <g
+                       id="g7495">
+                      <path
+                         style="fill:url(#radialGradient8871)"
+                         inkscape:connector-curvature="0"
+                         d="m 2190,781 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.006 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.009 22.1,-8.99 23.7,-20.7 l -11.1,0.002 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0 z"
+                         id="path7497" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7507">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath7503)"
+               id="g7509">
+              <g
+                 transform="translate(2056.7451,657.5947)"
+                 id="g7511">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c -33.2,-33.2 -33.2,-87.1 0.049,-120 33.2,-33.2 87.1,-33.2 120,0 33.2,33.2 33.2,87 -0.008,120 -32.9,33.2 -86.8,33.2 -120,0"
+                   id="path7513" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7533">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7519)"
+               id="g7535">
+              <g
+                 id="g7537">
+                <g
+                   id="g7539">
+                  <g
+                     id="g7541">
+                    <g
+                       id="g7543">
+                      <path
+                         style="fill:url(#radialGradient8873)"
+                         inkscape:connector-curvature="0"
+                         d="m 2100,588 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0.004 22.2,9.11 23.7,20.9 l -12,-10e-4 35.6,35.6 35.6,-35.6 -11.3,0 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.011 -44,13.9 -53.4,34 l 17.8,17.8 z"
+                         id="path7545" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7565">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7551)"
+               id="g7567">
+              <g
+                 id="g7569">
+                <g
+                   id="g7571">
+                  <g
+                     id="g7573">
+                    <g
+                       id="g7575">
+                      <path
+                         style="fill:url(#radialGradient8875)"
+                         inkscape:connector-curvature="0"
+                         d="m 2050,599 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.006 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.008 -22.1,-8.99 -23.7,-20.6 l 11.1,10e-4 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path7577" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7587">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath7583)"
+               id="g7589">
+              <g
+                 transform="translate(2056.7471,1017.5234)"
+                 id="g7591">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c -33.2,-33.2 -33.2,-87.1 0.049,-120 33.2,-33.2 87.1,-33.2 120,0 33.2,33.2 33.2,87 -0.008,120 -32.9,33.2 -86.8,33.2 -120,0"
+                   id="path7593" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7613">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7599)"
+               id="g7615">
+              <g
+                 id="g7617">
+                <g
+                   id="g7619">
+                  <g
+                     id="g7621">
+                    <g
+                       id="g7623">
+                      <path
+                         style="fill:url(#radialGradient8877)"
+                         inkscape:connector-curvature="0"
+                         d="m 2090,950 c 3.01,-9.78 12.1,-16.9 22.9,-16.9 12.2,0.005 22.2,9.11 23.7,20.9 l -12,0 35.6,35.6 35.6,-35.6 -11.3,0 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 L 2090,950 Z"
+                         id="path7625" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7645">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7631)"
+               id="g7647">
+              <g
+                 id="g7649">
+                <g
+                   id="g7651">
+                  <g
+                     id="g7653">
+                    <g
+                       id="g7655">
+                      <path
+                         style="fill:url(#radialGradient8879)"
+                         inkscape:connector-curvature="0"
+                         d="m 2040,961 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.009 -22.1,-8.99 -23.7,-20.6 l 11.1,10e-4 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path7657" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2134,974 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.4,9.41 24.7,9.41 34.1,0.008"
+             id="path7661" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2120,957 c -1.38,0 -2.35,-0.966 -2.35,-2.35 0,-1.28 0.924,-2.35 2.33,-2.35 1.39,0 2.33,0.966 2.33,2.37 0,1.34 -0.924,2.33 -2.31,2.33 m -0.021,-7.64 c -3.23,0 -5.86,2.06 -5.86,5.31 0,1.76 0.672,3.13 1.66,4.6 l 3.59,5.35 4.26,0 -3.65,-5.08 -0.063,-0.104 c 0.273,0.104 0.715,0.168 1.05,0.168 2.6,0 4.87,-1.95 4.87,-4.85 0,-3.38 -2.65,-5.4 -5.86,-5.4"
+             id="path7665" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2138,795 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
+             id="path7669" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2120,770 c -2.71,0 -4.96,1.43 -5.65,3.78 l 3.21,0.988 c 0.315,-1.03 1.24,-1.78 2.39,-1.78 1.2,0 2.23,0.735 2.23,2.16 0,1.76 -1.6,2.27 -3.04,2.27 -1.05,0 -2.58,-0.273 -3.63,-0.65 l 0.357,8.5 9.11,0 0,-3.02 -5.98,0 -0.127,-2.35 c 0.442,0.104 1.05,0.147 1.49,0.147 2.98,0 5.38,-1.6 5.38,-4.72 0,-3.61 -2.81,-5.31 -5.73,-5.31"
+             id="path7673" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2138,613 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
+             id="path7677" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2120,599 -0.063,0 -3.53,-5.5 3.59,0 0,5.5 z m 3.28,-8.36 0,-2.9 -3.3,0 0,2.9 -6.99,0 0,2.96 6.05,9.01 4.22,0 0,-9.11 2.06,0 0,-2.86 -2.04,0 z"
+             id="path7681" />
+          <path
+             style="fill:#2f2d2e;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2270,809 62.1,0 c 1.63,0 2.95,-1.32 2.95,-2.95 l 0,-62.1 c 0,-1.63 -1.32,-2.95 -2.95,-2.95 l -62.1,0 c -1.63,0 -2.95,1.32 -2.95,2.95 l 0,62.1 c 0,1.63 1.32,2.95 2.95,2.95"
+             id="path7685" />
+        </g>
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1810,833 134,1.41 -1.41,267 50.7,0"
+           id="path9767" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1810,872 183,0 16.9,-1.41"
+           id="path9769" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1810,911 95.7,0 -1.41,-262 95.7,0"
+           id="path9772" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:6.8602066;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6.86020675, 13.72041347;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1810,711 490,-0.322 -5.15,-61.1 186,0"
+           id="path9767-1" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1810,749 580,0.661 -6.1,126 140,0"
+           id="path9767-1-4" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1810,790 414,1.6 -4.36,305 267,3.21"
+           id="path9767-2" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer5"
+       inkscape:label="hex-y"
+       style="display:inline">
+      <g
+         transform="matrix(0.4,0,0,0.4,-56.741854,-144.46127)"
+         id="hexa-y">
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 22.5;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,864 487,2.81 1.41,115 m -488,-76 556,-1.41 -1.41,104"
+           id="path9858" />
+        <g
+           transform="matrix(1.6375361,0,0,-1.6061042,1762.4794,2222.6719)"
+           id="123">
+          <g
+             id="g4333">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath4329)"
+               id="g4335">
+              <g
+                 transform="translate(284.2432,1018.4248)"
+                 id="g4337">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.048,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.009,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path4339" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g4359">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath4345)"
+               id="g4361">
+              <g
+                 id="g4363">
+                <g
+                   id="g4365">
+                  <g
+                     id="g4367">
+                    <g
+                       id="g4369">
+                      <path
+                         style="fill:url(#radialGradient8828)"
+                         inkscape:connector-curvature="0"
+                         d="m 202,949 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0.006 22.2,9.11 23.7,20.9 l -12,-0.002 35.6,35.6 35.6,-35.6 -11.3,0.002 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 L 202,949 Z"
+                         id="path4371" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g4391">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath4377)"
+               id="g4393">
+              <g
+                 id="g4395">
+                <g
+                   id="g4397">
+                  <g
+                     id="g4399">
+                    <g
+                       id="g4401">
+                      <path
+                         style="fill:url(#radialGradient8830)"
+                         inkscape:connector-curvature="0"
+                         d="m 152,960 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.008 -22.1,-8.99 -23.7,-20.6 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path4403" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <path
+             style="fill:#100f0d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 241,973 c 9.4,-9.41 9.4,-24.7 -0.007,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.007,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
+             id="path4407" />
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 511,967 c 1.7,0.98 2.04,3.56 0.773,5.76 -1.267,2.2 -3.67,3.19 -5.37,2.21 l -153,-88.1 c -1.7,-0.98 -2.04,-3.56 -0.775,-5.76 1.27,-2.2 3.68,-3.19 5.37,-2.21 l 153,88.1 z"
+             id="path4411" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 511,967 c 1.7,0.98 2.04,3.56 0.773,5.76 -1.267,2.2 -3.67,3.19 -5.37,2.21 l -153,-88.1 c -1.7,-0.98 -2.04,-3.56 -0.775,-5.76 1.27,-2.2 3.68,-3.19 5.37,-2.21 l 153,88.1 z"
+             id="path4415" />
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 213,970 c -1.63,0.941 -3.98,-0.082 -5.24,-2.28 -1.27,-2.2 -0.981,-4.74 0.645,-5.68 l 146,-84.4 c 1.63,-0.939 3.98,0.082 5.24,2.28 1.27,2.2 0.983,4.74 -0.644,5.68 l -146,84.4 z"
+             id="path4419" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 213,970 c -1.63,0.941 -3.98,-0.082 -5.24,-2.28 -1.27,-2.2 -0.981,-4.74 0.645,-5.68 l 146,-84.4 c 1.63,-0.939 3.98,0.082 5.24,2.28 1.27,2.2 0.983,4.74 -0.644,5.68 l -146,84.4 z"
+             id="path4423" />
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 353,701 c -0.002,-2.06 2.06,-3.73 4.6,-3.73 2.54,0 4.6,1.67 4.6,3.73 l -0.002,185 c 0,2.06 -2.06,3.73 -4.6,3.73 -2.54,0 -4.6,-1.67 -4.6,-3.73 L 353,701 Z"
+             id="path4427" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 353,701 c -0.002,-2.06 2.06,-3.73 4.6,-3.73 2.54,0 4.6,1.67 4.6,3.73 l -0.002,185 c 0,2.06 -2.06,3.73 -4.6,3.73 -2.54,0 -4.6,-1.67 -4.6,-3.73 L 353,701 Z"
+             id="path4431" />
+          <g
+             id="g4441">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath4437)"
+               id="g4443">
+              <g
+                 transform="translate(429.3359,762.3701)"
+                 id="g4445">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.048,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.009,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path4447" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g4467">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath4453)"
+               id="g4469">
+              <g
+                 id="g4471">
+                <g
+                   id="g4473">
+                  <g
+                     id="g4475">
+                    <g
+                       id="g4477">
+                      <path
+                         style="fill:url(#radialGradient8832)"
+                         inkscape:connector-curvature="0"
+                         d="m 347,693 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0.005 22.2,9.11 23.7,20.9 l -12,-0.002 35.6,35.6 35.6,-35.6 -11.3,0.002 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 L 347,693 Z"
+                         id="path4479" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g4499">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath4485)"
+               id="g4501">
+              <g
+                 id="g4503">
+                <g
+                   id="g4505">
+                  <g
+                     id="g4507">
+                    <g
+                       id="g4509">
+                      <path
+                         style="fill:url(#radialGradient8834)"
+                         inkscape:connector-curvature="0"
+                         d="m 297,704 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.006 44.4,-14.1 53.7,-34.5 l -18,-18 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.007 -22.1,-8.99 -23.7,-20.7 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path4511" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <path
+             style="fill:#100f0d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 386,717 c 9.4,-9.41 9.4,-24.7 -0.007,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.007,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
+             id="path4515" />
+          <g
+             id="g4929">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath4925)"
+               id="g4931">
+              <g
+                 transform="translate(262.6084,1040.4229)"
+                 id="g4933">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path4935" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g4955">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath4941)"
+               id="g4957">
+              <g
+                 id="g4959">
+                <g
+                   id="g4961">
+                  <g
+                     id="g4963">
+                    <g
+                       id="g4965">
+                      <path
+                         style="fill:url(#radialGradient8836)"
+                         inkscape:connector-curvature="0"
+                         d="m 225,973 c -3.01,-9.78 -12.1,-16.9 -22.9,-16.9 -12.2,0.004 -22.2,9.11 -23.7,20.9 l 12,0 -35.6,35.6 -35.6,-35.6 11.3,0 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 225,973 Z"
+                         id="path4967" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g4987">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath4973)"
+               id="g4989">
+              <g
+                 id="g4991">
+                <g
+                   id="g4993">
+                  <g
+                     id="g4995">
+                    <g
+                       id="g4997">
+                      <path
+                         style="fill:url(#radialGradient8838)"
+                         inkscape:connector-curvature="0"
+                         d="m 275,984 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 l -11.1,0.002 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0 z"
+                         id="path4999" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7881">
+            <path
+               style="fill:url(#linearGradient8840)"
+               inkscape:connector-curvature="0"
+               d="m 346,929 2.77,0 0,-17.2 17.2,0 0,17.2 3.07,0 -11.5,11.5 -11.5,-11.5 z"
+               id="path7889" />
+          </g>
+          <g
+             id="g7907">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath7903)"
+               id="g7909">
+              <g
+                 transform="translate(406.8271,782.3682)"
+                 id="g7911">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.051,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path7913" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7933">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7919)"
+               id="g7935">
+              <g
+                 id="g7937">
+                <g
+                   id="g7939">
+                  <g
+                     id="g7941">
+                    <g
+                       id="g7943">
+                      <path
+                         style="fill:url(#radialGradient8842)"
+                         inkscape:connector-curvature="0"
+                         d="m 368,713 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0.003 -22.2,9.11 -23.7,20.9 l 12,-0.002 -35.6,35.6 -35.6,-35.6 11.3,-0.002 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.012 44,13.9 53.4,34 l -17.8,17.8 z"
+                         id="path7945" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g7965">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath7951)"
+               id="g7967">
+              <g
+                 id="g7969">
+                <g
+                   id="g7971">
+                  <g
+                     id="g7973">
+                    <g
+                       id="g7975">
+                      <path
+                         style="fill:url(#radialGradient8844)"
+                         inkscape:connector-curvature="0"
+                         d="m 418,724 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.005 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.006 22.1,-8.99 23.7,-20.7 l -11.1,0 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0.002 z"
+                         id="path7977" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <path
+             style="fill:#2f2d2e;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 326,919 62.1,0 c 1.63,0 2.95,-1.32 2.95,-2.95 l 0,-62.1 c 0,-1.63 -1.32,-2.96 -2.95,-2.96 l -62.1,0 c -1.63,0 -2.95,1.32 -2.95,2.96 l 0,62.1 c 0,1.63 1.32,2.95 2.95,2.95"
+             id="path8061" />
+          <g
+             style="fill-rule:nonzero"
+             transform="translate(0,-1.6)"
+             id="g5140">
+            <path
+               style="fill:#48484a"
+               inkscape:connector-curvature="0"
+               d="m 362,739 c 9.41,-9.41 9.41,-24.7 -0.007,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.008,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
+               id="path8445" />
+            <path
+               style="fill:#ffffff"
+               inkscape:connector-curvature="0"
+               d="m 344,715 c -2.71,0 -4.96,1.43 -5.65,3.78 l 3.21,0.987 c 0.315,-1.03 1.24,-1.79 2.39,-1.79 1.2,0 2.23,0.736 2.23,2.16 0,1.76 -1.6,2.27 -3.04,2.27 -1.05,0 -2.58,-0.272 -3.63,-0.651 l 0.357,8.5 9.11,0 0,-3.02 -5.98,0 -0.127,-2.35 c 0.442,0.105 1.05,0.146 1.49,0.146 2.98,0 5.38,-1.6 5.38,-4.72 0,-3.61 -2.81,-5.31 -5.73,-5.31"
+               id="path8449" />
+          </g>
+          <g
+             style="fill-rule:nonzero"
+             transform="translate(1.6,3.2)"
+             id="g5136">
+            <path
+               style="fill:#48484a"
+               inkscape:connector-curvature="0"
+               d="m 217,994 c 9.4,-9.41 9.4,-24.7 -0.008,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.008,34.1 9.4,9.41 24.7,9.41 34.1,0.008"
+               id="path8453" />
+            <path
+               style="fill:#ffffff"
+               inkscape:connector-curvature="0"
+               d="m 199,969 0,10.9 -2.77,-2.14 -1.83,2.5 4.89,3.59 3.23,0 0,-14.9 -3.53,0 z"
+               id="path8457" />
+          </g>
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 219,949 0,2.94 5.8,5.25 c 0.734,0.693 1.22,1.39 1.22,2.29 0,1.05 -0.736,1.78 -1.85,1.78 -1.18,0 -1.95,-0.924 -2.1,-2.25 l -3.38,0.461 c 0.335,3 2.77,4.79 5.67,4.79 2.73,0 5.38,-1.45 5.38,-4.56 0,-2.12 -1.24,-3.36 -2.6,-4.58 l -3.44,-3.07 6.07,0 0,-3.06 -10.8,0 z"
+             id="path10019" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 369,700 c -1.39,0 -2.35,-0.965 -2.35,-2.35 0,-1.28 0.924,-2.35 2.33,-2.35 1.38,0 2.33,0.967 2.33,2.37 0,1.34 -0.924,2.33 -2.31,2.33 m -0.021,-7.64 c -3.23,0 -5.86,2.06 -5.86,5.31 0,1.76 0.672,3.13 1.66,4.6 l 3.59,5.35 4.26,0 -3.65,-5.08 -0.063,-0.105 c 0.272,0.105 0.713,0.168 1.05,0.168 2.6,0 4.87,-1.95 4.87,-4.85 0,-3.38 -2.64,-5.4 -5.86,-5.4"
+             id="path10027" />
+          <g
+             transform="translate(299.2,0)"
+             id="g5144">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath4329)"
+               id="g5146">
+              <g
+                 transform="translate(284.2432,1018.4248)"
+                 id="g5148">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.048,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.009,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5150" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="translate(299.2,0)"
+             id="g5152">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath4345)"
+               id="g5154">
+              <g
+                 id="g5156">
+                <g
+                   id="g5158">
+                  <g
+                     id="g5160">
+                    <g
+                       id="g5162">
+                      <path
+                         style="fill:url(#radialGradient8846)"
+                         inkscape:connector-curvature="0"
+                         d="m 202,949 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0.006 22.2,9.11 23.7,20.9 l -12,-0.002 35.6,35.6 35.6,-35.6 -11.3,0.002 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 L 202,949 Z"
+                         id="path5164" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             transform="translate(299.2,0)"
+             id="g5166">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath4377)"
+               id="g5168">
+              <g
+                 id="g5170">
+                <g
+                   id="g5172">
+                  <g
+                     id="g5174">
+                    <g
+                       id="g5176">
+                      <path
+                         style="fill:url(#radialGradient8848)"
+                         inkscape:connector-curvature="0"
+                         d="m 152,960 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.008 -22.1,-8.99 -23.7,-20.6 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path5178" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <path
+             style="fill:#100f0d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 540,973 c 9.4,-9.41 9.4,-24.7 -0.007,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.007,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
+             id="path5180" />
+          <g
+             transform="translate(299.2,0)"
+             id="g5182">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath4925)"
+               id="g5184">
+              <g
+                 transform="translate(262.6084,1040.4229)"
+                 id="g5186">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5188" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="translate(299.2,0)"
+             id="g5190">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath4941)"
+               id="g5192">
+              <g
+                 id="g5194">
+                <g
+                   id="g5196">
+                  <g
+                     id="g5198">
+                    <g
+                       id="g5200">
+                      <path
+                         style="fill:url(#radialGradient8851)"
+                         inkscape:connector-curvature="0"
+                         d="m 225,973 c -3.01,-9.78 -12.1,-16.9 -22.9,-16.9 -12.2,0.004 -22.2,9.11 -23.7,20.9 l 12,0 -35.6,35.6 -35.6,-35.6 11.3,0 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 225,973 Z"
+                         id="path5202" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             transform="translate(299.2,0)"
+             id="g5204">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath4973)"
+               id="g5206">
+              <g
+                 id="g5208">
+                <g
+                   id="g5210">
+                  <g
+                     id="g5212">
+                    <g
+                       id="g5214">
+                      <path
+                         style="fill:url(#radialGradient8853)"
+                         inkscape:connector-curvature="0"
+                         d="m 275,984 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 l -11.1,0.002 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0 z"
+                         id="path5216" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             transform="translate(300.8,3.2)"
+             id="g5218">
+            <g
+               style="fill-rule:nonzero"
+               id="g5252">
+              <path
+                 style="fill:#48484a"
+                 inkscape:connector-curvature="0"
+                 d="m 217,994 c 9.4,-9.41 9.4,-24.7 -0.008,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.008,34.1 9.4,9.41 24.7,9.41 34.1,0.008"
+                 id="path5220" />
+              <path
+                 style="fill:#ffffff"
+                 inkscape:connector-curvature="0"
+                 d="m 201,969 c -2.71,0 -5.17,1.18 -5.96,3.95 l 3.28,0.862 c 0.273,-0.987 1.18,-1.85 2.52,-1.85 1.01,0 2.16,0.504 2.16,1.89 0,1.51 -1.55,1.95 -3.02,1.95 l -0.946,0 0,2.58 1.03,0 c 1.32,0 2.6,0.336 2.6,1.76 0,1.07 -0.902,1.64 -1.87,1.64 -1.01,0 -1.8,-0.65 -2.04,-1.66 l -3.28,0.756 c 0.713,2.5 3.06,3.78 5.54,3.78 2.62,0 5.23,-1.34 5.23,-4.2 0,-1.64 -1.05,-2.86 -2.5,-3.24 l 0,-0.062 c 1.68,-0.398 2.86,-1.78 2.86,-3.44 0,-3.25 -2.88,-4.72 -5.6,-4.72"
+                 id="path8341-5" />
+            </g>
+          </g>
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 526,961 -0.063,0 -3.53,-5.5 3.59,0 0,5.5 z m 3.28,-8.36 0,-2.9 -3.3,0 0,2.9 -6.99,0 0,2.96 6.05,9.01 4.22,0 0,-9.11 2.06,0 0,-2.86 -2.04,0 z"
+             id="path8161-0" />
+        </g>
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 22.5;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,702 158,1.41 -0.814,-67.5 67,0"
+           id="path9850" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,743 304,0 0,-23.9"
+           id="path9852" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 22.5;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,783 764,0 0,-78.8"
+           id="path9854" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 22.5;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,823 801,0.222 0,-84.7"
+           id="path9856" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer8"
+       inkscape:label="hex"
+       style="display:inline">
+      <g
+         transform="matrix(0.4,0,0,0.4,-56.741854,-148.46127)"
+         id="hexa">
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,706 381,4.22 -1.41,-71.8 40.8,0"
+           id="path9822" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,747 626,5.63"
+           id="path9824" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,789 526,7.04 -1.41,179 77.4,0 0,0 5.63,0"
+           id="path9826" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,830 382,4.22 0,253 40.8,0 0,0 -1.41,0"
+           id="path9828" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,865 237,0 0,71.8 m -237,-29.6 263,1.41 -1.19,-106"
+           id="path9830" />
+        <g
+           transform="matrix(1.25,0,0,-1.25,-596.76331,2570.3294)"
+           id="3454">
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2440,1270 c 3.33,-1.92 7.05,-1.7 8.32,0.508 1.27,2.2 -0.396,5.54 -3.72,7.46 l -299,173 c -3.32,1.92 -7.05,1.69 -8.32,-0.508 -1.27,-2.198 0.399,-5.54 3.72,-7.46 l 299,-173 z"
+             id="path4243" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 2440,1270 c 3.33,-1.92 7.05,-1.7 8.32,0.508 1.27,2.2 -0.396,5.54 -3.72,7.46 l -299,173 c -3.32,1.92 -7.05,1.69 -8.32,-0.508 -1.27,-2.198 0.399,-5.54 3.72,-7.46 l 299,-173 z"
+             id="path4247" />
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2450,1440 c 3.33,1.92 4.99,5.26 3.72,7.46 -1.27,2.2 -4.99,2.43 -8.32,0.506 l -299,-173 c -3.32,-1.92 -4.99,-5.26 -3.72,-7.46 1.27,-2.2 5,-2.43 8.32,-0.504 l 299,173 z"
+             id="path4251" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 2450,1440 c 3.33,1.92 4.99,5.26 3.72,7.46 -1.27,2.2 -4.99,2.43 -8.32,0.506 l -299,-173 c -3.32,-1.92 -4.99,-5.26 -3.72,-7.46 1.27,-2.2 5,-2.43 8.32,-0.504 l 299,173 z"
+             id="path4255" />
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2300,1530 c 0,3.84 -2.06,6.96 -4.6,6.95 -2.54,10e-4 -4.6,-3.11 -4.6,-6.95 l 0,-345 c 0,-3.84 2.06,-6.95 4.6,-6.95 2.54,0 4.6,3.12 4.6,6.96 l 0,345 z"
+             id="path4259" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 2300,1530 c 0,3.84 -2.06,6.96 -4.6,6.95 -2.54,10e-4 -4.6,-3.11 -4.6,-6.95 l 0,-345 c 0,-3.84 2.06,-6.95 4.6,-6.95 2.54,0 4.6,3.12 4.6,6.96 l 0,345 z"
+             id="path4263" />
+          <g
+             id="g4307">
+            <path
+               style="fill:url(#linearGradient8802)"
+               inkscape:connector-curvature="0"
+               d="m 2310,1410 2.77,0 0,-17.2 17.2,0 0,17.2 3.07,0 -11.5,11.5 -11.5,-11.5 z"
+               id="path4315" />
+          </g>
+          <g
+             id="g5845">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath5841)"
+               id="g5847">
+              <g
+                 transform="translate(2515.9893,1514.8203)"
+                 id="g5849">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.048,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.007,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5851" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5861">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath5857)"
+               id="g5863">
+              <g
+                 transform="translate(2355.4863,1607.2334)"
+                 id="g5865">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.047,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5867" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5877">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath5873)"
+               id="g5879">
+              <g
+                 transform="translate(2516.0371,1330.8896)"
+                 id="g5881">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.051,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5883" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5893">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath5889)"
+               id="g5895">
+              <g
+                 transform="translate(2354.9951,1235.6455)"
+                 id="g5897">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.048,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5899" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5919">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5905)"
+               id="g5921">
+              <g
+                 id="g5923">
+                <g
+                   id="g5925">
+                  <g
+                     id="g5927">
+                    <g
+                       id="g5929">
+                      <path
+                         style="fill:url(#radialGradient8804)"
+                         inkscape:connector-curvature="0"
+                         d="m 2430,1450 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 l -12,0 35.6,35.6 35.6,-35.6 -11.3,0 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 l 17.8,17.8 z"
+                         id="path5931" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5951">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5937)"
+               id="g5953">
+              <g
+                 id="g5955">
+                <g
+                   id="g5957">
+                  <g
+                     id="g5959">
+                    <g
+                       id="g5961">
+                      <path
+                         style="fill:url(#radialGradient8806)"
+                         inkscape:connector-curvature="0"
+                         d="m 2380,1460 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.6 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path5963" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5983">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5969)"
+               id="g5985">
+              <g
+                 id="g5987">
+                <g
+                   id="g5989">
+                  <g
+                     id="g5991">
+                    <g
+                       id="g5993">
+                      <path
+                         style="fill:url(#radialGradient8808)"
+                         inkscape:connector-curvature="0"
+                         d="m 2270,1170 c 3.01,-9.78 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 l -12,0 35.6,35.6 35.6,-35.6 -11.3,0 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.011 -44,13.9 -53.4,34 l 17.8,17.8 z"
+                         id="path5995" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g6015">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath6001)"
+               id="g6017">
+              <g
+                 id="g6019">
+                <g
+                   id="g6021">
+                  <g
+                     id="g6023">
+                    <g
+                       id="g6025">
+                      <path
+                         style="fill:url(#radialGradient8810)"
+                         inkscape:connector-curvature="0"
+                         d="m 2220,1180 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.6 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path6027" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g6047">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath6033)"
+               id="g6049">
+              <g
+                 id="g6051">
+                <g
+                   id="g6053">
+                  <g
+                     id="g6055">
+                    <g
+                       id="g6057">
+                      <path
+                         style="fill:url(#radialGradient8812)"
+                         inkscape:connector-curvature="0"
+                         d="m 2480,1260 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0 -22.2,9.11 -23.7,20.9 l 12,0 -35.6,35.6 -35.6,-35.6 11.3,0 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.011 44,13.9 53.4,34 L 2480,1260 Z"
+                         id="path6059" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g6079">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath6065)"
+               id="g6081">
+              <g
+                 id="g6083">
+                <g
+                   id="g6085">
+                  <g
+                     id="g6087">
+                    <g
+                       id="g6089">
+                      <path
+                         style="fill:url(#radialGradient8814)"
+                         inkscape:connector-curvature="0"
+                         d="m 2530,1270 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 l -11.1,0 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0 z"
+                         id="path6091" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g6111">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath6097)"
+               id="g6113">
+              <g
+                 id="g6115">
+                <g
+                   id="g6117">
+                  <g
+                     id="g6119">
+                    <g
+                       id="g6121">
+                      <path
+                         style="fill:url(#radialGradient8816)"
+                         inkscape:connector-curvature="0"
+                         d="m 2320,1540 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0.01 -22.2,9.11 -23.7,20.9 l 12,0 -35.6,35.6 -35.6,-35.6 11.3,10e-4 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.011 44,13.9 53.4,34 l -17.8,17.8 z"
+                         id="path6123" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g6143">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath6129)"
+               id="g6145">
+              <g
+                 id="g6147">
+                <g
+                   id="g6149">
+                  <g
+                     id="g6151">
+                    <g
+                       id="g6153">
+                      <path
+                         style="fill:url(#radialGradient8818)"
+                         inkscape:connector-curvature="0"
+                         d="m 2370,1550 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 l -11.1,0 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,10e-4 z"
+                         id="path6155" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2310,1560 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.4,9.41 24.7,9.41 34.1,0.01"
+             id="path6159" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2290,1540 0,10.9 -2.77,-2.14 -1.83,2.5 4.89,3.59 3.23,0 0,-14.9 -3.53,0 z"
+             id="path6163" />
+          <g
+             id="g6173">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath6169)"
+               id="g6175">
+              <g
+                 transform="translate(2191.2754,1327.0928)"
+                 id="g6177">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.047,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path6179" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g6199">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath6185)"
+               id="g6201">
+              <g
+                 id="g6203">
+                <g
+                   id="g6205">
+                  <g
+                     id="g6207">
+                    <g
+                       id="g6209">
+                      <path
+                         style="fill:url(#radialGradient8820)"
+                         inkscape:connector-curvature="0"
+                         d="m 2150,1260 c -3.01,-9.78 -12.1,-16.9 -22.9,-16.9 -12.2,0.01 -22.2,9.11 -23.7,20.9 l 12,0 -35.6,35.6 -35.6,-35.6 11.3,0 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 2150,1260 Z"
+                         id="path6211" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g6231">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath6217)"
+               id="g6233">
+              <g
+                 id="g6235">
+                <g
+                   id="g6237">
+                  <g
+                     id="g6239">
+                    <g
+                       id="g6241">
+                      <path
+                         style="fill:url(#radialGradient8822)"
+                         inkscape:connector-curvature="0"
+                         d="m 2200,1270 c -1.29,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 l -11.1,0 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0 z"
+                         id="path6243" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2150,1280 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
+             id="path6247" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2130,1260 c -2.71,0 -4.96,1.43 -5.65,3.78 l 3.21,0.988 c 0.316,-1.03 1.24,-1.79 2.4,-1.79 1.2,0 2.22,0.735 2.22,2.16 0,1.76 -1.6,2.27 -3.04,2.27 -1.05,0 -2.58,-0.272 -3.63,-0.65 l 0.356,8.5 9.11,0 0,-3.02 -5.98,0 -0.125,-2.35 c 0.441,0.104 1.05,0.146 1.49,0.146 2.98,0 5.38,-1.6 5.38,-4.72 0,-3.61 -2.81,-5.31 -5.73,-5.31"
+             id="path6251" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2470,1470 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.4,9.41 24.7,9.41 34.1,0.01"
+             id="path6255" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2450,1440 0,2.94 5.8,5.25 c 0.735,0.693 1.22,1.39 1.22,2.29 0,1.05 -0.735,1.78 -1.85,1.78 -1.18,0 -1.95,-0.924 -2.1,-2.25 l -3.38,0.462 c 0.336,3 2.77,4.79 5.67,4.79 2.73,0 5.38,-1.45 5.38,-4.56 0,-2.12 -1.24,-3.36 -2.6,-4.58 l -3.44,-3.07 6.07,0 0,-3.06 -10.8,0 z"
+             id="path6259" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2310,1190 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
+             id="path6263" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2300,1180 -0.063,0 -3.53,-5.5 3.59,0 0,5.5 z m 3.28,-8.36 0,-2.9 -3.3,0 0,2.9 -6.99,0 0,2.96 6.05,9.01 4.22,0 0,-9.11 2.06,0 0,-2.86 -2.04,0 z"
+             id="path6267" />
+          <g
+             id="g6277">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath6273)"
+               id="g6279">
+              <g
+                 transform="translate(2193.8848,1514.2402)"
+                 id="g6281">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.047,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path6283" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g6303">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath6289)"
+               id="g6305">
+              <g
+                 id="g6307">
+                <g
+                   id="g6309">
+                  <g
+                     id="g6311">
+                    <g
+                       id="g6313">
+                      <path
+                         style="fill:url(#radialGradient8824)"
+                         inkscape:connector-curvature="0"
+                         d="m 2110,1450 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 l -12,0 35.6,35.6 35.6,-35.6 -11.3,0 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 l 17.8,17.8 z"
+                         id="path6315" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g6335">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath6321)"
+               id="g6337">
+              <g
+                 id="g6339">
+                <g
+                   id="g6341">
+                  <g
+                     id="g6343">
+                    <g
+                       id="g6345">
+                      <path
+                         style="fill:url(#radialGradient8826)"
+                         inkscape:connector-curvature="0"
+                         d="m 2060,1460 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.6 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path6347" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2150,1470 c 9.4,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
+             id="path6351" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2130,1450 c -1.38,0 -2.35,-0.966 -2.35,-2.35 0,-1.28 0.924,-2.35 2.33,-2.35 1.39,0 2.33,0.966 2.33,2.37 0,1.34 -0.924,2.33 -2.31,2.33 m -0.021,-7.64 c -3.23,0 -5.86,2.06 -5.86,5.31 0,1.76 0.672,3.13 1.66,4.6 l 3.59,5.35 4.26,0 -3.65,-5.08 -0.063,-0.105 c 0.273,0.105 0.715,0.168 1.05,0.168 2.6,0 4.87,-1.95 4.87,-4.85 0,-3.38 -2.65,-5.4 -5.86,-5.4"
+             id="path6355" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2470,1290 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
+             id="path6359" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2450,1260 c -2.71,0 -5.16,1.18 -5.96,3.95 l 3.28,0.862 c 0.273,-0.988 1.18,-1.85 2.52,-1.85 1.01,0 2.16,0.504 2.16,1.89 0,1.51 -1.56,1.95 -3.02,1.95 l -0.946,0 0,2.58 1.03,0 c 1.32,0 2.6,0.336 2.6,1.76 0,1.07 -0.903,1.64 -1.87,1.64 -1.01,0 -1.81,-0.651 -2.04,-1.66 l -3.28,0.756 c 0.714,2.5 3.07,3.78 5.54,3.78 2.62,0 5.23,-1.34 5.23,-4.2 0,-1.64 -1.05,-2.86 -2.5,-3.23 l 0,-0.062 c 1.68,-0.399 2.86,-1.78 2.86,-3.44 0,-3.26 -2.88,-4.72 -5.61,-4.72"
+             id="path6363" />
+          <path
+             style="fill:#2f2d2e;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 2260,1390 62.1,0 c 1.63,0 2.95,-1.32 2.95,-2.95 l 0,-62.1 c 0,-1.63 -1.32,-2.96 -2.95,-2.96 l -62.1,0 c -1.63,0 -2.95,1.32 -2.95,2.96 l 0,62.1 c 0,1.63 1.32,2.95 2.95,2.95"
+             id="path7857" />
+        </g>
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer9"
+       inkscape:label="quadp"
+       style="display:inline">
+      <g
+         transform="matrix(0.4,0,0,0.4,-56.741854,-148.46127)"
+         id="quad-p">
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,829 197,-1.99 0,0"
+           id="path9655" />
+        <path
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,747 760,-1.99 0,43.8"
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0;marker-start:none"
+           id="path9471" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,707 354,-1.99 -1.99,-95.5 83.6,0"
+           id="path9546" />
+        <g
+           transform="matrix(1.8006689,0,0,-1.8006689,-600.9077,3339.2736)"
+           id="67657">
+          <g
+             id="g5429">
+            <path
+               style="fill:url(#linearGradient8784)"
+               inkscape:connector-curvature="0"
+               d="m 1640,1430 2.77,0 0,-17.2 17.2,0 0,17.2 3.07,0 -11.5,11.5 -11.5,-11.5 z"
+               id="path5437" />
+          </g>
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1620,1270 c 0,-2.54 2.06,-4.6 4.6,-4.6 2.54,0 4.6,2.06 4.6,4.6 l 0,228 c 0,2.54 -2.06,4.6 -4.6,4.6 -2.54,0 -4.6,-2.06 -4.6,-4.6 l 0,-228 z"
+             id="path5449" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 1620,1270 c 0,-2.54 2.06,-4.6 4.6,-4.6 2.54,0 4.6,2.06 4.6,4.6 l 0,228 c 0,2.54 -2.06,4.6 -4.6,4.6 -2.54,0 -4.6,-2.06 -4.6,-4.6 l 0,-228 z"
+             id="path5453" />
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1740,1380 c 2.54,0 4.6,2.06 4.6,4.6 0,2.54 -2.06,4.6 -4.6,4.6 l -228,0 c -2.54,0 -4.6,-2.06 -4.6,-4.6 0,-2.54 2.06,-4.6 4.6,-4.6 l 228,0 z"
+             id="path5457" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 1740,1380 c 2.54,0 4.6,2.06 4.6,4.6 0,2.54 -2.06,4.6 -4.6,4.6 l -228,0 c -2.54,0 -4.6,-2.06 -4.6,-4.6 0,-2.54 2.06,-4.6 4.6,-4.6 l 228,0 z"
+             id="path5461" />
+          <g
+             id="g5471">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath5467)"
+               id="g5473">
+              <g
+                 transform="translate(1823.7813,1443.3135)"
+                 id="g5475">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5477" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5487">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath5483)"
+               id="g5489">
+              <g
+                 transform="translate(1687.2949,1579.7949)"
+                 id="g5491">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.047,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5493" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5503">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath5499)"
+               id="g5505">
+              <g
+                 transform="translate(1689.418,1308.9482)"
+                 id="g5507">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.051,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5509" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5519">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath5515)"
+               id="g5521">
+              <g
+                 transform="translate(1552.9316,1445.4316)"
+                 id="g5523">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.047,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.01,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5525" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="matrix(82.988968,0,0,64.991364,1584.0928,1351.8216)"
+             id="g5537">
+            <image
+               transform="matrix(1,0,0,-1,0,1)"
+               xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFMAAABBCAYAAACtrJiQAAAABHNCSVQICAgIfAhkiAAADhxJREFUeJztnGt0HOV5x38zs5fZ++rqi6z73RfJsiQjOxDbhdQ3TIAPLSTpCYXGQNKeHpKU0LRJOKXknPRDD5Rwjg9Q04T0cCnQNjUXAwZh2ZZtbMzFtizJ1gVZ1tpaSXuf3ZmdmX6QpeAaYwuvbalHvy+rM6PZeeY/z/M+z/u8MyvULVliMktGEK+1Af+fmBUzg8yKmUFmxcwgs2JmEMtUDzDN8eQvCMLk37OMM2UxYVzIz3/OMs6Uw3xWwAszZTFnQ/vCzCagDDIrZgb5SgnoWiOKIol4nHg8jtVqweX2YLFYrvkQNOM8U5IkQmOjOJxOrl+1hsrqhcRjUYLDZzBNE1G8dpc0ozxTEARGR0YoKinll48+QmlZGaGxMT49fIT/ePlV2nfvxCE78Pn96Lp+1e2bUZ5pGAaapnLnt+6kqXk5gydPomkaq9es4sknH+eBH/0IQRQ4HRhCEISrXsZJc+bMeXiqB12rWlNJJMjLn8Nd3/0zFEUhlUqh6zpjoyOkkilWr17DyhUrOHy4g96e48gOx1UdS2eMZwqCQCIRp7K6lsLCQmKx2OQ+UZRIJhW6Ojsor6jg2WefZt3GWwgOnyERjyNJ0lWxccaIOeFddXWLsdllDOPcMVEQRERRor+vl1RK5Z9+9Uv+4r7vE4tFGR0ZuSqCzpgwV1UVuyzzne98G7/XQ0JJAmCaBoIgMH/+PHLz8jEMg2AwiKqqrFu7lqKSItrb9zISHMblcl9R22eMZ8ZjMUrLK6mqrCQUDk1uFwQRn8/Lttff5LHHn2B0dJSq6moAOo8dZcOGjWzd+gwLF9dzOjBEMpm8Yl6aAc8UABNTTyMIIlzszgsCCCJ6YgRDiSBaZRAtwIWThCAIRKMR1m+8mdWrv04wGJy0IT8vj86ubh568EH272unrW0XsbjCyhUt+Hxejnd3U1RUxK23bkIzBA7s34eqqTidrownpsv3TFNHEG1YvQXoyRBaaAg9GQIjzbjQZxFEMHXSkdOoY4M4CprxLfk26cQo6WjgrKBffCPSmobT6WRp/WKSijJ+0xgPcZfHw4GDh9DTaRYsKCISCbPlySfYfN8P6OvrZ9HiJQSDZwiFw/z0oQd55NF/BNPkzOlAxj00A55pYKYVHHObKLzhYexzGtCi/aSjAfR4CDOtACbp2AimlsRZtJK5K3/O4q/fTvGyFYh5G0lGT5KODCCIX+zZsViU0rJKvnXnHSiKMlmQi6KILMu8+NLL9Pf14HA6kWUHLreb3p7jbH9zO4IksnLl17BZrfT29nLdihaamprYu28/gcAQHo/nK0p3PpcvpiCBaaIGj6JjoaZlHVU3/imuwk0IWXWYGBipMTxlaym96VFqv7aRuRXz0RQNNZxkwbIFGK4Ghg/+OxabzFgohJJQcDgck4V3JBKmsWk5N9+8kbHR0clTu9xugsFhXnzhRVQ1hc1mn9zn9XpREgnef7+VQx9/Sk1VBQsXLeHU4ElKSktZv24d+/cfpL+/F4/Hm5GQz0g2FyQLglUm/tkuTh54AYUmyprLKGlZRE5eEzkVN1O27Hqy5nhRYymSkSSmbmACkiTQ91E70RNvowk2Vq25kezcPLo7O1BTKRwOJ0oiwbr162lsXEY49Ifkk5uTw8FDH/Latm04nK5z5uWmaSI7HDidTo53dbJ9+9skVY1lDfXoaQ2Hw8natTfR2trGmdNDOF2XP4ZmtDSyOvxg6ox1vMzJj1sxLMvJKfRjEUXUhEYqlsI0zMmR0WIRSSsaPTt/TTISAIudR/7hF9x99914/T4GBgbpOdGN35/Nw7/4OQIQjUYQBBHTNMjNy2fHu63sa9+D231+uJqmiSAIeL0+kqkku9t2smvPXhobG3G5nPizsikomM87b7+NJEmX3STJaGlkGGkEuxtbdgHqaA9Hn7uFI7s+RLKKmLpxXnoRLRJKMo0eHyKVNigsLMHhcDJ8JsCdd97B009tYfP9f4nT6WTrvz0HQElp2eTNVNUUPT29F7VL13Xcbg9z582ns+MIP/27nxGPJxgdCbJsaT2L6pYSjUYu+/ozX2eaJpgGVt88JKuNwR0/JDSqYHfbz/tXTU3j8dqpumULaUOguDCfvPx8QqEwx7u6ME2Tnzz4Yx5//DH6+/u5+557eeHFF1lQWEhZeQVDp4Y43t2FLDsuwSwT0zSZM3cevT3Had3ZhtvjweFyU15RSTqdvuxLv2JFu2noSO48jFSSzzr3Y/Xaz6kkTUEAw8TilTGtEoKpU1VTg2QZL1dEUSIajdBx5DALCubz6yce47bbb+XNN95i873389GhQwwHgwSGBnE4Li7m5xEFkVgsjiiOn8vtcmXkmq9sP9M0Ea12wkefJ1m3AqtNIq3qk/sESUS0WRj85C1kSaCmZhFKLD55uCCICAKcGR5GCI5w+2238s1NN/Psb57jN797noH+PmLRKM6zyccwjEswyUSySHg8LgxDR5IsmObFj7sUrnBz2ERyZaOcOkLviR5qmxcTDUQRAJvdQkLR2P2vDxPofIfyqlpKy0oJR84fuyaK9M/6+7BYrGz+3j2MjY6yc9dutm9/i317dmG1WsnKzhk/65dkZdM0kSQJj9uNaRggfdnca2pc+bm5IIAoMnLkeXRFQ5JETMDmlRkZjRPu2IaaUiivbSAnJ5dUKnVhY0UJwzDo7+slHo/zzVs28S+P/zN/+/c/o6i4jEBgiHA4hCiKF6w4TMPAarXhcrkmi/9MTSuvvJimicWdQ7xvF4ODEXxVuTh9MoJVJDzQDqKAINmpriieHC8vhiCMh3Rfbw/B4SB33PEnPPPMFv7qrx8gOzuHoVODxGOxL5wu6oaBzWZDlmU0LT2emIyZIiYgSDZEi4UTr/+Qg6++zXAgih5XUc4cQDcF/D4fNTXVJKLRKX2vKEqoqsrxri60tM59927m6ae38N27v4dksTB0ahBVVc8t5g0Du92Oy+lA18czuDEzxsyzmAaSMxctMsDgjr/htNOHPLcBLdyLKtgoKiikvr4Ot8eLqmmEw5GzfcpLu9eiKBGLRuiKhMnOzuahhx5kw9obeWrrb9nT1ko4NIbPn4Usy+iGjs0uY7fLpPXMiDjB1WsOmwaiRUZy+AADbeQ4iCIWu4O0pnLg4EecGjpFTlYW5RUVeDxeVFVF09RLOt/4PF5EURSCw2dYUFjIhvXrWNrQgI5E97GjhCNhTMMkJyePTZvWI4giTqeL9r37OfzJRzgvs0S6+ku9poEg2ZDcuQDYJYlUKsXune/R1rqDl+YXsKz5Ola2NNPc3Ex5ZSWJWIzh4DBpLX1Rb50opwKBAKIoUV+3hOXLl9O+YS2//d3zvLdjOwWFheTlzyEwFBhPPhlKQNd83VzXdSRJIjcvH4BIOMy2/3qFN1/7PZWVNTQub2bFdc001Nfj9nkZDQYJhyMYhv6lwo7P300GBwcRRYmm5mYaGhrY9voaykqKz37HeJhnqs6cdmtAssOB3WZHSSQYHBzgw4Mf8H5rK4c+OUJobAyvx01xSQnZubmIgoCqqmeF/WKbJraHQmMkUwqNjcuQZZmxsTEkScLr89G+dx+HP/3kssN82okZjUQoLi3n/h98H5fbh9VqIxwK0dV5lLa2nezZs5cjHZ2EQiHsNgvFxcXk5OWhaSqapk0usJ1vs4hpmEQjUVRVnSybvD4fe/d9wOFPPp6BY+aXMLE2Xrd0Kfdu3syG9Ws5fTpAT08fe/d9wMEPDnBqcIB3tr/Bu29tx5+VxeK6paxZs4rGZfWUlJaiqilGgiMkk8olVwP/d9n4qzKtxEyn08iyTN2SWgYG+hk6NYTskFmxooXVq1cTj0Z54Mc/4dCBffizskkmk7S17mDX++9RVFJKY1MzK1uaqa+vZ35BAbFImODI6JeOr4ahMzYWyki0TSsxlUSCgsJiaqtrCIVCmKaJklBIxOO4PV4MQyc0OorFYgVAlmUcDgeGYRAYGuSVl46z7b9fpbyyhutaWlh1w0pqF9Zis9kZCQaJRqPn1K9Ol5NwOEJfTw82+/ktwqkyrcRMJhVqFi5ifkEBJwcGJrdPrI3v2PEu/X0ncH2uqz7RTfd4vPh8fjRNo7vzKEcPf8x/vvISi+saWLniOpoal1FeUQHAyMgIaU2jqrqWrVu30t11jOycnMu2f1qJCVBdVX72Yas/eJBpGthsdjqOdZNKpfD5s76wOWEYBpIkTXaPkskku3e+x+6d7zFvfgH1DY20tDRTv2QJebm5vLbtf3hqyxZsdhuiKF52w2PaiKlpKm6Pl4rycuJn13kmsNmshMZGOXL4MBaL9aIXPbHfbrcj58/BNE3CoRBvvPZ73tn+OkXFZfj8fjo7jmAYBllZ2RnptE8bMePxOLULF1NdVUU4cm7Dw+320tPTQ39fz5TLlwlhnS4XLrcbXdcZGjrJZ5/14nK5xufoGRASptGzRpqq8o1v3ERVTS3JpHLOrMTldtPT1084FMJms33lc0w8pu1yufH7s7BabZfUnb9UpoWYpmnicDjZt/8Ae3a1UVVdy7x58xAEAcPQsVgsnBoKkNbT0/qlrmkR5oIg4PP7ad+9k48OfsCmW2/jj2/6I5bU1WEYOkoizrGOY4iXWIRfK4Sp/qzERClyJZAkiXgsRjQaweVy03L9Ddy/+R5cLjd33fXnJOJx5CmuRF5NppWYE4jieF8yEg6Rm5dPWUUVJ7o7r+lrKZfCtBRzAlEUSSQSJJMKfn/WtH8te1qMmRfCMAxkWUaWZWD6vwQ7veNmhjErZgaZFTODzIqZQWbFzCBfKZtP96x6rZiymNN5bnytmQ3zDDIrZgaZFTOD/C9uew7sSK2nLAAAAABJRU5ErkJggg=="
+               width="1"
+               height="1"
+               id="image5539" />
+          </g>
+          <g
+             id="g5567">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5553)"
+               id="g5569">
+              <g
+                 id="g5571">
+                <g
+                   id="g5573">
+                  <g
+                     id="g5575">
+                    <g
+                       id="g5577">
+                      <path
+                         style="fill:url(#radialGradient8786)"
+                         inkscape:connector-curvature="0"
+                         d="m 1740,1380 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0.01 22.2,9.11 23.7,20.9 l -12,0 35.6,35.6 35.6,-35.6 -11.3,0 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 l 17.8,17.8 z"
+                         id="path5579" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5599">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5585)"
+               id="g5601">
+              <g
+                 id="g5603">
+                <g
+                   id="g5605">
+                  <g
+                     id="g5607">
+                    <g
+                       id="g5609">
+                      <path
+                         style="fill:url(#radialGradient8788)"
+                         inkscape:connector-curvature="0"
+                         d="m 1690,1390 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.7 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path5611" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5631">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5617)"
+               id="g5633">
+              <g
+                 id="g5635">
+                <g
+                   id="g5637">
+                  <g
+                     id="g5639">
+                    <g
+                       id="g5641">
+                      <path
+                         style="fill:url(#radialGradient8790)"
+                         inkscape:connector-curvature="0"
+                         d="m 1470,1380 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 l -12,0 35.6,35.6 35.6,-35.6 -11.3,0 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.011 -44,13.9 -53.4,34 l 17.8,17.8 z"
+                         id="path5643" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5663">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5649)"
+               id="g5665">
+              <g
+                 id="g5667">
+                <g
+                   id="g5669">
+                  <g
+                     id="g5671">
+                    <g
+                       id="g5673">
+                      <path
+                         style="fill:url(#radialGradient8792)"
+                         inkscape:connector-curvature="0"
+                         d="m 1420,1390 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.6 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path5675" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5695">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5681)"
+               id="g5697">
+              <g
+                 id="g5699">
+                <g
+                   id="g5701">
+                  <g
+                     id="g5703">
+                    <g
+                       id="g5705">
+                      <path
+                         style="fill:url(#radialGradient8794)"
+                         inkscape:connector-curvature="0"
+                         d="m 1650,1240 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0 -22.2,9.11 -23.7,20.9 l 12,-10e-4 -35.6,35.6 -35.6,-35.6 11.3,0 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.012 44,13.9 53.4,34 l -17.8,17.8 z"
+                         id="path5707" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5727">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5713)"
+               id="g5729">
+              <g
+                 id="g5731">
+                <g
+                   id="g5733">
+                  <g
+                     id="g5735">
+                    <g
+                       id="g5737">
+                      <path
+                         style="fill:url(#radialGradient8796)"
+                         inkscape:connector-curvature="0"
+                         d="m 1700,1250 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.7 l -11.1,0 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0 z"
+                         id="path5739" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5759">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5745)"
+               id="g5761">
+              <g
+                 id="g5763">
+                <g
+                   id="g5765">
+                  <g
+                     id="g5767">
+                    <g
+                       id="g5769">
+                      <path
+                         style="fill:url(#radialGradient8798)"
+                         inkscape:connector-curvature="0"
+                         d="m 1650,1510 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0.01 -22.2,9.11 -23.7,20.9 l 12,0 -35.6,35.6 -35.6,-35.6 11.3,0 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 1650,1510 Z"
+                         id="path5771" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g5791">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5777)"
+               id="g5793">
+              <g
+                 id="g5795">
+                <g
+                   id="g5797">
+                  <g
+                     id="g5799">
+                    <g
+                       id="g5801">
+                      <path
+                         style="fill:url(#radialGradient8800)"
+                         inkscape:connector-curvature="0"
+                         d="m 1700,1520 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 l -11.1,0 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0 z"
+                         id="path5803" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1640,1540 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.409 -9.4,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
+             id="path5807" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1630,1510 0,10.9 -2.77,-2.14 -1.83,2.5 4.89,3.59 3.23,0 0,-14.9 -3.53,0 z"
+             id="path5811" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1780,1400 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
+             id="path5815" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1760,1380 0,2.94 5.8,5.25 c 0.735,0.694 1.22,1.39 1.22,2.29 0,1.05 -0.735,1.78 -1.85,1.78 -1.18,0 -1.95,-0.924 -2.1,-2.25 l -3.38,0.463 c 0.336,3 2.77,4.79 5.67,4.79 2.73,0 5.38,-1.45 5.38,-4.56 0,-2.12 -1.24,-3.36 -2.6,-4.58 l -3.44,-3.07 6.07,0 0,-3.06 -10.8,0 z"
+             id="path5819" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1510,1400 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
+             id="path5823" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1490,1390 -0.063,0 -3.53,-5.5 3.59,0 0,5.5 z m 3.28,-8.36 0,-2.9 -3.3,0 0,2.9 -6.99,0 0,2.96 6.05,9.01 4.22,0 0,-9.11 2.06,0 0,-2.86 -2.04,0 z"
+             id="path5827" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1650,1260 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
+             id="path5831" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1630,1240 c -2.71,0 -5.16,1.18 -5.96,3.95 l 3.28,0.861 c 0.274,-0.987 1.18,-1.85 2.52,-1.85 1.01,0 2.16,0.504 2.16,1.89 0,1.51 -1.55,1.95 -3.02,1.95 l -0.945,0 0,2.58 1.03,0 c 1.32,0 2.6,0.336 2.6,1.76 0,1.07 -0.903,1.64 -1.87,1.64 -1.01,0 -1.81,-0.65 -2.04,-1.66 l -3.28,0.756 c 0.713,2.5 3.06,3.78 5.54,3.78 2.62,0 5.23,-1.34 5.23,-4.2 0,-1.64 -1.05,-2.86 -2.5,-3.23 l 0,-0.063 c 1.68,-0.398 2.86,-1.78 2.86,-3.44 0,-3.25 -2.88,-4.72 -5.61,-4.72"
+             id="path5835" />
+          <path
+             style="fill:#2f2d2e;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1600,1420 62.1,0 c 1.63,0 2.95,-1.32 2.95,-2.95 l 0,-62.1 c 0,-1.63 -1.32,-2.96 -2.95,-2.96 l -62.1,0 c -1.63,0 -2.95,1.32 -2.95,2.96 l 0,62.1 c 0,1.63 1.32,2.95 2.95,2.95"
+             id="path7759" />
+        </g>
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,790 63.7,0 -1.99,312 402,0"
+           id="path9653" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer14"
+       inkscape:label="tri"
+       style="display:inline">
+      <g
+         id="tri"
+         transform="translate(-16.970563,-13.803392)">
+        <g
+           transform="matrix(0.73103688,0,0,-0.73103688,613.69731,1177.3486)"
+           id="1234">
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 533,1510 c 1.7,0.98 2.04,3.56 0.773,5.76 -1.267,2.2 -3.68,3.19 -5.37,2.21 l -153,-88.1 c -1.7,-0.98 -2.04,-3.56 -0.776,-5.76 1.27,-2.2 3.68,-3.19 5.38,-2.21 l 153,88.1 z"
+             id="path10031" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 533,1510 c 1.7,0.98 2.04,3.56 0.773,5.76 -1.267,2.2 -3.68,3.19 -5.37,2.21 l -153,-88.1 c -1.7,-0.98 -2.04,-3.56 -0.776,-5.76 1.27,-2.2 3.68,-3.19 5.38,-2.21 l 153,88.1 z"
+             id="path10035" />
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 235,1510 c -1.63,0.94 -3.98,-0.082 -5.24,-2.28 -1.27,-2.2 -0.981,-4.74 0.644,-5.68 l 146,-84.4 c 1.63,-0.939 3.98,0.082 5.24,2.28 1.27,2.2 0.983,4.74 -0.644,5.68 L 235,1510 Z"
+             id="path10039" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 235,1510 c -1.63,0.94 -3.98,-0.082 -5.24,-2.28 -1.27,-2.2 -0.981,-4.74 0.644,-5.68 l 146,-84.4 c 1.63,-0.939 3.98,0.082 5.24,2.28 1.27,2.2 0.983,4.74 -0.644,5.68 L 235,1510 Z"
+             id="path10043" />
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 375,1240 c -0.002,-2.06 2.06,-3.73 4.6,-3.73 2.54,0 4.6,1.67 4.6,3.73 l -0.002,185 c 0,2.06 -2.06,3.73 -4.6,3.73 -2.54,0 -4.6,-1.67 -4.6,-3.73 L 375,1240 Z"
+             id="path10047" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 375,1240 c -0.002,-2.06 2.06,-3.73 4.6,-3.73 2.54,0 4.6,1.67 4.6,3.73 l -0.002,185 c 0,2.06 -2.06,3.73 -4.6,3.73 -2.54,0 -4.6,-1.67 -4.6,-3.73 L 375,1240 Z"
+             id="path10051" />
+          <g
+             id="g10061">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath10057)"
+               id="g10063">
+              <g
+                 transform="translate(175.5146,1564.4219)"
+                 id="g10065">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c -33.2,-33.2 -33.2,-87.1 0.049,-120 33.2,-33.2 87.1,-33.2 120,0 33.2,33.2 33.2,87 -0.008,120 -32.9,33.2 -86.8,33.2 -120,0"
+                   id="path10067" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g10087">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath10073)"
+               id="g10089">
+              <g
+                 id="g10091">
+                <g
+                   id="g10093">
+                  <g
+                     id="g10095">
+                    <g
+                       id="g10097">
+                      <path
+                         style="fill:url(#radialGradient8738)"
+                         inkscape:connector-curvature="0"
+                         d="m 213,1500 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 l -12,0 35.6,35.6 35.6,-35.6 -11.3,0 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 L 213,1500 Z"
+                         id="path10099" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g10119">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath10105)"
+               id="g10121">
+              <g
+                 id="g10123">
+                <g
+                   id="g10125">
+                  <g
+                     id="g10127">
+                    <g
+                       id="g10129">
+                      <path
+                         style="fill:url(#radialGradient8740)"
+                         inkscape:connector-curvature="0"
+                         d="m 164,1510 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.6 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path10131" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g10143">
+            <path
+               style="fill:url(#linearGradient8742)"
+               inkscape:connector-curvature="0"
+               d="m 368,1470 2.77,0 0,-17.2 17.2,0 0,17.2 3.07,0 -11.5,11.5 -11.5,-11.5 z"
+               id="path10151" />
+          </g>
+          <g
+             id="g10169">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath10165)"
+               id="g10171">
+              <g
+                 transform="translate(587.4541,1567.4229)"
+                 id="g10173">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.047,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path10175" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g10195">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath10181)"
+               id="g10197">
+              <g
+                 id="g10199">
+                <g
+                   id="g10201">
+                  <g
+                     id="g10203">
+                    <g
+                       id="g10205">
+                      <path
+                         style="fill:url(#radialGradient8744)"
+                         inkscape:connector-curvature="0"
+                         d="m 550,1500 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0 -22.2,9.11 -23.7,20.9 l 12,0 -35.6,35.6 -35.6,-35.6 11.3,0 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 550,1500 Z"
+                         id="path10207" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g10227">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath10213)"
+               id="g10229">
+              <g
+                 id="g10231">
+                <g
+                   id="g10233">
+                  <g
+                     id="g10235">
+                    <g
+                       id="g10237">
+                      <path
+                         style="fill:url(#radialGradient8746)"
+                         inkscape:connector-curvature="0"
+                         d="m 599,1510 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 l -11.1,0 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0 z"
+                         id="path10239" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <path
+             style="fill:#2f2d2e;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 349,1460 62.1,0 c 1.63,0 2.95,-1.32 2.95,-2.95 l 0,-62.1 c 0,-1.63 -1.32,-2.96 -2.95,-2.96 l -62.1,0 c -1.63,0 -2.95,1.32 -2.95,2.96 l 0,62.1 c 0,1.63 1.32,2.95 2.95,2.95"
+             id="path10243" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 544,1522.7358 c 9.4,-9.41 9.4,-24.7 -0.008,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.409 -9.4,24.7 0.008,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
+             id="path10259" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 522,1500 0,2.94 5.8,5.25 c 0.734,0.693 1.22,1.39 1.22,2.29 0,1.05 -0.736,1.78 -1.85,1.78 -1.18,0 -1.95,-0.924 -2.1,-2.25 l -3.38,0.462 c 0.335,3 2.77,4.79 5.67,4.79 2.73,0 5.38,-1.45 5.38,-4.56 0,-2.12 -1.24,-3.36 -2.6,-4.58 l -3.44,-3.07 6.07,0 0,-3.06 -10.8,0 z"
+             id="path10263" />
+          <g
+             id="g10273">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath10269)"
+               id="g10275">
+              <g
+                 transform="translate(317.7236,1313.3682)"
+                 id="g10277">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c -33.2,-33.2 -33.2,-87.1 0.051,-120 33.2,-33.2 87.1,-33.2 120,0 33.2,33.2 33.2,87 -0.008,120 -32.9,33.2 -86.8,33.2 -120,0"
+                   id="path10279" />
+              </g>
+            </g>
+          </g>
+          <g
+             id="g10299">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath10285)"
+               id="g10301">
+              <g
+                 id="g10303">
+                <g
+                   id="g10305">
+                  <g
+                     id="g10307">
+                    <g
+                       id="g10309">
+                      <path
+                         style="fill:url(#radialGradient8748)"
+                         inkscape:connector-curvature="0"
+                         d="m 357,1240 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 l -12,0 35.6,35.6 35.6,-35.6 -11.3,0 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.012 -44,13.9 -53.4,34 L 357,1240 Z"
+                         id="path10311" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g10331">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath10317)"
+               id="g10333">
+              <g
+                 id="g10335">
+                <g
+                   id="g10337">
+                  <g
+                     id="g10339">
+                    <g
+                       id="g10341">
+                      <path
+                         style="fill:url(#radialGradient8750)"
+                         inkscape:connector-curvature="0"
+                         d="m 307,1250 c 1.29,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.7 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path10343" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 397,1264.5284 c 9.41,-9.41 9.41,-24.7 -0.008,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.008,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
+             id="path10347" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 380,1240 c -2.71,0 -5.16,1.18 -5.96,3.95 l 3.28,0.861 c 0.274,-0.988 1.18,-1.85 2.52,-1.85 1.01,0 2.16,0.504 2.16,1.89 0,1.51 -1.55,1.95 -3.02,1.95 l -0.945,0 0,2.58 1.03,0 c 1.32,0 2.6,0.336 2.6,1.76 0,1.07 -0.902,1.64 -1.87,1.64 -1.01,0 -1.81,-0.651 -2.04,-1.66 l -3.28,0.756 c 0.712,2.5 3.06,3.78 5.54,3.78 2.62,0 5.23,-1.34 5.23,-4.2 0,-1.64 -1.05,-2.86 -2.5,-3.23 l 0,-0.063 c 1.68,-0.399 2.86,-1.78 2.86,-3.44 0,-3.26 -2.88,-4.72 -5.6,-4.72"
+             id="path10351" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 253,1525.4716 c 9.4,-9.41 9.4,-24.7 -0.008,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.409 -9.4,24.7 0.008,34.1 9.4,9.41 24.7,9.41 34.1,0.01"
+             id="path10355" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 235,1500 0,10.9 -2.77,-2.14 -1.83,2.5 4.89,3.59 3.23,0 0,-14.9 -3.53,0 z"
+             id="path10359" />
+          <g
+             transform="matrix(0.22068409,0,0,-0.22068409,342.97168,1173.0784)"
+             id="g8736">
+            <path
+               style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="M 93.9,181 C 89.4,180 34.8,134 34.8,134 l 0,108 58.9,58.9"
+               id="path8738" />
+            <path
+               style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="M 94.4,299 264,193 265,82.6 c 0,0 -11.4,0.709 -14.3,0.709 -2.83,0 -116,61.4 -116,61.4 l -40.7,35.7 0,119"
+               id="path8740" />
+            <path
+               style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="m 34.8,133 11,-6 5.2,-15 68,-40.2"
+               id="path8742" />
+            <path
+               style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="m 46,126 55.5,47.4 5.56,-20.2 94.4,-56.6"
+               id="path8744" />
+            <path
+               style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="m 50.8,112 c 8.36,8.4 56.8,41.4 56.8,41.4"
+               id="path8746" />
+            <ellipse
+               style="fill:#ff0000;fill-rule:evenodd;stroke:#000000;stroke-width:0.99199998px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               stroke-miterlimit="4"
+               ry="44.900002"
+               cy="45.400002"
+               rx="70.099998"
+               cx="183"
+               id="ellipse8748" />
+            <ellipse
+               style="fill:#443838;fill-rule:evenodd;stroke:#000000;stroke-width:0.99199998px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               stroke-miterlimit="4"
+               ry="44.900002"
+               cy="51.299999"
+               rx="70.099998"
+               cx="183"
+               id="ellipse8750" />
+            <ellipse
+               style="fill:#443838;fill-rule:evenodd;stroke:#000000;stroke-width:0.99199998px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               stroke-miterlimit="4"
+               ry="44.900002"
+               cy="45.400002"
+               rx="70.099998"
+               cx="183"
+               id="ellipse8752" />
+            <path
+               style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="m 93.9,204 -34.8,20.2 0,8.61 35.3,-17.7"
+               id="path8754" />
+            <path
+               style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="M 59.1,232 1,183.5 1,172.9"
+               id="path8756" />
+            <path
+               style="fill:#333333;fill-rule:nonzero;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="M 58.1,224 0.496,173 33.3,154 95.5,204"
+               id="path8758" />
+            <path
+               style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="M 265,82.3 249,68.7"
+               id="path8760" />
+            <path
+               style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="m 266,103 c 0,0 33.3,-20.2 30.8,-20.7 -2.52,-0.496 -42.9,-36.9 -42.9,-36.9"
+               id="path8762" />
+            <path
+               style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="m 297,83.4 0.531,9.07 -32.4,18.7"
+               id="path8764" />
+            <path
+               style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="m 251,83.3 -7,-5"
+               id="path8766" />
+            <path
+               style="fill:#808080;fill-rule:nonzero"
+               inkscape:connector-curvature="0"
+               d="M 18,197 1.8,183.5 1.7291,179.32 c -0.0709,-4.11 -0.0709,-4.18 0.425,-3.83 0.248,0.177 7.58,6.66 16.3,14.4 l 15.8,14 0,3.33 c 0,1.84 -0.0354,3.37 -0.0709,3.33 -0.0354,0 -7.33,-6.09 -16.2,-13.5 z"
+               id="path8768" />
+            <path
+               style="fill:#808080;fill-rule:nonzero"
+               inkscape:connector-curvature="0"
+               d="M 47,221 35.7,211.5 19,195.4 l 16.5,9.28 2.09,1.88 c 1.13,1.03 6.09,5.42 11,9.78 7.05,6.24 9.04,7.87 9.43,7.72 0.461,-0.142 0.496,-0.0354 0.496,3.15 0,1.81 -0.0354,3.3 -0.0709,3.3 -0.0354,0 -5.17,-4.29 -11.4,-9.53 z"
+               id="path8770" />
+            <path
+               style="fill:#808080;fill-rule:nonzero"
+               inkscape:connector-curvature="0"
+               d="m 59.8,228 0.0709,-3.58 11.2,-6.52 c 10.6,-6.17 17.7,-10.2 21,-12 l 1.45,-0.78 0,4.85 0,4.85 -16.8,8.4 c -9.21,4.64 -16.8,8.4 -16.9,8.4 -0.0709,0 -0.106,-1.59 -0.0709,-3.58 z"
+               id="path8772" />
+            <path
+               style="fill:#808080;fill-rule:nonzero"
+               inkscape:connector-curvature="0"
+               d="m 94.9,251 c 0,-35.8 -0.0354,-50.1 0.425,-50.6 0.461,-0.496 0.638,2.27 0.177,1.81 -0.425,-0.425 -0.602,-3.61 -0.602,-11.1 l 0,-10.5 20.1,-17 20,-18 27,-14 c 40.2,-21.8 72.7,-39 81.4,-43.3 l 7.76,-3.76 6.52,-0.319 6.52,-0.319 -0.354,54.2 c -0.283,40.8 -0.496,54.4 -0.957,54.8 -0.319,0.319 -37.8,23.9 -83.2,52.5 -45.4,28.5 -83.1,52.2 -83.7,52.6 l -1.13,0.744 0,-46.9 z"
+               id="path8774" />
+            <path
+               style="fill:#808080;fill-rule:nonzero"
+               inkscape:connector-curvature="0"
+               d="m 64.4,270 -28.7,-29 0.2,-14 0.1,-13 11.2,9.28 c 6.17,5.1 11.9,9.92 12,10.3 0,0.354 6.7,-3.44 16.5,-8.36 9.46,-4.71 17.3,-8.5 17.4,-8.4 0.106,0.106 0.142,18.6 0.0709,41.2 l -0.106,41 -28.7,-28.7 z"
+               id="path8776" />
+            <path
+               style="fill:#808080;fill-rule:nonzero"
+               inkscape:connector-curvature="0"
+               d="m 64.4,178 -28.7,-23.1 0,-9.28 c 0,-7.26 0.142,-9.18 0.638,-8.86 0.319,0.213 5.95,4.82 12.5,10.2 17,14.1 34.4,28 39.8,31.9 l 4.64,3.26 0,9.46 c 0,5.24 -0.0709,9.5 -0.142,9.5 -0.0709,-0.0354 -13,-10.4 -28.8,-23.1 z"
+               id="path8778" />
+            <path
+               style="fill:#666666;fill-rule:nonzero"
+               inkscape:connector-curvature="0"
+               d="M 88.2,176 C 81.1,171 65.6,158 49.3,145 l -13.5,-11.2 4.18,-2.41 c 2.27,-1.31 4.61,-2.69 5.21,-3.08 0.957,-0.638 2.8,0.85 28.2,22.6 l 27.1,23.2 -2.37,2.13 c -5.03,4.43 -3.97,4.43 -9.89,0 z"
+               id="path8780" />
+            <path
+               style="fill:#666666;fill-rule:nonzero"
+               inkscape:connector-curvature="0"
+               d="m 73.7,149 -26.8,-23 2.02,-5.63 c 1.1,-3.08 2.13,-5.81 2.27,-6.06 0.142,-0.213 2.13,1.13 4.39,3.05 7.19,5.99 27.3,20.5 45.9,33.2 2.44,1.67 4.43,3.26 4.46,3.51 0,1.06 -4.75,17.9 -5.07,17.9 -0.177,0 -12.4,-10.3 -27.2,-23 z"
+               id="path8782" />
+            <path
+               style="fill:#666666;fill-rule:nonzero"
+               inkscape:connector-curvature="0"
+               d="M 91.8,142 C 67.7,125 52,113 52.8,112 53.013,111.787 68,102.75 86.2,91.9 l 32.8,-19.5 1.88,2.13 c 9.07,10.3 23.6,18 40.2,21.3 9.64,1.91 16.2,2.44 26,2.09 4.85,-0.213 9.64,-0.496 10.6,-0.638 0.957,-0.177 1.63,-0.213 1.49,-0.0709 -0.709,0.744 -91.6,54.9 -92.1,54.9 -0.319,0 -7.3,-4.68 -15.5,-10.4 z"
+               id="path8784" />
+            <path
+               style="fill:#666666;fill-rule:nonzero"
+               inkscape:connector-curvature="0"
+               d="m 104,166 c 0.815,-2.98 1.88,-6.84 2.34,-8.61 l 0.85,-3.15 46.5,-27.8 c 25.6,-15.3 46.8,-28.2 47.3,-28.7 0.461,-0.567 2.66,-1.38 5.28,-1.98 17.8,-4.18 33.1,-12.8 40.4,-22.8 0.992,-1.38 2.02,-2.44 2.27,-2.37 0.248,0.106 3.44,2.66 7.09,5.7 l 6.66,5.56 -2.73,0.319 c -1.52,0.177 -4.29,0.354 -6.2,0.39 -3.37,0.0354 -3.61,-0.0354 -6.66,-2.23 -3.3,-2.34 -4,-2.62 -4.5,-1.77 -0.177,0.248 1.1,1.42 2.8,2.59 l 3.12,2.09 -12.1,6.17 c -14.5,7.44 -31.9,16.7 -72.2,38.5 l -30.3,16.4 -15.5,13.6 c -8.54,7.48 -15.6,13.6 -15.7,13.6 -0.106,0 0.461,-2.44 1.28,-5.42 z"
+               id="path8786" />
+            <path
+               style="fill:#666666;fill-rule:nonzero"
+               inkscape:connector-curvature="0"
+               d="m 266,91.9 0,-10.2 -7.72,-6.56 -7.72,-6.52 1.38,-2.76 c 1.98,-4 3.12,-9.14 3.08,-14.3 l -0.0354,-4.46 1.1,0.957 c 0.567,0.496 4.25,3.79 8.15,7.26 9.74,8.68 25.7,22.4 29.1,25.2 1.59,1.2 2.76,2.41 2.62,2.66 -0.531,0.85 -28.9,19.1 -29.8,19.1 -0.106,0 -0.213,-4.61 -0.213,-10.3 z"
+               id="path8788" />
+            <path
+               style="fill:#808080;fill-rule:nonzero"
+               inkscape:connector-curvature="0"
+               d="m 266,106 c 0,-2.13 0.177,-3.22 0.496,-3.01 0.532,0.319 16,-9.07 25.1,-15.3 l 5.17,-3.51 0.0709,2.98 c 0.0709,1.67 0.106,3.33 0.142,3.76 0.0354,0.461 -5.74,4.07 -15.3,9.57 -8.43,4.89 -15.4,8.86 -15.6,8.86 -0.106,0 -0.177,-1.49 -0.177,-3.3 z"
+               id="path8790" />
+            <path
+               style="fill:#666666;fill-rule:nonzero"
+               inkscape:connector-curvature="0"
+               d="M 30.8,198 C 15.4,185 2.8,174 2.7,173 c -0.106,-0.354 3.12,-2.55 7.16,-4.93 4.04,-2.34 10.9,-6.38 15.3,-8.96 l 8.01,-4.71 30.2,24.3 c 16.6,13.4 30.3,24.5 30.4,24.8 0.106,0.283 -1.81,1.45 -4.25,2.62 -2.41,1.13 -4.78,2.41 -5.21,2.8 -0.425,0.39 -2.73,1.7 -5.07,2.91 -2.34,1.17 -7.97,4.15 -12.5,6.56 l -8.26,4.39 -27.8,-24.6 z"
+               id="path8792" />
+            <path
+               style="fill:#b3b3b3;fill-rule:nonzero;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="m 75.3,111 37.3,-24.2 38.4,24.4 c 0,0 -40.9,24.7 -41.2,24.6 C 108.95,135.552 75.3,111 75.3,111 Z"
+               id="path8794" />
+            <ellipse
+               style="fill:#4d4d4d;fill-rule:nonzero"
+               ry="9"
+               cy="45.400002"
+               rx="15.1"
+               cx="183"
+               id="ellipse8796" />
+            <path
+               style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+               inkscape:connector-curvature="0"
+               stroke-miterlimit="4"
+               d="m 93.9,221 c 6.1,-2 170,-102 170,-102"
+               id="path8798" />
+          </g>
+        </g>
+        <path
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 776.22871,147.74212 -22.08,0.0888 -70.4,0"
+           style="fill:none;stroke:#777777;stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3, 6;stroke-dashoffset:0;marker-start:none"
+           id="path9977" />
+        <path
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 996.22871,121.34212 0,43.6 -186.8,0 -56,0.3008 -69.2,0"
+           style="fill:none;stroke:#777777;stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3, 6;stroke-dashoffset:0;marker-start:none"
+           id="path9979" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3, 6;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 816.22871,265.34212 -64.8,0 0,-86.8 -65.6,0"
+           id="path9981" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3, 6;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 848.22871,345.34212 -124,0 0,-147.6 -40.8,0"
+           id="path9983" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer11"
+       inkscape:label="quadx"
+       style="display:inline">
+      <g
+         transform="matrix(0.4,0,0,0.4,-56.741854,-148.46127)"
+         id="quad-x">
+        <g
+           transform="matrix(1.8518693,0,0,1.8518693,452.11801,-1731.8917)"
+           id="5645654">
+          <g
+             transform="matrix(1,0,0,-1,0,2792.2535)"
+             id="g5011">
+            <path
+               style="fill:url(#linearGradient8754)"
+               inkscape:connector-curvature="0"
+               d="m 1000,1440 2.7,0 0,-16.7 16.7,0 0,16.7 2.99,0 -11.2,11.2 -11.2,-11.2 z"
+               id="path5019" />
+          </g>
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1090,1480 c 1.8,1.8 4.71,1.8 6.5,0 1.8,-1.8 1.8,-4.71 0,-6.5 l -161,-161 c -1.8,-1.8 -4.71,-1.8 -6.5,0 -1.8,1.8 -1.8,4.71 0,6.5 l 161,161 z"
+             id="path5031" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 1090,1480 c 1.8,1.8 4.71,1.8 6.5,0 1.8,-1.8 1.8,-4.71 0,-6.5 l -161,-161 c -1.8,-1.8 -4.71,-1.8 -6.5,0 -1.8,1.8 -1.8,4.71 0,6.5 l 161,161 z"
+             id="path5035" />
+          <path
+             style="fill:#2e2d2d;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1100,1320 c 1.8,-1.8 1.8,-4.71 0,-6.5 -1.8,-1.8 -4.71,-1.8 -6.5,0 l -161,161 c -1.8,1.8 -1.8,4.71 0,6.5 1.8,1.8 4.71,1.8 6.5,0 l 161,-161 z"
+             id="path5039" />
+          <path
+             style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
+             inkscape:connector-curvature="0"
+             stroke-miterlimit="10"
+             d="m 1100,1320 c 1.8,-1.8 1.8,-4.71 0,-6.5 -1.8,-1.8 -4.71,-1.8 -6.5,0 l -161,161 c -1.8,1.8 -1.8,4.71 0,6.5 1.8,1.8 4.71,1.8 6.5,0 l 161,-161 z"
+             id="path5043" />
+          <g
+             transform="matrix(1,0,0,-1,0,2792.2535)"
+             id="g5053">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath5049)"
+               id="g5055">
+              <g
+                 transform="translate(1170.2617,1551.2617)"
+                 id="g5057">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5059" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="matrix(1,0,0,-1,0,2792.2535)"
+             id="g5069">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath5065)"
+               id="g5071">
+              <g
+                 transform="translate(977.2441,1551.2617)"
+                 id="g5073">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5075" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="matrix(1,0,0,-1,0,2792.2535)"
+             id="g5085">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath5081)"
+               id="g5087">
+              <g
+                 transform="translate(1170.2617,1361.2432)"
+                 id="g5089">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5091" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="matrix(1,0,0,-1,0,2792.2535)"
+             id="g5101">
+            <g
+               style="opacity:0.5"
+               clip-path="url(#clipPath5097)"
+               id="g5103">
+              <g
+                 transform="translate(977.2441,1361.2432)"
+                 id="g5105">
+                <path
+                   style="fill:#b1c7eb;fill-rule:nonzero"
+                   inkscape:connector-curvature="0"
+                   d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
+                   id="path5107" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="matrix(82.988968,0,0,-64.991364,969.49512,1428.5608)"
+             id="g5119">
+            <image
+               transform="matrix(1,0,0,-1,0,1)"
+               xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFMAAABBCAYAAACtrJiQAAAABHNCSVQICAgIfAhkiAAADhxJREFUeJztnGt0HOV5x38zs5fZ++rqi6z73RfJsiQjOxDbhdQ3TIAPLSTpCYXGQNKeHpKU0LRJOKXknPRDD5Rwjg9Q04T0cCnQNjUXAwZh2ZZtbMzFtizJ1gVZ1tpaSXuf3ZmdmX6QpeAaYwuvbalHvy+rM6PZeeY/z/M+z/u8MyvULVliMktGEK+1Af+fmBUzg8yKmUFmxcwgs2JmEMtUDzDN8eQvCMLk37OMM2UxYVzIz3/OMs6Uw3xWwAszZTFnQ/vCzCagDDIrZgb5SgnoWiOKIol4nHg8jtVqweX2YLFYrvkQNOM8U5IkQmOjOJxOrl+1hsrqhcRjUYLDZzBNE1G8dpc0ozxTEARGR0YoKinll48+QmlZGaGxMT49fIT/ePlV2nfvxCE78Pn96Lp+1e2bUZ5pGAaapnLnt+6kqXk5gydPomkaq9es4sknH+eBH/0IQRQ4HRhCEISrXsZJc+bMeXiqB12rWlNJJMjLn8Nd3/0zFEUhlUqh6zpjoyOkkilWr17DyhUrOHy4g96e48gOx1UdS2eMZwqCQCIRp7K6lsLCQmKx2OQ+UZRIJhW6Ojsor6jg2WefZt3GWwgOnyERjyNJ0lWxccaIOeFddXWLsdllDOPcMVEQRERRor+vl1RK5Z9+9Uv+4r7vE4tFGR0ZuSqCzpgwV1UVuyzzne98G7/XQ0JJAmCaBoIgMH/+PHLz8jEMg2AwiKqqrFu7lqKSItrb9zISHMblcl9R22eMZ8ZjMUrLK6mqrCQUDk1uFwQRn8/Lttff5LHHn2B0dJSq6moAOo8dZcOGjWzd+gwLF9dzOjBEMpm8Yl6aAc8UABNTTyMIIlzszgsCCCJ6YgRDiSBaZRAtwIWThCAIRKMR1m+8mdWrv04wGJy0IT8vj86ubh568EH272unrW0XsbjCyhUt+Hxejnd3U1RUxK23bkIzBA7s34eqqTidrownpsv3TFNHEG1YvQXoyRBaaAg9GQIjzbjQZxFEMHXSkdOoY4M4CprxLfk26cQo6WjgrKBffCPSmobT6WRp/WKSijJ+0xgPcZfHw4GDh9DTaRYsKCISCbPlySfYfN8P6OvrZ9HiJQSDZwiFw/z0oQd55NF/BNPkzOlAxj00A55pYKYVHHObKLzhYexzGtCi/aSjAfR4CDOtACbp2AimlsRZtJK5K3/O4q/fTvGyFYh5G0lGT5KODCCIX+zZsViU0rJKvnXnHSiKMlmQi6KILMu8+NLL9Pf14HA6kWUHLreb3p7jbH9zO4IksnLl17BZrfT29nLdihaamprYu28/gcAQHo/nK0p3PpcvpiCBaaIGj6JjoaZlHVU3/imuwk0IWXWYGBipMTxlaym96VFqv7aRuRXz0RQNNZxkwbIFGK4Ghg/+OxabzFgohJJQcDgck4V3JBKmsWk5N9+8kbHR0clTu9xugsFhXnzhRVQ1hc1mn9zn9XpREgnef7+VQx9/Sk1VBQsXLeHU4ElKSktZv24d+/cfpL+/F4/Hm5GQz0g2FyQLglUm/tkuTh54AYUmyprLKGlZRE5eEzkVN1O27Hqy5nhRYymSkSSmbmACkiTQ91E70RNvowk2Vq25kezcPLo7O1BTKRwOJ0oiwbr162lsXEY49Ifkk5uTw8FDH/Latm04nK5z5uWmaSI7HDidTo53dbJ9+9skVY1lDfXoaQ2Hw8natTfR2trGmdNDOF2XP4ZmtDSyOvxg6ox1vMzJj1sxLMvJKfRjEUXUhEYqlsI0zMmR0WIRSSsaPTt/TTISAIudR/7hF9x99914/T4GBgbpOdGN35/Nw7/4OQIQjUYQBBHTNMjNy2fHu63sa9+D231+uJqmiSAIeL0+kqkku9t2smvPXhobG3G5nPizsikomM87b7+NJEmX3STJaGlkGGkEuxtbdgHqaA9Hn7uFI7s+RLKKmLpxXnoRLRJKMo0eHyKVNigsLMHhcDJ8JsCdd97B009tYfP9f4nT6WTrvz0HQElp2eTNVNUUPT29F7VL13Xcbg9z582ns+MIP/27nxGPJxgdCbJsaT2L6pYSjUYu+/ozX2eaJpgGVt88JKuNwR0/JDSqYHfbz/tXTU3j8dqpumULaUOguDCfvPx8QqEwx7u6ME2Tnzz4Yx5//DH6+/u5+557eeHFF1lQWEhZeQVDp4Y43t2FLDsuwSwT0zSZM3cevT3Had3ZhtvjweFyU15RSTqdvuxLv2JFu2noSO48jFSSzzr3Y/Xaz6kkTUEAw8TilTGtEoKpU1VTg2QZL1dEUSIajdBx5DALCubz6yce47bbb+XNN95i873389GhQwwHgwSGBnE4Li7m5xEFkVgsjiiOn8vtcmXkmq9sP9M0Ea12wkefJ1m3AqtNIq3qk/sESUS0WRj85C1kSaCmZhFKLD55uCCICAKcGR5GCI5w+2238s1NN/Psb57jN797noH+PmLRKM6zyccwjEswyUSySHg8LgxDR5IsmObFj7sUrnBz2ERyZaOcOkLviR5qmxcTDUQRAJvdQkLR2P2vDxPofIfyqlpKy0oJR84fuyaK9M/6+7BYrGz+3j2MjY6yc9dutm9/i317dmG1WsnKzhk/65dkZdM0kSQJj9uNaRggfdnca2pc+bm5IIAoMnLkeXRFQ5JETMDmlRkZjRPu2IaaUiivbSAnJ5dUKnVhY0UJwzDo7+slHo/zzVs28S+P/zN/+/c/o6i4jEBgiHA4hCiKF6w4TMPAarXhcrkmi/9MTSuvvJimicWdQ7xvF4ODEXxVuTh9MoJVJDzQDqKAINmpriieHC8vhiCMh3Rfbw/B4SB33PEnPPPMFv7qrx8gOzuHoVODxGOxL5wu6oaBzWZDlmU0LT2emIyZIiYgSDZEi4UTr/+Qg6++zXAgih5XUc4cQDcF/D4fNTXVJKLRKX2vKEqoqsrxri60tM59927m6ae38N27v4dksTB0ahBVVc8t5g0Du92Oy+lA18czuDEzxsyzmAaSMxctMsDgjr/htNOHPLcBLdyLKtgoKiikvr4Ot8eLqmmEw5GzfcpLu9eiKBGLRuiKhMnOzuahhx5kw9obeWrrb9nT1ko4NIbPn4Usy+iGjs0uY7fLpPXMiDjB1WsOmwaiRUZy+AADbeQ4iCIWu4O0pnLg4EecGjpFTlYW5RUVeDxeVFVF09RLOt/4PF5EURSCw2dYUFjIhvXrWNrQgI5E97GjhCNhTMMkJyePTZvWI4giTqeL9r37OfzJRzgvs0S6+ku9poEg2ZDcuQDYJYlUKsXune/R1rqDl+YXsKz5Ola2NNPc3Ex5ZSWJWIzh4DBpLX1Rb50opwKBAKIoUV+3hOXLl9O+YS2//d3zvLdjOwWFheTlzyEwFBhPPhlKQNd83VzXdSRJIjcvH4BIOMy2/3qFN1/7PZWVNTQub2bFdc001Nfj9nkZDQYJhyMYhv6lwo7P300GBwcRRYmm5mYaGhrY9voaykqKz37HeJhnqs6cdmtAssOB3WZHSSQYHBzgw4Mf8H5rK4c+OUJobAyvx01xSQnZubmIgoCqqmeF/WKbJraHQmMkUwqNjcuQZZmxsTEkScLr89G+dx+HP/3kssN82okZjUQoLi3n/h98H5fbh9VqIxwK0dV5lLa2nezZs5cjHZ2EQiHsNgvFxcXk5OWhaSqapk0usJ1vs4hpmEQjUVRVnSybvD4fe/d9wOFPPp6BY+aXMLE2Xrd0Kfdu3syG9Ws5fTpAT08fe/d9wMEPDnBqcIB3tr/Bu29tx5+VxeK6paxZs4rGZfWUlJaiqilGgiMkk8olVwP/d9n4qzKtxEyn08iyTN2SWgYG+hk6NYTskFmxooXVq1cTj0Z54Mc/4dCBffizskkmk7S17mDX++9RVFJKY1MzK1uaqa+vZ35BAbFImODI6JeOr4ahMzYWyki0TSsxlUSCgsJiaqtrCIVCmKaJklBIxOO4PV4MQyc0OorFYgVAlmUcDgeGYRAYGuSVl46z7b9fpbyyhutaWlh1w0pqF9Zis9kZCQaJRqPn1K9Ol5NwOEJfTw82+/ktwqkyrcRMJhVqFi5ifkEBJwcGJrdPrI3v2PEu/X0ncH2uqz7RTfd4vPh8fjRNo7vzKEcPf8x/vvISi+saWLniOpoal1FeUQHAyMgIaU2jqrqWrVu30t11jOycnMu2f1qJCVBdVX72Yas/eJBpGthsdjqOdZNKpfD5s76wOWEYBpIkTXaPkskku3e+x+6d7zFvfgH1DY20tDRTv2QJebm5vLbtf3hqyxZsdhuiKF52w2PaiKlpKm6Pl4rycuJn13kmsNmshMZGOXL4MBaL9aIXPbHfbrcj58/BNE3CoRBvvPZ73tn+OkXFZfj8fjo7jmAYBllZ2RnptE8bMePxOLULF1NdVUU4cm7Dw+320tPTQ39fz5TLlwlhnS4XLrcbXdcZGjrJZ5/14nK5xufoGRASptGzRpqq8o1v3ERVTS3JpHLOrMTldtPT1084FMJms33lc0w8pu1yufH7s7BabZfUnb9UpoWYpmnicDjZt/8Ae3a1UVVdy7x58xAEAcPQsVgsnBoKkNbT0/qlrmkR5oIg4PP7ad+9k48OfsCmW2/jj2/6I5bU1WEYOkoizrGOY4iXWIRfK4Sp/qzERClyJZAkiXgsRjQaweVy03L9Ddy/+R5cLjd33fXnJOJx5CmuRF5NppWYE4jieF8yEg6Rm5dPWUUVJ7o7r+lrKZfCtBRzAlEUSSQSJJMKfn/WtH8te1qMmRfCMAxkWUaWZWD6vwQ7veNmhjErZgaZFTODzIqZQWbFzCBfKZtP96x6rZiymNN5bnytmQ3zDDIrZgaZFTOD/C9uew7sSK2nLAAAAABJRU5ErkJggg=="
+               width="1"
+               height="1"
+               id="image5121" />
+          </g>
+          <g
+             transform="matrix(1,0,0,-1,0,2792.2535)"
+             id="g5149">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5135)"
+               id="g5151">
+              <g
+                 id="g5153">
+                <g
+                   id="g5155">
+                  <g
+                     id="g5157">
+                    <g
+                       id="g5159">
+                      <path
+                         style="fill:url(#radialGradient8756)"
+                         inkscape:connector-curvature="0"
+                         d="m 1090,1480 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 l -12,-10e-4 35.6,35.6 35.6,-35.6 -11.3,0 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 l 17.8,17.8 z"
+                         id="path5161" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             transform="matrix(1,0,0,-1,0,2792.2535)"
+             id="g5181">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5167)"
+               id="g5183">
+              <g
+                 id="g5185">
+                <g
+                   id="g5187">
+                  <g
+                     id="g5189">
+                    <g
+                       id="g5191">
+                      <path
+                         style="fill:url(#radialGradient8758)"
+                         inkscape:connector-curvature="0"
+                         d="m 1040,1490 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.7 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path5193" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             transform="matrix(1,0,0,-1,0,2792.2535)"
+             id="g5213">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5199)"
+               id="g5215">
+              <g
+                 id="g5217">
+                <g
+                   id="g5219">
+                  <g
+                     id="g5221">
+                    <g
+                       id="g5223">
+                      <path
+                         style="fill:url(#radialGradient8760)"
+                         inkscape:connector-curvature="0"
+                         d="m 895,1290 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 l -12,-10e-4 35.6,35.6 35.6,-35.6 -11.3,0 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 l 17.8,17.8 z"
+                         id="path5225" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             transform="matrix(1,0,0,-1,0,2792.2535)"
+             id="g5245">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5231)"
+               id="g5247">
+              <g
+                 id="g5249">
+                <g
+                   id="g5251">
+                  <g
+                     id="g5253">
+                    <g
+                       id="g5255">
+                      <path
+                         style="fill:url(#radialGradient8762)"
+                         inkscape:connector-curvature="0"
+                         d="m 845,1300 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.7 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 11.2,0 z"
+                         id="path5257" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             transform="matrix(1,0,0,-1,0,2792.2535)"
+             id="g5277">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5263)"
+               id="g5279">
+              <g
+                 id="g5281">
+                <g
+                   id="g5283">
+                  <g
+                     id="g5285">
+                    <g
+                       id="g5287">
+                      <path
+                         style="fill:url(#radialGradient8764)"
+                         inkscape:connector-curvature="0"
+                         d="m 1130,1290 c -3.01,-9.78 -12.1,-16.9 -22.9,-16.9 -12.2,0 -22.2,9.11 -23.7,20.9 l 12,-10e-4 -35.6,35.6 -35.6,-35.6 11.3,0 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.012 44,13.9 53.4,34 l -17.8,17.8 z"
+                         id="path5289" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             transform="matrix(1,0,0,-1,0,2792.2535)"
+             id="g5309">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5295)"
+               id="g5311">
+              <g
+                 id="g5313">
+                <g
+                   id="g5315">
+                  <g
+                     id="g5317">
+                    <g
+                       id="g5319">
+                      <path
+                         style="fill:url(#radialGradient8766)"
+                         inkscape:connector-curvature="0"
+                         d="m 1180,1300 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.7 l -11.1,0 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0 z"
+                         id="path5321" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             style="fill:url(#linearGradient8780)"
+             transform="matrix(1,0,0,-1,0,2792.2535)"
+             id="g5341">
+            <g
+               style="opacity:0.69999701;fill:url(#linearGradient8778)"
+               clip-path="url(#clipPath5327)"
+               id="g5343">
+              <g
+                 style="fill:url(#linearGradient8776)"
+                 id="g5345">
+                <g
+                   style="fill:url(#linearGradient8774)"
+                   id="g5347">
+                  <g
+                     style="fill:url(#linearGradient8772)"
+                     id="g5349">
+                    <g
+                       style="fill:url(#linearGradient8770)"
+                       id="g5351">
+                      <path
+                         style="fill:url(#linearGradient8768)"
+                         inkscape:connector-curvature="0"
+                         d="m 939,1480 c -3.01,-9.78 -12.1,-16.9 -22.9,-16.9 -12.2,0 -22.2,9.11 -23.7,20.9 l 12,0 -35.6,35.6 -35.6,-35.6 11.3,0 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 939,1480 Z"
+                         id="path5353" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             transform="matrix(1,0,0,-1,0,2792.2535)"
+             id="g5373">
+            <g
+               style="opacity:0.69999701"
+               clip-path="url(#clipPath5359)"
+               id="g5375">
+              <g
+                 id="g5377">
+                <g
+                   id="g5379">
+                  <g
+                     id="g5381">
+                    <g
+                       id="g5383">
+                      <path
+                         style="fill:url(#radialGradient8782)"
+                         inkscape:connector-curvature="0"
+                         d="m 989,1490 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 l -11.1,0 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0 z"
+                         id="path5385" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </g>
+          </g>
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 934,1288.1 c 9.4,9.41 9.4,24.7 -0.008,34.1 -9.41,9.41 -24.7,9.41 -34.1,0 -9.4,-9.41 -9.4,-24.7 0.008,-34.1 9.41,-9.41 24.7,-9.41 34.1,-0.01"
+             id="path5389" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 916,1312.7 0,-10.9 -2.77,2.14 -1.83,-2.5 4.89,-3.59 3.23,0 0,14.9 -3.53,0 z"
+             id="path5393" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1130,1288.1 c 9.4,9.41 9.4,24.7 -0.01,34.1 -9.41,9.41 -24.7,9.41 -34.1,0 -9.4,-9.41 -9.4,-24.7 0.01,-34.1 9.41,-9.41 24.7,-9.41 34.1,-0.01"
+             id="path5397" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1108.1,1312.7 0,-2.94 5.8,-5.25 c 0.734,-0.693 1.22,-1.39 1.22,-2.29 0,-1.05 -0.736,-1.78 -1.85,-1.78 -1.18,0 -1.95,0.924 -2.1,2.25 l -3.38,-0.462 c 0.335,-3 2.77,-4.79 5.67,-4.79 2.73,0 5.38,1.45 5.38,4.56 0,2.12 -1.24,3.36 -2.6,4.58 l -3.44,3.07 6.07,0 0,3.06 -10.8,0 z"
+             id="path5401" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 934,1477.3 c 9.4,9.41 9.4,24.7 -0.008,34.1 -9.41,9.41 -24.7,9.41 -34.1,0 -9.41,-9.41 -9.41,-24.7 0.006,-34.1 9.41,-9.41 24.7,-9.41 34.1,-0.01"
+             id="path5405" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 918,1490 -0.063,0 -3.53,5.5 3.59,0 0,-5.5 z m 3.28,8.36 0,2.9 -3.3,0 0,-2.9 -6.99,0 0,-2.96 6.05,-9.01 4.22,0 0,9.11 2.06,0 0,2.86 -2.04,0 z"
+             id="path5409" />
+          <path
+             style="fill:#48484a;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1124.6,1477.3 c 9.4,9.41 9.4,24.7 -0.01,34.1 -9.41,9.41 -24.7,9.41 -34.1,0 -9.4,-9.41 -9.4,-24.7 0.01,-34.1 9.41,-9.41 24.7,-9.41 34.1,-0.01"
+             id="path5413" />
+          <path
+             style="fill:#ffffff;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 1107.3,1502.7 c -2.71,0 -5.16,-1.18 -5.96,-3.95 l 3.28,-0.861 c 0.274,0.987 1.18,1.85 2.52,1.85 1.01,0 2.16,-0.504 2.16,-1.89 0,-1.51 -1.55,-1.95 -3.02,-1.95 l -0.945,0 0,-2.58 1.03,0 c 1.32,0 2.6,-0.336 2.6,-1.76 0,-1.07 -0.902,-1.64 -1.87,-1.64 -1.01,0 -1.81,0.65 -2.04,1.66 l -3.28,-0.756 c 0.712,-2.5 3.06,-3.78 5.54,-3.78 2.62,0 5.23,1.34 5.23,4.2 0,1.64 -1.05,2.86 -2.5,3.23 l 0,0.063 c 1.68,0.398 2.86,1.78 2.86,3.44 0,3.25 -2.88,4.72 -5.6,4.72"
+             id="path5417" />
+          <path
+             style="fill:#2f2d2e;fill-rule:nonzero"
+             inkscape:connector-curvature="0"
+             d="m 982,1360 62.1,0 c 1.63,0 2.95,1.32 2.95,2.95 l 0,62.1 c 0,1.63 -1.32,2.96 -2.95,2.96 l -62.1,0 c -1.63,0 -2.95,-1.32 -2.95,-2.96 l 0,-62.1 c 0,-1.63 1.32,-2.95 2.95,-2.95"
+             id="path7075" />
+        </g>
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,748 687,2.81 0,-22.5"
+           id="path9540" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,789 687,2.81 0,131"
+           id="path9544" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,829 174,-0.995 156,2.37 0,67.7"
+           id="path9542" />
+        <path
+           style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
+           inkscape:connector-curvature="0"
+           stroke-miterlimit="4"
+           d="m 1820,708 174,-0.995"
+           id="path9538" />
+      </g>
+    </g>
     <g
        transform="translate(-21.636986,-37.172948)"
        id="pwm">
@@ -2794,7 +11773,7 @@
            font-size="56px"
            xml:space="preserve"
            font-weight="bold"
-           style="font-size:56px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;font-family:Sans"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:56px;line-height:125%;font-family:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff"
            id="text9734"><tspan
              y="753.59766"
              x="629.06409"
@@ -2810,7 +11789,7 @@
            font-size="56px"
            xml:space="preserve"
            font-weight="bold"
-           style="font-size:56px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#488eff;font-family:Sans"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:56px;line-height:125%;font-family:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#488eff"
            id="text9734-2"><tspan
              y="819.59766"
              x="725.06409"
@@ -2826,7 +11805,7 @@
            font-size="56px"
            xml:space="preserve"
            font-weight="bold"
-           style="font-size:56px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffdc00;font-family:Sans"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:56px;line-height:125%;font-family:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffdc00"
            id="text9734-2-6"><tspan
              y="887.59766"
              x="697.06409"
@@ -2842,7 +11821,7 @@
            font-stretch="normal"
            font-size="56px"
            xml:space="preserve"
-           style="font-size:56px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:125%;letter-spacing:0px;word-spacing:0px;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#73ff00;fill-rule:nonzero;enable-background:accumulate;font-family:Sans"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:56px;line-height:125%;font-family:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;fill:#73ff00;fill-rule:nonzero;enable-background:accumulate"
            id="text9734-2-6-4"><tspan
              y="953.59766"
              x="715.06409"
@@ -2858,7 +11837,7 @@
            font-stretch="normal"
            font-size="56px"
            xml:space="preserve"
-           style="font-size:56px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-indent:0;text-align:end;text-decoration:none;line-height:125%;letter-spacing:0px;word-spacing:0px;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:end;baseline-shift:baseline;color:#000000;fill:#ff7e00;fill-rule:nonzero;enable-background:accumulate;font-family:Sans"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:56px;line-height:125%;font-family:Sans;text-indent:0;text-align:end;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:end;fill:#ff7e00;fill-rule:nonzero;enable-background:accumulate"
            id="text9734-2-6-4-2"><tspan
              y="1013.5977"
              x="831.17352"
@@ -2874,9110 +11853,6 @@
            d="m 862,718 278,1.39 1.58,76.5 37,0.11"
            id="path8856" />
       </g>
-    </g>
-    <g
-       transform="translate(-17.131942,-19.544384)"
-       id="controller-revomini"
-       inkscape:label="#controller">
-      <path
-         style="fill:url(#linearGradient8734)"
-         inkscape:connector-curvature="0"
-         d="m 530.25061,73.31614 9.00763,0 0,25.796734 22.41432,0 0,-25.796734 9.55228,0 -20.46617,-19.904887 z"
-         id="path10151-2-3" />
-      <image
-         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAABcCAYAAABTEPRqAAAABHNCSVQICAgIfAhkiAAAAydJREFU SInN1kuIV3UUB/DPGf8jhmVYkxNRiwpbBGGSMSRGNW1CJdEw3NWmVYGFYVmLHsta9JpqUbkpmuiF aS8oJCMjDYUQQnSSiYIeOiTZa5z01+KeO3Pn//8PtQnmwuX+fud873n/zvkppahfnI+fUXBBKUWT 2cJHyZwOwI34usHsAOxL4gszAYawCr1dAQ07OgA9/uWZDYBW2/4UHsn1CYh073+04b8ZGRELcBeu xt/4AkOllHE4U2eqC3ZjDtyThFGswEr8mbSbW6oM7sGbpZTPUuXnGMRl09LdSPlYSljdzgxsTeZh zG0HPJ3McdzQXtX3JXMCayfpyVyP0ziJdU2pgSuwF/PwKl5uBHIEnuoSpPp9uIXzsGuGVIzOpnpY hDtxJX7CS6WUPTWoH0dMd28C19UObEnix7gcz+f+rRqwHPdjaRJuSsChbsd/Lb5MwJb2bM5v2LB9 WjYTsAgP4dME7ehQkcC5OJ6gZT0RsToiNkXEpVBKOYnvMwRXwXuJHsYZqpZY27IcrlHVYMEfDeZw s+QG8D6+w348gFYpZVb0hw5ARKyJiE8iYjM6ktVnaqBs7darn1Udg04VEXELbpX9cRogIvrwHH7A k01A3WmfUaV7LS6eJiEi1mEDXi+lbOvwCj+qKvuJ9GCFajztwxuRLs30lMDdbcTrsUbV+Ya7lVzd N7sGiqrcduEgs2terMK1XfiP167t0L0NLq6TtSS/j6lmRf2MwcJEH28PWh2o+u+JiPggIg5GxIsR cU4tZmND54nG+gB656gax++qQ7wer+A2XIjRDp3p1faUMtSKiKW4BF+VUkZSbW9+/6KaEUV1uudh MX5L2kpYampO/qKavJONrNa5DO/gW9X0edQs6g+Tl5yI6FeV/AJsK6UcxaQXg6YGelG5urF2YD6O JeM1bE7AGM5q4XaciyOllA2pbjzVL2zJfozdETGgmjo7SykHavs+TPEjDRtO4d7ahr0NwzbhDvya +yXwbgJ2N+rh7aQ92GNqNhxrxOeb/Pb3YGduBiPi7FzXh2iE6jJ1OEUeNXWFPoa+WudFqpvX6WQe wkApxT8athIE2BWsmgAAAABJRU5ErkJggg== "
-         width="8"
-         height="92"
-         transform="translate(671,142.51434)"
-         id="image10745-4" />
-      <g
-         transform="matrix(1.0887723,0,0,1.065281,432.61098,99.35125)"
-         id="g8764">
-        <path
-           style="fill:#ffffff;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
-           inkscape:connector-curvature="0"
-           id="path8131"
-           d="M 203.083,1.012 H 19.572 c -7.224,0 -13.08,4.478 -13.08,10 V 201.05 c 0,5.522 5.855,10 13.08,10 h 183.512 c 7.223,0 13.079,-4.478 13.079,-10 V 11.012 c 0,-5.523 -5.857,-10 -13.08,-10 z M 19.523,204.315 c -3.92,0 -7.098,-3.178 -7.098,-7.097 0,-3.92 3.178,-7.097 7.098,-7.097 3.918,0 7.096,3.177 7.096,7.097 0,3.92 -3.178,7.097 -7.096,7.097 z M 19.522,21.924 c -3.919,0 -7.097,-3.178 -7.097,-7.097 0,-3.919 3.178,-7.097 7.097,-7.097 3.919,0 7.097,3.177 7.097,7.097 0,3.919 -3.178,7.097 -7.097,7.097 z m 182.942,182.064 c -3.92,0 -7.098,-3.178 -7.098,-7.098 0,-3.919 3.178,-7.096 7.098,-7.096 3.918,0 7.096,3.177 7.096,7.096 0,3.921 -3.178,7.098 -7.096,7.098 z m 0.194,-183.487 c -3.92,0 -7.098,-3.178 -7.098,-7.097 0,-3.919 3.178,-7.097 7.098,-7.097 3.918,0 7.096,3.177 7.096,7.097 -0.001,3.92 -3.178,7.097 -7.096,7.097 z" />
-        <rect
-           style="fill:#312d29"
-           height="5.0900002"
-           width="6.5190001"
-           y="135.117"
-           x="140.19701"
-           id="rect4320-3" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0900002"
-           width="3.5710001"
-           y="135.117"
-           x="146.67"
-           id="rect4322-2" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0900002"
-           width="3.5710001"
-           y="135.117"
-           x="136.67"
-           id="rect4324-1" />
-        <rect
-           style="fill:#312d29"
-           height="6.5190001"
-           width="5.0900002"
-           y="24.256001"
-           x="166.8"
-           id="rect4320_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0900002"
-           y="30.73"
-           x="166.8"
-           id="rect4322_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0900002"
-           y="20.73"
-           x="166.8"
-           id="rect4324_1_" />
-        <rect
-           style="fill:#312d29"
-           height="5.0879998"
-           width="6.5180001"
-           y="145.592"
-           x="164.828"
-           id="rect4408-1" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0879998"
-           width="3.572"
-           y="145.592"
-           x="161.3"
-           id="rect4410-3" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0879998"
-           width="3.572"
-           y="145.592"
-           x="171.3"
-           id="rect4412-2" />
-        <rect
-           style="fill:#312d29"
-           height="5.0879998"
-           width="6.5180001"
-           y="138.592"
-           x="166.828"
-           id="rect4408_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0879998"
-           width="3.572"
-           y="138.592"
-           x="163.3"
-           id="rect4410_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0879998"
-           width="3.572"
-           y="138.592"
-           x="173.3"
-           id="rect4412_1_" />
-        <rect
-           style="fill:#312d29"
-           height="6.5180001"
-           width="5.0900002"
-           y="152.383"
-           x="86.940002"
-           id="rect10515-5" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0900002"
-           y="158.856"
-           x="86.940002"
-           id="rect10517-3" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0900002"
-           y="148.856"
-           x="86.940002"
-           id="rect10519-5" />
-        <rect
-           style="fill:#312d29"
-           height="6.5180001"
-           width="5.0900002"
-           y="152.383"
-           x="79.940002"
-           id="rect10515_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0900002"
-           y="158.856"
-           x="79.940002"
-           id="rect10517_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0900002"
-           y="148.856"
-           x="79.940002"
-           id="rect10519_1_" />
-        <rect
-           style="fill:#bc781e"
-           height="5.0890002"
-           width="6.5180001"
-           y="145.991"
-           x="57.810001"
-           id="rect4219-1" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0890002"
-           width="3.5710001"
-           y="145.991"
-           x="64.282997"
-           id="rect4221-2" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0890002"
-           width="3.5710001"
-           y="145.991"
-           x="54.283001"
-           id="rect4223-2" />
-        <rect
-           style="fill:#bc781e"
-           height="6.5180001"
-           width="5.0900002"
-           y="150.646"
-           x="127.165"
-           id="rect10550-2" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5699999"
-           width="5.0900002"
-           y="157.121"
-           x="127.165"
-           id="rect10552-6" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5699999"
-           width="5.0900002"
-           y="147.121"
-           x="127.165"
-           id="rect10554-4" />
-        <rect
-           style="fill:#bc781e"
-           height="6.5180001"
-           width="5.0879998"
-           y="156.90601"
-           x="120.317"
-           id="rect10558-0" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5699999"
-           width="5.0879998"
-           y="163.381"
-           x="120.317"
-           id="rect10560-7" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5699999"
-           width="5.0890002"
-           y="153.381"
-           x="120.317"
-           id="rect10562-0" />
-        <rect
-           style="fill:#bc781e"
-           height="6.5180001"
-           width="5.0900002"
-           y="96.193001"
-           x="156.007"
-           id="rect10566-3" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.572"
-           width="5.0900002"
-           y="102.666"
-           x="156.007"
-           id="rect10568-4" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.572"
-           width="5.0900002"
-           y="92.666"
-           x="156.007"
-           id="rect10570-0" />
-        <rect
-           style="fill:#bc781e"
-           height="6.5180001"
-           width="5.0900002"
-           y="96.193001"
-           x="148.007"
-           id="rect10566_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.572"
-           width="5.0900002"
-           y="102.666"
-           x="148.007"
-           id="rect10568_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.572"
-           width="5.0900002"
-           y="92.666"
-           x="148.007"
-           id="rect10570_1_" />
-        <rect
-           style="fill:#bc781e"
-           height="5.0890002"
-           width="6.5180001"
-           y="6.96"
-           x="167.77499"
-           id="rect10574-0" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0890002"
-           width="3.5710001"
-           y="6.96"
-           x="174.24899"
-           id="rect10576-5" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0890002"
-           width="3.5710001"
-           y="6.96"
-           x="164.24899"
-           id="rect10578-3" />
-        <rect
-           style="fill:#42a839"
-           height="5.0890002"
-           width="6.5180001"
-           y="46.223"
-           x="16.167"
-           id="rect4416-1" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0890002"
-           width="3.572"
-           y="46.223"
-           x="22.639999"
-           id="rect4418-0" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0890002"
-           width="3.572"
-           y="46.223"
-           x="12.64"
-           id="rect4420-6" />
-        <rect
-           style="fill:#fbac0c"
-           height="5.0900002"
-           width="6.5180001"
-           y="172.005"
-           x="43.869999"
-           id="rect4416_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0900002"
-           width="3.572"
-           y="172.005"
-           x="50.342999"
-           id="rect4418_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0900002"
-           width="3.572"
-           y="172.005"
-           x="40.342999"
-           id="rect4420_1_" />
-        <rect
-           style="fill:#20abcc"
-           height="5.0900002"
-           width="6.5180001"
-           y="162.005"
-           x="43.869999"
-           id="rect4416_2_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0900002"
-           width="3.572"
-           y="162.005"
-           x="50.342999"
-           id="rect4418_2_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0900002"
-           width="3.572"
-           y="162.005"
-           x="40.342999"
-           id="rect4420_2_" />
-        <rect
-           style="fill:#ff7900"
-           height="5.0890002"
-           width="6.5180001"
-           y="58.402"
-           x="15.838"
-           id="rect4432-7" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0890002"
-           width="3.5710001"
-           y="58.402"
-           x="22.311001"
-           id="rect4434-5" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0890002"
-           width="3.5710001"
-           y="58.402"
-           x="12.311"
-           id="rect4436-0" />
-        <rect
-           style="fill:#bc781e"
-           height="6.5180001"
-           width="5.0890002"
-           y="20.334"
-           x="69.966003"
-           id="rect4280-0" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0890002"
-           y="26.808001"
-           x="69.966003"
-           id="rect4282-4" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0890002"
-           y="16.808001"
-           x="69.966003"
-           id="rect4284-5" />
-        <rect
-           style="fill:#bc781e"
-           height="6.5180001"
-           width="5.0890002"
-           y="56.049"
-           x="75.407997"
-           id="rect10763-4" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0890002"
-           y="62.521999"
-           x="75.407997"
-           id="rect10765-9" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0890002"
-           y="52.521999"
-           x="75.407997"
-           id="rect10767-5" />
-        <rect
-           style="fill:#bc781e"
-           height="5.0900002"
-           width="6.5180001"
-           y="52.145"
-           x="91.143997"
-           id="rect10771-6" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0900002"
-           width="3.572"
-           y="52.145"
-           x="87.615997"
-           id="rect10773-4" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0900002"
-           width="3.572"
-           y="52.145"
-           x="97.615997"
-           id="rect10775-8" />
-        <rect
-           style="fill:#bc781e"
-           height="6.5180001"
-           width="5.0890002"
-           y="131.85699"
-           x="57.523998"
-           id="rect10779-2" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0890002"
-           y="138.33099"
-           x="57.523998"
-           id="rect10781-1" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0890002"
-           y="128.33099"
-           x="57.523998"
-           id="rect10783-6" />
-        <rect
-           style="fill:#bc781e"
-           height="6.5180001"
-           width="5.0900002"
-           y="151.013"
-           x="113.275"
-           id="rect10795-8" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.572"
-           width="5.0900002"
-           y="157.485"
-           x="113.275"
-           id="rect10797-3" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.572"
-           width="5.0900002"
-           y="147.485"
-           x="113.275"
-           id="rect10799-1" />
-        <rect
-           style="fill:#312d29"
-           height="6.5190001"
-           width="5.0890002"
-           y="119.482"
-           x="73.119003"
-           id="rect10803-4" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0890002"
-           y="115.956"
-           x="73.119003"
-           id="rect10805-8" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0890002"
-           y="125.956"
-           x="73.119003"
-           id="rect10807-4" />
-        <rect
-           style="fill:#312d29"
-           height="6.5190001"
-           width="5.0890002"
-           y="127.865"
-           x="50.306999"
-           id="rect10819-9" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0890002"
-           y="124.339"
-           x="50.306999"
-           id="rect10821-2" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0890002"
-           y="134.339"
-           x="50.306999"
-           id="rect10823-0" />
-        <rect
-           style="fill:#312d29"
-           height="6.5190001"
-           width="5.0890002"
-           y="127.865"
-           x="43.306999"
-           id="rect10819_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0890002"
-           y="124.339"
-           x="43.306999"
-           id="rect10821_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.5710001"
-           width="5.0890002"
-           y="134.339"
-           x="43.306999"
-           id="rect10823_1_" />
-        <rect
-           style="fill:#312d29"
-           height="6.5180001"
-           width="5.0890002"
-           y="52.146999"
-           x="45.959"
-           id="rect10827-7" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.572"
-           width="5.0890002"
-           y="48.620998"
-           x="45.959"
-           id="rect10829-0" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.572"
-           width="5.0890002"
-           y="58.620998"
-           x="45.959"
-           id="rect10831-6" />
-        <rect
-           style="fill:#312d29"
-           height="6.5180001"
-           width="5.0890002"
-           y="52.146999"
-           x="52.959"
-           id="rect10827_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.572"
-           width="5.0890002"
-           y="48.620998"
-           x="52.959"
-           id="rect10829_1_" />
-        <rect
-           style="fill:#d3d0ce"
-           height="3.572"
-           width="5.0890002"
-           y="58.620998"
-           x="52.959"
-           id="rect10831_1_" />
-        <rect
-           style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-           height="8.5710001"
-           width="9.6429996"
-           y="41.332001"
-           x="170.64"
-           id="rect4556-0" />
-        <rect
-           style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-           height="8.5710001"
-           width="9.6429996"
-           y="56.332001"
-           x="170.64"
-           id="rect10898-7" />
-        <rect
-           style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-           height="8.5710001"
-           width="9.6429996"
-           y="71.332001"
-           x="170.64"
-           id="rect10906-0" />
-        <rect
-           style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-           height="8.5710001"
-           width="9.6429996"
-           y="86.332001"
-           x="170.64"
-           id="rect10914-5" />
-        <rect
-           style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-           height="8.5710001"
-           width="9.6429996"
-           y="101.332"
-           x="170.64"
-           id="rect10922-6" />
-        <rect
-           style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-           height="8.5710001"
-           width="9.6429996"
-           y="116.332"
-           x="170.64"
-           id="rect10930-7" />
-        <rect
-           style="fill:#a9814d"
-           height="8.0860004"
-           width="9.0950003"
-           y="30.511"
-           x="36.320999"
-           id="rect4790-3" />
-        <rect
-           style="fill:#d3d0ce"
-           height="4.4310002"
-           width="9.0950003"
-           y="38.542"
-           x="36.320999"
-           id="rect4792-8" />
-        <rect
-           style="fill:#d3d0ce"
-           height="4.4310002"
-           width="9.0950003"
-           y="26.135"
-           x="36.320999"
-           id="rect4794-4" />
-        <rect
-           style="fill:#a9814d"
-           height="9.0950003"
-           width="8.0860004"
-           y="16.808001"
-           x="50.665001"
-           id="rect12056-9" />
-        <rect
-           style="fill:#d3d0ce"
-           height="9.0950003"
-           width="4.4310002"
-           y="16.808001"
-           x="46.289001"
-           id="rect12058-2" />
-        <rect
-           style="fill:#d3d0ce"
-           height="9.0950003"
-           width="4.4320002"
-           y="16.808001"
-           x="58.695"
-           id="rect12060-6" />
-        <rect
-           style="fill:#a9814d"
-           height="9.0950003"
-           width="8.0860004"
-           y="73.853996"
-           x="150.177"
-           id="rect12064-5" />
-        <rect
-           style="fill:#d3d0ce"
-           height="9.0950003"
-           width="4.4310002"
-           y="73.853996"
-           x="158.20799"
-           id="rect12066-7" />
-        <rect
-           style="fill:#d3d0ce"
-           height="9.0950003"
-           width="4.4310002"
-           y="73.853996"
-           x="145.802"
-           id="rect12068-7" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 97.239,22.516 V 20.284"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5376-4" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 94.402,22.516 V 20.284"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5378-5" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 109.033,22.516 V 20.284"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5386-7" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 106.047,22.516 V 20.284"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5388-9" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 103.21,22.516 V 20.284"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5390-8" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 94.402,47.442 V 45.21"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5454-3" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 97.239,47.442 V 45.21"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5456-0" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 103.21,47.442 V 45.21"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5466-2" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 106.047,47.442 V 45.21"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5468-2" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 109.033,47.442 V 45.21"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5470-3" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,37.521 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5612-6" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,39.877 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5614-7" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,42.357 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5616-1" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,42.357 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5618-5" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,39.877 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5620-5" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,37.521 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5622-4" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,27.724 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5624-0" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,30.204 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5626-2" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,32.561 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5628-6" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,32.561 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5630-0" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,30.204 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5632-6" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,27.724 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5634-1" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 100.225,22.516 V 20.284"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5636-1" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,35.041 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5726-1" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 100.225,47.442 V 45.21"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5728-7" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,35.041 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5730-3" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,25.244 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5738-0" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,25.244 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path5740-0" />
-        <rect
-           style="fill:#6a6a6a;stroke:#000000;stroke-width:0.69999999"
-           height="25.917999"
-           width="24.347"
-           y="20.92"
-           x="89.485001"
-           id="rect4974-4" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 97.239,22.516 V 20.284"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12832-8" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 94.402,22.516 V 20.284"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12834-3" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 109.033,22.516 V 20.284"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12836-0" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 106.047,22.516 V 20.284"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12838-1" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 103.21,22.516 V 20.284"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12840-2" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 94.402,47.442 V 45.21"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12842-9" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 97.239,47.442 V 45.21"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12844" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 103.21,47.442 V 45.21"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12846-0" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 106.047,47.442 V 45.21"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12848" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 109.033,47.442 V 45.21"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12850-3" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,37.521 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12852-8" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,39.877 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12854-8" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,42.357 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12856-5" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,42.357 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12858-7" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,39.877 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12860-7" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,37.521 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12862-0" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,27.724 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12864-8" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,30.204 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12866-9" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,32.561 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12868-3" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,32.561 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12870-0" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,30.204 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12872-7" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,27.724 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12874-4" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 100.225,22.516 V 20.284"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12876-7" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,35.041 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12878-8" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 100.225,47.442 V 45.21"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12880-3" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,35.041 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12882-7" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 88.281,25.244 h 2.687"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12884-1" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 112.466,25.244 h 2.539"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12886-0" />
-        <rect
-           style="fill:#3e3e3e;stroke:#000000;stroke-width:0.69999999"
-           height="25.917999"
-           width="24.347"
-           y="20.92"
-           x="89.485001"
-           id="rect12888-0" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 142.249,51.205 V 49.404"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12832_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 139.96,51.205 V 49.404"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12834_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 151.763,51.205 V 49.404"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12836_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 149.354,51.205 V 49.404"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12838_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 147.066,51.205 V 49.404"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12840_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 139.96,71.312 V 69.511"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12842_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 142.249,71.312 V 69.511"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12844_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 147.066,71.312 V 69.511"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12846_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 149.354,71.312 V 69.511"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12848_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 151.763,71.312 V 69.511"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12850_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 135.023,63.309 h 2.168"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12852_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 135.023,65.209 h 2.168"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12854_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 135.023,67.21 h 2.168"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12856_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 154.533,67.21 h 2.047"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12858_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 154.533,65.209 h 2.047"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12860_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 154.533,63.309 h 2.047"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12862_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 135.023,55.406 h 2.168"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12864_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 135.023,57.407 h 2.168"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12866_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 135.023,59.308 h 2.168"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12868_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 154.533,59.308 h 2.047"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12870_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 154.533,57.407 h 2.047"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12872_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 154.533,55.406 h 2.047"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12874_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 144.658,51.205 V 49.404"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12876_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 135.023,61.308 h 2.168"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12878_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="M 144.658,71.312 V 69.511"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12880_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 154.533,61.308 h 2.047"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12882_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 135.023,53.405 h 2.168"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12884_1_" />
-        <path
-           style="fill:none;stroke:#e9dcdc;stroke-width:1.49290001;stroke-linecap:round;stroke-miterlimit:10"
-           d="m 154.533,53.405 h 2.047"
-           stroke-miterlimit="10"
-           inkscape:connector-curvature="0"
-           id="path12886_1_" />
-        <rect
-           style="fill:#4a4a4a;stroke:#000000;stroke-width:0.69999999"
-           height="20.907"
-           width="19.639"
-           y="49.917"
-           x="135.994"
-           id="rect12888_1_" />
-        <path
-           style="fill:#434242;stroke:#000000;stroke-width:3.6157999"
-           inkscape:connector-curvature="0"
-           d="m 75.291,79.213 h 53.691 c 1.039,0 1.879,0.841 1.879,1.879 v 53.959 c 0,1.039 -0.84,1.879 -1.879,1.879 H 75.291 c -1.038,0 -1.879,-0.84 -1.879,-1.879 V 81.093 c 0,-1.038 0.841,-1.88 1.879,-1.88 z"
-           id="rect3773-8" />
-        <g
-           transform="matrix(1.4970318,0,0,1,-211.28069,0.21205357)"
-           id="g3781">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 193.993,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3777-3" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 193.941,76.477 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3779-4" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-207.28069,0.21205357)"
-           id="g3785">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 193.329,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3787-5" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 193.278,76.477 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3789-0" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-203.28069,0.21205357)"
-           id="g3791">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 192.665,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3793-1" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 192.614,76.477 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3795-4" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-199.28069,0.21205357)"
-           id="g3797">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 192.001,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3799-5" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 191.95,76.477 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3801-6" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-195.28069,0.21205357)"
-           id="g3803">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 191.338,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3805-2" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 191.286,76.477 h 0.103"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3807-0" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-191.28069,0.21205357)"
-           id="g3809">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 190.674,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3811-3" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 190.623,76.477 h 0.103"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3813-5" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-187.28069,0.21205357)"
-           id="g3815">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 190.011,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3817-6" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 189.96,76.477 h 0.103"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3819-6" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-183.28069,0.21205357)"
-           id="g3821">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 189.348,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3823-6" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 189.297,76.477 h 0.101"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3825-7" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-179.28069,0.21205357)"
-           id="g3827">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 188.684,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3829-6" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 188.633,76.477 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3831-7" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-175.28069,0.21205357)"
-           id="g3833">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 188.02,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3835-7" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 187.97,76.477 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3837-1" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-171.28069,0.21205357)"
-           id="g3839">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 187.357,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3841-9" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 187.305,76.477 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3843-1" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-167.28069,0.21205357)"
-           id="g3845">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 186.693,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3847-6" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 186.643,76.477 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3849-2" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-163.28069,0.21205357)"
-           id="g3851">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 186.03,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3853-7" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 185.979,76.477 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3855-2" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-159.28069,0.21205357)"
-           id="g3857">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 185.366,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3859-7" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 185.316,76.477 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3861-6" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-155.28069,0.21205357)"
-           id="g3863">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 184.702,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3865-5" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 184.652,76.477 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3867-1" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-151.28069,0.21205357)"
-           id="g3869">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 184.039,78.221 V 72.315"
-             inkscape:connector-curvature="0"
-             id="path3871-3" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 183.988,76.477 h 0.103"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3873-9" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-211.28069,0.21205357)"
-           id="g3927">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 229.176,86.44 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path3929-9" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 230.34,86.364 v 0.153"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3931-5" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-207.28069,0.21205357)"
-           id="g3933">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 226.504,89.448 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path3935-9" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 227.668,89.37 v 0.153"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3937-2" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-203.28069,0.21205357)"
-           id="g3939">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 223.832,92.453 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path3941-6" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 224.996,92.378 v 0.153"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3943-5" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-199.28069,0.21205357)"
-           id="g3945">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 221.16,95.461 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path3947-3" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 222.324,95.384 v 0.153"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3949-2" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-195.28069,0.21205357)"
-           id="g3951">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 218.488,98.468 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path3953-4" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 219.652,98.391 v 0.154"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3955-4" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-191.28069,0.21205357)"
-           id="g3957">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 215.816,101.475 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path3959-4" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 216.98,101.398 v 0.152"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3961-2" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-187.28069,0.21205357)"
-           id="g3963">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 213.144,104.48 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path3965-7" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 214.308,104.405 v 0.152"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3967-9" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-183.28069,0.21205357)"
-           id="g3969">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 210.472,107.488 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path3971-2" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 211.636,107.411 v 0.152"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3973-3" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-179.28069,0.21205357)"
-           id="g3975">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 207.8,110.493 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path3977-7" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 208.964,110.417 v 0.154"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3979-3" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-175.28069,0.21205357)"
-           id="g3981">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 205.128,113.501 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path3983-1" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 206.292,113.424 v 0.154"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3985-5" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-171.28069,0.21205357)"
-           id="g3987">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 202.457,116.508 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path3989-7" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 203.62,116.431 v 0.153"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3991-8" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-167.28069,0.21205357)"
-           id="g3993">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 199.785,119.514 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path3995-5" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 200.948,119.437 v 0.153"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path3997-8" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-163.28069,0.21205357)"
-           id="g3999">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 197.113,122.52 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path4001-3" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 198.276,122.444 v 0.152"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4003-2" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-159.28069,0.21205357)"
-           id="g4005">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 194.441,125.527 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path4007-4" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 195.604,125.452 v 0.151"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4009-1" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-155.28069,0.21205357)"
-           id="g4011">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 191.769,128.534 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path4013-1" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 192.932,128.457 v 0.154"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4015-5" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-151.28069,0.21205357)"
-           id="g4017">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 189.097,131.541 h 3.945"
-             inkscape:connector-curvature="0"
-             id="path4019-9" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 190.261,131.464 v 0.154"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4021-5" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-211.28069,0.21205357)"
-           id="g4025">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 189.569,86.44 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4027-1" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 188.405,86.364 v 0.153"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4029-0" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-207.28069,0.21205357)"
-           id="g4031">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 186.897,89.448 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4033-6" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 185.733,89.37 v 0.153"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4035-4" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-203.28069,0.21205357)"
-           id="g4037">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 184.225,92.453 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4039-5" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 183.061,92.378 v 0.153"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4041-3" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-199.28069,0.21205357)"
-           id="g4043">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 181.554,95.461 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4045-0" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 180.389,95.384 v 0.153"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4047-8" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-195.28069,0.21205357)"
-           id="g4049">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 178.882,98.468 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4051-9" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 177.717,98.391 v 0.154"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4053-1" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-191.28069,0.21205357)"
-           id="g4055">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 176.21,101.475 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4057-3" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 175.045,101.398 v 0.152"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4059-4" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-187.28069,0.21205357)"
-           id="g4061">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 173.538,104.48 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4063-7" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 172.373,104.405 v 0.152"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4065-4" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-183.28069,0.21205357)"
-           id="g4067">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 170.866,107.488 H 166.92"
-             inkscape:connector-curvature="0"
-             id="path4069-6" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 169.701,107.411 v 0.152"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4071-3" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-179.28069,0.21205357)"
-           id="g4073">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 168.194,110.493 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4075-6" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 167.029,110.417 v 0.154"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4077-5" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-175.28069,0.21205357)"
-           id="g4079">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 165.522,113.501 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4081-2" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 164.357,113.424 v 0.154"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4083-8" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-171.28069,0.21205357)"
-           id="g4085">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 162.85,116.508 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4087-1" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 161.685,116.431 v 0.153"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4089-0" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-167.28069,0.21205357)"
-           id="g4091">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 160.178,119.514 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4093-3" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 159.013,119.437 v 0.153"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4095-1" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-163.28069,0.21205357)"
-           id="g4097">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="M 157.506,122.52 H 153.56"
-             inkscape:connector-curvature="0"
-             id="path4099-5" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 156.341,122.444 v 0.152"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4101-5" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-159.28069,0.21205357)"
-           id="g4103">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 154.834,125.527 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4105-2" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 153.669,125.452 v 0.151"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4107-2" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-155.28069,0.21205357)"
-           id="g4109">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 152.162,128.534 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4111-1" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 150.997,128.457 v 0.154"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4113-7" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-151.28069,0.21205357)"
-           id="g4115">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 149.49,131.541 h -3.946"
-             inkscape:connector-curvature="0"
-             id="path4117-4" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 148.325,131.464 v 0.154"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4119-8" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-211.28069,0.21205357)"
-           id="g4123">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 193.993,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4125-2" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 193.941,138.702 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4127-3" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-207.28069,0.21205357)"
-           id="g4129">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 193.329,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4131-6" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 193.278,138.702 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4133-3" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-203.28069,0.21205357)"
-           id="g4135">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 192.665,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4137-0" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 192.614,138.702 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4139-3" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-199.28069,0.21205357)"
-           id="g4141">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 192.001,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4143-5" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 191.95,138.702 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4145-2" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-195.28069,0.21205357)"
-           id="g4147">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 191.338,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4149-8" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 191.286,138.702 h 0.103"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4151-0" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-191.28069,0.21205357)"
-           id="g4153">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 190.674,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4155-7" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 190.623,138.702 h 0.103"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4157-2" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-187.28069,0.21205357)"
-           id="g4159">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 190.011,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4161-2" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 189.96,138.702 h 0.103"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4163-5" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-183.28069,0.21205357)"
-           id="g4165">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 189.348,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4167-9" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 189.297,138.702 h 0.101"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4169-1" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-179.28069,0.21205357)"
-           id="g4171">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 188.684,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4173-0" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 188.633,138.702 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4175-8" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-175.28069,0.21205357)"
-           id="g4177">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 188.02,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4179-5" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 187.97,138.702 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4181-0" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-171.28069,0.21205357)"
-           id="g4183">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 187.357,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4185-7" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 187.305,138.702 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4187-9" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-167.28069,0.21205357)"
-           id="g4189">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 186.693,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4191-0" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 186.643,138.702 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4193-5" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-163.28069,0.21205357)"
-           id="g4195">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 186.03,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4197-3" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 185.979,138.702 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4199-4" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-159.28069,0.21205357)"
-           id="g4201">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 185.366,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4203-1" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 185.316,138.702 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4205-0" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-155.28069,0.21205357)"
-           id="g4207">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 184.702,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4209-4" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 184.652,138.702 h 0.102"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4211" />
-        </g>
-        <g
-           transform="matrix(1.4970318,0,0,1,-151.28069,0.21205357)"
-           id="g4213">
-          <path
-             style="fill:none;stroke:#e9dcdc;stroke-width:1.80789995"
-             d="m 184.039,136.959 v 5.906"
-             inkscape:connector-curvature="0"
-             id="path4215" />
-          <path
-             style="fill:none;stroke:#8c8989;stroke-width:1.56550002;stroke-linecap:square"
-             d="m 183.988,138.702 h 0.103"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cc"
-             id="path4217-8" />
-        </g>
-        <rect
-           style="fill:#e9dcdc"
-           height="4.5489998"
-           width="2.5120001"
-           y="170.105"
-           x="164.326"
-           id="rect4867-5" />
-        <rect
-           style="fill:#8c8989"
-           height="1.0470001"
-           width="2.5120001"
-           y="171.412"
-           x="164.326"
-           id="rect4869-9" />
-        <rect
-           style="fill:#e9dcdc"
-           height="4.5489998"
-           width="2.5120001"
-           y="170.105"
-           x="160.183"
-           id="rect4877-2" />
-        <rect
-           style="fill:#8c8989"
-           height="1.0470001"
-           width="2.5120001"
-           y="171.412"
-           x="160.183"
-           id="rect4879-5" />
-        <rect
-           style="fill:#e9dcdc"
-           height="4.5489998"
-           width="2.51"
-           y="170.105"
-           x="156.04201"
-           id="rect4883-4" />
-        <rect
-           style="fill:#8c8989"
-           height="1.0470001"
-           width="2.51"
-           y="171.412"
-           x="156.04201"
-           id="rect4885-1" />
-        <rect
-           style="fill:#e9dcdc"
-           height="4.5489998"
-           width="2.51"
-           y="157.217"
-           x="156.04201"
-           id="rect4889-39" />
-        <rect
-           style="fill:#8c8989"
-           height="1.0470001"
-           width="2.51"
-           y="159.412"
-           x="156.04201"
-           id="rect4891-5" />
-        <rect
-           style="fill:#e9dcdc"
-           height="4.5489998"
-           width="2.5120001"
-           y="157.217"
-           x="164.326"
-           id="rect4901-8" />
-        <rect
-           style="fill:#8c8989"
-           height="1.0470001"
-           width="2.5120001"
-           y="159.412"
-           x="164.326"
-           id="rect4903-2" />
-        <path
-           style="fill:#6a6a6a;stroke:#000000;stroke-width:2.41429996"
-           inkscape:connector-curvature="0"
-           d="m 167.542,162.639 v 6.498 c 0,0.342 -0.277,0.621 -0.621,0.621 h -11.936 c -0.344,0 -0.623,-0.279 -0.623,-0.621 v -6.498 c 0,-0.344 0.279,-0.621 0.623,-0.621 h 11.936 c 0.344,0 0.621,0.277 0.621,0.621 z"
-           id="rect4841-7" />
-        <rect
-           style="fill:#e9dcdc"
-           height="4.5489998"
-           width="2.5120001"
-           y="166.33501"
-           x="147.20399"
-           id="rect4867_1_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.0470001"
-           width="2.5120001"
-           y="167.642"
-           x="147.20399"
-           id="rect4869_1_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="4.5489998"
-           width="2.5120001"
-           y="166.33501"
-           x="143.061"
-           id="rect4877_1_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.0470001"
-           width="2.5120001"
-           y="167.642"
-           x="143.061"
-           id="rect4879_1_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="4.5489998"
-           width="2.51"
-           y="166.33501"
-           x="138.92"
-           id="rect4883_1_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.0470001"
-           width="2.51"
-           y="167.642"
-           x="138.92"
-           id="rect4885_1_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="4.5489998"
-           width="2.51"
-           y="153.446"
-           x="138.92"
-           id="rect4889_1_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.0470001"
-           width="2.51"
-           y="155.642"
-           x="138.92"
-           id="rect4891_1_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="4.5489998"
-           width="2.5120001"
-           y="153.446"
-           x="147.20399"
-           id="rect4901_1_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.0470001"
-           width="2.5120001"
-           y="155.642"
-           x="147.20399"
-           id="rect4903_1_" />
-        <path
-           style="fill:#6a6a6a;stroke:#000000;stroke-width:2.41429996"
-           inkscape:connector-curvature="0"
-           d="m 150.42,158.868 v 6.498 c 0,0.342 -0.277,0.621 -0.621,0.621 h -11.936 c -0.344,0 -0.623,-0.279 -0.623,-0.621 v -6.498 c 0,-0.344 0.279,-0.621 0.623,-0.621 h 11.936 c 0.344,0 0.621,0.277 0.621,0.621 z"
-           id="rect4841_1_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="2.5120001"
-           width="4.5489998"
-           y="129.869"
-           x="148.49001"
-           id="rect4867_2_" />
-        <rect
-           style="fill:#8c8989"
-           height="2.5120001"
-           width="1.0470001"
-           y="129.869"
-           x="150.685"
-           id="rect4869_2_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="2.5120001"
-           width="4.5489998"
-           y="125.727"
-           x="148.49001"
-           id="rect4877_2_" />
-        <rect
-           style="fill:#8c8989"
-           height="2.5120001"
-           width="1.0470001"
-           y="125.727"
-           x="150.685"
-           id="rect4879_2_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="2.51"
-           width="4.5489998"
-           y="121.586"
-           x="148.49001"
-           id="rect4883_2_" />
-        <rect
-           style="fill:#8c8989"
-           height="2.51"
-           width="1.0470001"
-           y="121.586"
-           x="150.685"
-           id="rect4885_2_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="2.51"
-           width="4.5489998"
-           y="121.586"
-           x="161.37801"
-           id="rect4889_2_" />
-        <rect
-           style="fill:#8c8989"
-           height="2.51"
-           width="1.0470001"
-           y="121.586"
-           x="162.685"
-           id="rect4891_2_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="2.5120001"
-           width="4.5489998"
-           y="129.869"
-           x="161.37801"
-           id="rect4901_2_" />
-        <rect
-           style="fill:#8c8989"
-           height="2.5120001"
-           width="1.0470001"
-           y="129.869"
-           x="162.685"
-           id="rect4903_2_" />
-        <path
-           style="fill:#6a6a6a;stroke:#000000;stroke-width:2.41429996"
-           inkscape:connector-curvature="0"
-           d="m 160.505,133.086 h -6.498 c -0.342,0 -0.621,-0.277 -0.621,-0.621 v -11.936 c 0,-0.344 0.279,-0.623 0.621,-0.623 h 6.498 c 0.344,0 0.621,0.279 0.621,0.623 v 11.936 c 0,0.344 -0.277,0.621 -0.621,0.621 z"
-           id="rect4841_2_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="2.5120001"
-           width="4.5489998"
-           y="40.327"
-           x="47.349998"
-           id="rect4867_3_" />
-        <rect
-           style="fill:#8c8989"
-           height="2.5120001"
-           width="1.0470001"
-           y="40.327"
-           x="49.544998"
-           id="rect4869_3_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="2.5120001"
-           width="4.5489998"
-           y="36.185001"
-           x="47.349998"
-           id="rect4877_3_" />
-        <rect
-           style="fill:#8c8989"
-           height="2.5120001"
-           width="1.0470001"
-           y="36.185001"
-           x="49.544998"
-           id="rect4879_3_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="2.51"
-           width="4.5489998"
-           y="32.043999"
-           x="47.349998"
-           id="rect4883_3_" />
-        <rect
-           style="fill:#8c8989"
-           height="2.51"
-           width="1.0470001"
-           y="32.043999"
-           x="49.544998"
-           id="rect4885_3_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="2.51"
-           width="4.5489998"
-           y="32.043999"
-           x="60.238998"
-           id="rect4889_3_" />
-        <rect
-           style="fill:#8c8989"
-           height="2.51"
-           width="1.0470001"
-           y="32.043999"
-           x="61.544998"
-           id="rect4891_3_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="2.5120001"
-           width="4.5489998"
-           y="40.327"
-           x="60.238998"
-           id="rect4901_3_" />
-        <rect
-           style="fill:#8c8989"
-           height="2.5120001"
-           width="1.0470001"
-           y="40.327"
-           x="61.544998"
-           id="rect4903_3_" />
-        <path
-           style="fill:#6a6a6a;stroke:#000000;stroke-width:2.41429996"
-           inkscape:connector-curvature="0"
-           d="m 59.366,43.544 h -6.498 c -0.342,0 -0.621,-0.277 -0.621,-0.621 V 30.987 c 0,-0.344 0.279,-0.623 0.621,-0.623 h 6.498 c 0.344,0 0.621,0.279 0.621,0.623 v 11.936 c 0,0.344 -0.278,0.621 -0.621,0.621 z"
-           id="rect4841_3_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.723"
-           width="3.122"
-           y="75.561996"
-           x="46.395"
-           id="rect4867_4_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.723"
-           width="0.71899998"
-           y="75.561996"
-           x="47.901001"
-           id="rect4869_4_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.723"
-           width="3.122"
-           y="72.719002"
-           x="46.395"
-           id="rect4877_4_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.723"
-           width="0.71899998"
-           y="72.719002"
-           x="47.901001"
-           id="rect4879_4_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.722"
-           width="3.122"
-           y="69.876999"
-           x="46.395"
-           id="rect4883_4_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.722"
-           width="0.71899998"
-           y="69.876999"
-           x="47.901001"
-           id="rect4885_4_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.722"
-           width="3.122"
-           y="69.876999"
-           x="55.238998"
-           id="rect4889_4_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.722"
-           width="0.71799999"
-           y="69.876999"
-           x="56.136002"
-           id="rect4891_4_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.723"
-           width="3.122"
-           y="75.561996"
-           x="55.238998"
-           id="rect4901_4_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.723"
-           width="0.71799999"
-           y="75.561996"
-           x="56.136002"
-           id="rect4903_4_" />
-        <path
-           style="fill:#6a6a6a;stroke:#000000;stroke-width:1.5"
-           inkscape:connector-curvature="0"
-           d="m 54.64,77.769 h -4.459 c -0.234,0 -0.426,-0.19 -0.426,-0.426 v -8.19 c 0,-0.236 0.192,-0.428 0.426,-0.428 h 4.459 c 0.236,0 0.426,0.192 0.426,0.428 v 8.19 c 0,0.236 -0.19,0.426 -0.426,0.426 z"
-           id="rect4841_4_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.723"
-           width="3.122"
-           y="87.421997"
-           x="46.395"
-           id="rect4867_5_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.723"
-           width="0.71899998"
-           y="87.421997"
-           x="47.901001"
-           id="rect4869_5_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.723"
-           width="3.122"
-           y="84.579002"
-           x="46.395"
-           id="rect4877_5_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.723"
-           width="0.71899998"
-           y="84.579002"
-           x="47.901001"
-           id="rect4879_5_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.722"
-           width="3.122"
-           y="81.737"
-           x="46.395"
-           id="rect4883_5_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.722"
-           width="0.71899998"
-           y="81.737"
-           x="47.901001"
-           id="rect4885_5_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.722"
-           width="3.122"
-           y="81.737"
-           x="55.238998"
-           id="rect4889_5_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.722"
-           width="0.71799999"
-           y="81.737"
-           x="56.136002"
-           id="rect4891_5_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.723"
-           width="3.122"
-           y="87.421997"
-           x="55.238998"
-           id="rect4901_5_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.723"
-           width="0.71799999"
-           y="87.421997"
-           x="56.136002"
-           id="rect4903_5_" />
-        <path
-           style="fill:#6a6a6a;stroke:#000000;stroke-width:1.5"
-           inkscape:connector-curvature="0"
-           d="m 54.64,89.629 h -4.459 c -0.234,0 -0.426,-0.19 -0.426,-0.426 v -8.19 c 0,-0.236 0.192,-0.428 0.426,-0.428 h 4.459 c 0.236,0 0.426,0.192 0.426,0.428 v 8.19 c 0,0.236 -0.19,0.426 -0.426,0.426 z"
-           id="rect4841_5_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.723"
-           width="3.122"
-           y="99.281998"
-           x="46.395"
-           id="rect4867_6_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.723"
-           width="0.71899998"
-           y="99.281998"
-           x="47.901001"
-           id="rect4869_6_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.724"
-           width="3.122"
-           y="96.439003"
-           x="46.395"
-           id="rect4877_6_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.724"
-           width="0.71899998"
-           y="96.439003"
-           x="47.901001"
-           id="rect4879_6_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.722"
-           width="3.122"
-           y="93.598"
-           x="46.395"
-           id="rect4883_6_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.722"
-           width="0.71899998"
-           y="93.598"
-           x="47.901001"
-           id="rect4885_6_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.722"
-           width="3.122"
-           y="93.598"
-           x="55.238998"
-           id="rect4889_6_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.722"
-           width="0.71799999"
-           y="93.598"
-           x="56.136002"
-           id="rect4891_6_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.723"
-           width="3.122"
-           y="99.281998"
-           x="55.238998"
-           id="rect4901_6_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.723"
-           width="0.71799999"
-           y="99.281998"
-           x="56.136002"
-           id="rect4903_6_" />
-        <path
-           style="fill:#6a6a6a;stroke:#000000;stroke-width:1.5"
-           inkscape:connector-curvature="0"
-           d="m 54.64,101.489 h -4.459 c -0.234,0 -0.426,-0.19 -0.426,-0.426 v -8.19 c 0,-0.236 0.192,-0.428 0.426,-0.428 h 4.459 c 0.236,0 0.426,0.192 0.426,0.428 v 8.19 c 0,0.236 -0.19,0.426 -0.426,0.426 z"
-           id="rect4841_6_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.724"
-           width="3.122"
-           y="111.142"
-           x="46.395"
-           id="rect4867_7_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.724"
-           width="0.71899998"
-           y="111.142"
-           x="47.901001"
-           id="rect4869_7_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.724"
-           width="3.122"
-           y="108.3"
-           x="46.395"
-           id="rect4877_7_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.724"
-           width="0.71899998"
-           y="108.3"
-           x="47.901001"
-           id="rect4879_7_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.723"
-           width="3.122"
-           y="105.458"
-           x="46.395"
-           id="rect4883_7_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.723"
-           width="0.71899998"
-           y="105.458"
-           x="47.901001"
-           id="rect4885_7_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.723"
-           width="3.122"
-           y="105.458"
-           x="55.238998"
-           id="rect4889_7_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.723"
-           width="0.71799999"
-           y="105.458"
-           x="56.136002"
-           id="rect4891_7_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="1.724"
-           width="3.122"
-           y="111.142"
-           x="55.238998"
-           id="rect4901_7_" />
-        <rect
-           style="fill:#8c8989"
-           height="1.724"
-           width="0.71799999"
-           y="111.142"
-           x="56.136002"
-           id="rect4903_7_" />
-        <path
-           style="fill:#6a6a6a;stroke:#000000;stroke-width:1.5"
-           inkscape:connector-curvature="0"
-           d="m 54.64,113.35 h -4.459 c -0.234,0 -0.426,-0.19 -0.426,-0.427 v -8.19 c 0,-0.236 0.192,-0.428 0.426,-0.428 h 4.459 c 0.236,0 0.426,0.192 0.426,0.428 v 8.19 c 0,0.236 -0.19,0.427 -0.426,0.427 z"
-           id="rect4841_7_" />
-        <rect
-           style="fill:#fffde9;stroke:#828282;stroke-width:3.23519993;stroke-linecap:round;stroke-linejoin:round"
-           height="68.248001"
-           width="32.234001"
-           y="58.249001"
-           x="0.99900001"
-           id="rect5020-9" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.747"
-           width="6.7919998"
-           y="62.148998"
-           x="34.077"
-           id="rect4966-2-6" />
-        <rect
-           style="fill:#8c8989"
-           height="3.747"
-           width="1.561"
-           y="62.148998"
-           x="36.028"
-           id="rect4968-1-1" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.747"
-           width="6.7919998"
-           y="68.331001"
-           x="34.077"
-           id="rect5048-7" />
-        <rect
-           style="fill:#8c8989"
-           height="3.747"
-           width="1.561"
-           y="68.331001"
-           x="36.028"
-           id="rect5050-7" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.747"
-           width="6.7919998"
-           y="74.513"
-           x="34.077"
-           id="rect5054-1" />
-        <rect
-           style="fill:#8c8989"
-           height="3.747"
-           width="1.561"
-           y="74.513"
-           x="36.028"
-           id="rect5056-9" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.747"
-           width="6.7919998"
-           y="80.695"
-           x="34.077"
-           id="rect5060-0" />
-        <rect
-           style="fill:#8c8989"
-           height="3.747"
-           width="1.561"
-           y="80.695"
-           x="36.028"
-           id="rect5062-3" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.7460001"
-           width="6.7919998"
-           y="86.876999"
-           x="34.077"
-           id="rect5066-4" />
-        <rect
-           style="fill:#8c8989"
-           height="3.7460001"
-           width="1.561"
-           y="86.876999"
-           x="36.028"
-           id="rect5068-1" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.747"
-           width="6.7919998"
-           y="93.058998"
-           x="34.077"
-           id="rect5072-7" />
-        <rect
-           style="fill:#8c8989"
-           height="3.747"
-           width="1.561"
-           y="93.058998"
-           x="36.028"
-           id="rect5074-5" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.747"
-           width="6.7919998"
-           y="99.058998"
-           x="34.077"
-           id="rect14000-3" />
-        <rect
-           style="fill:#8c8989"
-           height="3.747"
-           width="1.561"
-           y="99.058998"
-           x="36.028"
-           id="rect14002-3" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.747"
-           width="6.7919998"
-           y="105.059"
-           x="34.077"
-           id="rect14006-2" />
-        <rect
-           style="fill:#8c8989"
-           height="3.747"
-           width="1.561"
-           y="105.059"
-           x="36.028"
-           id="rect14008-4" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.747"
-           width="6.7919998"
-           y="111.059"
-           x="34.077"
-           id="rect14000_1_" />
-        <rect
-           style="fill:#8c8989"
-           height="3.747"
-           width="1.561"
-           y="111.059"
-           x="36.028"
-           id="rect14002_1_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.747"
-           width="6.7919998"
-           y="117.059"
-           x="34.077"
-           id="rect14006_1_" />
-        <rect
-           style="fill:#8c8989"
-           height="3.747"
-           width="1.561"
-           y="117.059"
-           x="36.028"
-           id="rect14008_1_" />
-        <rect
-           style="fill:#fffde9;stroke:#828282;stroke-width:3.65829992;stroke-linecap:round;stroke-linejoin:round"
-           height="25.209999"
-           width="32.93"
-           y="183.14999"
-           x="51.1222"
-           id="rect14086-1" />
-        <rect
-           style="fill:#e9dcdc"
-           height="5.3109999"
-           width="3.747"
-           y="177.17999"
-           x="58.023201"
-           id="rect14090-2" />
-        <rect
-           style="fill:#8c8989"
-           height="1.222"
-           width="3.747"
-           y="179.743"
-           x="58.023201"
-           id="rect14092-9" />
-        <rect
-           style="fill:#e9dcdc"
-           height="5.3109999"
-           width="3.747"
-           y="177.17999"
-           x="64.205215"
-           id="rect14096-0" />
-        <rect
-           style="fill:#8c8989"
-           height="1.222"
-           width="3.747"
-           y="179.743"
-           x="64.205215"
-           id="rect14098-8" />
-        <rect
-           style="fill:#e9dcdc"
-           height="5.3109999"
-           width="3.747"
-           y="177.17999"
-           x="70.386215"
-           id="rect14102-7" />
-        <rect
-           style="fill:#8c8989"
-           height="1.222"
-           width="3.747"
-           y="179.743"
-           x="70.386215"
-           id="rect14104-4" />
-        <rect
-           style="fill:#e9dcdc"
-           height="5.3109999"
-           width="3.747"
-           y="177.17999"
-           x="76.569214"
-           id="rect14108-5" />
-        <rect
-           style="fill:#8c8989"
-           height="1.222"
-           width="3.747"
-           y="179.743"
-           x="76.569214"
-           id="rect14110-6" />
-        <rect
-           style="fill:#fffde9;stroke:#828282;stroke-width:3.65829992;stroke-linecap:round;stroke-linejoin:round"
-           height="25.209999"
-           width="32.931"
-           y="183.14999"
-           x="139.632"
-           id="rect14138-8" />
-        <rect
-           style="fill:#e9dcdc"
-           height="5.3109999"
-           width="3.747"
-           y="177.17999"
-           x="146.534"
-           id="rect14142-0" />
-        <rect
-           style="fill:#8c8989"
-           height="1.222"
-           width="3.747"
-           y="179.743"
-           x="146.534"
-           id="rect14144-7" />
-        <rect
-           style="fill:#e9dcdc"
-           height="5.3109999"
-           width="3.7460001"
-           y="177.17999"
-           x="152.716"
-           id="rect14148-7" />
-        <rect
-           style="fill:#8c8989"
-           height="1.222"
-           width="3.7460001"
-           y="179.743"
-           x="152.716"
-           id="rect14150-4" />
-        <rect
-           style="fill:#e9dcdc"
-           height="5.3109999"
-           width="3.7460001"
-           y="177.17999"
-           x="158.89799"
-           id="rect14154-3" />
-        <rect
-           style="fill:#8c8989"
-           height="1.222"
-           width="3.7460001"
-           y="179.743"
-           x="158.89799"
-           id="rect14156-1" />
-        <rect
-           style="fill:#e9dcdc"
-           height="5.3109999"
-           width="3.7460001"
-           y="177.17999"
-           x="165.08"
-           id="rect14160-3" />
-        <rect
-           style="fill:#8c8989"
-           height="1.222"
-           width="3.7460001"
-           y="179.743"
-           x="165.08"
-           id="rect14162-6" />
-        <rect
-           style="fill:#312d29"
-           height="5.0890002"
-           width="6.5180001"
-           y="5.4099998"
-           x="62.810001"
-           id="rect14194-3" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0890002"
-           width="3.5710001"
-           y="5.4099998"
-           x="69.282997"
-           id="rect14196-0" />
-        <rect
-           style="fill:#d3d0ce"
-           height="5.0890002"
-           width="3.5710001"
-           y="5.4099998"
-           x="59.283001"
-           id="rect14198-1" />
-        <rect
-           style="fill:#fffde9;stroke:#828282;stroke-width:3.65829992;stroke-linecap:round;stroke-linejoin:round"
-           height="32.931"
-           width="25.209999"
-           y="133.88499"
-           x="188.08299"
-           id="rect14138_1_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.747"
-           width="5.3109999"
-           y="156.16701"
-           x="182.112"
-           id="rect14142_1_" />
-        <rect
-           style="fill:#8c8989"
-           height="3.747"
-           width="1.222"
-           y="156.16701"
-           x="184.675"
-           id="rect14144_1_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.7460001"
-           width="5.3109999"
-           y="149.985"
-           x="182.112"
-           id="rect14148_1_" />
-        <rect
-           style="fill:#8c8989"
-           height="3.7460001"
-           width="1.222"
-           y="149.985"
-           x="184.675"
-           id="rect14150_1_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.7460001"
-           width="5.3109999"
-           y="143.804"
-           x="182.112"
-           id="rect14154_1_" />
-        <rect
-           style="fill:#8c8989"
-           height="3.7460001"
-           width="1.222"
-           y="143.804"
-           x="184.675"
-           id="rect14156_1_" />
-        <rect
-           style="fill:#e9dcdc"
-           height="3.7460001"
-           width="5.3109999"
-           y="137.62199"
-           x="182.112"
-           id="rect14160_1_" />
-        <rect
-           style="fill:#8c8989"
-           height="3.7460001"
-           width="1.222"
-           y="137.62199"
-           x="184.675"
-           id="rect14162_1_" />
-        <g
-           id="g12789"
-           onmousemove="Antenna connector">
-          <rect
-             x="97.285141"
-             y="169.758"
-             width="28.195999"
-             height="27.461"
-             id="rect8636"
-             style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square" />
-          <rect
-             x="101.77314"
-             y="195.395"
-             width="19.502001"
-             height="19.075001"
-             id="rect8652"
-             style="fill:url(#linearGradient8736)" />
-          <path
-             d="m 124.36614,193.487 c 0,1.423 -1.302,2.575 -2.91,2.575 h -19.86 c -1.608001,0 -2.912001,-1.152 -2.912001,-2.575 v -20.03 c 0,-1.422 1.303,-2.575 2.912001,-2.575 h 19.859 c 1.608,0 2.91,1.153 2.91,2.575 v 20.03 z"
-             id="path8654"
-             inkscape:connector-curvature="0"
-             style="fill:#dab452" />
-        </g>
-        <rect
-           style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square"
-           id="rect8656"
-           height="13.826"
-           width="45.997002"
-           y="38.695999"
-           x="168.086" />
-        <rect
-           style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square"
-           id="rect8658"
-           height="13.826"
-           width="45.997002"
-           y="53.695999"
-           x="168.086" />
-        <rect
-           style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square"
-           id="rect8660"
-           height="13.826"
-           width="45.997002"
-           y="68.695999"
-           x="168.086" />
-        <rect
-           style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square"
-           id="rect8662"
-           height="13.826"
-           width="45.997002"
-           y="83.695999"
-           x="168.086" />
-        <rect
-           style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square"
-           id="rect8664"
-           height="13.825"
-           width="45.997002"
-           y="98.695999"
-           x="168.086" />
-        <rect
-           style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:square"
-           id="rect8666"
-           height="13.825"
-           width="45.997002"
-           y="113.696"
-           x="168.086" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path8668"
-           d="m 110.126,10.926 0.563,1.734 c 3.82,-1.425 2.62,-7.761 -2.074,-6.405 4.021,-0.446 4.084,4.377 1.511,4.671 z" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path8670"
-           d="m 108.854,7.167 -0.563,-1.734 c -3.82,1.425 -2.62,7.761 2.075,6.405 -4.021,0.446 -4.084,-4.377 -1.512,-4.671 z" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path8672"
-           d="M 110.202,11.38" />
-        <path
-           style="fill:#070606"
-           inkscape:connector-curvature="0"
-           id="path8674"
-           d="m 98.619,13.405 h -1.59 L 95.548,10.35 H 95.39 v 2.083 H 93.94 V 5.672 c 0.381,-0.009 1.283,-0.148 1.711,-0.148 0.437,0 0.949,0.019 1.396,0.25 0.734,0.372 1.134,1.154 1.087,2.558 -0.093,1.144 -0.502,1.692 -1.125,1.916 l 1.61,3.157 z m -1.936,-5.39 c 0,-0.576 -0.205,-1.199 -0.819,-1.199 -0.158,0 -0.333,0.018 -0.474,0.046 v 2.38 c 0.892,0.336 1.293,-0.389 1.293,-1.227 z" />
-        <path
-           style="fill:#070606"
-           inkscape:connector-curvature="0"
-           id="path8676"
-           d="M 98.329,12.433 V 5.672 h 3.05 v 1.274 h -1.562 v 1.479 h 1.488 v 1.209 h -1.488 v 1.479 h 1.562 v 1.32 h -3.05 z" />
-        <path
-           style="fill:#070606"
-           inkscape:connector-curvature="0"
-           id="path8678"
-           d="m 103.88,10.359 0.707,-4.687 h 1.553 l -1.404,6.761 h -1.85 l -1.414,-6.761 h 1.562 l 0.708,4.687 0.074,0.567 0.064,-0.567 z" />
-        <path
-           style="fill:#070606"
-           inkscape:connector-curvature="0"
-           id="path8680"
-           d="M 113.285,12.433 V 5.672 h 1.469 v 5.44 h 1.646 v 1.32 h -3.115 z" />
-        <path
-           style="fill:#070606"
-           inkscape:connector-curvature="0"
-           id="path8682"
-           d="M 116.558,10.573 V 5.672 h 1.487 v 4.817 c 0.009,0.456 0.038,0.818 0.651,0.818 0.613,0 0.642,-0.362 0.651,-0.818 V 5.672 h 1.487 v 4.901 c 0,1.376 -0.763,1.99 -2.139,1.99 -1.356,0 -2.137,-0.614 -2.137,-1.99 z" />
-        <path
-           style="fill:#070606"
-           inkscape:connector-curvature="0"
-           id="path8684"
-           d="m 121.022,6.946 0.102,-1.274 h 3.952 l 0.121,1.274 h -1.292 v 5.487 H 122.38 V 6.946 h -1.358 z" />
-        <path
-           style="fill:#070606"
-           inkscape:connector-curvature="0"
-           id="path8686"
-           d="m 125.41,5.672 h 1.517 v 6.761 H 125.41 V 5.672 z" />
-        <path
-           style="fill:#070606"
-           inkscape:connector-curvature="0"
-           id="path8688"
-           d="m 127.177,9.029 c 0,-1.692 0.633,-3.542 2.604,-3.533 1.962,-0.009 2.595,1.841 2.586,3.533 0,1.711 -0.595,3.543 -2.586,3.534 -1.999,0.009 -2.584,-1.823 -2.604,-3.534 z m 1.563,0.019 c 0,0.93 0.186,2.269 1.041,2.306 0.847,-0.038 1.032,-1.376 1.032,-2.306 0,-0.921 -0.186,-2.111 -1.032,-2.167 -0.856,0.056 -1.041,1.246 -1.041,2.167 z" />
-        <path
-           style="fill:#070606"
-           inkscape:connector-curvature="0"
-           id="path8690"
-           d="M 132.598,12.433 V 5.672 h 1.256 l 1.423,3.32 v -3.32 h 1.433 v 6.761 h -1.19 l -1.469,-3.311 v 3.311 h -1.453 z" />
-        <circle
-           d="m 110.432,9.1289997 c 0,0.5180431 -0.41995,0.9380003 -0.938,0.9380003 -0.51804,0 -0.938,-0.4199572 -0.938,-0.9380003 0,-0.5180431 0.41996,-0.938 0.938,-0.938 0.51805,0 0.938,0.4199569 0.938,0.938 z"
-           style="fill:#070606"
-           sodipodi:ry="0.93800002"
-           sodipodi:rx="0.93800002"
-           sodipodi:cy="9.1289997"
-           sodipodi:cx="109.494"
-           id="circle8692"
-           r="0.93800002"
-           cy="9.1289997"
-           cx="109.494" />
-        <path
-           style="fill:#dbdbdb;stroke:#848484;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
-           inkscape:connector-curvature="0"
-           id="path8694"
-           d="m 35.028,179.497 c 0,1.104 -0.896,2 -2,2 H 6.084 c -1.104,0 -2,-0.896 -2,-2 l 2,-1.341 -2,-2.125 v -31 l 2,-2.375 -2,-1.288 c 0,-1.104 0.896,-2 2,-2 h 26.945 c 1.104,0 2,0.896 2,2 v 38.129 z" />
-        <rect
-           style="fill:#5a5a5a"
-           id="rect8696"
-           height="3.7460001"
-           width="9.3459997"
-           y="143.804"
-           x="9.7510004" />
-        <rect
-           style="fill:#5a5a5a"
-           id="rect8698"
-           height="3.7460001"
-           width="9.3459997"
-           y="172.804"
-           x="9.7510004" />
-        <rect
-           style="fill:#c4c4c4;stroke:#6d6d6d;stroke-width:0.69999999"
-           id="rect8700"
-           height="14.662"
-           width="26.266001"
-           y="17.379"
-           x="128.155" />
-        <circle
-           d="m 132.598,20.466 c 0,0.780378 -0.63262,1.413 -1.413,1.413 -0.78038,0 -1.413,-0.632622 -1.413,-1.413 0,-0.780379 0.63262,-1.413 1.413,-1.413 0.78038,0 1.413,0.632621 1.413,1.413 z"
-           style="fill:#2c2c2c"
-           sodipodi:ry="1.413"
-           sodipodi:rx="1.413"
-           sodipodi:cy="20.466"
-           sodipodi:cx="131.185"
-           id="circle8702"
-           r="1.413"
-           cy="20.466"
-           cx="131.185" />
-        <circle
-           d="m 153.14499,29.417 c 0,0.780378 -0.63262,1.413 -1.413,1.413 -0.78037,0 -1.413,-0.632622 -1.413,-1.413 0,-0.780379 0.63263,-1.413 1.413,-1.413 0.78038,0 1.413,0.632621 1.413,1.413 z"
-           style="fill:#2c2c2c"
-           sodipodi:ry="1.413"
-           sodipodi:rx="1.413"
-           sodipodi:cy="29.417"
-           sodipodi:cx="151.73199"
-           id="circle8704"
-           r="1.413"
-           cy="29.417"
-           cx="151.73199" />
-        <polygon
-           id="polygon8706"
-           points="191.036,13.319 186.194,11.031 181.129,13.319 186.083,4.74 " />
-        <polygon
-           id="polygon8708"
-           points="41.036,13.319 36.194,11.031 31.129,13.319 36.083,4.74 " />
-        <g
-           id="g8710">
-          <circle
-             d="m 195.585,45.712002 c 0,2.736571 -2.21842,4.955 -4.955,4.955 -2.73657,0 -4.955,-2.218429 -4.955,-4.955 0,-2.736571 2.21843,-4.955 4.955,-4.955 2.73658,0 4.955,2.218429 4.955,4.955 z"
-             style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-             sodipodi:ry="4.9549999"
-             sodipodi:rx="4.9549999"
-             sodipodi:cy="45.712002"
-             sodipodi:cx="190.63"
-             id="circle8712"
-             r="4.9549999"
-             cy="45.712002"
-             cx="190.63" />
-        </g>
-        <g
-           id="g8714">
-          <circle
-             d="m 210.585,45.712002 c 0,2.736571 -2.21842,4.955 -4.955,4.955 -2.73657,0 -4.955,-2.218429 -4.955,-4.955 0,-2.736571 2.21843,-4.955 4.955,-4.955 2.73658,0 4.955,2.218429 4.955,4.955 z"
-             style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-             sodipodi:ry="4.9549999"
-             sodipodi:rx="4.9549999"
-             sodipodi:cy="45.712002"
-             sodipodi:cx="205.63"
-             id="circle8716"
-             r="4.9549999"
-             cy="45.712002"
-             cx="205.63" />
-        </g>
-        <g
-           id="g8718">
-          <circle
-             d="m 195.585,60.712002 c 0,2.736571 -2.21842,4.955 -4.955,4.955 -2.73657,0 -4.955,-2.218429 -4.955,-4.955 0,-2.736571 2.21843,-4.955 4.955,-4.955 2.73658,0 4.955,2.218429 4.955,4.955 z"
-             style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-             sodipodi:ry="4.9549999"
-             sodipodi:rx="4.9549999"
-             sodipodi:cy="60.712002"
-             sodipodi:cx="190.63"
-             id="circle8720"
-             r="4.9549999"
-             cy="60.712002"
-             cx="190.63" />
-        </g>
-        <g
-           id="g8722">
-          <circle
-             d="m 210.585,60.712002 c 0,2.736571 -2.21842,4.955 -4.955,4.955 -2.73657,0 -4.955,-2.218429 -4.955,-4.955 0,-2.736571 2.21843,-4.955 4.955,-4.955 2.73658,0 4.955,2.218429 4.955,4.955 z"
-             style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-             sodipodi:ry="4.9549999"
-             sodipodi:rx="4.9549999"
-             sodipodi:cy="60.712002"
-             sodipodi:cx="205.63"
-             id="circle8724"
-             r="4.9549999"
-             cy="60.712002"
-             cx="205.63" />
-        </g>
-        <g
-           id="g8726">
-          <circle
-             d="m 195.585,75.711998 c 0,2.736571 -2.21842,4.955 -4.955,4.955 -2.73657,0 -4.955,-2.218429 -4.955,-4.955 0,-2.736571 2.21843,-4.955 4.955,-4.955 2.73658,0 4.955,2.218429 4.955,4.955 z"
-             style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-             sodipodi:ry="4.9549999"
-             sodipodi:rx="4.9549999"
-             sodipodi:cy="75.711998"
-             sodipodi:cx="190.63"
-             id="circle8728"
-             r="4.9549999"
-             cy="75.711998"
-             cx="190.63" />
-        </g>
-        <g
-           id="g8730">
-          <circle
-             d="m 210.585,75.711998 c 0,2.736571 -2.21842,4.955 -4.955,4.955 -2.73657,0 -4.955,-2.218429 -4.955,-4.955 0,-2.736571 2.21843,-4.955 4.955,-4.955 2.73658,0 4.955,2.218429 4.955,4.955 z"
-             style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-             sodipodi:ry="4.9549999"
-             sodipodi:rx="4.9549999"
-             sodipodi:cy="75.711998"
-             sodipodi:cx="205.63"
-             id="circle8732"
-             r="4.9549999"
-             cy="75.711998"
-             cx="205.63" />
-        </g>
-        <g
-           id="g8734">
-          <circle
-             d="m 195.585,90.711998 c 0,2.736571 -2.21842,4.955 -4.955,4.955 -2.73657,0 -4.955,-2.218429 -4.955,-4.955 0,-2.736571 2.21843,-4.955 4.955,-4.955 2.73658,0 4.955,2.218429 4.955,4.955 z"
-             style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-             sodipodi:ry="4.9549999"
-             sodipodi:rx="4.9549999"
-             sodipodi:cy="90.711998"
-             sodipodi:cx="190.63"
-             id="circle8736"
-             r="4.9549999"
-             cy="90.711998"
-             cx="190.63" />
-        </g>
-        <g
-           id="g8738">
-          <circle
-             d="m 210.585,90.711998 c 0,2.736571 -2.21842,4.955 -4.955,4.955 -2.73657,0 -4.955,-2.218429 -4.955,-4.955 0,-2.736571 2.21843,-4.955 4.955,-4.955 2.73658,0 4.955,2.218429 4.955,4.955 z"
-             style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-             sodipodi:ry="4.9549999"
-             sodipodi:rx="4.9549999"
-             sodipodi:cy="90.711998"
-             sodipodi:cx="205.63"
-             id="circle8740"
-             r="4.9549999"
-             cy="90.711998"
-             cx="205.63" />
-        </g>
-        <g
-           id="g8742">
-          <circle
-             d="m 195.585,105.712 c 0,2.73657 -2.21842,4.955 -4.955,4.955 -2.73657,0 -4.955,-2.21843 -4.955,-4.955 0,-2.73657 2.21843,-4.955 4.955,-4.955 2.73658,0 4.955,2.21843 4.955,4.955 z"
-             style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-             sodipodi:ry="4.9549999"
-             sodipodi:rx="4.9549999"
-             sodipodi:cy="105.712"
-             sodipodi:cx="190.63"
-             id="circle8744"
-             r="4.9549999"
-             cy="105.712"
-             cx="190.63" />
-        </g>
-        <g
-           id="g8746">
-          <circle
-             d="m 210.585,105.712 c 0,2.73657 -2.21842,4.955 -4.955,4.955 -2.73657,0 -4.955,-2.21843 -4.955,-4.955 0,-2.73657 2.21843,-4.955 4.955,-4.955 2.73658,0 4.955,2.21843 4.955,4.955 z"
-             style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-             sodipodi:ry="4.9549999"
-             sodipodi:rx="4.9549999"
-             sodipodi:cy="105.712"
-             sodipodi:cx="205.63"
-             id="circle8748"
-             r="4.9549999"
-             cy="105.712"
-             cx="205.63" />
-        </g>
-        <g
-           id="g8750">
-          <circle
-             d="m 195.585,120.712 c 0,2.73657 -2.21842,4.955 -4.955,4.955 -2.73657,0 -4.955,-2.21843 -4.955,-4.955 0,-2.73657 2.21843,-4.955 4.955,-4.955 2.73658,0 4.955,2.21843 4.955,4.955 z"
-             style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-             sodipodi:ry="4.9549999"
-             sodipodi:rx="4.9549999"
-             sodipodi:cy="120.712"
-             sodipodi:cx="190.63"
-             id="circle8752"
-             r="4.9549999"
-             cy="120.712"
-             cx="190.63" />
-        </g>
-        <g
-           id="g8754">
-          <circle
-             d="m 210.585,120.712 c 0,2.73657 -2.21842,4.955 -4.955,4.955 -2.73657,0 -4.955,-2.21843 -4.955,-4.955 0,-2.73657 2.21843,-4.955 4.955,-4.955 2.73658,0 4.955,2.21843 4.955,4.955 z"
-             style="fill:none;stroke:#dab452;stroke-width:1.5;stroke-linecap:square"
-             sodipodi:ry="4.9549999"
-             sodipodi:rx="4.9549999"
-             sodipodi:cy="120.712"
-             sodipodi:cx="205.63"
-             id="circle8756"
-             r="4.9549999"
-             cy="120.712"
-             cx="205.63" />
-        </g>
-      </g>
-    </g>
-    <g
-       id="tri"
-       transform="translate(-16.970563,-19.79899)">
-      <g
-         transform="matrix(0.73103688,0,0,-0.73103688,613.69731,1177.3486)"
-         id="1234">
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 533,1510 c 1.7,0.98 2.04,3.56 0.773,5.76 -1.267,2.2 -3.68,3.19 -5.37,2.21 l -153,-88.1 c -1.7,-0.98 -2.04,-3.56 -0.776,-5.76 1.27,-2.2 3.68,-3.19 5.38,-2.21 l 153,88.1 z"
-           id="path10031" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 533,1510 c 1.7,0.98 2.04,3.56 0.773,5.76 -1.267,2.2 -3.68,3.19 -5.37,2.21 l -153,-88.1 c -1.7,-0.98 -2.04,-3.56 -0.776,-5.76 1.27,-2.2 3.68,-3.19 5.38,-2.21 l 153,88.1 z"
-           id="path10035" />
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 235,1510 c -1.63,0.94 -3.98,-0.082 -5.24,-2.28 -1.27,-2.2 -0.981,-4.74 0.644,-5.68 l 146,-84.4 c 1.63,-0.939 3.98,0.082 5.24,2.28 1.27,2.2 0.983,4.74 -0.644,5.68 L 235,1510 z"
-           id="path10039" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 235,1510 c -1.63,0.94 -3.98,-0.082 -5.24,-2.28 -1.27,-2.2 -0.981,-4.74 0.644,-5.68 l 146,-84.4 c 1.63,-0.939 3.98,0.082 5.24,2.28 1.27,2.2 0.983,4.74 -0.644,5.68 L 235,1510 z"
-           id="path10043" />
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 375,1240 c -0.002,-2.06 2.06,-3.73 4.6,-3.73 2.54,0 4.6,1.67 4.6,3.73 l -0.002,185 c 0,2.06 -2.06,3.73 -4.6,3.73 -2.54,0 -4.6,-1.67 -4.6,-3.73 L 375,1240 z"
-           id="path10047" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 375,1240 c -0.002,-2.06 2.06,-3.73 4.6,-3.73 2.54,0 4.6,1.67 4.6,3.73 l -0.002,185 c 0,2.06 -2.06,3.73 -4.6,3.73 -2.54,0 -4.6,-1.67 -4.6,-3.73 L 375,1240 z"
-           id="path10051" />
-        <g
-           id="g10061">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath10057)"
-             id="g10063">
-            <g
-               transform="translate(175.5146,1564.4219)"
-               id="g10065">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c -33.2,-33.2 -33.2,-87.1 0.049,-120 33.2,-33.2 87.1,-33.2 120,0 33.2,33.2 33.2,87 -0.008,120 -32.9,33.2 -86.8,33.2 -120,0"
-                 id="path10067" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g10087">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath10073)"
-             id="g10089">
-            <g
-               id="g10091">
-              <g
-                 id="g10093">
-                <g
-                   id="g10095">
-                  <g
-                     id="g10097">
-                    <path
-                       style="fill:url(#radialGradient8738)"
-                       inkscape:connector-curvature="0"
-                       d="m 213,1500 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 h -12 l 35.6,35.6 35.6,-35.6 h -11.3 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 L 213,1500 z"
-                       id="path10099" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g10119">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath10105)"
-             id="g10121">
-            <g
-               id="g10123">
-              <g
-                 id="g10125">
-                <g
-                   id="g10127">
-                  <g
-                     id="g10129">
-                    <path
-                       style="fill:url(#radialGradient8740)"
-                       inkscape:connector-curvature="0"
-                       d="m 164,1510 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.6 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path10131" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g10143">
-          <path
-             style="fill:url(#linearGradient8742)"
-             inkscape:connector-curvature="0"
-             d="m 368,1470 2.77,0 0,-17.2 17.2,0 0,17.2 3.07,0 -11.5,11.5 -11.5,-11.5 z"
-             id="path10151" />
-        </g>
-        <g
-           id="g10169">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath10165)"
-             id="g10171">
-            <g
-               transform="translate(587.4541,1567.4229)"
-               id="g10173">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.047,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path10175" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g10195">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath10181)"
-             id="g10197">
-            <g
-               id="g10199">
-              <g
-                 id="g10201">
-                <g
-                   id="g10203">
-                  <g
-                     id="g10205">
-                    <path
-                       style="fill:url(#radialGradient8744)"
-                       inkscape:connector-curvature="0"
-                       d="m 550,1500 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0 -22.2,9.11 -23.7,20.9 h 12 l -35.6,35.6 -35.6,-35.6 h 11.3 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 550,1500 z"
-                       id="path10207" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g10227">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath10213)"
-             id="g10229">
-            <g
-               id="g10231">
-              <g
-                 id="g10233">
-                <g
-                   id="g10235">
-                  <g
-                     id="g10237">
-                    <path
-                       style="fill:url(#radialGradient8746)"
-                       inkscape:connector-curvature="0"
-                       d="m 599,1510 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 l -11.1,0 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 h -11.2 z"
-                       id="path10239" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           style="fill:#2f2d2e;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 349,1460 62.1,0 c 1.63,0 2.95,-1.32 2.95,-2.95 v -62.1 c 0,-1.63 -1.32,-2.96 -2.95,-2.96 H 349 c -1.63,0 -2.95,1.32 -2.95,2.96 v 62.1 c 0,1.63 1.32,2.95 2.95,2.95"
-           id="path10243" />
-        <path
-           style="fill:#c8c7c6;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 372,1420 -2.78,-9.4 7.16,-3.94 2.89,11 -7.27,2.36 z m -1.79,16.9 -3.03,-12.3 1.96,-0.745 11.1,-3.97 2.99,9.89 -13,7.07 z m 12.8,13.2 c -1.15,0.022 -2.18,-0.468 -2.61,-1.87 l -4.04,-13.6 6.49,-3.55 2.8,10.6 c 0.795,1.24 1.93,0.761 3.16,0.014 l 9.6,-6.33 c 0.85,-0.699 1.4,-1.66 1.35,-3.17 l -0.592,-8.39 c -0.113,-1.18 -0.826,-1.89 -1.37,-1.78 l -15.2,8.23 -2.69,-10.2 3.7,-1.34 v -0.01 l 15.2,-5.49 c 2.26,-0.824 4.28,1.66 4.36,5.4 l 0.065,13.4 c -0.049,3.31 -1.64,5.1 -3.24,6.39 l -12.7,9.9 c -1.06,0.864 -2.79,1.74 -4.3,1.77"
-           id="path10247" />
-        <path
-           style="fill:#658acf;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 368,1440 -1.31,0.757 1.16,4.26 -2.92,1.59 -6.44,-2.74 -8.89,2.35 7.9,-5.36 3.09,-7.39 4,-1.32 1.26,4.74 1.24,-0.195 0.906,3.31 z"
-           id="path10251" />
-        <path
-           style="fill:#c8c7c6;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 398,1400 2.56,0 c 0.279,0 0.5,-0.107 0.695,-0.296 0.1,-0.089 0.176,-0.2 0.215,-0.314 0.051,-0.119 0.084,-0.246 0.084,-0.387 v -0.914 c 0,-0.135 -0.033,-0.266 -0.084,-0.396 -0.039,-0.106 -0.115,-0.209 -0.215,-0.298 -0.195,-0.194 -0.416,-0.299 -0.695,-0.299 H 398 c -0.275,0 -0.504,0.105 -0.693,0.299 -0.104,0.089 -0.174,0.192 -0.225,0.298 -0.039,0.13 -0.078,0.261 -0.078,0.396 v 0.914 c 0,0.141 0.039,0.268 0.078,0.387 0.051,0.114 0.121,0.225 0.225,0.314 0.189,0.189 0.418,0.296 0.693,0.296 m -12.4,0 2.56,0 c 0.276,0 0.497,-0.107 0.688,-0.296 0.191,-0.187 0.309,-0.427 0.309,-0.701 v -0.914 c 0,-0.277 -0.118,-0.527 -0.309,-0.694 -0.184,-0.191 -0.41,-0.298 -0.676,-0.299 h -3.57 v 0.993 0.521 0.393 c 0,0.141 0.035,0.268 0.084,0.387 0.051,0.114 0.129,0.225 0.228,0.314 0.176,0.189 0.403,0.296 0.684,0.296 m -15,0 2.55,0 c 0.287,0 0.506,-0.107 0.701,-0.296 0.096,-0.089 0.166,-0.2 0.213,-0.314 0.053,-0.119 0.082,-0.246 0.082,-0.38 h -4.54 c 0,0.134 0.033,0.261 0.08,0.38 0.051,0.114 0.121,0.225 0.219,0.314 0.189,0.189 0.426,0.296 0.695,0.296 m -7.51,0 2.54,0 c 0.281,0 0.519,-0.107 0.715,-0.296 0.197,-0.187 0.281,-0.427 0.281,-0.701 v -0.914 c 0,-0.277 -0.084,-0.527 -0.281,-0.694 -0.196,-0.194 -0.434,-0.299 -0.715,-0.299 h -1.89 -1.64 v 0.993 0.521 0.393 c 0,0.141 0.02,0.268 0.073,0.387 0.062,0.114 0.135,0.225 0.224,0.314 0.18,0.189 0.42,0.296 0.7,0.296 m -7.52,0 2.54,0 c 0.277,0 0.522,-0.107 0.709,-0.296 0.088,-0.089 0.158,-0.2 0.215,-0.314 0.051,-0.119 0.074,-0.246 0.074,-0.387 v -0.914 c 0,-0.135 -0.023,-0.266 -0.074,-0.396 -0.057,-0.106 -0.127,-0.209 -0.215,-0.298 -0.187,-0.194 -0.432,-0.299 -0.709,-0.299 h -0.318 -2.22 c -0.281,0 -0.514,0.105 -0.713,0.299 -0.082,0.089 -0.158,0.192 -0.209,0.298 -0.057,0.13 -0.074,0.261 -0.074,0.396 v 0.914 c 0,0.141 0.017,0.268 0.074,0.387 0.051,0.114 0.127,0.225 0.209,0.314 0.199,0.189 0.432,0.296 0.713,0.296 m 42.4,1.04 c -0.278,0 -0.543,-0.05 -0.795,-0.167 -0.233,-0.088 -0.453,-0.241 -0.619,-0.419 -0.194,-0.19 -0.34,-0.406 -0.457,-0.652 -0.106,-0.255 -0.141,-0.521 -0.141,-0.794 v -0.929 c 0,-0.282 0.035,-0.548 0.141,-0.795 0.117,-0.243 0.263,-0.456 0.457,-0.642 0.166,-0.179 0.386,-0.332 0.619,-0.427 0.252,-0.115 0.517,-0.159 0.795,-0.159 h 2.69 c 0.277,0 0.543,0.044 0.791,0.159 0.236,0.095 0.459,0.248 0.637,0.427 0.189,0.186 0.334,0.399 0.445,0.642 0.096,0.247 0.147,0.513 0.147,0.795 v 0.929 c 0,0.273 -0.051,0.539 -0.147,0.794 -0.111,0.246 -0.256,0.462 -0.445,0.652 -0.178,0.178 -0.401,0.331 -0.637,0.419 -0.248,0.117 -0.514,0.167 -0.791,0.167 h -2.69 z m -27.4,0 c -0.274,0 -0.539,-0.05 -0.797,-0.167 -0.236,-0.088 -0.451,-0.241 -0.625,-0.419 -0.186,-0.19 -0.34,-0.406 -0.447,-0.652 -0.108,-0.252 -0.156,-0.509 -0.156,-0.786 v -0.929 c 0,-0.277 0.048,-0.542 0.156,-0.796 0.107,-0.243 0.261,-0.463 0.447,-0.649 0.174,-0.179 0.389,-0.332 0.625,-0.427 0.258,-0.115 0.523,-0.159 0.797,-0.159 h 4.11 v 1.04 h -4.05 c -0.269,0 -0.506,0.105 -0.695,0.299 -0.074,0.078 -0.133,0.161 -0.18,0.257 -0.058,0.097 -0.091,0.204 -0.107,0.304 h 5.63 v 1.06 c 0,0.277 -0.051,0.534 -0.145,0.786 -0.117,0.246 -0.254,0.462 -0.449,0.652 -0.182,0.178 -0.4,0.331 -0.644,0.419 -0.233,0.117 -0.5,0.167 -0.791,0.167 h -2.68 z m -15,0 c -0.291,0 -0.555,-0.05 -0.793,-0.167 -0.25,-0.088 -0.459,-0.241 -0.645,-0.419 -0.183,-0.19 -0.336,-0.406 -0.445,-0.652 -0.1,-0.255 -0.153,-0.521 -0.153,-0.794 v -0.929 c 0,-0.282 0.053,-0.548 0.153,-0.795 0.109,-0.243 0.262,-0.456 0.445,-0.642 0.186,-0.179 0.395,-0.332 0.645,-0.427 0.238,-0.115 0.502,-0.159 0.793,-0.159 h 2.01 0.664 2.8 v -1.99 h 1.11 v 1.99 h 0.928 0.36 2.32 c 0.283,0 0.543,0.044 0.783,0.159 0.252,0.095 0.463,0.248 0.654,0.427 0.192,0.186 0.334,0.399 0.436,0.642 0.099,0.247 0.158,0.513 0.158,0.795 v 0.929 c 0,0.273 -0.059,0.539 -0.158,0.794 -0.102,0.246 -0.244,0.462 -0.436,0.652 -0.191,0.178 -0.402,0.331 -0.654,0.419 -0.24,0.117 -0.5,0.167 -0.783,0.167 h -2.68 c -0.281,0 -0.545,-0.05 -0.793,-0.167 -0.244,-0.088 -0.455,-0.241 -0.642,-0.419 -0.186,-0.19 -0.338,-0.406 -0.44,-0.652 -0.107,-0.255 -0.164,-0.521 -0.164,-0.794 v -1.91 h -1.02 c 0.027,0.063 0.068,0.128 0.087,0.19 0.112,0.247 0.165,0.513 0.165,0.795 v 0.929 c 0,0.273 -0.053,0.539 -0.165,0.794 -0.091,0.246 -0.244,0.462 -0.423,0.652 -0.192,0.178 -0.407,0.331 -0.653,0.419 -0.252,0.117 -0.517,0.167 -0.797,0.167 h -2.68 z m 35.5,-4.98 1.1,0 0,5 -1.1,0 0,-5 z m -13,5 c -0.274,0 -0.539,-0.059 -0.791,-0.183 -0.229,-0.088 -0.446,-0.241 -0.625,-0.419 -0.186,-0.19 -0.336,-0.406 -0.451,-0.652 -0.096,-0.252 -0.139,-0.509 -0.139,-0.786 v -2.96 h 1.09 v 2.95 c 0,0.273 0.113,0.514 0.301,0.708 0.08,0.089 0.197,0.157 0.302,0.213 0.121,0.052 0.244,0.074 0.381,0.074 h 2.57 c 0.132,0 0.263,-0.022 0.369,-0.074 0.121,-0.056 0.244,-0.124 0.314,-0.213 0.197,-0.194 0.301,-0.435 0.301,-0.708 v -2.95 h 0.307 0.785 0.777 v -1.99 h 1.1 v 1.99 h 0.927 2.3 0.407 c 0.265,0 0.531,0.044 0.783,0.159 0.23,0.095 0.451,0.248 0.631,0.427 0.183,0.186 0.338,0.399 0.445,0.642 0.103,0.247 0.139,0.513 0.139,0.795 v 0.929 c 0,0.273 -0.036,0.539 -0.139,0.794 -0.107,0.246 -0.262,0.462 -0.445,0.652 -0.18,0.178 -0.401,0.331 -0.631,0.419 -0.252,0.117 -0.518,0.167 -0.783,0.167 h -2.71 c -0.279,0 -0.544,-0.05 -0.792,-0.167 -0.225,-0.088 -0.438,-0.241 -0.625,-0.419 -0.19,-0.19 -0.34,-0.406 -0.456,-0.652 -0.099,-0.255 -0.15,-0.521 -0.15,-0.794 v -1.91 h -0.777 v 1.91 0.01 c 0,0.277 -0.053,0.534 -0.139,0.786 -0.119,0.246 -0.262,0.462 -0.451,0.652 -0.184,0.178 -0.406,0.331 -0.643,0.419 -0.23,0.124 -0.496,0.183 -0.777,0.183 h -2.7 z m 25.6,1.43 0,-1.22 -0.49,0 0,-1.05 0.49,0 0,-2.13 c 0,-0.282 0.06,-0.548 0.154,-0.795 0.112,-0.243 0.252,-0.456 0.438,-0.642 0.195,-0.179 0.4,-0.332 0.652,-0.427 0.236,-0.115 0.502,-0.159 0.793,-0.159 h 0.791 v 1.04 h -0.777 c -0.27,0.025 -0.504,0.13 -0.664,0.32 -0.096,0.079 -0.168,0.192 -0.213,0.308 -0.049,0.104 -0.065,0.232 -0.065,0.365 v 2.12 h 1.72 v 0.224 0.83 h -1.72 v 1.22 h -1.11 z m -10.8,0.564 0,-4.96 c 0,-0.277 0.06,-0.542 0.162,-0.796 0.1,-0.243 0.24,-0.463 0.434,-0.638 0.197,-0.184 0.398,-0.332 0.66,-0.438 0.234,-0.115 0.49,-0.159 0.777,-0.159 h 0.221 v 1.04 h -0.201 c -0.262,0.025 -0.479,0.13 -0.664,0.32 -0.088,0.079 -0.157,0.192 -0.198,0.308 -0.064,0.104 -0.068,0.232 -0.068,0.365 v 4.96 h -1.12 z m -1.86,-1.1 1.1,0 0,1.1 -1.1,0 0,-1.1 z"
-           id="path10255" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 544,1522.7358 c 9.4,-9.41 9.4,-24.7 -0.008,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.409 -9.4,24.7 0.008,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
-           id="path10259" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 522,1500 0,2.94 5.8,5.25 c 0.734,0.693 1.22,1.39 1.22,2.29 0,1.05 -0.736,1.78 -1.85,1.78 -1.18,0 -1.95,-0.924 -2.1,-2.25 l -3.38,0.462 c 0.335,3 2.77,4.79 5.67,4.79 2.73,0 5.38,-1.45 5.38,-4.56 0,-2.12 -1.24,-3.36 -2.6,-4.58 l -3.44,-3.07 h 6.07 v -3.06 h -10.8 z"
-           id="path10263" />
-        <g
-           id="g10273">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath10269)"
-             id="g10275">
-            <g
-               transform="translate(317.7236,1313.3682)"
-               id="g10277">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c -33.2,-33.2 -33.2,-87.1 0.051,-120 33.2,-33.2 87.1,-33.2 120,0 33.2,33.2 33.2,87 -0.008,120 -32.9,33.2 -86.8,33.2 -120,0"
-                 id="path10279" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g10299">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath10285)"
-             id="g10301">
-            <g
-               id="g10303">
-              <g
-                 id="g10305">
-                <g
-                   id="g10307">
-                  <g
-                     id="g10309">
-                    <path
-                       style="fill:url(#radialGradient8748)"
-                       inkscape:connector-curvature="0"
-                       d="m 357,1240 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 h -12 l 35.6,35.6 35.6,-35.6 h -11.3 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.012 -44,13.9 -53.4,34 L 357,1240 z"
-                       id="path10311" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g10331">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath10317)"
-             id="g10333">
-            <g
-               id="g10335">
-              <g
-                 id="g10337">
-                <g
-                   id="g10339">
-                  <g
-                     id="g10341">
-                    <path
-                       style="fill:url(#radialGradient8750)"
-                       inkscape:connector-curvature="0"
-                       d="m 307,1250 c 1.29,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.7 H 367 l -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path10343" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 397,1264.5284 c 9.41,-9.41 9.41,-24.7 -0.008,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.008,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
-           id="path10347" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 380,1240 c -2.71,0 -5.16,1.18 -5.96,3.95 l 3.28,0.861 c 0.274,-0.988 1.18,-1.85 2.52,-1.85 1.01,0 2.16,0.504 2.16,1.89 0,1.51 -1.55,1.95 -3.02,1.95 h -0.945 v 2.58 h 1.03 c 1.32,0 2.6,0.336 2.6,1.76 0,1.07 -0.902,1.64 -1.87,1.64 -1.01,0 -1.81,-0.651 -2.04,-1.66 l -3.28,0.756 c 0.712,2.5 3.06,3.78 5.54,3.78 2.62,0 5.23,-1.34 5.23,-4.2 0,-1.64 -1.05,-2.86 -2.5,-3.23 v -0.063 c 1.68,-0.399 2.86,-1.78 2.86,-3.44 0,-3.26 -2.88,-4.72 -5.6,-4.72"
-           id="path10351" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 253,1525.4716 c 9.4,-9.41 9.4,-24.7 -0.008,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.409 -9.4,24.7 0.008,34.1 9.4,9.41 24.7,9.41 34.1,0.01"
-           id="path10355" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 235,1500 0,10.9 -2.77,-2.14 -1.83,2.5 4.89,3.59 3.23,0 0,-14.9 -3.53,0 z"
-           id="path10359" />
-        <g
-           transform="matrix(0.22068409,0,0,-0.22068409,342.97168,1173.0784)"
-           id="g8736">
-          <path
-             style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="M 93.9,181 C 89.4,180 34.8,134 34.8,134 v 108 l 58.9,58.9"
-             id="path8738" />
-          <path
-             style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="M 94.4,299 264,193 265,82.6 c 0,0 -11.4,0.709 -14.3,0.709 -2.83,0 -116,61.4 -116,61.4 l -40.7,35.7 v 119"
-             id="path8740" />
-          <path
-             style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="m 34.8,133 11,-6 5.2,-15 68,-40.2"
-             id="path8742" />
-          <path
-             style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="m 46,126 55.5,47.4 5.56,-20.2 94.4,-56.6"
-             id="path8744" />
-          <path
-             style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="m 50.8,112 c 8.36,8.4 56.8,41.4 56.8,41.4"
-             id="path8746" />
-          <ellipse
-             style="fill:#ff0000;fill-rule:evenodd;stroke:#000000;stroke-width:0.99199998px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             sodipodi:ry="44.900002"
-             sodipodi:rx="70.099998"
-             sodipodi:cy="45.400002"
-             sodipodi:cx="183"
-             stroke-miterlimit="4"
-             ry="44.900002"
-             cy="45.400002"
-             rx="70.099998"
-             cx="183"
-             d="m 253.1,45.400002 c 0,24.797586 -31.38484,44.900001 -70.1,44.900001 -38.71516,0 -70.1,-20.102415 -70.1,-44.900001 C 112.9,20.602415 144.28484,0.5 183,0.5 c 38.71516,0 70.1,20.102415 70.1,44.900002 z"
-             id="ellipse8748" />
-          <ellipse
-             style="fill:#443838;fill-rule:evenodd;stroke:#000000;stroke-width:0.99199998px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             sodipodi:ry="44.900002"
-             sodipodi:rx="70.099998"
-             sodipodi:cy="51.299999"
-             sodipodi:cx="183"
-             stroke-miterlimit="4"
-             ry="44.900002"
-             cy="51.299999"
-             rx="70.099998"
-             cx="183"
-             d="m 253.1,51.299999 c 0,24.797586 -31.38484,44.900002 -70.1,44.900002 -38.71516,0 -70.1,-20.102416 -70.1,-44.900002 0,-24.797586 31.38484,-44.9000013 70.1,-44.9000013 38.71516,0 70.1,20.1024153 70.1,44.9000013 z"
-             id="ellipse8750" />
-          <ellipse
-             style="fill:#443838;fill-rule:evenodd;stroke:#000000;stroke-width:0.99199998px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             sodipodi:ry="44.900002"
-             sodipodi:rx="70.099998"
-             sodipodi:cy="45.400002"
-             sodipodi:cx="183"
-             stroke-miterlimit="4"
-             ry="44.900002"
-             cy="45.400002"
-             rx="70.099998"
-             cx="183"
-             d="m 253.1,45.400002 c 0,24.797586 -31.38484,44.900001 -70.1,44.900001 -38.71516,0 -70.1,-20.102415 -70.1,-44.900001 C 112.9,20.602415 144.28484,0.5 183,0.5 c 38.71516,0 70.1,20.102415 70.1,44.900002 z"
-             id="ellipse8752" />
-          <path
-             style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="m 93.9,204 -34.8,20.2 0,8.61 35.3,-17.7"
-             id="path8754" />
-          <path
-             style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="M 59.1,232 1,183.5 1,172.9"
-             id="path8756" />
-          <path
-             style="fill:#333333;fill-rule:nonzero;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="M 58.1,224 0.496,173 33.3,154 95.5,204"
-             id="path8758" />
-          <path
-             style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="M 265,82.3 249,68.7"
-             id="path8760" />
-          <path
-             style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="m 266,103 c 0,0 33.3,-20.2 30.8,-20.7 -2.52,-0.496 -42.9,-36.9 -42.9,-36.9"
-             id="path8762" />
-          <path
-             style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="m 297,83.4 0.531,9.07 -32.4,18.7"
-             id="path8764" />
-          <path
-             style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="m 251,83.3 -7,-5"
-             id="path8766" />
-          <path
-             style="fill:#808080;fill-rule:nonzero"
-             inkscape:connector-curvature="0"
-             d="M 18,197 1.8,183.5 1.7291,179.32 c -0.0709,-4.11 -0.0709,-4.18 0.425,-3.83 0.248,0.177 7.58,6.66 16.3,14.4 l 15.8,14 v 3.33 c 0,1.84 -0.0354,3.37 -0.0709,3.33 -0.0354,0 -7.33,-6.09 -16.2,-13.5 z"
-             id="path8768" />
-          <path
-             style="fill:#808080;fill-rule:nonzero"
-             inkscape:connector-curvature="0"
-             d="M 47,221 35.7,211.5 19,195.4 l 16.5,9.28 2.09,1.88 c 1.13,1.03 6.09,5.42 11,9.78 7.05,6.24 9.04,7.87 9.43,7.72 0.461,-0.142 0.496,-0.0354 0.496,3.15 0,1.81 -0.0354,3.3 -0.0709,3.3 -0.0354,0 -5.17,-4.29 -11.4,-9.53 z"
-             id="path8770" />
-          <path
-             style="fill:#808080;fill-rule:nonzero"
-             inkscape:connector-curvature="0"
-             d="m 59.8,228 0.0709,-3.58 11.2,-6.52 c 10.6,-6.17 17.7,-10.2 21,-12 l 1.45,-0.78 v 4.85 4.85 l -16.8,8.4 c -9.21,4.64 -16.8,8.4 -16.9,8.4 -0.0709,0 -0.106,-1.59 -0.0709,-3.58 z"
-             id="path8772" />
-          <path
-             style="fill:#808080;fill-rule:nonzero"
-             inkscape:connector-curvature="0"
-             d="m 94.9,251 c 0,-35.8 -0.0354,-50.1 0.425,-50.6 0.461,-0.496 0.638,2.27 0.177,1.81 -0.425,-0.425 -0.602,-3.61 -0.602,-11.1 v -10.5 l 20.1,-17 20,-18 27,-14 c 40.2,-21.8 72.7,-39 81.4,-43.3 l 7.76,-3.76 6.52,-0.319 6.52,-0.319 -0.354,54.2 c -0.283,40.8 -0.496,54.4 -0.957,54.8 -0.319,0.319 -37.8,23.9 -83.2,52.5 -45.4,28.5 -83.1,52.2 -83.7,52.6 l -1.13,0.744 v -46.9 z"
-             id="path8774" />
-          <path
-             style="fill:#808080;fill-rule:nonzero"
-             inkscape:connector-curvature="0"
-             d="m 64.4,270 -28.7,-29 0.2,-14 0.1,-13 11.2,9.28 c 6.17,5.1 11.9,9.92 12,10.3 0,0.354 6.7,-3.44 16.5,-8.36 9.46,-4.71 17.3,-8.5 17.4,-8.4 0.106,0.106 0.142,18.6 0.0709,41.2 l -0.106,41 -28.7,-28.7 z"
-             id="path8776" />
-          <path
-             style="fill:#808080;fill-rule:nonzero"
-             inkscape:connector-curvature="0"
-             d="m 64.4,178 -28.7,-23.1 0,-9.28 c 0,-7.26 0.142,-9.18 0.638,-8.86 0.319,0.213 5.95,4.82 12.5,10.2 17,14.1 34.4,28 39.8,31.9 l 4.64,3.26 v 9.46 c 0,5.24 -0.0709,9.5 -0.142,9.5 -0.0709,-0.0354 -13,-10.4 -28.8,-23.1 z"
-             id="path8778" />
-          <path
-             style="fill:#666666;fill-rule:nonzero"
-             inkscape:connector-curvature="0"
-             d="M 88.2,176 C 81.1,171 65.6,158 49.3,145 l -13.5,-11.2 4.18,-2.41 c 2.27,-1.31 4.61,-2.69 5.21,-3.08 0.957,-0.638 2.8,0.85 28.2,22.6 l 27.1,23.2 -2.37,2.13 c -5.03,4.43 -3.97,4.43 -9.89,0 z"
-             id="path8780" />
-          <path
-             style="fill:#666666;fill-rule:nonzero"
-             inkscape:connector-curvature="0"
-             d="m 73.7,149 -26.8,-23 2.02,-5.63 c 1.1,-3.08 2.13,-5.81 2.27,-6.06 0.142,-0.213 2.13,1.13 4.39,3.05 7.19,5.99 27.3,20.5 45.9,33.2 2.44,1.67 4.43,3.26 4.46,3.51 0,1.06 -4.75,17.9 -5.07,17.9 -0.177,0 -12.4,-10.3 -27.2,-23 z"
-             id="path8782" />
-          <path
-             style="fill:#666666;fill-rule:nonzero"
-             inkscape:connector-curvature="0"
-             d="M 91.8,142 C 67.7,125 52,113 52.8,112 53.013,111.787 68,102.75 86.2,91.9 l 32.8,-19.5 1.88,2.13 c 9.07,10.3 23.6,18 40.2,21.3 9.64,1.91 16.2,2.44 26,2.09 4.85,-0.213 9.64,-0.496 10.6,-0.638 0.957,-0.177 1.63,-0.213 1.49,-0.0709 -0.709,0.744 -91.6,54.9 -92.1,54.9 -0.319,0 -7.3,-4.68 -15.5,-10.4 z"
-             id="path8784" />
-          <path
-             style="fill:#666666;fill-rule:nonzero"
-             inkscape:connector-curvature="0"
-             d="m 104,166 c 0.815,-2.98 1.88,-6.84 2.34,-8.61 l 0.85,-3.15 46.5,-27.8 c 25.6,-15.3 46.8,-28.2 47.3,-28.7 0.461,-0.567 2.66,-1.38 5.28,-1.98 17.8,-4.18 33.1,-12.8 40.4,-22.8 0.992,-1.38 2.02,-2.44 2.27,-2.37 0.248,0.106 3.44,2.66 7.09,5.7 l 6.66,5.56 -2.73,0.319 c -1.52,0.177 -4.29,0.354 -6.2,0.39 -3.37,0.0354 -3.61,-0.0354 -6.66,-2.23 -3.3,-2.34 -4,-2.62 -4.5,-1.77 -0.177,0.248 1.1,1.42 2.8,2.59 l 3.12,2.09 -12.1,6.17 c -14.5,7.44 -31.9,16.7 -72.2,38.5 l -30.3,16.4 -15.5,13.6 c -8.54,7.48 -15.6,13.6 -15.7,13.6 -0.106,0 0.461,-2.44 1.28,-5.42 z"
-             id="path8786" />
-          <path
-             style="fill:#666666;fill-rule:nonzero"
-             inkscape:connector-curvature="0"
-             d="m 266,91.9 0,-10.2 -7.72,-6.56 -7.72,-6.52 1.38,-2.76 c 1.98,-4 3.12,-9.14 3.08,-14.3 l -0.0354,-4.46 1.1,0.957 c 0.567,0.496 4.25,3.79 8.15,7.26 9.74,8.68 25.7,22.4 29.1,25.2 1.59,1.2 2.76,2.41 2.62,2.66 -0.531,0.85 -28.9,19.1 -29.8,19.1 -0.106,0 -0.213,-4.61 -0.213,-10.3 z"
-             id="path8788" />
-          <path
-             style="fill:#808080;fill-rule:nonzero"
-             inkscape:connector-curvature="0"
-             d="m 266,106 c 0,-2.13 0.177,-3.22 0.496,-3.01 0.532,0.319 16,-9.07 25.1,-15.3 l 5.17,-3.51 0.0709,2.98 c 0.0709,1.67 0.106,3.33 0.142,3.76 0.0354,0.461 -5.74,4.07 -15.3,9.57 -8.43,4.89 -15.4,8.86 -15.6,8.86 -0.106,0 -0.177,-1.49 -0.177,-3.3 z"
-             id="path8790" />
-          <path
-             style="fill:#666666;fill-rule:nonzero"
-             inkscape:connector-curvature="0"
-             d="M 30.8,198 C 15.4,185 2.8,174 2.7,173 c -0.106,-0.354 3.12,-2.55 7.16,-4.93 4.04,-2.34 10.9,-6.38 15.3,-8.96 l 8.01,-4.71 30.2,24.3 c 16.6,13.4 30.3,24.5 30.4,24.8 0.106,0.283 -1.81,1.45 -4.25,2.62 -2.41,1.13 -4.78,2.41 -5.21,2.8 -0.425,0.39 -2.73,1.7 -5.07,2.91 -2.34,1.17 -7.97,4.15 -12.5,6.56 l -8.26,4.39 -27.8,-24.6 z"
-             id="path8792" />
-          <path
-             style="fill:#b3b3b3;fill-rule:nonzero;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="m 75.3,111 37.3,-24.2 38.4,24.4 c 0,0 -40.9,24.7 -41.2,24.6 C 108.95,135.552 75.3,111 75.3,111 z"
-             id="path8794" />
-          <ellipse
-             style="fill:#4d4d4d;fill-rule:nonzero"
-             sodipodi:ry="9"
-             sodipodi:rx="15.1"
-             sodipodi:cy="45.400002"
-             sodipodi:cx="183"
-             ry="9"
-             cy="45.400002"
-             rx="15.1"
-             cx="183"
-             d="m 198.1,45.400002 c 0,4.970562 -6.7605,9 -15.1,9 -8.3395,0 -15.1,-4.029438 -15.1,-9 0,-4.970563 6.7605,-9 15.1,-9 8.3395,0 15.1,4.029437 15.1,9 z"
-             id="ellipse8796" />
-          <path
-             style="fill:none;stroke:#000000;stroke-width:0.99212599px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
-             inkscape:connector-curvature="0"
-             stroke-miterlimit="4"
-             d="m 93.9,221 c 6.1,-2 170,-102 170,-102"
-             id="path8798" />
-        </g>
-      </g>
-      <path
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 776.22871,147.74212 -22.08,0.0888 -70.4,0"
-         style="fill:none;stroke:#777777;stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3, 6;stroke-dashoffset:0;marker-start:none"
-         id="path9977" />
-      <path
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 996.22871,121.34212 0,43.6 -186.8,0 -56,0.3008 -69.2,0"
-         style="fill:none;stroke:#777777;stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3, 6;stroke-dashoffset:0;marker-start:none"
-         id="path9979" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3, 6;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 816.22871,265.34212 -64.8,0 0,-86.8 -65.6,0"
-         id="path9981" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3, 6;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 848.22871,345.34212 -124,0 0,-147.6 -40.8,0"
-         id="path9983" />
-    </g>
-    <g
-       id="controller-coptercontrol"
-       inkscape:label="#controller"
-       transform="translate(-16.970563,-19.79899)">
-      <rect
-         id="rect9798"
-         rx="14.194314"
-         ry="10.835353"
-         height="227.54242"
-         width="227.54243"
-         stroke-miterlimit="4"
-         y="99.148933"
-         x="438.74414"
-         style="fill:#171717;stroke:#000000;stroke-width:2.16707063;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
-      <rect
-         style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
-         x="507.61179"
-         y="244.72189"
-         width="7.064651"
-         height="5.5151949"
-         id="rect4320" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="515.19653"
-         y="244.72189"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect4322" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="504.36118"
-         y="244.72189"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect4324" />
-      <rect
-         style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
-         x="-279.05756"
-         y="612.47388"
-         width="7.0646501"
-         height="5.5151954"
-         id="rect4408"
-         transform="matrix(0,-1,1,0,0,0)" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="-271.47281"
-         y="612.47388"
-         width="3.868221"
-         height="5.5151954"
-         id="rect4410"
-         transform="matrix(0,-1,1,0,0,0)" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="-282.30814"
-         y="612.47388"
-         width="3.868221"
-         height="5.5151954"
-         id="rect4412"
-         transform="matrix(0,-1,1,0,0,0)" />
-      <rect
-         style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
-         x="587.396"
-         y="149.71573"
-         width="7.064651"
-         height="5.5151949"
-         id="rect10507" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="594.98071"
-         y="149.71573"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect10509" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="584.14539"
-         y="149.71573"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect10511" />
-      <rect
-         style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
-         x="523.35864"
-         y="259.94388"
-         width="7.064651"
-         height="5.5151949"
-         id="rect10515" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="530.94342"
-         y="259.94388"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect10517" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="520.10803"
-         y="259.94388"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect10519" />
-      <rect
-         style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
-         x="494.18936"
-         y="256.50372"
-         width="7.064651"
-         height="5.5151949"
-         id="rect4219" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="501.77411"
-         y="256.50372"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect4221" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="490.93878"
-         y="256.50372"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect4223" />
-      <rect
-         style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
-         x="596.80658"
-         y="266.47675"
-         width="7.064651"
-         height="5.5151949"
-         id="rect10550" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="604.3913"
-         y="266.47675"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect10552" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="593.55597"
-         y="266.47675"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect10554" />
-      <rect
-         style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
-         x="596.01923"
-         y="279.3367"
-         width="7.064651"
-         height="5.5151949"
-         id="rect10558" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="603.60394"
-         y="279.3367"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect10560" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="592.76862"
-         y="279.3367"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect10562" />
-      <rect
-         style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
-         x="590.50781"
-         y="185.90521"
-         width="7.064651"
-         height="5.5151949"
-         id="rect10566" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="598.09253"
-         y="185.90521"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect10568" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="587.2572"
-         y="185.90521"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect10570" />
-      <rect
-         style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
-         x="613.34076"
-         y="105.85859"
-         width="7.064651"
-         height="5.5151949"
-         id="rect10574" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="620.92554"
-         y="105.85859"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect10576" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="610.09015"
-         y="105.85859"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect10578" />
-      <rect
-         style="fill:#0052ff;stroke-width:0;stroke-miterlimit:4"
-         x="449.0675"
-         y="148.40121"
-         width="7.064651"
-         height="5.5151949"
-         id="rect4416" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="456.65225"
-         y="148.40121"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect4418" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="445.81689"
-         y="148.40121"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect4420" />
-      <rect
-         style="fill:#ff7900;stroke-width:0;stroke-miterlimit:4"
-         x="448.71127"
-         y="161.59825"
-         width="7.064651"
-         height="5.5151949"
-         id="rect4432" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="456.29602"
-         y="161.59825"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect4434" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="445.46066"
-         y="161.59825"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect4436" />
-      <rect
-         style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
-         x="117.81582"
-         y="-508.21155"
-         width="7.0646501"
-         height="5.5151954"
-         id="rect4280"
-         transform="matrix(0,1,-1,0,0,0)" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="125.40057"
-         y="-508.21155"
-         width="3.868221"
-         height="5.5151954"
-         id="rect4282"
-         transform="matrix(0,1,-1,0,0,0)" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="114.56521"
-         y="-508.21155"
-         width="3.868221"
-         height="5.5151954"
-         id="rect4284"
-         transform="matrix(0,1,-1,0,0,0)" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
-         x="152.48895"
-         y="-508.21155"
-         width="7.0646501"
-         height="5.5151954"
-         id="rect10763" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="160.0737"
-         y="-508.21155"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10765" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="149.23834"
-         y="-508.21155"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10767" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
-         x="161.61464"
-         y="-567.24731"
-         width="7.0646501"
-         height="5.5151954"
-         id="rect10771" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="169.19939"
-         y="-567.24731"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10773" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="158.36404"
-         y="-567.24731"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10775" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
-         x="266.85629"
-         y="-482.47665"
-         width="7.0646501"
-         height="5.5151954"
-         id="rect10779" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="274.44104"
-         y="-482.47665"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10781" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="263.60568"
-         y="-482.47665"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10783" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
-         x="289.68927"
-         y="-482.47665"
-         width="7.0646501"
-         height="5.5151954"
-         id="rect10787" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="297.27402"
-         y="-482.47665"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10789" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="286.43866"
-         y="-482.47665"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10791" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#bc781e;stroke-width:0;stroke-miterlimit:4"
-         x="280.24115"
-         y="-530.76709"
-         width="7.0646501"
-         height="5.5151954"
-         id="rect10795" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="287.8259"
-         y="-530.76709"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10797" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="276.99054"
-         y="-530.76709"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10799" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
-         x="-234.70383"
-         y="511.16895"
-         width="7.0646501"
-         height="5.5151954"
-         id="rect10803" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="-227.11908"
-         y="511.16895"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10805" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="-237.95442"
-         y="511.16895"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10807" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
-         x="-234.96628"
-         y="499.62125"
-         width="7.0646501"
-         height="5.5151954"
-         id="rect10811" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="-227.38153"
-         y="499.62125"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10813" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="-238.21687"
-         y="499.62125"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10815" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
-         x="-235.75362"
-         y="488.336"
-         width="7.0646501"
-         height="5.5151954"
-         id="rect10819" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="-228.16887"
-         y="488.336"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10821" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="-239.00423"
-         y="488.336"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10823" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
-         x="-198.74844"
-         y="489.38577"
-         width="7.0646501"
-         height="5.5151954"
-         id="rect10827" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="-191.1637"
-         y="489.38577"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10829" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="-201.99905"
-         y="489.38577"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10831" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
-         x="-199.01088"
-         y="506.18246"
-         width="7.0646501"
-         height="5.5151954"
-         id="rect10835" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="-191.42613"
-         y="506.18246"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10837" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="-202.26149"
-         y="506.18246"
-         width="3.868221"
-         height="5.5151954"
-         id="rect10839" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 660.83109,147.16536 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
-         id="path4550"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 643.49452,147.16536 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
-         id="path4554"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <rect
-         x="616.76898"
-         y="141.73187"
-         width="10.445282"
-         height="9.2858973"
-         id="rect4556"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 660.83109,162.33485 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
-         id="path10894"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 643.49452,162.33485 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
-         id="path10896"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <rect
-         x="616.76898"
-         y="156.90137"
-         width="10.445282"
-         height="9.2858973"
-         id="rect10898"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 660.83109,179.67142 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
-         id="path10902"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 643.49452,179.67142 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
-         id="path10904"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <rect
-         x="616.76898"
-         y="174.23793"
-         width="10.445282"
-         height="9.2858973"
-         id="rect10906"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 660.83109,197.00798 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
-         id="path10910"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 643.49452,197.00798 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
-         id="path10912"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <rect
-         x="616.76898"
-         y="191.57449"
-         width="10.445282"
-         height="9.2858973"
-         id="rect10914"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 660.83109,214.34455 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
-         id="path10918"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 643.49452,214.34455 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
-         id="path10920"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <rect
-         x="616.76898"
-         y="208.91106"
-         width="10.445282"
-         height="9.2858973"
-         id="rect10922"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 660.83109,229.51404 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
-         id="path10926"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m 643.49452,229.51404 c 0,3.09891 -2.5138,5.61271 -5.61272,5.61271 -3.09891,0 -5.61271,-2.5138 -5.61271,-5.61271 0,-3.09891 2.5138,-5.61271 5.61271,-5.61271 3.09892,0 5.61272,2.5138 5.61272,5.61271 z"
-         id="path10928"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <rect
-         x="616.76898"
-         y="224.08055"
-         width="10.445282"
-         height="9.2858973"
-         id="rect10930"
-         style="fill:none;stroke:#f2edda;stroke-width:1.62530303;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#a9814d;stroke-width:0;stroke-miterlimit:4"
-         x="151.32674"
-         y="-495.40668"
-         width="8.7648525"
-         height="9.8560762"
-         id="rect4790" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="160.73685"
-         y="-495.40668"
-         width="4.79916"
-         height="9.8560762"
-         id="rect4792" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="147.29382"
-         y="-495.40668"
-         width="4.79916"
-         height="9.8560762"
-         id="rect4794" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#a9814d;stroke-width:0;stroke-miterlimit:4"
-         x="116.6536"
-         y="-495.40668"
-         width="8.7648525"
-         height="9.8560762"
-         id="rect12056" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="126.06372"
-         y="-495.40668"
-         width="4.79916"
-         height="9.8560762"
-         id="rect12058" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="112.6207"
-         y="-495.40668"
-         width="4.79916"
-         height="9.8560762"
-         id="rect12060" />
-      <rect
-         style="fill:#a9814d;stroke-width:0;stroke-miterlimit:4"
-         x="456.07767"
-         y="277.10086"
-         width="8.7648525"
-         height="9.8560753"
-         id="rect12064" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="465.48776"
-         y="277.10086"
-         width="4.79916"
-         height="9.8560753"
-         id="rect12066" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="452.04474"
-         y="277.10086"
-         width="4.79916"
-         height="9.8560753"
-         id="rect12068" />
-      <rect
-         style="fill:#a9814d;stroke-width:0;stroke-miterlimit:4"
-         x="492.91785"
-         y="277.10086"
-         width="8.7648525"
-         height="9.8560753"
-         id="rect12072" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="502.32797"
-         y="277.10086"
-         width="4.79916"
-         height="9.8560753"
-         id="rect12074" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="488.88495"
-         y="277.10086"
-         width="4.79916"
-         height="9.8560753"
-         id="rect12076" />
-      <path
-         id="path5376"
-         d="m 532.94311,107.25258 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5378"
-         d="m 529.69251,107.25258 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5386"
-         d="m 545.94554,107.25258 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5388"
-         d="m 542.69493,107.25258 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5390"
-         d="m 539.44433,107.25258 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5454"
-         d="m 529.69251,139.75864 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5456"
-         d="m 532.94311,139.75864 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5466"
-         d="m 539.44433,139.75864 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5468"
-         d="m 542.69493,139.75864 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5470"
-         d="m 545.94554,139.75864 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5612"
-         d="m 523.19129,126.75621 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5614"
-         d="m 523.19129,129.79011 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5616"
-         d="m 523.19129,133.04072 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5618"
-         d="m 549.19614,133.04072 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5620"
-         d="m 549.19614,129.79011 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5622"
-         d="m 549.19614,126.75621 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5624"
-         d="m 523.19129,113.9705 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5626"
-         d="m 523.19129,117.2211 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5628"
-         d="m 523.19129,120.255 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5630"
-         d="m 549.19614,120.255 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5632"
-         d="m 549.19614,117.2211 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5634"
-         d="m 549.19614,113.9705 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5636"
-         d="m 536.19372,107.25258 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5726"
-         d="m 523.19129,123.50561 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5728"
-         d="m 536.19372,139.75864 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5730"
-         d="m 549.19614,123.50561 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5738"
-         d="m 523.19129,110.71989 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path5740"
-         d="m 549.19614,110.71989 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <rect
-         style="fill:#6a6a6a;stroke:#000000;stroke-width:0.75847471;stroke-miterlimit:4;stroke-dasharray:none"
-         x="524.66852"
-         y="105.10838"
-         stroke-miterlimit="4"
-         width="26.32991"
-         height="33.806301"
-         id="rect4974" />
-      <path
-         id="path12832"
-         d="m 532.94311,107.25258 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12834"
-         d="m 529.69251,107.25258 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12836"
-         d="m 545.94554,107.25258 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12838"
-         d="m 542.69493,107.25258 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12840"
-         d="m 539.44433,107.25258 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12842"
-         d="m 529.69251,139.75864 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path13512"
-         d="m 532.94311,139.75864 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12846"
-         d="m 539.44433,139.75864 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path13515"
-         d="m 542.69493,139.75864 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12850"
-         d="m 545.94554,139.75864 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12852"
-         d="m 523.19129,126.75621 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12854"
-         d="m 523.19129,129.79011 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12856"
-         d="m 523.19129,133.04072 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12858"
-         d="m 549.19614,133.04072 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12860"
-         d="m 549.19614,129.79011 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12862"
-         d="m 549.19614,126.75621 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12864"
-         d="m 523.19129,113.9705 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12866"
-         d="m 523.19129,117.2211 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12868"
-         d="m 523.19129,120.255 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12870"
-         d="m 549.19614,120.255 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12872"
-         d="m 549.19614,117.2211 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12874"
-         d="m 549.19614,113.9705 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12876"
-         d="m 536.19372,107.25258 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12878"
-         d="m 523.19129,123.50561 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12880"
-         d="m 536.19372,139.75864 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12882"
-         d="m 549.19614,123.50561 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12884"
-         d="m 523.19129,110.71989 2.91472,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12886"
-         d="m 549.19614,110.71989 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <rect
-         style="fill:#6a6a6a;stroke:#000000;stroke-width:0.75847471;stroke-miterlimit:4;stroke-dasharray:none"
-         x="524.66852"
-         y="105.10838"
-         stroke-miterlimit="4"
-         width="26.32991"
-         height="33.806301"
-         id="rect12888" />
-      <path
-         id="path12894"
-         d="m 533.68543,149.16923 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12896"
-         d="m 530.43483,149.16923 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12898"
-         d="m 546.68786,149.16923 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12900"
-         d="m 543.43725,149.16923 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12902"
-         d="m 540.18665,149.16923 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12904"
-         d="m 530.43483,181.67529 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12906"
-         d="m 533.68543,181.67529 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12908"
-         d="m 540.18665,181.67529 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12910"
-         d="m 543.43725,181.67529 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12912"
-         d="m 546.68786,181.67529 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12914"
-         d="m 523.93362,168.67287 2.91471,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12916"
-         d="m 523.93362,171.70677 2.91471,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12918"
-         d="m 523.93362,174.95738 2.91471,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12920"
-         d="m 549.93846,174.95738 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12922"
-         d="m 549.93846,171.70677 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12924"
-         d="m 549.93846,168.67287 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12926"
-         d="m 523.93362,155.88715 2.91471,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12928"
-         d="m 523.93362,159.13776 2.91471,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12930"
-         d="m 523.93362,162.17166 2.91471,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12932"
-         d="m 549.93846,162.17166 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12934"
-         d="m 549.93846,159.13776 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12936"
-         d="m 549.93846,155.88715 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12938"
-         d="m 536.93604,149.16923 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12940"
-         d="m 523.93362,165.42226 2.91471,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12942"
-         d="m 536.93604,181.67529 0,-2.91471"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12944"
-         d="m 549.93846,165.42226 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12946"
-         d="m 523.93362,152.63655 2.91471,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <path
-         id="path12948"
-         d="m 549.93846,152.63655 2.75218,0"
-         inkscape:connector-curvature="0"
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.61765516;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" />
-      <rect
-         style="fill:#6a6a6a;stroke:#000000;stroke-width:0.75847471;stroke-miterlimit:4;stroke-dasharray:none"
-         x="525.41083"
-         y="147.02502"
-         stroke-miterlimit="4"
-         width="26.32991"
-         height="33.806301"
-         id="rect12950" />
-      <rect
-         style="fill:#6a6a6a;stroke:#000000;stroke-width:2.16960835;stroke-miterlimit:4;stroke-dasharray:none"
-         x="544.84949"
-         y="207.27293"
-         stroke-miterlimit="4"
-         width="45.789528"
-         height="46.029259"
-         ry="1.4983482"
-         id="rect3773" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 549.32105,206.71507 0,-4.7108"
-         id="path3777" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 549.32105,205.51639 0.12203,0"
-         id="path3779" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 551.7184,206.71507 0,-4.7108"
-         id="path3787" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 551.7184,205.51639 0.12203,0"
-         id="path3789" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 554.11576,206.71507 0,-4.7108"
-         id="path3793" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 554.11576,205.51639 0.12203,0"
-         id="path3795" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 556.51312,206.71507 0,-4.7108"
-         id="path3799" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 556.51312,205.51639 0.12203,0"
-         id="path3801" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 558.91048,206.71507 0,-4.7108"
-         id="path3805" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 558.91048,205.51639 0.12203,0"
-         id="path3807" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 561.30783,206.71507 0,-4.7108"
-         id="path3811" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 561.30783,205.51639 0.12203,0"
-         id="path3813" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 563.70519,206.71507 0,-4.7108"
-         id="path3817" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 563.70519,205.51639 0.12203,0"
-         id="path3819" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 566.10255,206.71507 0,-4.7108"
-         id="path3823" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 566.10255,205.51639 0.12203,0"
-         id="path3825" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 568.49991,206.71507 0,-4.7108"
-         id="path3829" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 568.49991,205.51639 0.12203,0"
-         id="path3831" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 570.89726,206.71507 0,-4.7108"
-         id="path3835" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 570.89726,205.51639 0.12203,0"
-         id="path3837" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 573.29462,206.71507 0,-4.7108"
-         id="path3841" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 573.29462,205.51639 0.12203,0"
-         id="path3843" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 575.69198,206.71507 0,-4.7108"
-         id="path3847" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 575.69198,205.51639 0.12203,0"
-         id="path3849" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 578.08934,206.71507 0,-4.7108"
-         id="path3853" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 578.08934,205.51639 0.12203,0"
-         id="path3855" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 580.48669,206.71507 0,-4.7108"
-         id="path3859" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 580.48669,205.51639 0.12203,0"
-         id="path3861" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 582.88405,206.71507 0,-4.7108"
-         id="path3865" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 582.88405,205.51639 0.12203,0"
-         id="path3867" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 585.28141,206.71507 0,-4.7108"
-         id="path3871" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 585.28141,205.51639 0.12203,0"
-         id="path3873" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,213.54644 4.71081,0"
-         id="path3929" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,213.54644 0,0.12202"
-         id="path3931" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,215.9438 4.71081,0"
-         id="path3935" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,215.9438 0,0.12202"
-         id="path3937" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,218.34116 4.71081,0"
-         id="path3941" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,218.34116 0,0.12202"
-         id="path3943" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,220.73851 4.71081,0"
-         id="path3947" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,220.73851 0,0.12202"
-         id="path3949" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,223.13587 4.71081,0"
-         id="path3953" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,223.13587 0,0.12202"
-         id="path3955" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,225.53323 4.71081,0"
-         id="path3959" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,225.53323 0,0.12202"
-         id="path3961" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,227.93058 4.71081,0"
-         id="path3965" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,227.93058 0,0.12202"
-         id="path3967" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,230.32794 4.71081,0"
-         id="path3971" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,230.32794 0,0.12202"
-         id="path3973" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,232.7253 4.71081,0"
-         id="path3977" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,232.7253 0,0.12202"
-         id="path3979" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,235.12266 4.71081,0"
-         id="path3983" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,235.12266 0,0.12202"
-         id="path3985" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,237.52001 4.71081,0"
-         id="path3989" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,237.52001 0,0.12202"
-         id="path3991" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,239.91737 4.71081,0"
-         id="path3995" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,239.91737 0,0.12202"
-         id="path3997" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,242.31473 4.71081,0"
-         id="path4001" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,242.31473 0,0.12202"
-         id="path4003" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,244.71208 4.71081,0"
-         id="path4007" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,244.71208 0,0.12202"
-         id="path4009" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,247.10944 4.71081,0"
-         id="path4013" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,247.10944 0,0.12202"
-         id="path4015" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 591.43136,249.5068 4.71081,0"
-         id="path4019" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 592.63004,249.5068 0,0.12202"
-         id="path4021" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,213.54644 -4.71081,0"
-         id="path4027" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,213.54644 0,0.12202"
-         id="path4029" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,215.9438 -4.71081,0"
-         id="path4033" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,215.9438 0,0.12202"
-         id="path4035" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,218.34116 -4.71081,0"
-         id="path4039" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,218.34116 0,0.12202"
-         id="path4041" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,220.73851 -4.71081,0"
-         id="path4045" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,220.73851 0,0.12202"
-         id="path4047" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,223.13587 -4.71081,0"
-         id="path4051" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,223.13587 0,0.12202"
-         id="path4053" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,225.53323 -4.71081,0"
-         id="path4057" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,225.53323 0,0.12202"
-         id="path4059" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,227.93058 -4.71081,0"
-         id="path4063" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,227.93058 0,0.12202"
-         id="path4065" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,230.32794 -4.71081,0"
-         id="path4069" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,230.32794 0,0.12202"
-         id="path4071" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,232.7253 -4.71081,0"
-         id="path4075" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,232.7253 0,0.12202"
-         id="path4077" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,235.12266 -4.71081,0"
-         id="path4081" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,235.12266 0,0.12202"
-         id="path4083" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,237.52001 -4.71081,0"
-         id="path4087" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,237.52001 0,0.12202"
-         id="path4089" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,239.91737 -4.71081,0"
-         id="path4093" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,239.91737 0,0.12202"
-         id="path4095" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,242.31473 -4.71081,0"
-         id="path4099" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,242.31473 0,0.12202"
-         id="path4101" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,244.71208 -4.71081,0"
-         id="path4105" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,244.71208 0,0.12202"
-         id="path4107" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,247.10944 -4.71081,0"
-         id="path4111" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,247.10944 0,0.12202"
-         id="path4113" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 543.76405,249.5068 -4.71081,0"
-         id="path4117" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 542.56537,249.5068 0,0.12202"
-         id="path4119" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 549.32105,253.94049 0,4.7108"
-         id="path4125" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 549.32105,255.13916 0.12203,0"
-         id="path4127" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 551.7184,253.94049 0,4.7108"
-         id="path4131" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 551.7184,255.13916 0.12203,0"
-         id="path4133" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 554.11576,253.94049 0,4.7108"
-         id="path4137" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 554.11576,255.13916 0.12203,0"
-         id="path4139" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 556.51312,253.94049 0,4.7108"
-         id="path4143" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 556.51312,255.13916 0.12203,0"
-         id="path4145" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 558.91048,253.94049 0,4.7108"
-         id="path4149" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 558.91048,255.13916 0.12203,0"
-         id="path4151" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 561.30783,253.94049 0,4.7108"
-         id="path4155" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 561.30783,255.13916 0.12203,0"
-         id="path4157" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 563.70519,253.94049 0,4.7108"
-         id="path4161" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 563.70519,255.13916 0.12203,0"
-         id="path4163" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 566.10255,253.94049 0,4.7108"
-         id="path4167" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 566.10255,255.13916 0.12203,0"
-         id="path4169" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 568.49991,253.94049 0,4.7108"
-         id="path4173" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 568.49991,255.13916 0.12203,0"
-         id="path4175" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 570.89726,253.94049 0,4.7108"
-         id="path4179" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 570.89726,255.13916 0.12203,0"
-         id="path4181" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 573.29462,253.94049 0,4.7108"
-         id="path4185" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 573.29462,255.13916 0.12203,0"
-         id="path4187" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 575.69198,253.94049 0,4.7108"
-         id="path4191" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 575.69198,255.13916 0.12203,0"
-         id="path4193" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 578.08934,253.94049 0,4.7108"
-         id="path4197" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 578.08934,255.13916 0.12203,0"
-         id="path4199" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 580.48669,253.94049 0,4.7108"
-         id="path4203-8" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 580.48669,255.13916 0.12203,0"
-         id="path4205" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 582.88405,253.94049 0,4.7108"
-         id="path4209" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 582.88405,255.13916 0.12203,0"
-         id="path4211-8" />
-      <path
-         style="fill:none;stroke:#e9dcdc;stroke-width:1.32574069px;stroke-linecap:butt;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 585.28141,253.94049 0,4.7108"
-         id="path4215-2" />
-      <path
-         style="fill:none;stroke:#8c8989;stroke-width:1.1479758px;stroke-linecap:square;stroke-linejoin:miter"
-         inkscape:connector-curvature="0"
-         d="m 585.28141,255.13916 0.12203,0"
-         id="path4217" />
-      <rect
-         id="rect4867"
-         height="2.7210622"
-         width="4.9367957"
-         y="274.48654"
-         x="584.37372"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect4869"
-         height="2.7210622"
-         width="1.135463"
-         y="274.48654"
-         x="586.16888"
-         style="fill:#8c8989" />
-      <rect
-         id="rect4877"
-         height="2.7210622"
-         width="4.9367957"
-         y="278.97452"
-         x="584.37372"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect4879"
-         height="2.7210622"
-         width="1.135463"
-         y="278.97452"
-         x="586.16888"
-         style="fill:#8c8989" />
-      <rect
-         id="rect4883"
-         height="2.7210622"
-         width="4.9367957"
-         y="283.46252"
-         x="584.37372"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect4885"
-         height="2.7210622"
-         width="1.135463"
-         y="283.46252"
-         x="586.16888"
-         style="fill:#8c8989" />
-      <rect
-         id="rect4889"
-         transform="scale(-1,1)"
-         height="2.7210622"
-         width="4.9367957"
-         y="283.46252"
-         x="-575.68927"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect4891"
-         transform="scale(-1,1)"
-         height="2.7210622"
-         width="1.135463"
-         y="283.46252"
-         x="-573.89404"
-         style="fill:#8c8989" />
-      <rect
-         id="rect4901"
-         transform="scale(-1,1)"
-         height="2.7210622"
-         width="4.9367957"
-         y="274.48654"
-         x="-575.68927"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect4903"
-         transform="scale(-1,1)"
-         height="2.7210622"
-         width="1.135463"
-         y="274.48654"
-         x="-573.89404"
-         style="fill:#8c8989" />
-      <rect
-         style="fill:#6a6a6a;stroke:#000000;stroke-width:1.08160698;stroke-miterlimit:4;stroke-dasharray:none"
-         x="575.72699"
-         y="273.93018"
-         stroke-miterlimit="4"
-         width="8.3925524"
-         height="14.271826"
-         ry="0.6731993"
-         id="rect4841" />
-      <rect
-         id="rect13881"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="2.7210624"
-         width="4.9367952"
-         y="-623.52423"
-         x="127.2851"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect13883"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="2.7210624"
-         width="1.1354629"
-         y="-623.52423"
-         x="129.08029"
-         style="fill:#8c8989" />
-      <rect
-         id="rect13887"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="2.7210624"
-         width="4.9367952"
-         y="-619.03619"
-         x="127.2851"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect13889"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="2.7210624"
-         width="1.1354629"
-         y="-619.03619"
-         x="129.08029"
-         style="fill:#8c8989" />
-      <rect
-         id="rect13893"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="2.7210624"
-         width="4.9367952"
-         y="-614.54822"
-         x="127.2851"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect13895"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="2.7210624"
-         width="1.1354629"
-         y="-614.54822"
-         x="129.08029"
-         style="fill:#8c8989" />
-      <rect
-         id="rect13899"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="2.7210624"
-         width="4.9367952"
-         y="-614.54822"
-         x="-118.60066"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect13901"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="2.7210624"
-         width="1.1354629"
-         y="-614.54822"
-         x="-116.80547"
-         style="fill:#8c8989" />
-      <rect
-         id="rect13905"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="2.7210624"
-         width="4.9367952"
-         y="-623.52423"
-         x="-118.60066"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect13907"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="2.7210624"
-         width="1.1354629"
-         y="-623.52423"
-         x="-116.80547"
-         style="fill:#8c8989" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#6a6a6a;stroke:#000000;stroke-width:1.08160698;stroke-miterlimit:4;stroke-dasharray:none"
-         x="118.63837"
-         y="-624.08057"
-         stroke-miterlimit="4"
-         width="8.3925524"
-         height="14.271827"
-         ry="0.67319936"
-         id="rect13909" />
-      <rect
-         style="fill:#fffcfc;stroke:#828282;stroke-width:2.17025805;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-         x="179.77756"
-         y="-467.97284"
-         stroke-miterlimit="4"
-         width="59.816059"
-         height="34.898285"
-         transform="matrix(0,1,-1,0,0,0)"
-         id="rect5020" />
-      <rect
-         id="rect4966-2"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="7.3681602"
-         y="-191.53841"
-         x="468.33835"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect4968-1"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="1.6946768"
-         y="-191.53841"
-         x="471.01767"
-         style="fill:#8c8989" />
-      <rect
-         id="rect5048"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="7.3681602"
-         y="-198.23674"
-         x="468.33835"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect5050"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="1.6946768"
-         y="-198.23674"
-         x="471.01767"
-         style="fill:#8c8989" />
-      <rect
-         id="rect5054"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="7.3681602"
-         y="-204.93506"
-         x="468.33835"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect5056"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="1.6946768"
-         y="-204.93506"
-         x="471.01767"
-         style="fill:#8c8989" />
-      <rect
-         id="rect5060"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="7.3681602"
-         y="-211.63339"
-         x="468.33835"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect5062"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="1.6946768"
-         y="-211.63339"
-         x="471.01767"
-         style="fill:#8c8989" />
-      <rect
-         id="rect5066"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="7.3681602"
-         y="-218.33173"
-         x="468.33835"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect5068"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="1.6946768"
-         y="-218.33173"
-         x="471.01767"
-         style="fill:#8c8989" />
-      <rect
-         id="rect5072"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="7.3681602"
-         y="-225.03006"
-         x="468.33835"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect5074"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="1.6946768"
-         y="-225.03006"
-         x="471.01767"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14000"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="7.3681602"
-         y="-231.53119"
-         x="468.33835"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14002"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="1.6946768"
-         y="-231.53119"
-         x="471.01767"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14006"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="7.3681602"
-         y="-238.0323"
-         x="468.33835"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14008"
-         transform="scale(1,-1)"
-         height="4.0611815"
-         width="1.6946768"
-         y="-238.0323"
-         x="471.01767"
-         style="fill:#8c8989" />
-      <rect
-         id="rect4867-0"
-         transform="scale(-1,-1)"
-         height="3.9238191"
-         width="5.7475319"
-         y="-273.86774"
-         x="-456.31073"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect4869-4"
-         transform="scale(-1,-1)"
-         height="3.9238191"
-         width="1.3219323"
-         y="-273.86774"
-         x="-454.2207"
-         style="fill:#8c8989" />
-      <rect
-         id="rect4877-3"
-         transform="scale(-1,-1)"
-         height="3.9238191"
-         width="5.7475319"
-         y="-267.39597"
-         x="-456.31073"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect4879-4"
-         transform="scale(-1,-1)"
-         height="3.9238191"
-         width="1.3219323"
-         y="-267.39597"
-         x="-454.2207"
-         style="fill:#8c8989" />
-      <rect
-         id="rect4883-6"
-         transform="scale(-1,-1)"
-         height="3.9238191"
-         width="5.7475319"
-         y="-260.92419"
-         x="-456.31073"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect4885-2"
-         transform="scale(-1,-1)"
-         height="3.9238191"
-         width="1.3219323"
-         y="-260.92419"
-         x="-454.2207"
-         style="fill:#8c8989" />
-      <rect
-         id="rect4889-3"
-         transform="scale(1,-1)"
-         height="3.9238191"
-         width="5.7475319"
-         y="-260.92419"
-         x="466.42136"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect4891-3"
-         transform="scale(1,-1)"
-         height="3.9238191"
-         width="1.3219323"
-         y="-260.92419"
-         x="468.51135"
-         style="fill:#8c8989" />
-      <rect
-         id="rect4901-7"
-         transform="scale(1,-1)"
-         height="3.9238191"
-         width="5.7475319"
-         y="-273.86774"
-         x="466.42136"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect4903-8"
-         transform="scale(1,-1)"
-         height="3.9238191"
-         width="1.3219323"
-         y="-273.86774"
-         x="468.51135"
-         style="fill:#8c8989" />
-      <rect
-         transform="scale(-1,-1)"
-         style="fill:#6a6a6a;stroke:#000000;stroke-width:1.0816052;stroke-miterlimit:4;stroke-dasharray:none"
-         x="-466.37744"
-         y="-274.67001"
-         stroke-miterlimit="4"
-         width="9.7708044"
-         height="20.580219"
-         ry="0.97076511"
-         id="rect4841-1" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         x="-308.31299"
-         y="621.14215"
-         width="3.868221"
-         height="5.5151954"
-         id="rect14080"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         x="-316.98129"
-         y="621.14215"
-         width="3.868221"
-         height="5.5151954"
-         id="rect14082"
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4" />
-      <rect
-         style="fill:#fffcfc;stroke:#828282;stroke-width:2.1680696;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-         x="490.68149"
-         y="296.49902"
-         stroke-miterlimit="4"
-         width="35.702084"
-         height="27.293268"
-         id="rect14086" />
-      <rect
-         id="rect14090"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="5.7624946"
-         y="-502.82507"
-         x="-295.9913"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14092"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="1.3253738"
-         y="-502.82507"
-         x="-293.89584"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14096"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="5.7624946"
-         y="-509.52341"
-         x="-295.9913"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14098"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="1.3253738"
-         y="-509.52341"
-         x="-293.89584"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14102"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="5.7624946"
-         y="-516.22174"
-         x="-295.9913"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14104"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="1.3253738"
-         y="-516.22174"
-         x="-293.89584"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14108"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="5.7624946"
-         y="-522.9201"
-         x="-295.9913"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14110"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="1.3253738"
-         y="-522.9201"
-         x="-293.89584"
-         style="fill:#8c8989" />
-      <rect
-         style="fill:#fffcfc;stroke:#828282;stroke-width:2.1680696;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
-         x="575.19727"
-         y="296.49902"
-         stroke-miterlimit="4"
-         width="35.702084"
-         height="27.293268"
-         id="rect14138" />
-      <rect
-         id="rect14142"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="5.7624946"
-         y="-587.34082"
-         x="-295.9913"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14144"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="1.3253738"
-         y="-587.34082"
-         x="-293.89584"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14148"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="5.7624946"
-         y="-594.03918"
-         x="-295.9913"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14150"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="1.3253738"
-         y="-594.03918"
-         x="-293.89584"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14154"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="5.7624946"
-         y="-600.73749"
-         x="-295.9913"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14156"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="1.3253738"
-         y="-600.73749"
-         x="-293.89584"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14160"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="5.7624946"
-         y="-607.43579"
-         x="-295.9913"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14162"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.061182"
-         width="1.3253738"
-         y="-607.43579"
-         x="-293.89584"
-         style="fill:#8c8989" />
-      <rect
-         style="fill:#00440d;stroke-width:0;stroke-miterlimit:4"
-         x="631.93884"
-         y="249.09335"
-         width="16.967201"
-         height="21.734783"
-         id="rect14166" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="650.15515"
-         y="249.09335"
-         width="9.2903233"
-         height="21.734783"
-         id="rect14168" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="624.13184"
-         y="249.09335"
-         width="9.2903233"
-         height="21.734783"
-         id="rect14170" />
-      <rect
-         id="rect14172"
-         height="30.880756"
-         width="20.045404"
-         stroke-miterlimit="4"
-         y="112.47642"
-         x="577.76172"
-         style="fill:#6a6a6a;stroke:#000000;stroke-width:0.75847471;stroke-miterlimit:4;stroke-dasharray:none" />
-      <rect
-         style="fill:#312d29;stroke-width:0;stroke-miterlimit:4"
-         x="474.20758"
-         y="135.60159"
-         width="7.064651"
-         height="5.5151949"
-         id="rect14194" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="481.79233"
-         y="135.60159"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect14196" />
-      <rect
-         style="fill:#d3d0ce;stroke-width:0;stroke-miterlimit:4"
-         x="470.957"
-         y="135.60159"
-         width="3.8682213"
-         height="5.5151949"
-         id="rect14198" />
-      <rect
-         id="rect14204"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="4.0624456"
-         width="7.6110497"
-         y="-563.91339"
-         x="308.06442"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14206"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="4.0624456"
-         width="1.7505414"
-         y="-563.91339"
-         x="310.83209"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14210"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="4.0624456"
-         width="7.6110497"
-         y="-557.21295"
-         x="308.06442"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14212"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="4.0624456"
-         width="1.7505414"
-         y="-557.21295"
-         x="310.83209"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14216"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="4.0624456"
-         width="7.6110497"
-         y="-550.51251"
-         x="308.06442"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14218"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="4.0624456"
-         width="1.7505414"
-         y="-550.51251"
-         x="310.83209"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14222"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.0624456"
-         width="7.6110497"
-         y="-550.51251"
-         x="-286.00735"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14224"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.0624456"
-         width="1.7505414"
-         y="-550.51251"
-         x="-283.23969"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14228"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.0624456"
-         width="7.6110497"
-         y="-563.91339"
-         x="-286.00735"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14230"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.0624456"
-         width="1.7505414"
-         y="-563.91339"
-         x="-283.23969"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14242"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.0624456"
-         width="7.6110497"
-         y="-556.98328"
-         x="-286.00735"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14244"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.0624456"
-         width="1.7505414"
-         y="-556.98328"
-         x="-283.23969"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14248"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.0624456"
-         width="7.6110497"
-         y="-544.04181"
-         x="-286.00735"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14250"
-         transform="matrix(0,-1,-1,0,0,0)"
-         height="4.0624456"
-         width="1.7505414"
-         y="-544.04181"
-         x="-283.23969"
-         style="fill:#8c8989" />
-      <rect
-         id="rect14254"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="4.0624456"
-         width="7.6110497"
-         y="-544.04181"
-         x="308.06442"
-         style="fill:#e9dcdc" />
-      <rect
-         id="rect14256"
-         transform="matrix(0,1,-1,0,0,0)"
-         height="4.0624456"
-         width="1.7505414"
-         y="-544.04181"
-         x="310.83209"
-         style="fill:#8c8989" />
-      <rect
-         transform="matrix(0,1,-1,0,0,0)"
-         style="fill:#6a6a6a;stroke:#000000;stroke-width:1.08261442;stroke-miterlimit:4;stroke-dasharray:none"
-         x="284.95566"
-         y="-564.74396"
-         stroke-miterlimit="4"
-         width="24.216976"
-         height="27.404684"
-         ry="1.2931794"
-         id="rect14232" />
-      <path
-         style="fill:url(#linearGradient8752)"
-         inkscape:connector-curvature="0"
-         d="m 530.25061,73.31614 9.00763,0 0,25.796734 22.41432,0 0,-25.796734 9.55228,0 -20.46617,-19.904887 z"
-         id="path10151-2" />
-      <image
-         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAABcCAYAAABTEPRqAAAABHNCSVQICAgIfAhkiAAAAydJREFU SInN1kuIV3UUB/DPGf8jhmVYkxNRiwpbBGGSMSRGNW1CJdEw3NWmVYGFYVmLHsta9JpqUbkpmuiF aS8oJCMjDYUQQnSSiYIeOiTZa5z01+KeO3Pn//8PtQnmwuX+fud873n/zvkppahfnI+fUXBBKUWT 2cJHyZwOwI34usHsAOxL4gszAYawCr1dAQ07OgA9/uWZDYBW2/4UHsn1CYh073+04b8ZGRELcBeu xt/4AkOllHE4U2eqC3ZjDtyThFGswEr8mbSbW6oM7sGbpZTPUuXnGMRl09LdSPlYSljdzgxsTeZh zG0HPJ3McdzQXtX3JXMCayfpyVyP0ziJdU2pgSuwF/PwKl5uBHIEnuoSpPp9uIXzsGuGVIzOpnpY hDtxJX7CS6WUPTWoH0dMd28C19UObEnix7gcz+f+rRqwHPdjaRJuSsChbsd/Lb5MwJb2bM5v2LB9 WjYTsAgP4dME7ehQkcC5OJ6gZT0RsToiNkXEpVBKOYnvMwRXwXuJHsYZqpZY27IcrlHVYMEfDeZw s+QG8D6+w348gFYpZVb0hw5ARKyJiE8iYjM6ktVnaqBs7darn1Udg04VEXELbpX9cRogIvrwHH7A k01A3WmfUaV7LS6eJiEi1mEDXi+lbOvwCj+qKvuJ9GCFajztwxuRLs30lMDdbcTrsUbV+Ya7lVzd N7sGiqrcduEgs2terMK1XfiP167t0L0NLq6TtSS/j6lmRf2MwcJEH28PWh2o+u+JiPggIg5GxIsR cU4tZmND54nG+gB656gax++qQ7wer+A2XIjRDp3p1faUMtSKiKW4BF+VUkZSbW9+/6KaEUV1uudh MX5L2kpYampO/qKavJONrNa5DO/gW9X0edQs6g+Tl5yI6FeV/AJsK6UcxaQXg6YGelG5urF2YD6O JeM1bE7AGM5q4XaciyOllA2pbjzVL2zJfozdETGgmjo7SykHavs+TPEjDRtO4d7ahr0NwzbhDvya +yXwbgJ2N+rh7aQ92GNqNhxrxOeb/Pb3YGduBiPi7FzXh2iE6jJ1OEUeNXWFPoa+WudFqpvX6WQe wkApxT8athIE2BWsmgAAAABJRU5ErkJggg== "
-         width="8"
-         height="92"
-         transform="translate(671,142.51434)"
-         id="image10745" />
-    </g>
-    <g
-       transform="matrix(0.4,0,0,0.4,-56.741854,-154.45687)"
-       id="quad-x">
-      <g
-         transform="matrix(1.8518693,0,0,1.8518693,452.11801,-1731.8917)"
-         id="5645654">
-        <g
-           transform="matrix(1,0,0,-1,0,2792.2535)"
-           id="g5011">
-          <path
-             style="fill:url(#linearGradient8754)"
-             inkscape:connector-curvature="0"
-             d="m 1000,1440 2.7,0 0,-16.7 16.7,0 0,16.7 2.99,0 -11.2,11.2 -11.2,-11.2 z"
-             id="path5019" />
-        </g>
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1090,1480 c 1.8,1.8 4.71,1.8 6.5,0 1.8,-1.8 1.8,-4.71 0,-6.5 l -161,-161 c -1.8,-1.8 -4.71,-1.8 -6.5,0 -1.8,1.8 -1.8,4.71 0,6.5 l 161,161 z"
-           id="path5031" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 1090,1480 c 1.8,1.8 4.71,1.8 6.5,0 1.8,-1.8 1.8,-4.71 0,-6.5 l -161,-161 c -1.8,-1.8 -4.71,-1.8 -6.5,0 -1.8,1.8 -1.8,4.71 0,6.5 l 161,161 z"
-           id="path5035" />
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1100,1320 c 1.8,-1.8 1.8,-4.71 0,-6.5 -1.8,-1.8 -4.71,-1.8 -6.5,0 l -161,161 c -1.8,1.8 -1.8,4.71 0,6.5 1.8,1.8 4.71,1.8 6.5,0 l 161,-161 z"
-           id="path5039" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 1100,1320 c 1.8,-1.8 1.8,-4.71 0,-6.5 -1.8,-1.8 -4.71,-1.8 -6.5,0 l -161,161 c -1.8,1.8 -1.8,4.71 0,6.5 1.8,1.8 4.71,1.8 6.5,0 l 161,-161 z"
-           id="path5043" />
-        <g
-           transform="matrix(1,0,0,-1,0,2792.2535)"
-           id="g5053">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath5049)"
-             id="g5055">
-            <g
-               transform="translate(1170.2617,1551.2617)"
-               id="g5057">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5059" />
-            </g>
-          </g>
-        </g>
-        <g
-           transform="matrix(1,0,0,-1,0,2792.2535)"
-           id="g5069">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath5065)"
-             id="g5071">
-            <g
-               transform="translate(977.2441,1551.2617)"
-               id="g5073">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5075" />
-            </g>
-          </g>
-        </g>
-        <g
-           transform="matrix(1,0,0,-1,0,2792.2535)"
-           id="g5085">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath5081)"
-             id="g5087">
-            <g
-               transform="translate(1170.2617,1361.2432)"
-               id="g5089">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5091" />
-            </g>
-          </g>
-        </g>
-        <g
-           transform="matrix(1,0,0,-1,0,2792.2535)"
-           id="g5101">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath5097)"
-             id="g5103">
-            <g
-               transform="translate(977.2441,1361.2432)"
-               id="g5105">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5107" />
-            </g>
-          </g>
-        </g>
-        <g
-           transform="matrix(82.988968,0,0,-64.991364,969.49512,1428.5608)"
-           id="g5119">
-          <image
-             transform="matrix(1,0,0,-1,0,1)"
-             xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFMAAABBCAYAAACtrJiQAAAABHNCSVQICAgIfAhkiAAADhxJREFUeJztnGt0HOV5x38zs5fZ++rqi6z73RfJsiQjOxDbhdQ3TIAPLSTpCYXGQNKeHpKU0LRJOKXknPRDD5Rwjg9Q04T0cCnQNjUXAwZh2ZZtbMzFtizJ1gVZ1tpaSXuf3ZmdmX6QpeAaYwuvbalHvy+rM6PZeeY/z/M+z/u8MyvULVliMktGEK+1Af+fmBUzg8yKmUFmxcwgs2JmEMtUDzDN8eQvCMLk37OMM2UxYVzIz3/OMs6Uw3xWwAszZTFnQ/vCzCagDDIrZgb5SgnoWiOKIol4nHg8jtVqweX2YLFYrvkQNOM8U5IkQmOjOJxOrl+1hsrqhcRjUYLDZzBNE1G8dpc0ozxTEARGR0YoKinll48+QmlZGaGxMT49fIT/ePlV2nfvxCE78Pn96Lp+1e2bUZ5pGAaapnLnt+6kqXk5gydPomkaq9es4sknH+eBH/0IQRQ4HRhCEISrXsZJc+bMeXiqB12rWlNJJMjLn8Nd3/0zFEUhlUqh6zpjoyOkkilWr17DyhUrOHy4g96e48gOx1UdS2eMZwqCQCIRp7K6lsLCQmKx2OQ+UZRIJhW6Ojsor6jg2WefZt3GWwgOnyERjyNJ0lWxccaIOeFddXWLsdllDOPcMVEQRERRor+vl1RK5Z9+9Uv+4r7vE4tFGR0ZuSqCzpgwV1UVuyzzne98G7/XQ0JJAmCaBoIgMH/+PHLz8jEMg2AwiKqqrFu7lqKSItrb9zISHMblcl9R22eMZ8ZjMUrLK6mqrCQUDk1uFwQRn8/Lttff5LHHn2B0dJSq6moAOo8dZcOGjWzd+gwLF9dzOjBEMpm8Yl6aAc8UABNTTyMIIlzszgsCCCJ6YgRDiSBaZRAtwIWThCAIRKMR1m+8mdWrv04wGJy0IT8vj86ubh568EH272unrW0XsbjCyhUt+Hxejnd3U1RUxK23bkIzBA7s34eqqTidrownpsv3TFNHEG1YvQXoyRBaaAg9GQIjzbjQZxFEMHXSkdOoY4M4CprxLfk26cQo6WjgrKBffCPSmobT6WRp/WKSijJ+0xgPcZfHw4GDh9DTaRYsKCISCbPlySfYfN8P6OvrZ9HiJQSDZwiFw/z0oQd55NF/BNPkzOlAxj00A55pYKYVHHObKLzhYexzGtCi/aSjAfR4CDOtACbp2AimlsRZtJK5K3/O4q/fTvGyFYh5G0lGT5KODCCIX+zZsViU0rJKvnXnHSiKMlmQi6KILMu8+NLL9Pf14HA6kWUHLreb3p7jbH9zO4IksnLl17BZrfT29nLdihaamprYu28/gcAQHo/nK0p3PpcvpiCBaaIGj6JjoaZlHVU3/imuwk0IWXWYGBipMTxlaym96VFqv7aRuRXz0RQNNZxkwbIFGK4Ghg/+OxabzFgohJJQcDgck4V3JBKmsWk5N9+8kbHR0clTu9xugsFhXnzhRVQ1hc1mn9zn9XpREgnef7+VQx9/Sk1VBQsXLeHU4ElKSktZv24d+/cfpL+/F4/Hm5GQz0g2FyQLglUm/tkuTh54AYUmyprLKGlZRE5eEzkVN1O27Hqy5nhRYymSkSSmbmACkiTQ91E70RNvowk2Vq25kezcPLo7O1BTKRwOJ0oiwbr162lsXEY49Ifkk5uTw8FDH/Latm04nK5z5uWmaSI7HDidTo53dbJ9+9skVY1lDfXoaQ2Hw8natTfR2trGmdNDOF2XP4ZmtDSyOvxg6ox1vMzJj1sxLMvJKfRjEUXUhEYqlsI0zMmR0WIRSSsaPTt/TTISAIudR/7hF9x99914/T4GBgbpOdGN35/Nw7/4OQIQjUYQBBHTNMjNy2fHu63sa9+D231+uJqmiSAIeL0+kqkku9t2smvPXhobG3G5nPizsikomM87b7+NJEmX3STJaGlkGGkEuxtbdgHqaA9Hn7uFI7s+RLKKmLpxXnoRLRJKMo0eHyKVNigsLMHhcDJ8JsCdd97B009tYfP9f4nT6WTrvz0HQElp2eTNVNUUPT29F7VL13Xcbg9z582ns+MIP/27nxGPJxgdCbJsaT2L6pYSjUYu+/ozX2eaJpgGVt88JKuNwR0/JDSqYHfbz/tXTU3j8dqpumULaUOguDCfvPx8QqEwx7u6ME2Tnzz4Yx5//DH6+/u5+557eeHFF1lQWEhZeQVDp4Y43t2FLDsuwSwT0zSZM3cevT3Had3ZhtvjweFyU15RSTqdvuxLv2JFu2noSO48jFSSzzr3Y/Xaz6kkTUEAw8TilTGtEoKpU1VTg2QZL1dEUSIajdBx5DALCubz6yce47bbb+XNN95i873389GhQwwHgwSGBnE4Li7m5xEFkVgsjiiOn8vtcmXkmq9sP9M0Ea12wkefJ1m3AqtNIq3qk/sESUS0WRj85C1kSaCmZhFKLD55uCCICAKcGR5GCI5w+2238s1NN/Psb57jN797noH+PmLRKM6zyccwjEswyUSySHg8LgxDR5IsmObFj7sUrnBz2ERyZaOcOkLviR5qmxcTDUQRAJvdQkLR2P2vDxPofIfyqlpKy0oJR84fuyaK9M/6+7BYrGz+3j2MjY6yc9dutm9/i317dmG1WsnKzhk/65dkZdM0kSQJj9uNaRggfdnca2pc+bm5IIAoMnLkeXRFQ5JETMDmlRkZjRPu2IaaUiivbSAnJ5dUKnVhY0UJwzDo7+slHo/zzVs28S+P/zN/+/c/o6i4jEBgiHA4hCiKF6w4TMPAarXhcrkmi/9MTSuvvJimicWdQ7xvF4ODEXxVuTh9MoJVJDzQDqKAINmpriieHC8vhiCMh3Rfbw/B4SB33PEnPPPMFv7qrx8gOzuHoVODxGOxL5wu6oaBzWZDlmU0LT2emIyZIiYgSDZEi4UTr/+Qg6++zXAgih5XUc4cQDcF/D4fNTXVJKLRKX2vKEqoqsrxri60tM59927m6ae38N27v4dksTB0ahBVVc8t5g0Du92Oy+lA18czuDEzxsyzmAaSMxctMsDgjr/htNOHPLcBLdyLKtgoKiikvr4Ot8eLqmmEw5GzfcpLu9eiKBGLRuiKhMnOzuahhx5kw9obeWrrb9nT1ko4NIbPn4Usy+iGjs0uY7fLpPXMiDjB1WsOmwaiRUZy+AADbeQ4iCIWu4O0pnLg4EecGjpFTlYW5RUVeDxeVFVF09RLOt/4PF5EURSCw2dYUFjIhvXrWNrQgI5E97GjhCNhTMMkJyePTZvWI4giTqeL9r37OfzJRzgvs0S6+ku9poEg2ZDcuQDYJYlUKsXune/R1rqDl+YXsKz5Ola2NNPc3Ex5ZSWJWIzh4DBpLX1Rb50opwKBAKIoUV+3hOXLl9O+YS2//d3zvLdjOwWFheTlzyEwFBhPPhlKQNd83VzXdSRJIjcvH4BIOMy2/3qFN1/7PZWVNTQub2bFdc001Nfj9nkZDQYJhyMYhv6lwo7P300GBwcRRYmm5mYaGhrY9voaykqKz37HeJhnqs6cdmtAssOB3WZHSSQYHBzgw4Mf8H5rK4c+OUJobAyvx01xSQnZubmIgoCqqmeF/WKbJraHQmMkUwqNjcuQZZmxsTEkScLr89G+dx+HP/3kssN82okZjUQoLi3n/h98H5fbh9VqIxwK0dV5lLa2nezZs5cjHZ2EQiHsNgvFxcXk5OWhaSqapk0usJ1vs4hpmEQjUVRVnSybvD4fe/d9wOFPPp6BY+aXMLE2Xrd0Kfdu3syG9Ws5fTpAT08fe/d9wMEPDnBqcIB3tr/Bu29tx5+VxeK6paxZs4rGZfWUlJaiqilGgiMkk8olVwP/d9n4qzKtxEyn08iyTN2SWgYG+hk6NYTskFmxooXVq1cTj0Z54Mc/4dCBffizskkmk7S17mDX++9RVFJKY1MzK1uaqa+vZ35BAbFImODI6JeOr4ahMzYWyki0TSsxlUSCgsJiaqtrCIVCmKaJklBIxOO4PV4MQyc0OorFYgVAlmUcDgeGYRAYGuSVl46z7b9fpbyyhutaWlh1w0pqF9Zis9kZCQaJRqPn1K9Ol5NwOEJfTw82+/ktwqkyrcRMJhVqFi5ifkEBJwcGJrdPrI3v2PEu/X0ncH2uqz7RTfd4vPh8fjRNo7vzKEcPf8x/vvISi+saWLniOpoal1FeUQHAyMgIaU2jqrqWrVu30t11jOycnMu2f1qJCVBdVX72Yas/eJBpGthsdjqOdZNKpfD5s76wOWEYBpIkTXaPkskku3e+x+6d7zFvfgH1DY20tDRTv2QJebm5vLbtf3hqyxZsdhuiKF52w2PaiKlpKm6Pl4rycuJn13kmsNmshMZGOXL4MBaL9aIXPbHfbrcj58/BNE3CoRBvvPZ73tn+OkXFZfj8fjo7jmAYBllZ2RnptE8bMePxOLULF1NdVUU4cm7Dw+320tPTQ39fz5TLlwlhnS4XLrcbXdcZGjrJZ5/14nK5xufoGRASptGzRpqq8o1v3ERVTS3JpHLOrMTldtPT1084FMJms33lc0w8pu1yufH7s7BabZfUnb9UpoWYpmnicDjZt/8Ae3a1UVVdy7x58xAEAcPQsVgsnBoKkNbT0/qlrmkR5oIg4PP7ad+9k48OfsCmW2/jj2/6I5bU1WEYOkoizrGOY4iXWIRfK4Sp/qzERClyJZAkiXgsRjQaweVy03L9Ddy/+R5cLjd33fXnJOJx5CmuRF5NppWYE4jieF8yEg6Rm5dPWUUVJ7o7r+lrKZfCtBRzAlEUSSQSJJMKfn/WtH8te1qMmRfCMAxkWUaWZWD6vwQ7veNmhjErZgaZFTODzIqZQWbFzCBfKZtP96x6rZiymNN5bnytmQ3zDDIrZgaZFTOD/C9uew7sSK2nLAAAAABJRU5ErkJggg=="
-             width="1"
-             height="1"
-             id="image5121" />
-        </g>
-        <g
-           transform="matrix(1,0,0,-1,0,2792.2535)"
-           id="g5149">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5135)"
-             id="g5151">
-            <g
-               id="g5153">
-              <g
-                 id="g5155">
-                <g
-                   id="g5157">
-                  <g
-                     id="g5159">
-                    <path
-                       style="fill:url(#radialGradient8756)"
-                       inkscape:connector-curvature="0"
-                       d="m 1090,1480 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 l -12,-10e-4 35.6,35.6 35.6,-35.6 h -11.3 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 l 17.8,17.8 z"
-                       id="path5161" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           transform="matrix(1,0,0,-1,0,2792.2535)"
-           id="g5181">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5167)"
-             id="g5183">
-            <g
-               id="g5185">
-              <g
-                 id="g5187">
-                <g
-                   id="g5189">
-                  <g
-                     id="g5191">
-                    <path
-                       style="fill:url(#radialGradient8758)"
-                       inkscape:connector-curvature="0"
-                       d="m 1040,1490 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.7 h 11.1 l -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path5193" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           transform="matrix(1,0,0,-1,0,2792.2535)"
-           id="g5213">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5199)"
-             id="g5215">
-            <g
-               id="g5217">
-              <g
-                 id="g5219">
-                <g
-                   id="g5221">
-                  <g
-                     id="g5223">
-                    <path
-                       style="fill:url(#radialGradient8760)"
-                       inkscape:connector-curvature="0"
-                       d="m 895,1290 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 l -12,-10e-4 35.6,35.6 35.6,-35.6 h -11.3 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 l 17.8,17.8 z"
-                       id="path5225" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           transform="matrix(1,0,0,-1,0,2792.2535)"
-           id="g5245">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5231)"
-             id="g5247">
-            <g
-               id="g5249">
-              <g
-                 id="g5251">
-                <g
-                   id="g5253">
-                  <g
-                     id="g5255">
-                    <path
-                       style="fill:url(#radialGradient8762)"
-                       inkscape:connector-curvature="0"
-                       d="m 845,1300 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.7 H 905 l -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path5257" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           transform="matrix(1,0,0,-1,0,2792.2535)"
-           id="g5277">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5263)"
-             id="g5279">
-            <g
-               id="g5281">
-              <g
-                 id="g5283">
-                <g
-                   id="g5285">
-                  <g
-                     id="g5287">
-                    <path
-                       style="fill:url(#radialGradient8764)"
-                       inkscape:connector-curvature="0"
-                       d="m 1130,1290 c -3.01,-9.78 -12.1,-16.9 -22.9,-16.9 -12.2,0 -22.2,9.11 -23.7,20.9 l 12,-10e-4 -35.6,35.6 -35.6,-35.6 h 11.3 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.012 44,13.9 53.4,34 l -17.8,17.8 z"
-                       id="path5289" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           transform="matrix(1,0,0,-1,0,2792.2535)"
-           id="g5309">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5295)"
-             id="g5311">
-            <g
-               id="g5313">
-              <g
-                 id="g5315">
-                <g
-                   id="g5317">
-                  <g
-                     id="g5319">
-                    <path
-                       style="fill:url(#radialGradient8766)"
-                       inkscape:connector-curvature="0"
-                       d="m 1180,1300 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.7 H 1120 l 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 h -11.2 z"
-                       id="path5321" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           style="fill:url(#linearGradient8780)"
-           transform="matrix(1,0,0,-1,0,2792.2535)"
-           id="g5341">
-          <g
-             style="opacity:0.69999701;fill:url(#linearGradient8778)"
-             clip-path="url(#clipPath5327)"
-             id="g5343">
-            <g
-               style="fill:url(#linearGradient8776)"
-               id="g5345">
-              <g
-                 style="fill:url(#linearGradient8774)"
-                 id="g5347">
-                <g
-                   style="fill:url(#linearGradient8772)"
-                   id="g5349">
-                  <g
-                     style="fill:url(#linearGradient8770)"
-                     id="g5351">
-                    <path
-                       style="fill:url(#linearGradient8768)"
-                       inkscape:connector-curvature="0"
-                       d="m 939,1480 c -3.01,-9.78 -12.1,-16.9 -22.9,-16.9 -12.2,0 -22.2,9.11 -23.7,20.9 h 12 l -35.6,35.6 -35.6,-35.6 h 11.3 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 939,1480 z"
-                       id="path5353" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           transform="matrix(1,0,0,-1,0,2792.2535)"
-           id="g5373">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5359)"
-             id="g5375">
-            <g
-               id="g5377">
-              <g
-                 id="g5379">
-                <g
-                   id="g5381">
-                  <g
-                     id="g5383">
-                    <path
-                       style="fill:url(#radialGradient8782)"
-                       inkscape:connector-curvature="0"
-                       d="m 989,1490 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 H 929 l 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 h -11.2 z"
-                       id="path5385" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 934,1288.1 c 9.4,9.41 9.4,24.7 -0.008,34.1 -9.41,9.41 -24.7,9.41 -34.1,0 -9.4,-9.41 -9.4,-24.7 0.008,-34.1 9.41,-9.41 24.7,-9.41 34.1,-0.01"
-           id="path5389" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 916,1312.7 0,-10.9 -2.77,2.14 -1.83,-2.5 4.89,-3.59 3.23,0 0,14.9 -3.53,0 z"
-           id="path5393" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1130,1288.1 c 9.4,9.41 9.4,24.7 -0.01,34.1 -9.41,9.41 -24.7,9.41 -34.1,0 -9.4,-9.41 -9.4,-24.7 0.01,-34.1 9.41,-9.41 24.7,-9.41 34.1,-0.01"
-           id="path5397" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1108.1,1312.7 0,-2.94 5.8,-5.25 c 0.734,-0.693 1.22,-1.39 1.22,-2.29 0,-1.05 -0.736,-1.78 -1.85,-1.78 -1.18,0 -1.95,0.924 -2.1,2.25 l -3.38,-0.462 c 0.335,-3 2.77,-4.79 5.67,-4.79 2.73,0 5.38,1.45 5.38,4.56 0,2.12 -1.24,3.36 -2.6,4.58 l -3.44,3.07 h 6.07 v 3.06 h -10.8 z"
-           id="path5401" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 934,1477.3 c 9.4,9.41 9.4,24.7 -0.008,34.1 -9.41,9.41 -24.7,9.41 -34.1,0 -9.41,-9.41 -9.41,-24.7 0.006,-34.1 9.41,-9.41 24.7,-9.41 34.1,-0.01"
-           id="path5405" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 918,1490 -0.063,0 -3.53,5.5 3.59,0 0,-5.5 z m 3.28,8.36 0,2.9 -3.3,0 0,-2.9 -6.99,0 0,-2.96 6.05,-9.01 4.22,0 0,9.11 2.06,0 0,2.86 -2.04,0 z"
-           id="path5409" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1124.6,1477.3 c 9.4,9.41 9.4,24.7 -0.01,34.1 -9.41,9.41 -24.7,9.41 -34.1,0 -9.4,-9.41 -9.4,-24.7 0.01,-34.1 9.41,-9.41 24.7,-9.41 34.1,-0.01"
-           id="path5413" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1107.3,1502.7 c -2.71,0 -5.16,-1.18 -5.96,-3.95 l 3.28,-0.861 c 0.274,0.987 1.18,1.85 2.52,1.85 1.01,0 2.16,-0.504 2.16,-1.89 0,-1.51 -1.55,-1.95 -3.02,-1.95 h -0.945 v -2.58 h 1.03 c 1.32,0 2.6,-0.336 2.6,-1.76 0,-1.07 -0.902,-1.64 -1.87,-1.64 -1.01,0 -1.81,0.65 -2.04,1.66 l -3.28,-0.756 c 0.712,-2.5 3.06,-3.78 5.54,-3.78 2.62,0 5.23,1.34 5.23,4.2 0,1.64 -1.05,2.86 -2.5,3.23 v 0.063 c 1.68,0.398 2.86,1.78 2.86,3.44 0,3.25 -2.88,4.72 -5.6,4.72"
-           id="path5417" />
-        <path
-           style="fill:#2f2d2e;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 982,1360 62.1,0 c 1.63,0 2.95,1.32 2.95,2.95 v 62.1 c 0,1.63 -1.32,2.96 -2.95,2.96 H 982 c -1.63,0 -2.95,-1.32 -2.95,-2.96 v -62.1 c 0,-1.63 1.32,-2.95 2.95,-2.95"
-           id="path7075" />
-        <path
-           style="fill:#c8c7c6;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1010,1400 -2.78,9.4 7.16,3.94 2.89,-11 -7.27,-2.36 z m -1.79,-16.9 -3.03,12.3 1.96,0.744 11.1,3.97 2.99,-9.89 -13,-7.07 z m 12.8,-13.2 c -1.15,-0.021 -2.18,0.469 -2.61,1.87 l -4.04,13.6 6.49,3.55 2.8,-10.6 c 0.793,-1.24 1.93,-0.76 3.16,-0.014 l 9.6,6.33 c 0.848,0.699 1.4,1.66 1.35,3.17 l -0.592,8.39 c -0.113,1.18 -0.826,1.89 -1.37,1.78 l -15.2,-8.23 -2.69,10.2 3.7,1.34 v 0.01 l 15.2,5.49 c 2.26,0.825 4.28,-1.66 4.36,-5.4 l 0.065,-13.4 c -0.049,-3.31 -1.64,-5.1 -3.24,-6.39 l -12.7,-9.89 c -1.06,-0.865 -2.79,-1.75 -4.3,-1.77"
-           id="path7079" />
-        <path
-           style="fill:#658acf;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1000,1380 -1.31,-0.756 1.16,-4.26 -2.92,-1.59 -6.44,2.74 -8.88,-2.35 7.9,5.35 3.1,7.39 4,1.32 1.26,-4.74 1.24,0.196 0.906,-3.31 z"
-           id="path7083" />
-        <path
-           style="fill:#c8c7c6;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1030,1420 2.56,0 c 0.281,0 0.5,0.107 0.695,0.297 0.102,0.088 0.176,0.199 0.215,0.314 0.051,0.118 0.086,0.246 0.086,0.387 v 0.914 c 0,0.135 -0.035,0.266 -0.086,0.395 -0.039,0.107 -0.113,0.209 -0.215,0.298 -0.195,0.194 -0.414,0.299 -0.695,0.299 H 1030 c -0.275,0 -0.504,-0.105 -0.691,-0.299 -0.104,-0.089 -0.176,-0.191 -0.225,-0.298 -0.041,-0.129 -0.08,-0.26 -0.08,-0.395 v -0.914 c 0,-0.141 0.039,-0.269 0.08,-0.387 0.049,-0.115 0.121,-0.226 0.225,-0.314 0.187,-0.19 0.416,-0.297 0.691,-0.297 m -12.4,0 2.56,0 c 0.278,0 0.498,0.107 0.69,0.297 0.191,0.187 0.307,0.426 0.307,0.701 v 0.914 c 0,0.277 -0.116,0.526 -0.307,0.693 -0.184,0.192 -0.41,0.299 -0.676,0.299 h -3.57 v -0.992 -0.521 -0.393 c 0,-0.141 0.035,-0.269 0.084,-0.387 0.051,-0.115 0.129,-0.226 0.228,-0.314 0.176,-0.19 0.403,-0.297 0.684,-0.297 m -15,0 2.55,0 c 0.287,0 0.508,0.107 0.703,0.297 0.094,0.088 0.164,0.199 0.211,0.314 0.053,0.118 0.082,0.246 0.082,0.379 h -4.54 c 0,-0.133 0.033,-0.261 0.082,-0.379 0.049,-0.115 0.119,-0.226 0.217,-0.314 0.189,-0.19 0.426,-0.297 0.697,-0.297 m -7.51,0 2.54,0 c 0.281,0 0.519,0.107 0.715,0.297 0.197,0.187 0.281,0.426 0.281,0.701 v 0.914 c 0,0.277 -0.084,0.526 -0.281,0.693 -0.196,0.194 -0.434,0.299 -0.715,0.299 h -1.89 -1.64 v -0.992 -0.521 -0.393 c 0,-0.141 0.02,-0.269 0.073,-0.387 0.062,-0.115 0.135,-0.226 0.226,-0.314 0.18,-0.19 0.418,-0.297 0.7,-0.297 m -7.52,0 2.54,0 c 0.277,0 0.522,0.107 0.711,0.297 0.088,0.088 0.156,0.199 0.213,0.314 0.051,0.118 0.074,0.246 0.074,0.387 v 0.914 c 0,0.135 -0.023,0.266 -0.074,0.395 -0.057,0.107 -0.125,0.209 -0.213,0.298 -0.189,0.194 -0.434,0.299 -0.711,0.299 h -0.318 -2.22 c -0.283,0 -0.516,-0.105 -0.713,-0.299 -0.082,-0.089 -0.158,-0.191 -0.211,-0.298 -0.055,-0.129 -0.074,-0.26 -0.074,-0.395 v -0.914 c 0,-0.141 0.019,-0.269 0.074,-0.387 0.053,-0.115 0.129,-0.226 0.211,-0.314 0.197,-0.19 0.43,-0.297 0.713,-0.297 m 42.4,-1.04 c -0.28,0 -0.543,0.049 -0.797,0.166 -0.231,0.088 -0.451,0.242 -0.619,0.42 -0.192,0.189 -0.338,0.406 -0.456,0.652 -0.107,0.254 -0.14,0.52 -0.14,0.793 v 0.93 c 0,0.281 0.033,0.547 0.14,0.795 0.118,0.242 0.264,0.455 0.456,0.642 0.168,0.178 0.388,0.332 0.619,0.426 0.254,0.115 0.517,0.16 0.797,0.16 h 2.69 c 0.277,0 0.543,-0.045 0.791,-0.16 0.236,-0.094 0.457,-0.248 0.637,-0.426 0.187,-0.187 0.332,-0.4 0.443,-0.642 0.098,-0.248 0.148,-0.514 0.148,-0.795 v -0.93 c 0,-0.273 -0.05,-0.539 -0.148,-0.793 -0.111,-0.246 -0.256,-0.463 -0.443,-0.652 -0.18,-0.178 -0.401,-0.332 -0.637,-0.42 -0.248,-0.117 -0.514,-0.166 -0.791,-0.166 h -2.69 z m -27.4,0 c -0.276,0 -0.541,0.049 -0.799,0.166 -0.236,0.088 -0.451,0.242 -0.623,0.42 -0.186,0.189 -0.34,0.406 -0.449,0.652 -0.108,0.252 -0.156,0.508 -0.156,0.785 v 0.93 c 0,0.277 0.048,0.541 0.156,0.795 0.109,0.244 0.263,0.463 0.449,0.65 0.172,0.178 0.387,0.332 0.623,0.426 0.258,0.115 0.523,0.16 0.799,0.16 h 4.11 v -1.04 h -4.04 c -0.271,0 -0.508,-0.105 -0.697,-0.299 -0.074,-0.078 -0.133,-0.16 -0.18,-0.257 -0.056,-0.096 -0.091,-0.203 -0.107,-0.303 h 5.63 v -1.06 c 0,-0.277 -0.053,-0.533 -0.145,-0.785 -0.117,-0.246 -0.254,-0.463 -0.451,-0.652 -0.182,-0.178 -0.4,-0.332 -0.644,-0.42 -0.233,-0.117 -0.498,-0.166 -0.791,-0.166 h -2.68 z m -15,0 c -0.289,0 -0.555,0.049 -0.791,0.166 -0.252,0.088 -0.461,0.242 -0.647,0.42 -0.183,0.189 -0.334,0.406 -0.445,0.652 -0.1,0.254 -0.153,0.52 -0.153,0.793 v 0.93 c 0,0.281 0.053,0.547 0.153,0.795 0.111,0.242 0.262,0.455 0.445,0.642 0.186,0.178 0.395,0.332 0.647,0.426 0.236,0.115 0.502,0.16 0.791,0.16 h 2.01 0.664 2.8 v 1.99 h 1.11 v -1.99 h 0.928 0.36 2.32 c 0.283,0 0.545,-0.045 0.783,-0.16 0.254,-0.094 0.463,-0.248 0.656,-0.426 0.192,-0.187 0.332,-0.4 0.434,-0.642 0.099,-0.248 0.158,-0.514 0.158,-0.795 v -0.93 c 0,-0.273 -0.059,-0.539 -0.158,-0.793 -0.102,-0.246 -0.242,-0.463 -0.434,-0.652 -0.193,-0.178 -0.402,-0.332 -0.656,-0.42 -0.238,-0.117 -0.5,-0.166 -0.783,-0.166 h -2.68 c -0.281,0 -0.545,0.049 -0.793,0.166 -0.242,0.088 -0.455,0.242 -0.64,0.42 -0.188,0.189 -0.34,0.406 -0.44,0.652 -0.109,0.254 -0.166,0.52 -0.166,0.793 v 1.91 h -1.02 c 0.025,-0.062 0.066,-0.127 0.085,-0.189 0.112,-0.248 0.165,-0.514 0.165,-0.795 v -0.93 c 0,-0.273 -0.053,-0.539 -0.165,-0.793 -0.091,-0.246 -0.244,-0.463 -0.423,-0.652 -0.192,-0.178 -0.407,-0.332 -0.653,-0.42 -0.252,-0.117 -0.515,-0.166 -0.797,-0.166 h -2.68 z m 35.5,4.98 1.1,0 0,-5 -1.1,0 0,5 z m -13,-5 c -0.272,0 -0.539,0.059 -0.791,0.182 -0.227,0.088 -0.446,0.242 -0.625,0.42 -0.186,0.189 -0.336,0.406 -0.451,0.652 -0.096,0.252 -0.139,0.508 -0.139,0.785 v 2.96 h 1.09 v -2.95 c 0,-0.273 0.111,-0.513 0.299,-0.707 0.08,-0.09 0.199,-0.158 0.304,-0.213 0.121,-0.052 0.242,-0.074 0.379,-0.074 h 2.57 c 0.132,0 0.263,0.022 0.369,0.074 0.121,0.055 0.244,0.123 0.314,0.213 0.197,0.194 0.303,0.434 0.303,0.707 v 2.95 h 0.305 0.785 0.779 v 1.99 h 1.09 v -1.99 h 0.927 2.3 0.407 c 0.265,0 0.531,-0.045 0.781,-0.16 0.23,-0.094 0.453,-0.248 0.631,-0.426 0.185,-0.187 0.338,-0.4 0.445,-0.642 0.103,-0.248 0.141,-0.514 0.141,-0.795 v -0.93 c 0,-0.273 -0.038,-0.539 -0.141,-0.793 -0.107,-0.246 -0.26,-0.463 -0.445,-0.652 -0.178,-0.178 -0.401,-0.332 -0.631,-0.42 -0.25,-0.117 -0.516,-0.166 -0.781,-0.166 h -2.71 c -0.279,0 -0.542,0.049 -0.792,0.166 -0.225,0.088 -0.438,0.242 -0.625,0.42 -0.188,0.189 -0.338,0.406 -0.454,0.652 -0.099,0.254 -0.15,0.52 -0.15,0.793 v 1.91 h -0.779 v -1.91 -0.01 c 0,-0.277 -0.053,-0.533 -0.139,-0.785 -0.117,-0.246 -0.262,-0.463 -0.449,-0.652 -0.184,-0.178 -0.406,-0.332 -0.643,-0.42 -0.23,-0.123 -0.498,-0.182 -0.779,-0.182 h -2.7 z m 25.6,-1.43 0,1.22 -0.49,0 0,1.05 0.49,0 0,2.13 c 0,0.281 0.062,0.547 0.154,0.795 0.113,0.242 0.254,0.455 0.44,0.642 0.193,0.178 0.4,0.332 0.652,0.426 0.234,0.115 0.5,0.16 0.791,0.16 h 0.791 v -1.04 h -0.777 c -0.27,-0.025 -0.504,-0.129 -0.664,-0.32 -0.096,-0.078 -0.168,-0.191 -0.211,-0.307 -0.049,-0.105 -0.065,-0.232 -0.065,-0.365 v -2.12 h 1.72 v -0.223 -0.83 h -1.72 v -1.22 h -1.11 z m -10.8,-0.563 0,4.96 c 0,0.277 0.06,0.541 0.162,0.795 0.1,0.244 0.238,0.463 0.432,0.639 0.197,0.183 0.398,0.332 0.66,0.437 0.236,0.115 0.492,0.16 0.777,0.16 h 0.221 v -1.04 h -0.201 c -0.262,-0.025 -0.477,-0.129 -0.664,-0.32 -0.088,-0.078 -0.157,-0.191 -0.198,-0.307 -0.064,-0.105 -0.068,-0.232 -0.068,-0.365 v -4.96 h -1.12 z m -1.86,1.1 1.1,0 0,-1.1 -1.1,0 0,1.1 z"
-           id="path7087" />
-      </g>
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,748 687,2.81 0,-22.5"
-         id="path9540" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,789 687,2.81 0,131"
-         id="path9544" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,829 174,-0.995 156,2.37 0,67.7"
-         id="path9542" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,708 174,-0.995"
-         id="path9538" />
-    </g>
-    <g
-       transform="matrix(0.4,0,0,0.4,-56.741854,-154.45687)"
-       id="quad-p">
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,829 197,-1.99 0,0"
-         id="path9655" />
-      <path
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,747 760,-1.99 0,43.8"
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0;marker-start:none"
-         id="path9471" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,707 354,-1.99 -1.99,-95.5 83.6,0"
-         id="path9546" />
-      <g
-         transform="matrix(1.8006689,0,0,-1.8006689,-600.9077,3339.2736)"
-         id="67657">
-        <g
-           id="g5429">
-          <path
-             style="fill:url(#linearGradient8784)"
-             inkscape:connector-curvature="0"
-             d="m 1640,1430 2.77,0 0,-17.2 17.2,0 0,17.2 3.07,0 -11.5,11.5 -11.5,-11.5 z"
-             id="path5437" />
-        </g>
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1620,1270 c 0,-2.54 2.06,-4.6 4.6,-4.6 2.54,0 4.6,2.06 4.6,4.6 v 228 c 0,2.54 -2.06,4.6 -4.6,4.6 -2.54,0 -4.6,-2.06 -4.6,-4.6 v -228 z"
-           id="path5449" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 1620,1270 c 0,-2.54 2.06,-4.6 4.6,-4.6 2.54,0 4.6,2.06 4.6,4.6 v 228 c 0,2.54 -2.06,4.6 -4.6,4.6 -2.54,0 -4.6,-2.06 -4.6,-4.6 v -228 z"
-           id="path5453" />
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1740,1380 c 2.54,0 4.6,2.06 4.6,4.6 0,2.54 -2.06,4.6 -4.6,4.6 h -228 c -2.54,0 -4.6,-2.06 -4.6,-4.6 0,-2.54 2.06,-4.6 4.6,-4.6 h 228 z"
-           id="path5457" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 1740,1380 c 2.54,0 4.6,2.06 4.6,4.6 0,2.54 -2.06,4.6 -4.6,4.6 h -228 c -2.54,0 -4.6,-2.06 -4.6,-4.6 0,-2.54 2.06,-4.6 4.6,-4.6 h 228 z"
-           id="path5461" />
-        <g
-           id="g5471">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath5467)"
-             id="g5473">
-            <g
-               transform="translate(1823.7813,1443.3135)"
-               id="g5475">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5477" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5487">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath5483)"
-             id="g5489">
-            <g
-               transform="translate(1687.2949,1579.7949)"
-               id="g5491">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.047,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5493" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5503">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath5499)"
-             id="g5505">
-            <g
-               transform="translate(1689.418,1308.9482)"
-               id="g5507">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.051,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5509" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5519">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath5515)"
-             id="g5521">
-            <g
-               transform="translate(1552.9316,1445.4316)"
-               id="g5523">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.047,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.01,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5525" />
-            </g>
-          </g>
-        </g>
-        <g
-           transform="matrix(82.988968,0,0,64.991364,1584.0928,1351.8216)"
-           id="g5537">
-          <image
-             transform="matrix(1,0,0,-1,0,1)"
-             xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFMAAABBCAYAAACtrJiQAAAABHNCSVQICAgIfAhkiAAADhxJREFUeJztnGt0HOV5x38zs5fZ++rqi6z73RfJsiQjOxDbhdQ3TIAPLSTpCYXGQNKeHpKU0LRJOKXknPRDD5Rwjg9Q04T0cCnQNjUXAwZh2ZZtbMzFtizJ1gVZ1tpaSXuf3ZmdmX6QpeAaYwuvbalHvy+rM6PZeeY/z/M+z/u8MyvULVliMktGEK+1Af+fmBUzg8yKmUFmxcwgs2JmEMtUDzDN8eQvCMLk37OMM2UxYVzIz3/OMs6Uw3xWwAszZTFnQ/vCzCagDDIrZgb5SgnoWiOKIol4nHg8jtVqweX2YLFYrvkQNOM8U5IkQmOjOJxOrl+1hsrqhcRjUYLDZzBNE1G8dpc0ozxTEARGR0YoKinll48+QmlZGaGxMT49fIT/ePlV2nfvxCE78Pn96Lp+1e2bUZ5pGAaapnLnt+6kqXk5gydPomkaq9es4sknH+eBH/0IQRQ4HRhCEISrXsZJc+bMeXiqB12rWlNJJMjLn8Nd3/0zFEUhlUqh6zpjoyOkkilWr17DyhUrOHy4g96e48gOx1UdS2eMZwqCQCIRp7K6lsLCQmKx2OQ+UZRIJhW6Ojsor6jg2WefZt3GWwgOnyERjyNJ0lWxccaIOeFddXWLsdllDOPcMVEQRERRor+vl1RK5Z9+9Uv+4r7vE4tFGR0ZuSqCzpgwV1UVuyzzne98G7/XQ0JJAmCaBoIgMH/+PHLz8jEMg2AwiKqqrFu7lqKSItrb9zISHMblcl9R22eMZ8ZjMUrLK6mqrCQUDk1uFwQRn8/Lttff5LHHn2B0dJSq6moAOo8dZcOGjWzd+gwLF9dzOjBEMpm8Yl6aAc8UABNTTyMIIlzszgsCCCJ6YgRDiSBaZRAtwIWThCAIRKMR1m+8mdWrv04wGJy0IT8vj86ubh568EH272unrW0XsbjCyhUt+Hxejnd3U1RUxK23bkIzBA7s34eqqTidrownpsv3TFNHEG1YvQXoyRBaaAg9GQIjzbjQZxFEMHXSkdOoY4M4CprxLfk26cQo6WjgrKBffCPSmobT6WRp/WKSijJ+0xgPcZfHw4GDh9DTaRYsKCISCbPlySfYfN8P6OvrZ9HiJQSDZwiFw/z0oQd55NF/BNPkzOlAxj00A55pYKYVHHObKLzhYexzGtCi/aSjAfR4CDOtACbp2AimlsRZtJK5K3/O4q/fTvGyFYh5G0lGT5KODCCIX+zZsViU0rJKvnXnHSiKMlmQi6KILMu8+NLL9Pf14HA6kWUHLreb3p7jbH9zO4IksnLl17BZrfT29nLdihaamprYu28/gcAQHo/nK0p3PpcvpiCBaaIGj6JjoaZlHVU3/imuwk0IWXWYGBipMTxlaym96VFqv7aRuRXz0RQNNZxkwbIFGK4Ghg/+OxabzFgohJJQcDgck4V3JBKmsWk5N9+8kbHR0clTu9xugsFhXnzhRVQ1hc1mn9zn9XpREgnef7+VQx9/Sk1VBQsXLeHU4ElKSktZv24d+/cfpL+/F4/Hm5GQz0g2FyQLglUm/tkuTh54AYUmyprLKGlZRE5eEzkVN1O27Hqy5nhRYymSkSSmbmACkiTQ91E70RNvowk2Vq25kezcPLo7O1BTKRwOJ0oiwbr162lsXEY49Ifkk5uTw8FDH/Latm04nK5z5uWmaSI7HDidTo53dbJ9+9skVY1lDfXoaQ2Hw8natTfR2trGmdNDOF2XP4ZmtDSyOvxg6ox1vMzJj1sxLMvJKfRjEUXUhEYqlsI0zMmR0WIRSSsaPTt/TTISAIudR/7hF9x99914/T4GBgbpOdGN35/Nw7/4OQIQjUYQBBHTNMjNy2fHu63sa9+D231+uJqmiSAIeL0+kqkku9t2smvPXhobG3G5nPizsikomM87b7+NJEmX3STJaGlkGGkEuxtbdgHqaA9Hn7uFI7s+RLKKmLpxXnoRLRJKMo0eHyKVNigsLMHhcDJ8JsCdd97B009tYfP9f4nT6WTrvz0HQElp2eTNVNUUPT29F7VL13Xcbg9z582ns+MIP/27nxGPJxgdCbJsaT2L6pYSjUYu+/ozX2eaJpgGVt88JKuNwR0/JDSqYHfbz/tXTU3j8dqpumULaUOguDCfvPx8QqEwx7u6ME2Tnzz4Yx5//DH6+/u5+557eeHFF1lQWEhZeQVDp4Y43t2FLDsuwSwT0zSZM3cevT3Had3ZhtvjweFyU15RSTqdvuxLv2JFu2noSO48jFSSzzr3Y/Xaz6kkTUEAw8TilTGtEoKpU1VTg2QZL1dEUSIajdBx5DALCubz6yce47bbb+XNN95i873389GhQwwHgwSGBnE4Li7m5xEFkVgsjiiOn8vtcmXkmq9sP9M0Ea12wkefJ1m3AqtNIq3qk/sESUS0WRj85C1kSaCmZhFKLD55uCCICAKcGR5GCI5w+2238s1NN/Psb57jN797noH+PmLRKM6zyccwjEswyUSySHg8LgxDR5IsmObFj7sUrnBz2ERyZaOcOkLviR5qmxcTDUQRAJvdQkLR2P2vDxPofIfyqlpKy0oJR84fuyaK9M/6+7BYrGz+3j2MjY6yc9dutm9/i317dmG1WsnKzhk/65dkZdM0kSQJj9uNaRggfdnca2pc+bm5IIAoMnLkeXRFQ5JETMDmlRkZjRPu2IaaUiivbSAnJ5dUKnVhY0UJwzDo7+slHo/zzVs28S+P/zN/+/c/o6i4jEBgiHA4hCiKF6w4TMPAarXhcrkmi/9MTSuvvJimicWdQ7xvF4ODEXxVuTh9MoJVJDzQDqKAINmpriieHC8vhiCMh3Rfbw/B4SB33PEnPPPMFv7qrx8gOzuHoVODxGOxL5wu6oaBzWZDlmU0LT2emIyZIiYgSDZEi4UTr/+Qg6++zXAgih5XUc4cQDcF/D4fNTXVJKLRKX2vKEqoqsrxri60tM59927m6ae38N27v4dksTB0ahBVVc8t5g0Du92Oy+lA18czuDEzxsyzmAaSMxctMsDgjr/htNOHPLcBLdyLKtgoKiikvr4Ot8eLqmmEw5GzfcpLu9eiKBGLRuiKhMnOzuahhx5kw9obeWrrb9nT1ko4NIbPn4Usy+iGjs0uY7fLpPXMiDjB1WsOmwaiRUZy+AADbeQ4iCIWu4O0pnLg4EecGjpFTlYW5RUVeDxeVFVF09RLOt/4PF5EURSCw2dYUFjIhvXrWNrQgI5E97GjhCNhTMMkJyePTZvWI4giTqeL9r37OfzJRzgvs0S6+ku9poEg2ZDcuQDYJYlUKsXune/R1rqDl+YXsKz5Ola2NNPc3Ex5ZSWJWIzh4DBpLX1Rb50opwKBAKIoUV+3hOXLl9O+YS2//d3zvLdjOwWFheTlzyEwFBhPPhlKQNd83VzXdSRJIjcvH4BIOMy2/3qFN1/7PZWVNTQub2bFdc001Nfj9nkZDQYJhyMYhv6lwo7P300GBwcRRYmm5mYaGhrY9voaykqKz37HeJhnqs6cdmtAssOB3WZHSSQYHBzgw4Mf8H5rK4c+OUJobAyvx01xSQnZubmIgoCqqmeF/WKbJraHQmMkUwqNjcuQZZmxsTEkScLr89G+dx+HP/3kssN82okZjUQoLi3n/h98H5fbh9VqIxwK0dV5lLa2nezZs5cjHZ2EQiHsNgvFxcXk5OWhaSqapk0usJ1vs4hpmEQjUVRVnSybvD4fe/d9wOFPPp6BY+aXMLE2Xrd0Kfdu3syG9Ws5fTpAT08fe/d9wMEPDnBqcIB3tr/Bu29tx5+VxeK6paxZs4rGZfWUlJaiqilGgiMkk8olVwP/d9n4qzKtxEyn08iyTN2SWgYG+hk6NYTskFmxooXVq1cTj0Z54Mc/4dCBffizskkmk7S17mDX++9RVFJKY1MzK1uaqa+vZ35BAbFImODI6JeOr4ahMzYWyki0TSsxlUSCgsJiaqtrCIVCmKaJklBIxOO4PV4MQyc0OorFYgVAlmUcDgeGYRAYGuSVl46z7b9fpbyyhutaWlh1w0pqF9Zis9kZCQaJRqPn1K9Ol5NwOEJfTw82+/ktwqkyrcRMJhVqFi5ifkEBJwcGJrdPrI3v2PEu/X0ncH2uqz7RTfd4vPh8fjRNo7vzKEcPf8x/vvISi+saWLniOpoal1FeUQHAyMgIaU2jqrqWrVu30t11jOycnMu2f1qJCVBdVX72Yas/eJBpGthsdjqOdZNKpfD5s76wOWEYBpIkTXaPkskku3e+x+6d7zFvfgH1DY20tDRTv2QJebm5vLbtf3hqyxZsdhuiKF52w2PaiKlpKm6Pl4rycuJn13kmsNmshMZGOXL4MBaL9aIXPbHfbrcj58/BNE3CoRBvvPZ73tn+OkXFZfj8fjo7jmAYBllZ2RnptE8bMePxOLULF1NdVUU4cm7Dw+320tPTQ39fz5TLlwlhnS4XLrcbXdcZGjrJZ5/14nK5xufoGRASptGzRpqq8o1v3ERVTS3JpHLOrMTldtPT1084FMJms33lc0w8pu1yufH7s7BabZfUnb9UpoWYpmnicDjZt/8Ae3a1UVVdy7x58xAEAcPQsVgsnBoKkNbT0/qlrmkR5oIg4PP7ad+9k48OfsCmW2/jj2/6I5bU1WEYOkoizrGOY4iXWIRfK4Sp/qzERClyJZAkiXgsRjQaweVy03L9Ddy/+R5cLjd33fXnJOJx5CmuRF5NppWYE4jieF8yEg6Rm5dPWUUVJ7o7r+lrKZfCtBRzAlEUSSQSJJMKfn/WtH8te1qMmRfCMAxkWUaWZWD6vwQ7veNmhjErZgaZFTODzIqZQWbFzCBfKZtP96x6rZiymNN5bnytmQ3zDDIrZgaZFTOD/C9uew7sSK2nLAAAAABJRU5ErkJggg=="
-             width="1"
-             height="1"
-             id="image5539" />
-        </g>
-        <g
-           id="g5567">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5553)"
-             id="g5569">
-            <g
-               id="g5571">
-              <g
-                 id="g5573">
-                <g
-                   id="g5575">
-                  <g
-                     id="g5577">
-                    <path
-                       style="fill:url(#radialGradient8786)"
-                       inkscape:connector-curvature="0"
-                       d="m 1740,1380 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0.01 22.2,9.11 23.7,20.9 h -12 l 35.6,35.6 35.6,-35.6 h -11.3 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 l 17.8,17.8 z"
-                       id="path5579" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5599">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5585)"
-             id="g5601">
-            <g
-               id="g5603">
-              <g
-                 id="g5605">
-                <g
-                   id="g5607">
-                  <g
-                     id="g5609">
-                    <path
-                       style="fill:url(#radialGradient8788)"
-                       inkscape:connector-curvature="0"
-                       d="m 1690,1390 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.7 h 11.1 l -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path5611" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5631">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5617)"
-             id="g5633">
-            <g
-               id="g5635">
-              <g
-                 id="g5637">
-                <g
-                   id="g5639">
-                  <g
-                     id="g5641">
-                    <path
-                       style="fill:url(#radialGradient8790)"
-                       inkscape:connector-curvature="0"
-                       d="m 1470,1380 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 h -12 l 35.6,35.6 35.6,-35.6 h -11.3 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.011 -44,13.9 -53.4,34 l 17.8,17.8 z"
-                       id="path5643" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5663">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5649)"
-             id="g5665">
-            <g
-               id="g5667">
-              <g
-                 id="g5669">
-                <g
-                   id="g5671">
-                  <g
-                     id="g5673">
-                    <path
-                       style="fill:url(#radialGradient8792)"
-                       inkscape:connector-curvature="0"
-                       d="m 1420,1390 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.6 h 11.1 l -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path5675" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5695">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5681)"
-             id="g5697">
-            <g
-               id="g5699">
-              <g
-                 id="g5701">
-                <g
-                   id="g5703">
-                  <g
-                     id="g5705">
-                    <path
-                       style="fill:url(#radialGradient8794)"
-                       inkscape:connector-curvature="0"
-                       d="m 1650,1240 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0 -22.2,9.11 -23.7,20.9 l 12,-10e-4 -35.6,35.6 -35.6,-35.6 h 11.3 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.012 44,13.9 53.4,34 l -17.8,17.8 z"
-                       id="path5707" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5727">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5713)"
-             id="g5729">
-            <g
-               id="g5731">
-              <g
-                 id="g5733">
-                <g
-                   id="g5735">
-                  <g
-                     id="g5737">
-                    <path
-                       style="fill:url(#radialGradient8796)"
-                       inkscape:connector-curvature="0"
-                       d="m 1700,1250 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.7 H 1640 l 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 h -11.2 z"
-                       id="path5739" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5759">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5745)"
-             id="g5761">
-            <g
-               id="g5763">
-              <g
-                 id="g5765">
-                <g
-                   id="g5767">
-                  <g
-                     id="g5769">
-                    <path
-                       style="fill:url(#radialGradient8798)"
-                       inkscape:connector-curvature="0"
-                       d="m 1650,1510 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0.01 -22.2,9.11 -23.7,20.9 h 12 l -35.6,35.6 -35.6,-35.6 h 11.3 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 1650,1510 z"
-                       id="path5771" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5791">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5777)"
-             id="g5793">
-            <g
-               id="g5795">
-              <g
-                 id="g5797">
-                <g
-                   id="g5799">
-                  <g
-                     id="g5801">
-                    <path
-                       style="fill:url(#radialGradient8800)"
-                       inkscape:connector-curvature="0"
-                       d="m 1700,1520 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 l -11.1,0 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 h -11.2 z"
-                       id="path5803" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1640,1540 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.409 -9.4,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
-           id="path5807" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1630,1510 0,10.9 -2.77,-2.14 -1.83,2.5 4.89,3.59 3.23,0 0,-14.9 -3.53,0 z"
-           id="path5811" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1780,1400 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
-           id="path5815" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1760,1380 0,2.94 5.8,5.25 c 0.735,0.694 1.22,1.39 1.22,2.29 0,1.05 -0.735,1.78 -1.85,1.78 -1.18,0 -1.95,-0.924 -2.1,-2.25 l -3.38,0.463 c 0.336,3 2.77,4.79 5.67,4.79 2.73,0 5.38,-1.45 5.38,-4.56 0,-2.12 -1.24,-3.36 -2.6,-4.58 l -3.44,-3.07 h 6.07 v -3.06 h -10.8 z"
-           id="path5819" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1510,1400 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
-           id="path5823" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1490,1390 -0.063,0 -3.53,-5.5 3.59,0 0,5.5 z m 3.28,-8.36 0,-2.9 -3.3,0 0,2.9 -6.99,0 0,2.96 6.05,9.01 4.22,0 0,-9.11 2.06,0 0,-2.86 -2.04,0 z"
-           id="path5827" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1650,1260 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
-           id="path5831" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1630,1240 c -2.71,0 -5.16,1.18 -5.96,3.95 l 3.28,0.861 c 0.274,-0.987 1.18,-1.85 2.52,-1.85 1.01,0 2.16,0.504 2.16,1.89 0,1.51 -1.55,1.95 -3.02,1.95 h -0.945 v 2.58 h 1.03 c 1.32,0 2.6,0.336 2.6,1.76 0,1.07 -0.903,1.64 -1.87,1.64 -1.01,0 -1.81,-0.65 -2.04,-1.66 l -3.28,0.756 c 0.713,2.5 3.06,3.78 5.54,3.78 2.62,0 5.23,-1.34 5.23,-4.2 0,-1.64 -1.05,-2.86 -2.5,-3.23 v -0.063 c 1.68,-0.398 2.86,-1.78 2.86,-3.44 0,-3.25 -2.88,-4.72 -5.61,-4.72"
-           id="path5835" />
-        <path
-           style="fill:#2f2d2e;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1600,1420 62.1,0 c 1.63,0 2.95,-1.32 2.95,-2.95 v -62.1 c 0,-1.63 -1.32,-2.96 -2.95,-2.96 H 1600 c -1.63,0 -2.95,1.32 -2.95,2.96 v 62.1 c 0,1.63 1.32,2.95 2.95,2.95"
-           id="path7759" />
-        <path
-           style="fill:#c8c7c6;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1620,1380 -2.78,-9.4 7.16,-3.94 2.89,11 -7.27,2.36 z m -1.79,16.9 -3.03,-12.3 1.96,-0.745 11.1,-3.97 2.99,9.89 -13,7.07 z m 12.8,13.2 c -1.15,0.022 -2.18,-0.468 -2.61,-1.87 l -4.04,-13.6 6.49,-3.55 2.8,10.6 c 0.793,1.24 1.93,0.761 3.16,0.014 l 9.6,-6.33 c 0.848,-0.699 1.4,-1.66 1.35,-3.17 l -0.592,-8.39 c -0.113,-1.18 -0.826,-1.89 -1.37,-1.78 l -15.2,8.23 -2.69,-10.2 3.7,-1.34 v -0.01 l 15.2,-5.49 c 2.26,-0.825 4.28,1.66 4.36,5.4 l 0.065,13.4 c -0.049,3.31 -1.64,5.1 -3.24,6.39 l -12.7,9.9 c -1.06,0.864 -2.79,1.74 -4.3,1.77"
-           id="path7763" />
-        <path
-           style="fill:#658acf;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1620,1400 -1.31,0.757 1.16,4.26 -2.92,1.59 -6.44,-2.74 -8.88,2.35 7.9,-5.36 3.1,-7.39 4,-1.32 1.26,4.74 1.24,-0.195 0.906,3.31 z"
-           id="path7767" />
-        <path
-           style="fill:#c8c7c6;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 1650,1360 2.56,0 c 0.281,0 0.5,-0.107 0.695,-0.297 0.102,-0.088 0.176,-0.199 0.215,-0.314 0.051,-0.118 0.086,-0.246 0.086,-0.387 v -0.914 c 0,-0.135 -0.035,-0.266 -0.086,-0.395 -0.039,-0.107 -0.113,-0.209 -0.215,-0.298 -0.195,-0.194 -0.414,-0.299 -0.695,-0.299 H 1650 c -0.275,0 -0.504,0.105 -0.691,0.299 -0.104,0.089 -0.176,0.191 -0.225,0.298 -0.041,0.129 -0.08,0.26 -0.08,0.395 v 0.914 c 0,0.141 0.039,0.269 0.08,0.387 0.049,0.115 0.121,0.226 0.225,0.314 0.187,0.19 0.416,0.297 0.691,0.297 m -12.4,0 2.56,0 c 0.278,0 0.498,-0.107 0.69,-0.297 0.191,-0.187 0.307,-0.426 0.307,-0.701 v -0.914 c 0,-0.277 -0.116,-0.526 -0.307,-0.693 -0.184,-0.192 -0.41,-0.299 -0.676,-0.299 h -3.57 v 0.992 0.521 0.393 c 0,0.141 0.035,0.269 0.084,0.387 0.051,0.115 0.129,0.226 0.228,0.314 0.176,0.19 0.403,0.297 0.684,0.297 m -15,0 2.55,0 c 0.287,0 0.508,-0.107 0.703,-0.297 0.094,-0.088 0.164,-0.199 0.211,-0.314 0.053,-0.118 0.082,-0.246 0.082,-0.379 h -4.54 c 0,0.133 0.033,0.261 0.082,0.379 0.049,0.115 0.119,0.226 0.217,0.314 0.189,0.19 0.426,0.297 0.697,0.297 m -7.51,0 2.54,0 c 0.281,0 0.519,-0.107 0.715,-0.297 0.197,-0.187 0.281,-0.426 0.281,-0.701 v -0.914 c 0,-0.277 -0.084,-0.526 -0.281,-0.693 -0.196,-0.194 -0.434,-0.299 -0.715,-0.299 h -1.89 -1.64 v 0.992 0.521 0.393 c 0,0.141 0.02,0.269 0.073,0.387 0.062,0.115 0.135,0.226 0.226,0.314 0.18,0.19 0.418,0.297 0.7,0.297 m -7.52,0 2.54,0 c 0.277,0 0.522,-0.107 0.711,-0.297 0.088,-0.088 0.156,-0.199 0.213,-0.314 0.051,-0.118 0.074,-0.246 0.074,-0.387 v -0.914 c 0,-0.135 -0.023,-0.266 -0.074,-0.395 -0.057,-0.107 -0.125,-0.209 -0.213,-0.298 -0.189,-0.194 -0.434,-0.299 -0.711,-0.299 h -0.318 -2.22 c -0.283,0 -0.516,0.105 -0.713,0.299 -0.082,0.089 -0.158,0.191 -0.211,0.298 -0.055,0.129 -0.074,0.26 -0.074,0.395 v 0.914 c 0,0.141 0.019,0.269 0.074,0.387 0.053,0.115 0.129,0.226 0.211,0.314 0.197,0.19 0.43,0.297 0.713,0.297 m 42.4,1.04 c -0.28,0 -0.543,-0.049 -0.797,-0.166 -0.231,-0.088 -0.451,-0.242 -0.619,-0.42 -0.192,-0.189 -0.338,-0.406 -0.456,-0.652 -0.107,-0.254 -0.14,-0.52 -0.14,-0.793 v -0.93 c 0,-0.281 0.033,-0.547 0.14,-0.795 0.118,-0.242 0.264,-0.455 0.456,-0.642 0.168,-0.178 0.388,-0.332 0.619,-0.426 0.254,-0.115 0.517,-0.16 0.797,-0.16 h 2.69 c 0.277,0 0.543,0.045 0.791,0.16 0.236,0.094 0.457,0.248 0.637,0.426 0.187,0.187 0.332,0.4 0.443,0.642 0.098,0.248 0.148,0.514 0.148,0.795 v 0.93 c 0,0.273 -0.05,0.539 -0.148,0.793 -0.111,0.246 -0.256,0.463 -0.443,0.652 -0.18,0.178 -0.401,0.332 -0.637,0.42 -0.248,0.117 -0.514,0.166 -0.791,0.166 h -2.69 z m -27.4,0 c -0.276,0 -0.541,-0.049 -0.799,-0.166 -0.236,-0.088 -0.451,-0.242 -0.623,-0.42 -0.186,-0.189 -0.34,-0.406 -0.449,-0.652 -0.108,-0.252 -0.156,-0.508 -0.156,-0.785 v -0.93 c 0,-0.277 0.048,-0.541 0.156,-0.795 0.109,-0.244 0.263,-0.463 0.449,-0.65 0.172,-0.178 0.387,-0.332 0.623,-0.426 0.258,-0.115 0.523,-0.16 0.799,-0.16 h 4.11 v 1.04 h -4.04 c -0.271,0 -0.508,0.105 -0.697,0.299 -0.074,0.078 -0.133,0.16 -0.18,0.257 -0.056,0.096 -0.091,0.203 -0.107,0.303 h 5.63 v 1.06 c 0,0.277 -0.053,0.533 -0.145,0.785 -0.117,0.246 -0.254,0.463 -0.451,0.652 -0.182,0.178 -0.4,0.332 -0.644,0.42 -0.233,0.117 -0.498,0.166 -0.791,0.166 h -2.68 z m -15,0 c -0.289,0 -0.555,-0.049 -0.791,-0.166 -0.252,-0.088 -0.461,-0.242 -0.647,-0.42 -0.183,-0.189 -0.334,-0.406 -0.445,-0.652 -0.1,-0.254 -0.153,-0.52 -0.153,-0.793 v -0.93 c 0,-0.281 0.053,-0.547 0.153,-0.795 0.111,-0.242 0.262,-0.455 0.445,-0.642 0.186,-0.178 0.395,-0.332 0.647,-0.426 0.236,-0.115 0.502,-0.16 0.791,-0.16 h 2.01 0.664 2.8 v -1.99 h 1.11 v 1.99 h 0.928 0.36 2.32 c 0.283,0 0.545,0.045 0.783,0.16 0.254,0.094 0.463,0.248 0.656,0.426 0.192,0.187 0.332,0.4 0.434,0.642 0.099,0.248 0.158,0.514 0.158,0.795 v 0.93 c 0,0.273 -0.059,0.539 -0.158,0.793 -0.102,0.246 -0.242,0.463 -0.434,0.652 -0.193,0.178 -0.402,0.332 -0.656,0.42 -0.238,0.117 -0.5,0.166 -0.783,0.166 h -2.68 c -0.281,0 -0.545,-0.049 -0.793,-0.166 -0.242,-0.088 -0.455,-0.242 -0.64,-0.42 -0.188,-0.189 -0.34,-0.406 -0.44,-0.652 -0.109,-0.254 -0.166,-0.52 -0.166,-0.793 v -1.91 h -1.02 c 0.025,0.062 0.066,0.127 0.085,0.189 0.112,0.248 0.165,0.514 0.165,0.795 v 0.93 c 0,0.273 -0.053,0.539 -0.165,0.793 -0.091,0.246 -0.244,0.463 -0.423,0.652 -0.192,0.178 -0.407,0.332 -0.653,0.42 -0.252,0.117 -0.515,0.166 -0.797,0.166 h -2.68 z m 35.5,-4.98 1.1,0 0,5 -1.1,0 0,-5 z m -13,5 c -0.272,0 -0.539,-0.059 -0.791,-0.182 -0.227,-0.088 -0.446,-0.242 -0.625,-0.42 -0.186,-0.189 -0.336,-0.406 -0.451,-0.652 -0.096,-0.252 -0.139,-0.508 -0.139,-0.785 v -2.96 h 1.09 v 2.95 c 0,0.273 0.111,0.513 0.299,0.707 0.08,0.09 0.199,0.158 0.304,0.213 0.121,0.052 0.242,0.074 0.379,0.074 h 2.57 c 0.132,0 0.263,-0.022 0.369,-0.074 0.121,-0.055 0.244,-0.123 0.314,-0.213 0.197,-0.194 0.303,-0.434 0.303,-0.707 v -2.95 h 0.305 0.785 0.779 v -1.99 h 1.09 v 1.99 h 0.927 2.3 0.407 c 0.265,0 0.531,0.045 0.781,0.16 0.23,0.094 0.453,0.248 0.631,0.426 0.185,0.187 0.338,0.4 0.445,0.642 0.103,0.248 0.141,0.514 0.141,0.795 v 0.93 c 0,0.273 -0.038,0.539 -0.141,0.793 -0.107,0.246 -0.26,0.463 -0.445,0.652 -0.178,0.178 -0.401,0.332 -0.631,0.42 -0.25,0.117 -0.516,0.166 -0.781,0.166 h -2.71 c -0.279,0 -0.542,-0.049 -0.792,-0.166 -0.225,-0.088 -0.438,-0.242 -0.625,-0.42 -0.188,-0.189 -0.338,-0.406 -0.454,-0.652 -0.099,-0.254 -0.15,-0.52 -0.15,-0.793 v -1.91 h -0.779 v 1.91 0.01 c 0,0.277 -0.053,0.533 -0.139,0.785 -0.117,0.246 -0.262,0.463 -0.449,0.652 -0.184,0.178 -0.406,0.332 -0.643,0.42 -0.23,0.123 -0.498,0.182 -0.779,0.182 h -2.7 z m 25.6,1.43 0,-1.22 -0.49,0 0,-1.05 0.49,0 0,-2.13 c 0,-0.281 0.062,-0.547 0.154,-0.795 0.113,-0.242 0.254,-0.455 0.44,-0.642 0.193,-0.178 0.4,-0.332 0.652,-0.426 0.234,-0.115 0.5,-0.16 0.791,-0.16 h 0.791 v 1.04 h -0.777 c -0.27,0.025 -0.504,0.129 -0.664,0.32 -0.096,0.078 -0.168,0.191 -0.211,0.307 -0.049,0.105 -0.065,0.232 -0.065,0.365 v 2.12 h 1.72 v 0.223 0.83 h -1.72 v 1.22 h -1.11 z m -10.8,0.563 0,-4.96 c 0,-0.277 0.06,-0.541 0.162,-0.795 0.1,-0.244 0.238,-0.463 0.432,-0.639 0.197,-0.183 0.398,-0.332 0.66,-0.437 0.236,-0.115 0.492,-0.16 0.777,-0.16 h 0.221 v 1.04 h -0.201 c -0.262,0.025 -0.477,0.129 -0.664,0.32 -0.088,0.078 -0.157,0.191 -0.198,0.307 -0.064,0.105 -0.068,0.232 -0.068,0.365 v 4.96 h -1.12 z m -1.86,-1.1 1.1,0 0,1.1 -1.1,0 0,-1.1 z"
-           id="path7771" />
-      </g>
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,790 63.7,0 -1.99,312 402,0"
-         id="path9653" />
-    </g>
-    <g
-       transform="matrix(0.4,0,0,0.4,-56.741854,-154.45687)"
-       id="hexa">
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,706 381,4.22 -1.41,-71.8 40.8,0"
-         id="path9822" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,747 626,5.63"
-         id="path9824" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,789 526,7.04 -1.41,179 77.4,0 0,0 5.63,0"
-         id="path9826" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,830 382,4.22 0,253 40.8,0 0,0 -1.41,0"
-         id="path9828" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,865 237,0 0,71.8 m -237,-29.6 263,1.41 -1.19,-106"
-         id="path9830" />
-      <g
-         transform="matrix(1.25,0,0,-1.25,-596.76331,2570.3294)"
-         id="3454">
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2440,1270 c 3.33,-1.92 7.05,-1.7 8.32,0.508 1.27,2.2 -0.396,5.54 -3.72,7.46 l -299,173 c -3.32,1.92 -7.05,1.69 -8.32,-0.508 -1.27,-2.198 0.399,-5.54 3.72,-7.46 l 299,-173 z"
-           id="path4243" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 2440,1270 c 3.33,-1.92 7.05,-1.7 8.32,0.508 1.27,2.2 -0.396,5.54 -3.72,7.46 l -299,173 c -3.32,1.92 -7.05,1.69 -8.32,-0.508 -1.27,-2.198 0.399,-5.54 3.72,-7.46 l 299,-173 z"
-           id="path4247" />
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2450,1440 c 3.33,1.92 4.99,5.26 3.72,7.46 -1.27,2.2 -4.99,2.43 -8.32,0.506 l -299,-173 c -3.32,-1.92 -4.99,-5.26 -3.72,-7.46 1.27,-2.2 5,-2.43 8.32,-0.504 l 299,173 z"
-           id="path4251" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 2450,1440 c 3.33,1.92 4.99,5.26 3.72,7.46 -1.27,2.2 -4.99,2.43 -8.32,0.506 l -299,-173 c -3.32,-1.92 -4.99,-5.26 -3.72,-7.46 1.27,-2.2 5,-2.43 8.32,-0.504 l 299,173 z"
-           id="path4255" />
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2300,1530 c 0,3.84 -2.06,6.96 -4.6,6.95 -2.54,10e-4 -4.6,-3.11 -4.6,-6.95 v -345 c 0,-3.84 2.06,-6.95 4.6,-6.95 2.54,0 4.6,3.12 4.6,6.96 l 0,345 z"
-           id="path4259" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 2300,1530 c 0,3.84 -2.06,6.96 -4.6,6.95 -2.54,10e-4 -4.6,-3.11 -4.6,-6.95 v -345 c 0,-3.84 2.06,-6.95 4.6,-6.95 2.54,0 4.6,3.12 4.6,6.96 l 0,345 z"
-           id="path4263" />
-        <g
-           id="g4307">
-          <path
-             style="fill:url(#linearGradient8802)"
-             inkscape:connector-curvature="0"
-             d="m 2310,1410 2.77,0 0,-17.2 17.2,0 0,17.2 3.07,0 -11.5,11.5 -11.5,-11.5 z"
-             id="path4315" />
-        </g>
-        <g
-           id="g5845">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath5841)"
-             id="g5847">
-            <g
-               transform="translate(2515.9893,1514.8203)"
-               id="g5849">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.048,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.007,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5851" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5861">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath5857)"
-             id="g5863">
-            <g
-               transform="translate(2355.4863,1607.2334)"
-               id="g5865">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.047,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5867" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5877">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath5873)"
-             id="g5879">
-            <g
-               transform="translate(2516.0371,1330.8896)"
-               id="g5881">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.051,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5883" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5893">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath5889)"
-             id="g5895">
-            <g
-               transform="translate(2354.9951,1235.6455)"
-               id="g5897">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.048,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5899" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5919">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5905)"
-             id="g5921">
-            <g
-               id="g5923">
-              <g
-                 id="g5925">
-                <g
-                   id="g5927">
-                  <g
-                     id="g5929">
-                    <path
-                       style="fill:url(#radialGradient8804)"
-                       inkscape:connector-curvature="0"
-                       d="m 2430,1450 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 h -12 l 35.6,35.6 35.6,-35.6 h -11.3 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 l 17.8,17.8 z"
-                       id="path5931" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5951">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5937)"
-             id="g5953">
-            <g
-               id="g5955">
-              <g
-                 id="g5957">
-                <g
-                   id="g5959">
-                  <g
-                     id="g5961">
-                    <path
-                       style="fill:url(#radialGradient8806)"
-                       inkscape:connector-curvature="0"
-                       d="m 2380,1460 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.6 l 11.1,0 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path5963" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g5983">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath5969)"
-             id="g5985">
-            <g
-               id="g5987">
-              <g
-                 id="g5989">
-                <g
-                   id="g5991">
-                  <g
-                     id="g5993">
-                    <path
-                       style="fill:url(#radialGradient8808)"
-                       inkscape:connector-curvature="0"
-                       d="m 2270,1170 c 3.01,-9.78 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 h -12 l 35.6,35.6 35.6,-35.6 h -11.3 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.011 -44,13.9 -53.4,34 l 17.8,17.8 z"
-                       id="path5995" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g6015">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath6001)"
-             id="g6017">
-            <g
-               id="g6019">
-              <g
-                 id="g6021">
-                <g
-                   id="g6023">
-                  <g
-                     id="g6025">
-                    <path
-                       style="fill:url(#radialGradient8810)"
-                       inkscape:connector-curvature="0"
-                       d="m 2220,1180 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.6 h 11.1 l -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path6027" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g6047">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath6033)"
-             id="g6049">
-            <g
-               id="g6051">
-              <g
-                 id="g6053">
-                <g
-                   id="g6055">
-                  <g
-                     id="g6057">
-                    <path
-                       style="fill:url(#radialGradient8812)"
-                       inkscape:connector-curvature="0"
-                       d="m 2480,1260 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0 -22.2,9.11 -23.7,20.9 h 12 l -35.6,35.6 -35.6,-35.6 h 11.3 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.011 44,13.9 53.4,34 L 2480,1260 z"
-                       id="path6059" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g6079">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath6065)"
-             id="g6081">
-            <g
-               id="g6083">
-              <g
-                 id="g6085">
-                <g
-                   id="g6087">
-                  <g
-                     id="g6089">
-                    <path
-                       style="fill:url(#radialGradient8814)"
-                       inkscape:connector-curvature="0"
-                       d="m 2530,1270 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 H 2470 l 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 h -11.2 z"
-                       id="path6091" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g6111">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath6097)"
-             id="g6113">
-            <g
-               id="g6115">
-              <g
-                 id="g6117">
-                <g
-                   id="g6119">
-                  <g
-                     id="g6121">
-                    <path
-                       style="fill:url(#radialGradient8816)"
-                       inkscape:connector-curvature="0"
-                       d="m 2320,1540 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0.01 -22.2,9.11 -23.7,20.9 h 12 l -35.6,35.6 -35.6,-35.6 11.3,10e-4 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.011 44,13.9 53.4,34 l -17.8,17.8 z"
-                       id="path6123" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g6143">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath6129)"
-             id="g6145">
-            <g
-               id="g6147">
-              <g
-                 id="g6149">
-                <g
-                   id="g6151">
-                  <g
-                     id="g6153">
-                    <path
-                       style="fill:url(#radialGradient8818)"
-                       inkscape:connector-curvature="0"
-                       d="m 2370,1550 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 H 2310 l 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,10e-4 z"
-                       id="path6155" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2310,1560 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.4,9.41 24.7,9.41 34.1,0.01"
-           id="path6159" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2290,1540 0,10.9 -2.77,-2.14 -1.83,2.5 4.89,3.59 3.23,0 0,-14.9 -3.53,0 z"
-           id="path6163" />
-        <g
-           id="g6173">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath6169)"
-             id="g6175">
-            <g
-               transform="translate(2191.2754,1327.0928)"
-               id="g6177">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.047,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path6179" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g6199">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath6185)"
-             id="g6201">
-            <g
-               id="g6203">
-              <g
-                 id="g6205">
-                <g
-                   id="g6207">
-                  <g
-                     id="g6209">
-                    <path
-                       style="fill:url(#radialGradient8820)"
-                       inkscape:connector-curvature="0"
-                       d="m 2150,1260 c -3.01,-9.78 -12.1,-16.9 -22.9,-16.9 -12.2,0.01 -22.2,9.11 -23.7,20.9 h 12 l -35.6,35.6 -35.6,-35.6 h 11.3 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 2150,1260 z"
-                       id="path6211" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g6231">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath6217)"
-             id="g6233">
-            <g
-               id="g6235">
-              <g
-                 id="g6237">
-                <g
-                   id="g6239">
-                  <g
-                     id="g6241">
-                    <path
-                       style="fill:url(#radialGradient8822)"
-                       inkscape:connector-curvature="0"
-                       d="m 2200,1270 c -1.29,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 H 2140 l 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 h -11.2 z"
-                       id="path6243" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2150,1280 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
-           id="path6247" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2130,1260 c -2.71,0 -4.96,1.43 -5.65,3.78 l 3.21,0.988 c 0.316,-1.03 1.24,-1.79 2.4,-1.79 1.2,0 2.22,0.735 2.22,2.16 0,1.76 -1.6,2.27 -3.04,2.27 -1.05,0 -2.58,-0.272 -3.63,-0.65 l 0.356,8.5 h 9.11 v -3.02 h -5.98 l -0.125,-2.35 c 0.441,0.104 1.05,0.146 1.49,0.146 2.98,0 5.38,-1.6 5.38,-4.72 0,-3.61 -2.81,-5.31 -5.73,-5.31"
-           id="path6251" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2470,1470 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.4,9.41 24.7,9.41 34.1,0.01"
-           id="path6255" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2450,1440 0,2.94 5.8,5.25 c 0.735,0.693 1.22,1.39 1.22,2.29 0,1.05 -0.735,1.78 -1.85,1.78 -1.18,0 -1.95,-0.924 -2.1,-2.25 l -3.38,0.462 c 0.336,3 2.77,4.79 5.67,4.79 2.73,0 5.38,-1.45 5.38,-4.56 0,-2.12 -1.24,-3.36 -2.6,-4.58 l -3.44,-3.07 h 6.07 v -3.06 h -10.8 z"
-           id="path6259" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2310,1190 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
-           id="path6263" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2300,1180 -0.063,0 -3.53,-5.5 3.59,0 0,5.5 z m 3.28,-8.36 0,-2.9 -3.3,0 0,2.9 -6.99,0 0,2.96 6.05,9.01 4.22,0 0,-9.11 2.06,0 0,-2.86 -2.04,0 z"
-           id="path6267" />
-        <g
-           id="g6277">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath6273)"
-             id="g6279">
-            <g
-               transform="translate(2193.8848,1514.2402)"
-               id="g6281">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.047,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path6283" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g6303">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath6289)"
-             id="g6305">
-            <g
-               id="g6307">
-              <g
-                 id="g6309">
-                <g
-                   id="g6311">
-                  <g
-                     id="g6313">
-                    <path
-                       style="fill:url(#radialGradient8824)"
-                       inkscape:connector-curvature="0"
-                       d="m 2110,1450 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0 22.2,9.11 23.7,20.9 h -12 l 35.6,35.6 35.6,-35.6 h -11.3 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 l 17.8,17.8 z"
-                       id="path6315" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g6335">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath6321)"
-             id="g6337">
-            <g
-               id="g6339">
-              <g
-                 id="g6341">
-                <g
-                   id="g6343">
-                  <g
-                     id="g6345">
-                    <path
-                       style="fill:url(#radialGradient8826)"
-                       inkscape:connector-curvature="0"
-                       d="m 2060,1460 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.01 -22.1,-8.99 -23.7,-20.6 h 11.1 l -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path6347" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2150,1470 c 9.4,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
-           id="path6351" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2130,1450 c -1.38,0 -2.35,-0.966 -2.35,-2.35 0,-1.28 0.924,-2.35 2.33,-2.35 1.39,0 2.33,0.966 2.33,2.37 0,1.34 -0.924,2.33 -2.31,2.33 m -0.021,-7.64 c -3.23,0 -5.86,2.06 -5.86,5.31 0,1.76 0.672,3.13 1.66,4.6 l 3.59,5.35 h 4.26 l -3.65,-5.08 -0.063,-0.105 c 0.273,0.105 0.715,0.168 1.05,0.168 2.6,0 4.87,-1.95 4.87,-4.85 0,-3.38 -2.65,-5.4 -5.86,-5.4"
-           id="path6355" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2470,1290 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.01"
-           id="path6359" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2450,1260 c -2.71,0 -5.16,1.18 -5.96,3.95 l 3.28,0.862 c 0.273,-0.988 1.18,-1.85 2.52,-1.85 1.01,0 2.16,0.504 2.16,1.89 0,1.51 -1.56,1.95 -3.02,1.95 h -0.946 v 2.58 h 1.03 c 1.32,0 2.6,0.336 2.6,1.76 0,1.07 -0.903,1.64 -1.87,1.64 -1.01,0 -1.81,-0.651 -2.04,-1.66 l -3.28,0.756 c 0.714,2.5 3.07,3.78 5.54,3.78 2.62,0 5.23,-1.34 5.23,-4.2 0,-1.64 -1.05,-2.86 -2.5,-3.23 v -0.062 c 1.68,-0.399 2.86,-1.78 2.86,-3.44 0,-3.26 -2.88,-4.72 -5.61,-4.72"
-           id="path6363" />
-        <path
-           style="fill:#2f2d2e;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2260,1390 62.1,0 c 1.63,0 2.95,-1.32 2.95,-2.95 v -62.1 c 0,-1.63 -1.32,-2.96 -2.95,-2.96 H 2260 c -1.63,0 -2.95,1.32 -2.95,2.96 v 62.1 c 0,1.63 1.32,2.95 2.95,2.95"
-           id="path7857" />
-        <path
-           style="fill:#c8c7c6;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2290,1360 -2.78,-9.4 7.16,-3.94 2.89,11 -7.27,2.36 z m -1.79,16.9 -3.03,-12.3 1.96,-0.745 11.1,-3.97 2.99,9.89 -13,7.07 z m 12.8,13.2 c -1.15,0.022 -2.18,-0.468 -2.61,-1.87 l -4.04,-13.6 6.49,-3.55 2.8,10.6 c 0.794,1.24 1.93,0.76 3.16,0.014 l 9.6,-6.33 c 0.849,-0.699 1.4,-1.66 1.35,-3.17 l -0.592,-8.39 c -0.113,-1.18 -0.826,-1.89 -1.37,-1.78 l -15.2,8.23 -2.69,-10.2 3.7,-1.34 v -0.01 l 15.2,-5.49 c 2.26,-0.825 4.28,1.66 4.36,5.4 l 0.065,13.4 c -0.049,3.31 -1.64,5.1 -3.24,6.39 l -12.7,9.9 c -1.06,0.865 -2.79,1.75 -4.3,1.77"
-           id="path7861" />
-        <path
-           style="fill:#658acf;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2280,1370 -1.31,0.756 1.16,4.26 -2.92,1.59 -6.44,-2.74 -8.89,2.35 7.9,-5.35 3.1,-7.39 4,-1.32 1.26,4.74 1.24,-0.196 0.906,3.31 z"
-           id="path7865" />
-        <path
-           style="fill:#c8c7c6;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2310,1340 2.56,0 c 0.28,0 0.5,-0.107 0.695,-0.297 0.101,-0.088 0.176,-0.199 0.215,-0.314 0.051,-0.118 0.085,-0.246 0.085,-0.387 v -0.914 c 0,-0.135 -0.034,-0.266 -0.085,-0.395 -0.039,-0.107 -0.114,-0.209 -0.215,-0.298 -0.195,-0.194 -0.415,-0.299 -0.695,-0.299 H 2310 c -0.275,0 -0.504,0.105 -0.692,0.299 -0.104,0.089 -0.175,0.191 -0.225,0.298 -0.04,0.129 -0.079,0.26 -0.079,0.395 v 0.914 c 0,0.141 0.039,0.269 0.079,0.387 0.05,0.115 0.121,0.226 0.225,0.314 0.188,0.19 0.417,0.297 0.692,0.297 m -12.4,0 2.56,0 c 0.277,0 0.498,-0.107 0.689,-0.297 0.191,-0.187 0.308,-0.426 0.308,-0.701 v -0.914 c 0,-0.277 -0.117,-0.526 -0.308,-0.693 -0.184,-0.192 -0.41,-0.299 -0.676,-0.299 h -3.57 v 0.992 0.521 0.393 c 0,0.141 0.035,0.269 0.084,0.387 0.051,0.115 0.129,0.226 0.228,0.314 0.176,0.19 0.403,0.297 0.684,0.297 m -15,0 2.55,0 c 0.287,0 0.507,-0.107 0.702,-0.297 0.095,-0.088 0.165,-0.199 0.212,-0.314 0.053,-0.118 0.082,-0.246 0.082,-0.379 h -4.54 c 0,0.133 0.033,0.261 0.081,0.379 0.05,0.115 0.12,0.226 0.218,0.314 0.189,0.19 0.426,0.297 0.696,0.297 m -7.51,0 2.54,0 c 0.281,0 0.519,-0.107 0.715,-0.297 0.197,-0.187 0.281,-0.426 0.281,-0.701 v -0.914 c 0,-0.277 -0.084,-0.526 -0.281,-0.693 -0.196,-0.194 -0.434,-0.299 -0.715,-0.299 h -1.89 -1.64 v 0.992 0.521 0.393 c 0,0.141 0.02,0.269 0.073,0.387 0.062,0.115 0.135,0.226 0.225,0.314 0.18,0.19 0.419,0.297 0.7,0.297 m -7.52,0 2.54,0 c 0.277,0 0.522,-0.107 0.71,-0.297 0.088,-0.088 0.157,-0.199 0.214,-0.314 0.051,-0.118 0.074,-0.246 0.074,-0.387 v -0.914 c 0,-0.135 -0.023,-0.266 -0.074,-0.395 -0.057,-0.107 -0.126,-0.209 -0.214,-0.298 -0.188,-0.194 -0.433,-0.299 -0.71,-0.299 h -0.318 -2.22 c -0.282,0 -0.515,0.105 -0.713,0.299 -0.082,0.089 -0.158,0.191 -0.21,0.298 -0.056,0.129 -0.074,0.26 -0.074,0.395 v 0.914 c 0,0.141 0.018,0.269 0.074,0.387 0.052,0.115 0.128,0.226 0.21,0.314 0.198,0.19 0.431,0.297 0.713,0.297 m 42.4,1.04 c -0.279,0 -0.543,-0.049 -0.796,-0.166 -0.232,-0.088 -0.452,-0.242 -0.619,-0.42 -0.193,-0.189 -0.339,-0.406 -0.456,-0.652 -0.107,-0.254 -0.141,-0.52 -0.141,-0.793 v -0.93 c 0,-0.281 0.034,-0.547 0.141,-0.795 0.117,-0.242 0.263,-0.455 0.456,-0.642 0.167,-0.178 0.387,-0.332 0.619,-0.426 0.253,-0.115 0.517,-0.16 0.796,-0.16 h 2.69 c 0.277,0 0.543,0.045 0.791,0.16 0.236,0.094 0.458,0.248 0.637,0.426 0.188,0.187 0.333,0.4 0.444,0.642 0.097,0.248 0.148,0.514 0.148,0.795 v 0.93 c 0,0.273 -0.051,0.539 -0.148,0.793 -0.111,0.246 -0.256,0.463 -0.444,0.652 -0.179,0.178 -0.401,0.332 -0.637,0.42 -0.248,0.117 -0.514,0.166 -0.791,0.166 h -2.69 z m -27.4,0 c -0.275,0 -0.54,-0.049 -0.798,-0.166 -0.236,-0.088 -0.451,-0.242 -0.624,-0.42 -0.186,-0.189 -0.34,-0.406 -0.448,-0.652 -0.108,-0.252 -0.156,-0.508 -0.156,-0.785 v -0.93 c 0,-0.277 0.048,-0.541 0.156,-0.795 0.108,-0.244 0.262,-0.463 0.448,-0.65 0.173,-0.178 0.388,-0.332 0.624,-0.426 0.258,-0.115 0.523,-0.16 0.798,-0.16 h 4.11 v 1.04 h -4.05 c -0.27,0 -0.507,0.105 -0.696,0.299 -0.074,0.078 -0.133,0.16 -0.18,0.257 -0.057,0.096 -0.091,0.203 -0.107,0.303 h 5.63 v 1.06 c 0,0.277 -0.052,0.533 -0.145,0.785 -0.117,0.246 -0.254,0.463 -0.45,0.652 -0.182,0.178 -0.4,0.332 -0.644,0.42 -0.233,0.117 -0.499,0.166 -0.791,0.166 h -2.68 z m -15,0 c -0.29,0 -0.555,-0.049 -0.792,-0.166 -0.251,-0.088 -0.46,-0.242 -0.646,-0.42 -0.183,-0.189 -0.335,-0.406 -0.445,-0.652 -0.1,-0.254 -0.153,-0.52 -0.153,-0.793 v -0.93 c 0,-0.281 0.053,-0.547 0.153,-0.795 0.11,-0.242 0.262,-0.455 0.445,-0.642 0.186,-0.178 0.395,-0.332 0.646,-0.426 0.237,-0.115 0.502,-0.16 0.792,-0.16 h 2.01 0.664 2.8 v -1.99 h 1.11 v 1.99 h 0.928 0.36 2.32 c 0.283,0 0.544,0.045 0.783,0.16 0.253,0.094 0.463,0.248 0.655,0.426 0.192,0.187 0.333,0.4 0.435,0.642 0.099,0.248 0.158,0.514 0.158,0.795 v 0.93 c 0,0.273 -0.059,0.539 -0.158,0.793 -0.102,0.246 -0.243,0.463 -0.435,0.652 -0.192,0.178 -0.402,0.332 -0.655,0.42 -0.239,0.117 -0.5,0.166 -0.783,0.166 h -2.68 c -0.281,0 -0.545,-0.049 -0.793,-0.166 -0.243,-0.088 -0.455,-0.242 -0.641,-0.42 -0.187,-0.189 -0.339,-0.406 -0.44,-0.652 -0.108,-0.254 -0.165,-0.52 -0.165,-0.793 v -1.91 h -1.02 c 0.026,0.062 0.067,0.127 0.086,0.189 0.112,0.248 0.165,0.514 0.165,0.795 v 0.93 c 0,0.273 -0.053,0.539 -0.165,0.793 -0.091,0.246 -0.244,0.463 -0.423,0.652 -0.192,0.178 -0.407,0.332 -0.653,0.42 -0.252,0.117 -0.516,0.166 -0.797,0.166 h -2.68 z m 35.5,-4.98 1.1,0 0,5 -1.1,0 0,-5 z m -13,5 c -0.273,0 -0.539,-0.059 -0.791,-0.182 -0.228,-0.088 -0.446,-0.242 -0.625,-0.42 -0.186,-0.189 -0.336,-0.406 -0.451,-0.652 -0.096,-0.252 -0.139,-0.508 -0.139,-0.785 v -2.96 h 1.09 v 2.95 c 0,0.273 0.112,0.513 0.3,0.707 0.08,0.09 0.198,0.158 0.303,0.213 0.121,0.052 0.243,0.074 0.38,0.074 h 2.57 c 0.132,0 0.263,-0.022 0.369,-0.074 0.121,-0.055 0.244,-0.123 0.314,-0.213 0.197,-0.194 0.302,-0.434 0.302,-0.707 v -2.95 h 0.306 0.785 0.778 v -1.99 h 1.1 v 1.99 h 0.927 2.3 0.407 c 0.265,0 0.531,0.045 0.782,0.16 0.23,0.094 0.452,0.248 0.631,0.426 0.184,0.187 0.338,0.4 0.445,0.642 0.103,0.248 0.14,0.514 0.14,0.795 v 0.93 c 0,0.273 -0.037,0.539 -0.14,0.793 -0.107,0.246 -0.261,0.463 -0.445,0.652 -0.179,0.178 -0.401,0.332 -0.631,0.42 -0.251,0.117 -0.517,0.166 -0.782,0.166 h -2.71 c -0.279,0 -0.543,-0.049 -0.792,-0.166 -0.225,-0.088 -0.438,-0.242 -0.625,-0.42 -0.189,-0.189 -0.339,-0.406 -0.455,-0.652 -0.099,-0.254 -0.15,-0.52 -0.15,-0.793 v -1.91 h -0.778 v 1.91 0.01 c 0,0.277 -0.053,0.533 -0.139,0.785 -0.118,0.246 -0.262,0.463 -0.45,0.652 -0.184,0.178 -0.406,0.332 -0.643,0.42 -0.23,0.123 -0.497,0.182 -0.778,0.182 h -2.7 z m 25.6,1.43 0,-1.22 -0.49,0 0,-1.05 0.49,0 0,-2.13 c 0,-0.281 0.061,-0.547 0.154,-0.795 0.113,-0.242 0.253,-0.455 0.439,-0.642 0.194,-0.178 0.4,-0.332 0.652,-0.426 0.235,-0.115 0.501,-0.16 0.792,-0.16 h 0.791 v 1.04 h -0.777 c -0.27,0.025 -0.504,0.129 -0.664,0.32 -0.096,0.078 -0.168,0.191 -0.212,0.307 -0.049,0.105 -0.065,0.232 -0.065,0.365 v 2.12 h 1.72 v 0.223 0.83 h -1.72 v 1.22 h -1.11 z m -10.8,0.563 0,-4.96 c 0,-0.277 0.06,-0.541 0.162,-0.795 0.1,-0.244 0.239,-0.463 0.433,-0.639 0.197,-0.183 0.398,-0.332 0.66,-0.437 0.235,-0.115 0.491,-0.16 0.777,-0.16 h 0.221 v 1.04 h -0.201 c -0.262,0.025 -0.478,0.129 -0.664,0.32 -0.088,0.078 -0.157,0.191 -0.198,0.307 -0.064,0.105 -0.068,0.232 -0.068,0.365 v 4.96 h -1.12 z m -1.86,-1.1 1.1,0 0,1.1 -1.1,0 0,-1.1 z"
-           id="path7869" />
-      </g>
-    </g>
-    <g
-       transform="matrix(0.4,0,0,0.4,-56.741854,-150.45687)"
-       id="hexa-y">
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 22.5;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,864 487,2.81 1.41,115 m -488,-76 556,-1.41 -1.41,104"
-         id="path9858" />
-      <g
-         transform="matrix(1.6375361,0,0,-1.6061042,1762.4794,2222.6719)"
-         id="123">
-        <g
-           id="g4333">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath4329)"
-             id="g4335">
-            <g
-               transform="translate(284.2432,1018.4248)"
-               id="g4337">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.048,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.009,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path4339" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g4359">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath4345)"
-             id="g4361">
-            <g
-               id="g4363">
-              <g
-                 id="g4365">
-                <g
-                   id="g4367">
-                  <g
-                     id="g4369">
-                    <path
-                       style="fill:url(#radialGradient8828)"
-                       inkscape:connector-curvature="0"
-                       d="m 202,949 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0.006 22.2,9.11 23.7,20.9 l -12,-0.002 35.6,35.6 35.6,-35.6 -11.3,0.002 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 L 202,949 z"
-                       id="path4371" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g4391">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath4377)"
-             id="g4393">
-            <g
-               id="g4395">
-              <g
-                 id="g4397">
-                <g
-                   id="g4399">
-                  <g
-                     id="g4401">
-                    <path
-                       style="fill:url(#radialGradient8830)"
-                       inkscape:connector-curvature="0"
-                       d="m 152,960 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.008 -22.1,-8.99 -23.7,-20.6 H 212 l -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path4403" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           style="fill:#100f0d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 241,973 c 9.4,-9.41 9.4,-24.7 -0.007,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.007,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
-           id="path4407" />
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 511,967 c 1.7,0.98 2.04,3.56 0.773,5.76 -1.267,2.2 -3.67,3.19 -5.37,2.21 l -153,-88.1 c -1.7,-0.98 -2.04,-3.56 -0.775,-5.76 1.27,-2.2 3.68,-3.19 5.37,-2.21 l 153,88.1 z"
-           id="path4411" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 511,967 c 1.7,0.98 2.04,3.56 0.773,5.76 -1.267,2.2 -3.67,3.19 -5.37,2.21 l -153,-88.1 c -1.7,-0.98 -2.04,-3.56 -0.775,-5.76 1.27,-2.2 3.68,-3.19 5.37,-2.21 l 153,88.1 z"
-           id="path4415" />
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 213,970 c -1.63,0.941 -3.98,-0.082 -5.24,-2.28 -1.27,-2.2 -0.981,-4.74 0.645,-5.68 l 146,-84.4 c 1.63,-0.939 3.98,0.082 5.24,2.28 1.27,2.2 0.983,4.74 -0.644,5.68 l -146,84.4 z"
-           id="path4419" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 213,970 c -1.63,0.941 -3.98,-0.082 -5.24,-2.28 -1.27,-2.2 -0.981,-4.74 0.645,-5.68 l 146,-84.4 c 1.63,-0.939 3.98,0.082 5.24,2.28 1.27,2.2 0.983,4.74 -0.644,5.68 l -146,84.4 z"
-           id="path4423" />
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 353,701 c -0.002,-2.06 2.06,-3.73 4.6,-3.73 2.54,0 4.6,1.67 4.6,3.73 l -0.002,185 c 0,2.06 -2.06,3.73 -4.6,3.73 -2.54,0 -4.6,-1.67 -4.6,-3.73 L 353,701 z"
-           id="path4427" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 353,701 c -0.002,-2.06 2.06,-3.73 4.6,-3.73 2.54,0 4.6,1.67 4.6,3.73 l -0.002,185 c 0,2.06 -2.06,3.73 -4.6,3.73 -2.54,0 -4.6,-1.67 -4.6,-3.73 L 353,701 z"
-           id="path4431" />
-        <g
-           id="g4441">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath4437)"
-             id="g4443">
-            <g
-               transform="translate(429.3359,762.3701)"
-               id="g4445">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.048,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.009,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path4447" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g4467">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath4453)"
-             id="g4469">
-            <g
-               id="g4471">
-              <g
-                 id="g4473">
-                <g
-                   id="g4475">
-                  <g
-                     id="g4477">
-                    <path
-                       style="fill:url(#radialGradient8832)"
-                       inkscape:connector-curvature="0"
-                       d="m 347,693 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0.005 22.2,9.11 23.7,20.9 l -12,-0.002 35.6,35.6 35.6,-35.6 -11.3,0.002 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 L 347,693 z"
-                       id="path4479" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g4499">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath4485)"
-             id="g4501">
-            <g
-               id="g4503">
-              <g
-                 id="g4505">
-                <g
-                   id="g4507">
-                  <g
-                     id="g4509">
-                    <path
-                       style="fill:url(#radialGradient8834)"
-                       inkscape:connector-curvature="0"
-                       d="m 297,704 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.006 44.4,-14.1 53.7,-34.5 l -18,-18 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.007 -22.1,-8.99 -23.7,-20.7 h 11.1 l -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path4511" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           style="fill:#100f0d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 386,717 c 9.4,-9.41 9.4,-24.7 -0.007,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.007,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
-           id="path4515" />
-        <g
-           id="g4929">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath4925)"
-             id="g4931">
-            <g
-               transform="translate(262.6084,1040.4229)"
-               id="g4933">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path4935" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g4955">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath4941)"
-             id="g4957">
-            <g
-               id="g4959">
-              <g
-                 id="g4961">
-                <g
-                   id="g4963">
-                  <g
-                     id="g4965">
-                    <path
-                       style="fill:url(#radialGradient8836)"
-                       inkscape:connector-curvature="0"
-                       d="m 225,973 c -3.01,-9.78 -12.1,-16.9 -22.9,-16.9 -12.2,0.004 -22.2,9.11 -23.7,20.9 h 12 l -35.6,35.6 -35.6,-35.6 h 11.3 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 225,973 z"
-                       id="path4967" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g4987">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath4973)"
-             id="g4989">
-            <g
-               id="g4991">
-              <g
-                 id="g4993">
-                <g
-                   id="g4995">
-                  <g
-                     id="g4997">
-                    <path
-                       style="fill:url(#radialGradient8838)"
-                       inkscape:connector-curvature="0"
-                       d="m 275,984 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 l -11.1,0.002 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 h -11.2 z"
-                       id="path4999" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7881">
-          <path
-             style="fill:url(#linearGradient8840)"
-             inkscape:connector-curvature="0"
-             d="m 346,929 2.77,0 0,-17.2 17.2,0 0,17.2 3.07,0 -11.5,11.5 -11.5,-11.5 z"
-             id="path7889" />
-        </g>
-        <g
-           id="g7907">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath7903)"
-             id="g7909">
-            <g
-               transform="translate(406.8271,782.3682)"
-               id="g7911">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.051,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path7913" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7933">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7919)"
-             id="g7935">
-            <g
-               id="g7937">
-              <g
-                 id="g7939">
-                <g
-                   id="g7941">
-                  <g
-                     id="g7943">
-                    <path
-                       style="fill:url(#radialGradient8842)"
-                       inkscape:connector-curvature="0"
-                       d="m 368,713 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0.003 -22.2,9.11 -23.7,20.9 l 12,-0.002 -35.6,35.6 -35.6,-35.6 11.3,-0.002 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.012 44,13.9 53.4,34 l -17.8,17.8 z"
-                       id="path7945" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7965">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7951)"
-             id="g7967">
-            <g
-               id="g7969">
-              <g
-                 id="g7971">
-                <g
-                   id="g7973">
-                  <g
-                     id="g7975">
-                    <path
-                       style="fill:url(#radialGradient8844)"
-                       inkscape:connector-curvature="0"
-                       d="m 418,724 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.005 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.006 22.1,-8.99 23.7,-20.7 H 358 l 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 -11.2,0.002 z"
-                       id="path7977" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           style="fill:#2f2d2e;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 326,919 62.1,0 c 1.63,0 2.95,-1.32 2.95,-2.95 v -62.1 c 0,-1.63 -1.32,-2.96 -2.95,-2.96 H 326 c -1.63,0 -2.95,1.32 -2.95,2.96 v 62.1 c 0,1.63 1.32,2.95 2.95,2.95"
-           id="path8061" />
-        <path
-           style="fill:#c8c7c6;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 350,883 -2.78,-9.4 7.16,-3.94 2.89,11 -7.27,2.36 z m -1.79,16.9 -3.03,-12.3 1.96,-0.745 11.1,-3.97 2.99,9.89 -13,7.07 z m 12.8,13.2 c -1.15,0.022 -2.18,-0.468 -2.61,-1.87 l -4.04,-13.6 6.49,-3.55 2.8,10.6 c 0.795,1.24 1.93,0.76 3.16,0.014 l 9.6,-6.33 c 0.85,-0.699 1.4,-1.66 1.35,-3.17 l -0.592,-8.39 c -0.113,-1.18 -0.826,-1.89 -1.37,-1.78 l -15.2,8.23 -2.69,-10.2 3.7,-1.34 v -0.006 l 15.2,-5.49 c 2.26,-0.825 4.28,1.66 4.36,5.4 l 0.065,13.4 c -0.049,3.31 -1.64,5.1 -3.24,6.39 l -12.7,9.9 c -1.06,0.865 -2.79,1.75 -4.3,1.77"
-           id="path8065" />
-        <path
-           style="fill:#658acf;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 346,897 -1.31,0.756 1.16,4.26 -2.92,1.59 -6.44,-2.74 -8.89,2.35 7.9,-5.35 3.09,-7.39 4,-1.32 1.26,4.74 1.24,-0.196 0.906,3.31 z"
-           id="path8069" />
-        <path
-           style="fill:#c8c7c6;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 376,862 2.56,0 c 0.279,0 0.5,-0.107 0.695,-0.297 0.1,-0.088 0.176,-0.199 0.215,-0.314 0.051,-0.118 0.084,-0.246 0.084,-0.387 v -0.914 c 0,-0.135 -0.033,-0.266 -0.084,-0.395 -0.039,-0.107 -0.115,-0.209 -0.215,-0.298 -0.195,-0.194 -0.416,-0.299 -0.695,-0.299 H 376 c -0.275,0 -0.504,0.105 -0.693,0.299 -0.104,0.089 -0.174,0.191 -0.225,0.298 -0.039,0.129 -0.078,0.26 -0.078,0.395 v 0.914 c 0,0.141 0.039,0.269 0.078,0.387 0.051,0.115 0.121,0.226 0.225,0.314 0.189,0.19 0.418,0.297 0.693,0.297 m -12.4,0 2.56,0 c 0.276,0 0.497,-0.107 0.688,-0.297 0.191,-0.187 0.309,-0.426 0.309,-0.701 v -0.914 c 0,-0.277 -0.118,-0.526 -0.309,-0.693 -0.184,-0.192 -0.41,-0.299 -0.676,-0.299 h -3.57 v 0.992 0.521 0.393 c 0,0.141 0.035,0.269 0.084,0.387 0.051,0.115 0.129,0.226 0.228,0.314 0.176,0.19 0.403,0.297 0.684,0.297 m -15,0 2.55,0 c 0.287,0 0.506,-0.107 0.701,-0.297 0.096,-0.088 0.166,-0.199 0.213,-0.314 0.053,-0.118 0.082,-0.246 0.082,-0.379 h -4.54 c 0,0.133 0.033,0.261 0.08,0.379 0.051,0.115 0.121,0.226 0.219,0.314 0.189,0.19 0.426,0.297 0.695,0.297 m -7.51,0 2.54,0 c 0.281,0 0.519,-0.107 0.715,-0.297 0.197,-0.187 0.281,-0.426 0.281,-0.701 v -0.914 c 0,-0.277 -0.084,-0.526 -0.281,-0.693 -0.196,-0.194 -0.434,-0.299 -0.715,-0.299 h -1.89 -1.64 v 0.992 0.521 0.393 c 0,0.141 0.02,0.269 0.073,0.387 0.062,0.115 0.135,0.226 0.224,0.314 0.18,0.19 0.42,0.297 0.7,0.297 m -7.52,0 2.54,0 c 0.277,0 0.522,-0.107 0.709,-0.297 0.088,-0.088 0.158,-0.199 0.215,-0.314 0.051,-0.118 0.074,-0.246 0.074,-0.387 v -0.914 c 0,-0.135 -0.023,-0.266 -0.074,-0.395 -0.057,-0.107 -0.127,-0.209 -0.215,-0.298 -0.187,-0.194 -0.432,-0.299 -0.709,-0.299 h -0.318 -2.22 c -0.281,0 -0.514,0.105 -0.713,0.299 -0.082,0.089 -0.158,0.191 -0.209,0.298 -0.057,0.129 -0.074,0.26 -0.074,0.395 v 0.914 c 0,0.141 0.017,0.269 0.074,0.387 0.051,0.115 0.127,0.226 0.209,0.314 0.199,0.19 0.432,0.297 0.713,0.297 m 42.4,1.04 c -0.278,0 -0.543,-0.049 -0.795,-0.166 -0.233,-0.088 -0.453,-0.242 -0.619,-0.42 -0.194,-0.189 -0.34,-0.406 -0.457,-0.652 -0.106,-0.254 -0.141,-0.52 -0.141,-0.793 v -0.93 c 0,-0.281 0.035,-0.547 0.141,-0.795 0.117,-0.242 0.263,-0.455 0.457,-0.642 0.166,-0.178 0.386,-0.332 0.619,-0.426 0.252,-0.115 0.517,-0.16 0.795,-0.16 h 2.69 c 0.277,0 0.543,0.045 0.791,0.16 0.236,0.094 0.459,0.248 0.637,0.426 0.189,0.187 0.334,0.4 0.445,0.642 0.096,0.248 0.147,0.514 0.147,0.795 v 0.93 c 0,0.273 -0.051,0.539 -0.147,0.793 -0.111,0.246 -0.256,0.463 -0.445,0.652 -0.178,0.178 -0.401,0.332 -0.637,0.42 -0.248,0.117 -0.514,0.166 -0.791,0.166 h -2.69 z m -27.4,0 c -0.274,0 -0.539,-0.049 -0.797,-0.166 -0.236,-0.088 -0.451,-0.242 -0.625,-0.42 -0.186,-0.189 -0.34,-0.406 -0.447,-0.652 -0.108,-0.252 -0.156,-0.508 -0.156,-0.785 v -0.93 c 0,-0.277 0.048,-0.541 0.156,-0.795 0.107,-0.244 0.261,-0.463 0.447,-0.65 0.174,-0.178 0.389,-0.332 0.625,-0.426 0.258,-0.115 0.523,-0.16 0.797,-0.16 h 4.11 v 1.04 h -4.05 c -0.269,0 -0.506,0.105 -0.695,0.299 -0.074,0.078 -0.133,0.16 -0.18,0.257 -0.058,0.096 -0.091,0.203 -0.107,0.303 h 5.63 v 1.06 c 0,0.277 -0.051,0.533 -0.145,0.785 -0.117,0.246 -0.254,0.463 -0.449,0.652 -0.182,0.178 -0.4,0.332 -0.644,0.42 -0.233,0.117 -0.5,0.166 -0.791,0.166 h -2.68 z m -15,0 c -0.291,0 -0.555,-0.049 -0.793,-0.166 -0.25,-0.088 -0.459,-0.242 -0.645,-0.42 -0.183,-0.189 -0.336,-0.406 -0.445,-0.652 -0.1,-0.254 -0.153,-0.52 -0.153,-0.793 v -0.93 c 0,-0.281 0.053,-0.547 0.153,-0.795 0.109,-0.242 0.262,-0.455 0.445,-0.642 0.186,-0.178 0.395,-0.332 0.645,-0.426 0.238,-0.115 0.502,-0.16 0.793,-0.16 h 2.01 0.664 2.8 v -1.99 h 1.11 v 1.99 h 0.928 0.36 2.32 c 0.283,0 0.543,0.045 0.783,0.16 0.252,0.094 0.463,0.248 0.654,0.426 0.192,0.187 0.334,0.4 0.436,0.642 0.099,0.248 0.158,0.514 0.158,0.795 v 0.93 c 0,0.273 -0.059,0.539 -0.158,0.793 -0.102,0.246 -0.244,0.463 -0.436,0.652 -0.191,0.178 -0.402,0.332 -0.654,0.42 -0.24,0.117 -0.5,0.166 -0.783,0.166 h -2.68 c -0.281,0 -0.545,-0.049 -0.793,-0.166 -0.244,-0.088 -0.455,-0.242 -0.642,-0.42 -0.186,-0.189 -0.338,-0.406 -0.44,-0.652 -0.107,-0.254 -0.164,-0.52 -0.164,-0.793 v -1.91 h -1.02 c 0.027,0.062 0.068,0.127 0.087,0.189 0.112,0.248 0.165,0.514 0.165,0.795 v 0.93 c 0,0.273 -0.053,0.539 -0.165,0.793 -0.091,0.246 -0.244,0.463 -0.423,0.652 -0.192,0.178 -0.407,0.332 -0.653,0.42 -0.252,0.117 -0.517,0.166 -0.797,0.166 h -2.68 z m 35.5,-4.98 1.1,0 0,5 -1.1,0 0,-5 z m -13,5 c -0.274,0 -0.539,-0.059 -0.791,-0.182 -0.229,-0.088 -0.446,-0.242 -0.625,-0.42 -0.186,-0.189 -0.336,-0.406 -0.451,-0.652 -0.096,-0.252 -0.139,-0.508 -0.139,-0.785 v -2.96 h 1.09 v 2.95 c 0,0.273 0.113,0.513 0.301,0.707 0.08,0.09 0.197,0.158 0.302,0.213 0.121,0.052 0.244,0.074 0.381,0.074 h 2.57 c 0.132,0 0.263,-0.022 0.369,-0.074 0.121,-0.055 0.244,-0.123 0.314,-0.213 0.197,-0.194 0.301,-0.434 0.301,-0.707 v -2.95 h 0.307 0.785 0.777 v -1.99 h 1.1 v 1.99 h 0.927 2.3 0.407 c 0.265,0 0.531,0.045 0.783,0.16 0.23,0.094 0.451,0.248 0.631,0.426 0.183,0.187 0.338,0.4 0.445,0.642 0.103,0.248 0.139,0.514 0.139,0.795 v 0.93 c 0,0.273 -0.036,0.539 -0.139,0.793 -0.107,0.246 -0.262,0.463 -0.445,0.652 -0.18,0.178 -0.401,0.332 -0.631,0.42 -0.252,0.117 -0.518,0.166 -0.783,0.166 h -2.71 c -0.279,0 -0.544,-0.049 -0.792,-0.166 -0.225,-0.088 -0.438,-0.242 -0.625,-0.42 -0.19,-0.189 -0.34,-0.406 -0.456,-0.652 -0.099,-0.254 -0.15,-0.52 -0.15,-0.793 v -1.91 h -0.777 v 1.91 0.008 c 0,0.277 -0.053,0.533 -0.139,0.785 -0.119,0.246 -0.262,0.463 -0.451,0.652 -0.184,0.178 -0.406,0.332 -0.643,0.42 -0.23,0.123 -0.496,0.182 -0.777,0.182 h -2.7 z m 25.6,1.43 0,-1.22 -0.49,0 0,-1.05 0.49,0 0,-2.13 c 0,-0.281 0.06,-0.547 0.154,-0.795 0.112,-0.242 0.252,-0.455 0.438,-0.642 0.195,-0.178 0.4,-0.332 0.652,-0.426 0.236,-0.115 0.502,-0.16 0.793,-0.16 h 0.791 v 1.04 h -0.777 c -0.27,0.025 -0.504,0.129 -0.664,0.32 -0.096,0.078 -0.168,0.191 -0.213,0.307 -0.049,0.105 -0.065,0.232 -0.065,0.365 v 2.12 h 1.72 v 0.223 0.83 h -1.72 v 1.22 h -1.11 z m -10.8,0.563 0,-4.96 c 0,-0.277 0.06,-0.541 0.162,-0.795 0.1,-0.244 0.24,-0.463 0.434,-0.639 0.197,-0.183 0.398,-0.332 0.66,-0.437 0.234,-0.115 0.49,-0.16 0.777,-0.16 h 0.221 v 1.04 l -0.201,0.004 c -0.262,0.025 -0.479,0.129 -0.664,0.32 -0.088,0.078 -0.157,0.191 -0.198,0.307 -0.064,0.105 -0.068,0.232 -0.068,0.365 v 4.96 h -1.12 z m -1.86,-1.1 1.1,0 0,1.1 -1.1,0 0,-1.1 z"
-           id="path8073" />
-        <g
-           style="fill-rule:nonzero"
-           transform="translate(0,-1.6)"
-           id="g5140">
-          <path
-             style="fill:#48484a"
-             inkscape:connector-curvature="0"
-             d="m 362,739 c 9.41,-9.41 9.41,-24.7 -0.007,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.008,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
-             id="path8445" />
-          <path
-             style="fill:#ffffff"
-             inkscape:connector-curvature="0"
-             d="m 344,715 c -2.71,0 -4.96,1.43 -5.65,3.78 l 3.21,0.987 c 0.315,-1.03 1.24,-1.79 2.39,-1.79 1.2,0 2.23,0.736 2.23,2.16 0,1.76 -1.6,2.27 -3.04,2.27 -1.05,0 -2.58,-0.272 -3.63,-0.651 l 0.357,8.5 h 9.11 v -3.02 h -5.98 l -0.127,-2.35 c 0.442,0.105 1.05,0.146 1.49,0.146 2.98,0 5.38,-1.6 5.38,-4.72 0,-3.61 -2.81,-5.31 -5.73,-5.31"
-             id="path8449" />
-        </g>
-        <g
-           style="fill-rule:nonzero"
-           transform="translate(1.6,3.2)"
-           id="g5136">
-          <path
-             style="fill:#48484a"
-             inkscape:connector-curvature="0"
-             d="m 217,994 c 9.4,-9.41 9.4,-24.7 -0.008,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.008,34.1 9.4,9.41 24.7,9.41 34.1,0.008"
-             id="path8453" />
-          <path
-             style="fill:#ffffff"
-             inkscape:connector-curvature="0"
-             d="m 199,969 0,10.9 -2.77,-2.14 -1.83,2.5 4.89,3.59 3.23,0 0,-14.9 -3.53,0 z"
-             id="path8457" />
-        </g>
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 219,949 0,2.94 5.8,5.25 c 0.734,0.693 1.22,1.39 1.22,2.29 0,1.05 -0.736,1.78 -1.85,1.78 -1.18,0 -1.95,-0.924 -2.1,-2.25 l -3.38,0.461 c 0.335,3 2.77,4.79 5.67,4.79 2.73,0 5.38,-1.45 5.38,-4.56 0,-2.12 -1.24,-3.36 -2.6,-4.58 l -3.44,-3.07 h 6.07 v -3.06 h -10.8 z"
-           id="path10019" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 369,700 c -1.39,0 -2.35,-0.965 -2.35,-2.35 0,-1.28 0.924,-2.35 2.33,-2.35 1.38,0 2.33,0.967 2.33,2.37 0,1.34 -0.924,2.33 -2.31,2.33 m -0.021,-7.64 c -3.23,0 -5.86,2.06 -5.86,5.31 0,1.76 0.672,3.13 1.66,4.6 l 3.59,5.35 h 4.26 l -3.65,-5.08 -0.063,-0.105 c 0.272,0.105 0.713,0.168 1.05,0.168 2.6,0 4.87,-1.95 4.87,-4.85 0,-3.38 -2.64,-5.4 -5.86,-5.4"
-           id="path10027" />
-        <g
-           transform="translate(299.2,0)"
-           id="g5144">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath4329)"
-             id="g5146">
-            <g
-               transform="translate(284.2432,1018.4248)"
-               id="g5148">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.048,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.009,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5150" />
-            </g>
-          </g>
-        </g>
-        <g
-           transform="translate(299.2,0)"
-           id="g5152">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath4345)"
-             id="g5154">
-            <g
-               id="g5156">
-              <g
-                 id="g5158">
-                <g
-                   id="g5160">
-                  <g
-                     id="g5162">
-                    <path
-                       style="fill:url(#radialGradient8846)"
-                       inkscape:connector-curvature="0"
-                       d="m 202,949 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0.006 22.2,9.11 23.7,20.9 l -12,-0.002 35.6,35.6 35.6,-35.6 -11.3,0.002 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 L 202,949 z"
-                       id="path5164" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           transform="translate(299.2,0)"
-           id="g5166">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath4377)"
-             id="g5168">
-            <g
-               id="g5170">
-              <g
-                 id="g5172">
-                <g
-                   id="g5174">
-                  <g
-                     id="g5176">
-                    <path
-                       style="fill:url(#radialGradient8848)"
-                       inkscape:connector-curvature="0"
-                       d="m 152,960 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.01 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.008 -22.1,-8.99 -23.7,-20.6 H 212 l -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path5178" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           style="fill:#100f0d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 540,973 c 9.4,-9.41 9.4,-24.7 -0.007,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.007,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
-           id="path5180" />
-        <g
-           transform="translate(299.2,0)"
-           id="g5182">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath4925)"
-             id="g5184">
-            <g
-               transform="translate(262.6084,1040.4229)"
-               id="g5186">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path5188" />
-            </g>
-          </g>
-        </g>
-        <g
-           transform="translate(299.2,0)"
-           id="g5190">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath4941)"
-             id="g5192">
-            <g
-               id="g5194">
-              <g
-                 id="g5196">
-                <g
-                   id="g5198">
-                  <g
-                     id="g5200">
-                    <path
-                       style="fill:url(#radialGradient8851)"
-                       inkscape:connector-curvature="0"
-                       d="m 225,973 c -3.01,-9.78 -12.1,-16.9 -22.9,-16.9 -12.2,0.004 -22.2,9.11 -23.7,20.9 h 12 l -35.6,35.6 -35.6,-35.6 h 11.3 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 225,973 z"
-                       id="path5202" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           transform="translate(299.2,0)"
-           id="g5204">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath4973)"
-             id="g5206">
-            <g
-               id="g5208">
-              <g
-                 id="g5210">
-                <g
-                   id="g5212">
-                  <g
-                     id="g5214">
-                    <path
-                       style="fill:url(#radialGradient8853)"
-                       inkscape:connector-curvature="0"
-                       d="m 275,984 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.01 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.01 22.1,-8.99 23.7,-20.6 l -11.1,0.002 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 h -11.2 z"
-                       id="path5216" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           transform="translate(300.8,3.2)"
-           id="g5218">
-          <g
-             style="fill-rule:nonzero"
-             id="g5252">
-            <path
-               style="fill:#48484a"
-               inkscape:connector-curvature="0"
-               d="m 217,994 c 9.4,-9.41 9.4,-24.7 -0.008,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.008,34.1 9.4,9.41 24.7,9.41 34.1,0.008"
-               id="path5220" />
-            <path
-               style="fill:#ffffff"
-               inkscape:connector-curvature="0"
-               d="m 201,969 c -2.71,0 -5.17,1.18 -5.96,3.95 l 3.28,0.862 c 0.273,-0.987 1.18,-1.85 2.52,-1.85 1.01,0 2.16,0.504 2.16,1.89 0,1.51 -1.55,1.95 -3.02,1.95 h -0.946 v 2.58 h 1.03 c 1.32,0 2.6,0.336 2.6,1.76 0,1.07 -0.902,1.64 -1.87,1.64 -1.01,0 -1.8,-0.65 -2.04,-1.66 l -3.28,0.756 c 0.713,2.5 3.06,3.78 5.54,3.78 2.62,0 5.23,-1.34 5.23,-4.2 0,-1.64 -1.05,-2.86 -2.5,-3.24 v -0.062 c 1.68,-0.398 2.86,-1.78 2.86,-3.44 0,-3.25 -2.88,-4.72 -5.6,-4.72"
-               id="path8341-5" />
-          </g>
-        </g>
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 526,961 -0.063,0 -3.53,-5.5 3.59,0 0,5.5 z m 3.28,-8.36 0,-2.9 -3.3,0 0,2.9 -6.99,0 0,2.96 6.05,9.01 4.22,0 0,-9.11 2.06,0 0,-2.86 -2.04,0 z"
-           id="path8161-0" />
-      </g>
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 22.5;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,702 158,1.41 -0.814,-67.5 67,0"
-         id="path9850" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,743 304,0 0,-23.9"
-         id="path9852" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 22.5;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,783 764,0 0,-78.8"
-         id="path9854" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 22.5;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1820,823 801,0.222 0,-84.7"
-         id="path9856" />
-    </g>
-    <g
-       transform="matrix(0.4,0,0,0.4,-56.741854,-154.45687)"
-       id="hexa-h">
-      <g
-         transform="matrix(1.25,0,0,-1.25,-575.71068,1844.8336)"
-         id="6165">
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2480,772 c 3.92,0 7.09,2.06 7.09,4.6 0,2.54 -3.17,4.6 -7.09,4.6 h -352 c -3.92,0 -7.09,-2.06 -7.09,-4.6 0,-2.54 3.17,-4.6 7.09,-4.6 h 352 z"
-           id="path4203" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 2480,772 c 3.92,0 7.09,2.06 7.09,4.6 0,2.54 -3.17,4.6 -7.09,4.6 h -352 c -3.92,0 -7.09,-2.06 -7.09,-4.6 0,-2.54 3.17,-4.6 7.09,-4.6 h 352 z"
-           id="path4207" />
-        <g
-           id="g7099">
-          <path
-             style="fill:url(#linearGradient8855)"
-             inkscape:connector-curvature="0"
-             d="m 2290,818 2.7,0 0,-16.7 16.7,0 0,16.7 2.99,0 -11.2,11.2 -11.2,-11.2 z"
-             id="path7107" />
-        </g>
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2470,595 c 3.95,-3.95 8.6,-5.69 10.4,-3.9 1.8,1.8 0.051,6.45 -3.9,10.4 l -355,355 c -3.95,3.95 -8.6,5.69 -10.4,3.9 -1.8,-1.8 -0.053,-6.45 3.9,-10.4 l 355,-355 z"
-           id="path7119" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 2470,595 c 3.95,-3.95 8.6,-5.69 10.4,-3.9 1.8,1.8 0.051,6.45 -3.9,10.4 l -355,355 c -3.95,3.95 -8.6,5.69 -10.4,3.9 -1.8,-1.8 -0.053,-6.45 3.9,-10.4 l 355,-355 z"
-           id="path7123" />
-        <path
-           style="fill:#2e2d2d;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2470,944 c 3.9,3.9 5.6,8.51 3.8,10.3 -1.8,1.8 -6.41,0.093 -10.3,-3.8 l -350,-350 c -3.9,-3.9 -5.6,-8.51 -3.8,-10.3 1.8,-1.8 6.41,-0.093 10.3,3.8 l 350,350 z"
-           id="path7127" />
-        <path
-           style="fill:none;stroke:#2e2d2d;stroke-width:8.50399971;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-           inkscape:connector-curvature="0"
-           stroke-miterlimit="10"
-           d="m 2470,944 c 3.9,3.9 5.6,8.51 3.8,10.3 -1.8,1.8 -6.41,0.093 -10.3,-3.8 l -350,-350 c -3.9,-3.9 -5.6,-8.51 -3.8,-10.3 1.8,-1.8 6.41,-0.093 10.3,3.8 l 350,350 z"
-           id="path7131" />
-        <g
-           transform="matrix(82.988968,0,0,64.991364,2254.6221,743.15219)"
-           id="g7143">
-          <image
-             transform="matrix(1,0,0,-1,0,1)"
-             xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFMAAABBCAYAAACtrJiQAAAABHNCSVQICAgIfAhkiAAADhxJREFUeJztnGt0HOV5x38zs5fZ++rqi6z73RfJsiQjOxDbhdQ3TIAPLSTpCYXGQNKeHpKU0LRJOKXknPRDD5Rwjg9Q04T0cCnQNjUXAwZh2ZZtbMzFtizJ1gVZ1tpaSXuf3ZmdmX6QpeAaYwuvbalHvy+rM6PZeeY/z/M+z/u8MyvULVliMktGEK+1Af+fmBUzg8yKmUFmxcwgs2JmEMtUDzDN8eQvCMLk37OMM2UxYVzIz3/OMs6Uw3xWwAszZTFnQ/vCzCagDDIrZgb5SgnoWiOKIol4nHg8jtVqweX2YLFYrvkQNOM8U5IkQmOjOJxOrl+1hsrqhcRjUYLDZzBNE1G8dpc0ozxTEARGR0YoKinll48+QmlZGaGxMT49fIT/ePlV2nfvxCE78Pn96Lp+1e2bUZ5pGAaapnLnt+6kqXk5gydPomkaq9es4sknH+eBH/0IQRQ4HRhCEISrXsZJc+bMeXiqB12rWlNJJMjLn8Nd3/0zFEUhlUqh6zpjoyOkkilWr17DyhUrOHy4g96e48gOx1UdS2eMZwqCQCIRp7K6lsLCQmKx2OQ+UZRIJhW6Ojsor6jg2WefZt3GWwgOnyERjyNJ0lWxccaIOeFddXWLsdllDOPcMVEQRERRor+vl1RK5Z9+9Uv+4r7vE4tFGR0ZuSqCzpgwV1UVuyzzne98G7/XQ0JJAmCaBoIgMH/+PHLz8jEMg2AwiKqqrFu7lqKSItrb9zISHMblcl9R22eMZ8ZjMUrLK6mqrCQUDk1uFwQRn8/Lttff5LHHn2B0dJSq6moAOo8dZcOGjWzd+gwLF9dzOjBEMpm8Yl6aAc8UABNTTyMIIlzszgsCCCJ6YgRDiSBaZRAtwIWThCAIRKMR1m+8mdWrv04wGJy0IT8vj86ubh568EH272unrW0XsbjCyhUt+Hxejnd3U1RUxK23bkIzBA7s34eqqTidrownpsv3TFNHEG1YvQXoyRBaaAg9GQIjzbjQZxFEMHXSkdOoY4M4CprxLfk26cQo6WjgrKBffCPSmobT6WRp/WKSijJ+0xgPcZfHw4GDh9DTaRYsKCISCbPlySfYfN8P6OvrZ9HiJQSDZwiFw/z0oQd55NF/BNPkzOlAxj00A55pYKYVHHObKLzhYexzGtCi/aSjAfR4CDOtACbp2AimlsRZtJK5K3/O4q/fTvGyFYh5G0lGT5KODCCIX+zZsViU0rJKvnXnHSiKMlmQi6KILMu8+NLL9Pf14HA6kWUHLreb3p7jbH9zO4IksnLl17BZrfT29nLdihaamprYu28/gcAQHo/nK0p3PpcvpiCBaaIGj6JjoaZlHVU3/imuwk0IWXWYGBipMTxlaym96VFqv7aRuRXz0RQNNZxkwbIFGK4Ghg/+OxabzFgohJJQcDgck4V3JBKmsWk5N9+8kbHR0clTu9xugsFhXnzhRVQ1hc1mn9zn9XpREgnef7+VQx9/Sk1VBQsXLeHU4ElKSktZv24d+/cfpL+/F4/Hm5GQz0g2FyQLglUm/tkuTh54AYUmyprLKGlZRE5eEzkVN1O27Hqy5nhRYymSkSSmbmACkiTQ91E70RNvowk2Vq25kezcPLo7O1BTKRwOJ0oiwbr162lsXEY49Ifkk5uTw8FDH/Latm04nK5z5uWmaSI7HDidTo53dbJ9+9skVY1lDfXoaQ2Hw8natTfR2trGmdNDOF2XP4ZmtDSyOvxg6ox1vMzJj1sxLMvJKfRjEUXUhEYqlsI0zMmR0WIRSSsaPTt/TTISAIudR/7hF9x99914/T4GBgbpOdGN35/Nw7/4OQIQjUYQBBHTNMjNy2fHu63sa9+D231+uJqmiSAIeL0+kqkku9t2smvPXhobG3G5nPizsikomM87b7+NJEmX3STJaGlkGGkEuxtbdgHqaA9Hn7uFI7s+RLKKmLpxXnoRLRJKMo0eHyKVNigsLMHhcDJ8JsCdd97B009tYfP9f4nT6WTrvz0HQElp2eTNVNUUPT29F7VL13Xcbg9z582ns+MIP/27nxGPJxgdCbJsaT2L6pYSjUYu+/ozX2eaJpgGVt88JKuNwR0/JDSqYHfbz/tXTU3j8dqpumULaUOguDCfvPx8QqEwx7u6ME2Tnzz4Yx5//DH6+/u5+557eeHFF1lQWEhZeQVDp4Y43t2FLDsuwSwT0zSZM3cevT3Had3ZhtvjweFyU15RSTqdvuxLv2JFu2noSO48jFSSzzr3Y/Xaz6kkTUEAw8TilTGtEoKpU1VTg2QZL1dEUSIajdBx5DALCubz6yce47bbb+XNN95i873389GhQwwHgwSGBnE4Li7m5xEFkVgsjiiOn8vtcmXkmq9sP9M0Ea12wkefJ1m3AqtNIq3qk/sESUS0WRj85C1kSaCmZhFKLD55uCCICAKcGR5GCI5w+2238s1NN/Psb57jN797noH+PmLRKM6zyccwjEswyUSySHg8LgxDR5IsmObFj7sUrnBz2ERyZaOcOkLviR5qmxcTDUQRAJvdQkLR2P2vDxPofIfyqlpKy0oJR84fuyaK9M/6+7BYrGz+3j2MjY6yc9dutm9/i317dmG1WsnKzhk/65dkZdM0kSQJj9uNaRggfdnca2pc+bm5IIAoMnLkeXRFQ5JETMDmlRkZjRPu2IaaUiivbSAnJ5dUKnVhY0UJwzDo7+slHo/zzVs28S+P/zN/+/c/o6i4jEBgiHA4hCiKF6w4TMPAarXhcrkmi/9MTSuvvJimicWdQ7xvF4ODEXxVuTh9MoJVJDzQDqKAINmpriieHC8vhiCMh3Rfbw/B4SB33PEnPPPMFv7qrx8gOzuHoVODxGOxL5wu6oaBzWZDlmU0LT2emIyZIiYgSDZEi4UTr/+Qg6++zXAgih5XUc4cQDcF/D4fNTXVJKLRKX2vKEqoqsrxri60tM59927m6ae38N27v4dksTB0ahBVVc8t5g0Du92Oy+lA18czuDEzxsyzmAaSMxctMsDgjr/htNOHPLcBLdyLKtgoKiikvr4Ot8eLqmmEw5GzfcpLu9eiKBGLRuiKhMnOzuahhx5kw9obeWrrb9nT1ko4NIbPn4Usy+iGjs0uY7fLpPXMiDjB1WsOmwaiRUZy+AADbeQ4iCIWu4O0pnLg4EecGjpFTlYW5RUVeDxeVFVF09RLOt/4PF5EURSCw2dYUFjIhvXrWNrQgI5E97GjhCNhTMMkJyePTZvWI4giTqeL9r37OfzJRzgvs0S6+ku9poEg2ZDcuQDYJYlUKsXune/R1rqDl+YXsKz5Ola2NNPc3Ex5ZSWJWIzh4DBpLX1Rb50opwKBAKIoUV+3hOXLl9O+YS2//d3zvLdjOwWFheTlzyEwFBhPPhlKQNd83VzXdSRJIjcvH4BIOMy2/3qFN1/7PZWVNTQub2bFdc001Nfj9nkZDQYJhyMYhv6lwo7P300GBwcRRYmm5mYaGhrY9voaykqKz37HeJhnqs6cdmtAssOB3WZHSSQYHBzgw4Mf8H5rK4c+OUJobAyvx01xSQnZubmIgoCqqmeF/WKbJraHQmMkUwqNjcuQZZmxsTEkScLr89G+dx+HP/3kssN82okZjUQoLi3n/h98H5fbh9VqIxwK0dV5lLa2nezZs5cjHZ2EQiHsNgvFxcXk5OWhaSqapk0usJ1vs4hpmEQjUVRVnSybvD4fe/d9wOFPPp6BY+aXMLE2Xrd0Kfdu3syG9Ws5fTpAT08fe/d9wMEPDnBqcIB3tr/Bu29tx5+VxeK6paxZs4rGZfWUlJaiqilGgiMkk8olVwP/d9n4qzKtxEyn08iyTN2SWgYG+hk6NYTskFmxooXVq1cTj0Z54Mc/4dCBffizskkmk7S17mDX++9RVFJKY1MzK1uaqa+vZ35BAbFImODI6JeOr4ahMzYWyki0TSsxlUSCgsJiaqtrCIVCmKaJklBIxOO4PV4MQyc0OorFYgVAlmUcDgeGYRAYGuSVl46z7b9fpbyyhutaWlh1w0pqF9Zis9kZCQaJRqPn1K9Ol5NwOEJfTw82+/ktwqkyrcRMJhVqFi5ifkEBJwcGJrdPrI3v2PEu/X0ncH2uqz7RTfd4vPh8fjRNo7vzKEcPf8x/vvISi+saWLniOpoal1FeUQHAyMgIaU2jqrqWrVu30t11jOycnMu2f1qJCVBdVX72Yas/eJBpGthsdjqOdZNKpfD5s76wOWEYBpIkTXaPkskku3e+x+6d7zFvfgH1DY20tDRTv2QJebm5vLbtf3hqyxZsdhuiKF52w2PaiKlpKm6Pl4rycuJn13kmsNmshMZGOXL4MBaL9aIXPbHfbrcj58/BNE3CoRBvvPZ73tn+OkXFZfj8fjo7jmAYBllZ2RnptE8bMePxOLULF1NdVUU4cm7Dw+320tPTQ39fz5TLlwlhnS4XLrcbXdcZGjrJZ5/14nK5xufoGRASptGzRpqq8o1v3ERVTS3JpHLOrMTldtPT1084FMJms33lc0w8pu1yufH7s7BabZfUnb9UpoWYpmnicDjZt/8Ae3a1UVVdy7x58xAEAcPQsVgsnBoKkNbT0/qlrmkR5oIg4PP7ad+9k48OfsCmW2/jj2/6I5bU1WEYOkoizrGOY4iXWIRfK4Sp/qzERClyJZAkiXgsRjQaweVy03L9Ddy/+R5cLjd33fXnJOJx5CmuRF5NppWYE4jieF8yEg6Rm5dPWUUVJ7o7r+lrKZfCtBRzAlEUSSQSJJMKfn/WtH8te1qMmRfCMAxkWUaWZWD6vwQ7veNmhjErZgaZFTODzIqZQWbFzCBfKZtP96x6rZiymNN5bnytmQ3zDDIrZgaZFTOD/C9uew7sSK2nLAAAAABJRU5ErkJggg=="
-             width="1"
-             height="1"
-             id="image7145" />
-        </g>
-        <g
-           id="g7163">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath7159)"
-             id="g7165">
-            <g
-               transform="translate(2538.3311,837.6123)"
-               id="g7167">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path7169" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7189">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7175)"
-             id="g7191">
-            <g
-               id="g7193">
-              <g
-                 id="g7195">
-                <g
-                   id="g7197">
-                  <g
-                     id="g7199">
-                    <path
-                       style="fill:url(#radialGradient8857)"
-                       inkscape:connector-curvature="0"
-                       d="m 2460,771 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0.004 22.2,9.11 23.7,20.9 l -12,-10e-4 35.6,35.6 35.6,-35.6 h -11.3 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 l 17.8,17.8 z"
-                       id="path7201" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7221">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7207)"
-             id="g7223">
-            <g
-               id="g7225">
-              <g
-                 id="g7227">
-                <g
-                   id="g7229">
-                  <g
-                     id="g7231">
-                    <path
-                       style="fill:url(#radialGradient8859)"
-                       inkscape:connector-curvature="0"
-                       d="m 2410,781 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.006 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.009 -22.1,-8.99 -23.7,-20.7 l 11.1,0.002 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path7233" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7243">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath7239)"
-             id="g7245">
-            <g
-               transform="translate(2538.3311,657.5947)"
-               id="g7247">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path7249" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7269">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7255)"
-             id="g7271">
-            <g
-               id="g7273">
-              <g
-                 id="g7275">
-                <g
-                   id="g7277">
-                  <g
-                     id="g7279">
-                    <path
-                       style="fill:url(#radialGradient8861)"
-                       inkscape:connector-curvature="0"
-                       d="m 2500,588 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0.004 -22.2,9.11 -23.7,20.9 l 12,-10e-4 -35.6,35.6 -35.6,-35.6 h 11.3 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.011 44,13.9 53.4,34 l -17.8,17.8 z"
-                       id="path7281" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7301">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7287)"
-             id="g7303">
-            <g
-               id="g7305">
-              <g
-                 id="g7307">
-                <g
-                   id="g7309">
-                  <g
-                     id="g7311">
-                    <path
-                       style="fill:url(#radialGradient8863)"
-                       inkscape:connector-curvature="0"
-                       d="m 2550,599 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.006 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.008 22.1,-8.99 23.7,-20.6 l -11.1,10e-4 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 h -11.2 z"
-                       id="path7313" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7323">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath7319)"
-             id="g7325">
-            <g
-               transform="translate(2538.3252,1017.5234)"
-               id="g7327">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c 33.2,-33.2 33.2,-87.1 -0.049,-120 -33.2,-33.2 -87.1,-33.2 -120,0 -33.2,33.2 -33.2,87 0.008,120 32.9,33.2 86.8,33.2 120,0"
-                 id="path7329" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7349">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7335)"
-             id="g7351">
-            <g
-               id="g7353">
-              <g
-                 id="g7355">
-                <g
-                   id="g7357">
-                  <g
-                     id="g7359">
-                    <path
-                       style="fill:url(#radialGradient8865)"
-                       inkscape:connector-curvature="0"
-                       d="m 2500,950 c -3.01,-9.78 -12.1,-16.9 -22.9,-16.9 -12.2,0.005 -22.2,9.11 -23.7,20.9 h 12 l -35.6,35.6 -35.6,-35.6 h 11.3 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 L 2500,950 z"
-                       id="path7361" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7381">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7367)"
-             id="g7383">
-            <g
-               id="g7385">
-              <g
-                 id="g7387">
-                <g
-                   id="g7389">
-                  <g
-                     id="g7391">
-                    <path
-                       style="fill:url(#radialGradient8867)"
-                       inkscape:connector-curvature="0"
-                       d="m 2550,961 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.009 22.1,-8.99 23.7,-20.6 l -11.1,10e-4 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 h -11.2 z"
-                       id="path7393" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2500,974 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.4,9.41 24.7,9.41 34.1,0.008"
-           id="path7397" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2480,949 0,10.9 -2.77,-2.14 -1.83,2.5 4.89,3.59 3.23,0 0,-14.9 -3.53,0 z"
-           id="path7401" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2496,795 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
-           id="path7405" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2470,770 0,2.94 5.8,5.25 c 0.735,0.694 1.22,1.39 1.22,2.29 0,1.05 -0.735,1.78 -1.85,1.78 -1.18,0 -1.95,-0.924 -2.1,-2.25 l -3.38,0.463 c 0.336,3 2.77,4.79 5.67,4.79 2.73,0 5.38,-1.45 5.38,-4.56 0,-2.12 -1.24,-3.36 -2.6,-4.58 l -3.44,-3.07 h 6.07 v -3.06 h -10.8 z"
-           id="path7409" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2490,613 c 9.4,-9.41 9.4,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
-           id="path7413" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2480,588 c -2.71,0 -5.16,1.18 -5.96,3.95 l 3.28,0.861 c 0.273,-0.987 1.18,-1.85 2.52,-1.85 1.01,0 2.16,0.504 2.16,1.89 0,1.51 -1.56,1.95 -3.02,1.95 h -0.946 v 2.58 h 1.03 c 1.32,0 2.6,0.336 2.6,1.76 0,1.07 -0.903,1.64 -1.87,1.64 -1.01,0 -1.81,-0.65 -2.04,-1.66 l -3.28,0.756 c 0.714,2.5 3.07,3.78 5.54,3.78 2.62,0 5.23,-1.34 5.23,-4.2 0,-1.64 -1.05,-2.86 -2.5,-3.23 v -0.063 c 1.68,-0.398 2.86,-1.78 2.86,-3.44 0,-3.25 -2.88,-4.72 -5.61,-4.72"
-           id="path7417" />
-        <g
-           id="g7427">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath7423)"
-             id="g7429">
-            <g
-               transform="translate(2056.7451,837.6123)"
-               id="g7431">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c -33.2,-33.2 -33.2,-87.1 0.049,-120 33.2,-33.2 87.1,-33.2 120,0 33.2,33.2 33.2,87 -0.008,120 -32.9,33.2 -86.8,33.2 -120,0"
-                 id="path7433" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7453">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7439)"
-             id="g7455">
-            <g
-               id="g7457">
-              <g
-                 id="g7459">
-                <g
-                   id="g7461">
-                  <g
-                     id="g7463">
-                    <path
-                       style="fill:url(#radialGradient8869)"
-                       inkscape:connector-curvature="0"
-                       d="m 2140,771 c -3.01,-9.77 -12.1,-16.9 -22.9,-16.9 -12.2,0.004 -22.2,9.11 -23.7,20.9 l 12,-10e-4 -35.6,35.6 -35.6,-35.6 h 11.3 c 1.64,-31.1 27.4,-55.8 58.9,-55.8 23.6,-0.01 44,13.9 53.4,34 l -17.8,17.8 z"
-                       id="path7465" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7485">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7471)"
-             id="g7487">
-            <g
-               id="g7489">
-              <g
-                 id="g7491">
-                <g
-                   id="g7493">
-                  <g
-                     id="g7495">
-                    <path
-                       style="fill:url(#radialGradient8871)"
-                       inkscape:connector-curvature="0"
-                       d="m 2190,781 c -1.3,31.4 -27.2,56.5 -58.9,56.5 -23.8,0.006 -44.4,-14.1 -53.7,-34.5 l 17.4,-17.4 c 3.24,9.35 12.1,16.1 22.6,16.1 12.1,0.009 22.1,-8.99 23.7,-20.7 l -11.1,0.002 10.3,-10.3 17.8,-17.8 7.46,-7.46 35.6,35.6 h -11.2 z"
-                       id="path7497" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7507">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath7503)"
-             id="g7509">
-            <g
-               transform="translate(2056.7451,657.5947)"
-               id="g7511">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c -33.2,-33.2 -33.2,-87.1 0.049,-120 33.2,-33.2 87.1,-33.2 120,0 33.2,33.2 33.2,87 -0.008,120 -32.9,33.2 -86.8,33.2 -120,0"
-                 id="path7513" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7533">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7519)"
-             id="g7535">
-            <g
-               id="g7537">
-              <g
-                 id="g7539">
-                <g
-                   id="g7541">
-                  <g
-                     id="g7543">
-                    <path
-                       style="fill:url(#radialGradient8873)"
-                       inkscape:connector-curvature="0"
-                       d="m 2100,588 c 3.01,-9.77 12.1,-16.9 22.9,-16.9 12.2,0.004 22.2,9.11 23.7,20.9 l -12,-10e-4 35.6,35.6 35.6,-35.6 h -11.3 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.011 -44,13.9 -53.4,34 l 17.8,17.8 z"
-                       id="path7545" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7565">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7551)"
-             id="g7567">
-            <g
-               id="g7569">
-              <g
-                 id="g7571">
-                <g
-                   id="g7573">
-                  <g
-                     id="g7575">
-                    <path
-                       style="fill:url(#radialGradient8875)"
-                       inkscape:connector-curvature="0"
-                       d="m 2050,599 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0.006 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.008 -22.1,-8.99 -23.7,-20.6 l 11.1,10e-4 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path7577" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7587">
-          <g
-             style="opacity:0.5"
-             clip-path="url(#clipPath7583)"
-             id="g7589">
-            <g
-               transform="translate(2056.7471,1017.5234)"
-               id="g7591">
-              <path
-                 style="fill:#b1c7eb;fill-rule:nonzero"
-                 inkscape:connector-curvature="0"
-                 d="m 0,0 c -33.2,-33.2 -33.2,-87.1 0.049,-120 33.2,-33.2 87.1,-33.2 120,0 33.2,33.2 33.2,87 -0.008,120 -32.9,33.2 -86.8,33.2 -120,0"
-                 id="path7593" />
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7613">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7599)"
-             id="g7615">
-            <g
-               id="g7617">
-              <g
-                 id="g7619">
-                <g
-                   id="g7621">
-                  <g
-                     id="g7623">
-                    <path
-                       style="fill:url(#radialGradient8877)"
-                       inkscape:connector-curvature="0"
-                       d="m 2090,950 c 3.01,-9.78 12.1,-16.9 22.9,-16.9 12.2,0.005 22.2,9.11 23.7,20.9 h -12 l 35.6,35.6 35.6,-35.6 h -11.3 c -1.64,-31.1 -27.4,-55.8 -58.9,-55.8 -23.6,-0.01 -44,13.9 -53.4,34 L 2090,950 z"
-                       id="path7625" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <g
-           id="g7645">
-          <g
-             style="opacity:0.69999701"
-             clip-path="url(#clipPath7631)"
-             id="g7647">
-            <g
-               id="g7649">
-              <g
-                 id="g7651">
-                <g
-                   id="g7653">
-                  <g
-                     id="g7655">
-                    <path
-                       style="fill:url(#radialGradient8879)"
-                       inkscape:connector-curvature="0"
-                       d="m 2040,961 c 1.3,31.4 27.2,56.5 58.9,56.5 23.8,0 44.4,-14.1 53.7,-34.5 l -17.4,-17.4 c -3.24,9.35 -12.1,16.1 -22.6,16.1 -12.1,0.009 -22.1,-8.99 -23.7,-20.6 l 11.1,10e-4 -10.3,-10.3 -17.8,-17.8 -7.46,-7.46 -35.6,35.6 h 11.2 z"
-                       id="path7657" />
-                  </g>
-                </g>
-              </g>
-            </g>
-          </g>
-        </g>
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2134,974 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.4,9.41 -9.4,24.7 0.01,34.1 9.4,9.41 24.7,9.41 34.1,0.008"
-           id="path7661" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2120,957 c -1.38,0 -2.35,-0.966 -2.35,-2.35 0,-1.28 0.924,-2.35 2.33,-2.35 1.39,0 2.33,0.966 2.33,2.37 0,1.34 -0.924,2.33 -2.31,2.33 m -0.021,-7.64 c -3.23,0 -5.86,2.06 -5.86,5.31 0,1.76 0.672,3.13 1.66,4.6 l 3.59,5.35 h 4.26 l -3.65,-5.08 -0.063,-0.104 c 0.273,0.104 0.715,0.168 1.05,0.168 2.6,0 4.87,-1.95 4.87,-4.85 0,-3.38 -2.65,-5.4 -5.86,-5.4"
-           id="path7665" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2138,795 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
-           id="path7669" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2120,770 c -2.71,0 -4.96,1.43 -5.65,3.78 l 3.21,0.988 c 0.315,-1.03 1.24,-1.78 2.39,-1.78 1.2,0 2.23,0.735 2.23,2.16 0,1.76 -1.6,2.27 -3.04,2.27 -1.05,0 -2.58,-0.273 -3.63,-0.65 l 0.357,8.5 h 9.11 v -3.02 h -5.98 l -0.127,-2.35 c 0.442,0.104 1.05,0.147 1.49,0.147 2.98,0 5.38,-1.6 5.38,-4.72 0,-3.61 -2.81,-5.31 -5.73,-5.31"
-           id="path7673" />
-        <path
-           style="fill:#48484a;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2138,613 c 9.41,-9.41 9.41,-24.7 -0.01,-34.1 -9.41,-9.41 -24.7,-9.41 -34.1,0 -9.41,9.41 -9.41,24.7 0.01,34.1 9.41,9.41 24.7,9.41 34.1,0.008"
-           id="path7677" />
-        <path
-           style="fill:#ffffff;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2120,599 -0.063,0 -3.53,-5.5 3.59,0 0,5.5 z m 3.28,-8.36 0,-2.9 -3.3,0 0,2.9 -6.99,0 0,2.96 6.05,9.01 4.22,0 0,-9.11 2.06,0 0,-2.86 -2.04,0 z"
-           id="path7681" />
-        <path
-           style="fill:#2f2d2e;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2270,809 62.1,0 c 1.63,0 2.95,-1.32 2.95,-2.95 v -62.1 c 0,-1.63 -1.32,-2.95 -2.95,-2.95 H 2270 c -1.63,0 -2.95,1.32 -2.95,2.95 v 62.1 c 0,1.63 1.32,2.95 2.95,2.95"
-           id="path7685" />
-        <path
-           style="fill:#c8c7c6;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2290,774 -2.78,-9.4 7.16,-3.94 2.89,11 -7.27,2.36 z m -1.79,16.9 -3.04,-12.3 1.96,-0.745 11.1,-3.97 2.99,9.89 -13,7.07 z m 12.8,13.2 c -1.15,0.022 -2.18,-0.468 -2.61,-1.87 l -4.04,-13.6 6.49,-3.55 2.8,10.6 c 0.793,1.24 1.93,0.761 3.16,0.014 l 9.6,-6.33 c 0.848,-0.699 1.4,-1.66 1.35,-3.17 l -0.592,-8.39 c -0.113,-1.18 -0.826,-1.89 -1.37,-1.78 l -15.2,8.23 -2.69,-10.2 3.7,-1.34 v -0.006 l 15.2,-5.49 c 2.26,-0.824 4.28,1.66 4.36,5.4 l 0.065,13.4 c -0.049,3.31 -1.64,5.1 -3.24,6.39 l -12.7,9.9 c -1.06,0.864 -2.79,1.74 -4.3,1.77"
-           id="path7689" />
-        <path
-           style="fill:#658acf;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2290,787 -1.31,0.757 1.16,4.26 -2.92,1.59 -6.44,-2.74 -8.88,2.35 7.89,-5.36 3.1,-7.39 4,-1.32 1.26,4.74 1.24,-0.195 0.908,3.31 z"
-           id="path7693" />
-        <path
-           style="fill:#c8c7c6;fill-rule:nonzero"
-           inkscape:connector-curvature="0"
-           d="m 2320,752 2.56,0 c 0.281,0 0.5,-0.107 0.695,-0.296 0.102,-0.089 0.176,-0.2 0.215,-0.314 0.051,-0.119 0.086,-0.246 0.086,-0.387 v -0.914 c 0,-0.135 -0.035,-0.266 -0.086,-0.396 -0.039,-0.106 -0.113,-0.209 -0.215,-0.298 -0.195,-0.194 -0.414,-0.299 -0.695,-0.299 H 2320 c -0.275,0 -0.504,0.105 -0.691,0.299 -0.104,0.089 -0.176,0.192 -0.225,0.298 -0.041,0.13 -0.08,0.261 -0.08,0.396 v 0.914 c 0,0.141 0.039,0.268 0.08,0.387 0.049,0.114 0.121,0.225 0.225,0.314 0.187,0.189 0.416,0.296 0.691,0.296 m -12.4,0 2.56,0 c 0.278,0 0.498,-0.107 0.69,-0.296 0.191,-0.187 0.307,-0.427 0.307,-0.701 v -0.914 c 0,-0.277 -0.116,-0.527 -0.307,-0.694 -0.184,-0.191 -0.41,-0.298 -0.676,-0.299 h -3.57 v 0.993 0.521 0.393 c 0,0.141 0.033,0.268 0.082,0.387 0.051,0.114 0.131,0.225 0.23,0.314 0.174,0.189 0.401,0.296 0.682,0.296 m -15,0 2.55,0 c 0.287,0 0.508,-0.107 0.703,-0.296 0.096,-0.089 0.164,-0.2 0.213,-0.314 0.053,-0.119 0.082,-0.246 0.082,-0.38 h -4.54 c 0,0.134 0.035,0.261 0.082,0.38 0.049,0.114 0.121,0.225 0.217,0.314 0.191,0.189 0.428,0.296 0.697,0.296 m -7.51,0 2.54,0 c 0.281,0 0.521,-0.107 0.715,-0.296 0.197,-0.187 0.281,-0.427 0.281,-0.701 v -0.914 c 0,-0.277 -0.084,-0.527 -0.281,-0.694 -0.194,-0.194 -0.434,-0.299 -0.715,-0.299 h -1.89 -1.64 v 0.993 0.521 0.393 c 0,0.141 0.018,0.268 0.071,0.387 0.062,0.114 0.135,0.225 0.226,0.314 0.18,0.189 0.418,0.296 0.7,0.296 m -7.52,0 2.54,0 c 0.275,0 0.52,-0.107 0.709,-0.296 0.088,-0.089 0.158,-0.2 0.213,-0.314 0.053,-0.119 0.074,-0.246 0.074,-0.387 v -0.914 c 0,-0.135 -0.021,-0.266 -0.074,-0.396 -0.055,-0.106 -0.125,-0.209 -0.213,-0.298 -0.189,-0.194 -0.434,-0.299 -0.709,-0.299 h -0.318 -2.22 c -0.283,0 -0.516,0.105 -0.713,0.299 -0.082,0.089 -0.158,0.192 -0.211,0.298 -0.055,0.13 -0.072,0.261 -0.072,0.396 v 0.914 c 0,0.141 0.017,0.268 0.072,0.387 0.053,0.114 0.129,0.225 0.211,0.314 0.197,0.189 0.43,0.296 0.713,0.296 m 42.4,1.04 c -0.28,0 -0.543,-0.05 -0.797,-0.167 -0.231,-0.088 -0.451,-0.241 -0.619,-0.419 -0.192,-0.19 -0.338,-0.406 -0.456,-0.652 -0.107,-0.255 -0.14,-0.521 -0.14,-0.794 v -0.929 c 0,-0.282 0.033,-0.548 0.14,-0.795 0.118,-0.243 0.264,-0.456 0.456,-0.642 0.168,-0.179 0.388,-0.332 0.619,-0.427 0.254,-0.115 0.517,-0.159 0.797,-0.159 h 2.69 c 0.277,0 0.543,0.044 0.791,0.159 0.236,0.095 0.457,0.248 0.637,0.427 0.187,0.186 0.332,0.399 0.443,0.642 0.098,0.247 0.148,0.513 0.148,0.795 v 0.929 c 0,0.273 -0.05,0.539 -0.148,0.794 -0.111,0.246 -0.256,0.462 -0.443,0.652 -0.18,0.178 -0.401,0.331 -0.637,0.419 -0.248,0.117 -0.514,0.167 -0.791,0.167 h -2.69 z m -27.4,0 c -0.274,0 -0.539,-0.05 -0.797,-0.167 -0.238,-0.088 -0.453,-0.241 -0.625,-0.419 -0.186,-0.19 -0.34,-0.406 -0.449,-0.652 -0.108,-0.252 -0.156,-0.509 -0.156,-0.786 v -0.929 c 0,-0.277 0.048,-0.542 0.156,-0.796 0.109,-0.243 0.263,-0.463 0.449,-0.649 0.172,-0.179 0.387,-0.332 0.625,-0.427 0.258,-0.115 0.523,-0.159 0.797,-0.159 h 4.11 v 1.04 h -4.05 c -0.269,0 -0.506,0.105 -0.697,0.299 -0.072,0.078 -0.131,0.161 -0.178,0.257 -0.058,0.097 -0.093,0.204 -0.109,0.304 h 5.63 v 1.06 c 0,0.277 -0.053,0.534 -0.145,0.786 -0.117,0.246 -0.254,0.462 -0.451,0.652 -0.182,0.178 -0.398,0.331 -0.644,0.419 -0.233,0.117 -0.498,0.167 -0.789,0.167 h -2.68 z m -15,0 c -0.289,0 -0.553,-0.05 -0.791,-0.167 -0.252,-0.088 -0.461,-0.241 -0.647,-0.419 -0.183,-0.19 -0.334,-0.406 -0.445,-0.652 -0.098,-0.255 -0.151,-0.521 -0.151,-0.794 v -0.929 c 0,-0.282 0.053,-0.548 0.151,-0.795 0.111,-0.243 0.262,-0.456 0.445,-0.642 0.186,-0.179 0.395,-0.332 0.647,-0.427 0.238,-0.115 0.502,-0.159 0.791,-0.159 h 2.01 0.664 2.8 v -1.99 h 1.11 v 1.99 h 0.926 0.36 2.33 c 0.281,0 0.543,0.044 0.781,0.159 0.254,0.095 0.463,0.248 0.656,0.427 0.192,0.186 0.334,0.399 0.434,0.642 0.101,0.247 0.158,0.513 0.158,0.795 v 0.929 c 0,0.273 -0.057,0.539 -0.158,0.794 -0.1,0.246 -0.242,0.462 -0.434,0.652 -0.193,0.178 -0.402,0.331 -0.656,0.419 -0.238,0.117 -0.5,0.167 -0.781,0.167 h -2.69 c -0.281,0 -0.543,-0.05 -0.793,-0.167 -0.242,-0.088 -0.453,-0.241 -0.64,-0.419 -0.186,-0.19 -0.34,-0.406 -0.44,-0.652 -0.109,-0.255 -0.164,-0.521 -0.164,-0.794 v -1.91 h -1.02 c 0.027,0.063 0.066,0.128 0.087,0.19 0.112,0.247 0.164,0.513 0.164,0.795 v 0.929 c 0,0.273 -0.052,0.539 -0.164,0.794 -0.093,0.246 -0.244,0.462 -0.423,0.652 -0.194,0.178 -0.407,0.331 -0.655,0.419 -0.252,0.117 -0.515,0.167 -0.797,0.167 h -2.68 z m 35.5,-4.98 1.1,0 0,5 -1.1,0 0,-5 z m -13,5 c -0.272,0 -0.537,-0.059 -0.791,-0.183 -0.227,-0.088 -0.446,-0.241 -0.625,-0.419 -0.186,-0.19 -0.336,-0.406 -0.451,-0.652 -0.096,-0.252 -0.139,-0.509 -0.139,-0.786 v -2.96 h 1.09 v 2.95 c 0,0.273 0.111,0.514 0.299,0.708 0.082,0.089 0.199,0.157 0.304,0.213 0.121,0.052 0.242,0.074 0.379,0.074 h 2.57 c 0.132,0 0.265,-0.022 0.369,-0.074 0.121,-0.056 0.244,-0.124 0.314,-0.213 0.197,-0.194 0.303,-0.435 0.303,-0.708 v -2.95 h 0.306 0.784 0.779 v -1.99 h 1.1 v 1.99 h 0.925 2.3 0.407 c 0.265,0 0.531,0.044 0.781,0.159 0.23,0.095 0.453,0.248 0.631,0.427 0.185,0.186 0.338,0.399 0.445,0.642 0.103,0.247 0.141,0.513 0.141,0.795 v 0.929 c 0,0.273 -0.038,0.539 -0.141,0.794 -0.107,0.246 -0.26,0.462 -0.445,0.652 -0.178,0.178 -0.401,0.331 -0.631,0.419 -0.25,0.117 -0.516,0.167 -0.781,0.167 h -2.71 c -0.279,0 -0.542,-0.05 -0.792,-0.167 -0.223,-0.088 -0.438,-0.241 -0.625,-0.419 -0.188,-0.19 -0.338,-0.406 -0.454,-0.652 -0.099,-0.255 -0.15,-0.521 -0.15,-0.794 v -1.91 h -0.779 v 1.91 0.008 c 0,0.277 -0.051,0.534 -0.139,0.786 -0.117,0.246 -0.26,0.462 -0.449,0.652 -0.184,0.178 -0.406,0.331 -0.643,0.419 -0.23,0.124 -0.496,0.183 -0.779,0.183 h -2.7 z m 25.6,1.43 0,-1.22 -0.49,0 0,-1.05 0.49,0 0,-2.13 c 0,-0.282 0.062,-0.548 0.154,-0.795 0.113,-0.243 0.254,-0.456 0.44,-0.642 0.193,-0.179 0.4,-0.332 0.652,-0.427 0.234,-0.115 0.5,-0.159 0.791,-0.159 h 0.791 v 1.04 h -0.777 c -0.27,0.025 -0.504,0.13 -0.664,0.32 -0.096,0.079 -0.168,0.192 -0.211,0.308 -0.049,0.104 -0.065,0.232 -0.065,0.365 v 2.12 h 1.72 v 0.224 0.83 h -1.72 v 1.22 h -1.11 z m -10.8,0.564 0,-4.96 c 0,-0.277 0.06,-0.542 0.162,-0.796 0.1,-0.243 0.238,-0.463 0.432,-0.638 0.197,-0.184 0.398,-0.332 0.66,-0.438 0.236,-0.115 0.492,-0.159 0.777,-0.159 h 0.221 v 1.04 l -0.201,0.003 c -0.262,0.025 -0.477,0.13 -0.664,0.32 -0.088,0.079 -0.157,0.192 -0.198,0.308 -0.064,0.104 -0.068,0.232 -0.068,0.365 v 4.96 h -1.12 z m -1.86,-1.1 1.1,0 0,1.1 -1.1,0 0,-1.1 z"
-           id="path7697" />
-      </g>
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1810,833 134,1.41 -1.41,267 50.7,0"
-         id="path9767" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1810,872 183,0 16.9,-1.41"
-         id="path9769" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1810,911 95.7,0 -1.41,-262 95.7,0"
-         id="path9772" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:6.8602066;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:6.86020675, 13.72041347;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1810,711 490,-0.322 -5.15,-61.1 186,0"
-         id="path9767-1" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1810,749 580,0.661 -6.1,126 140,0"
-         id="path9767-1-4" />
-      <path
-         style="fill:none;stroke:#777777;stroke-width:7.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.5, 15;stroke-dashoffset:0"
-         inkscape:connector-curvature="0"
-         stroke-miterlimit="4"
-         d="m 1810,790 414,1.6 -4.36,305 267,3.21"
-         id="path9767-2" />
     </g>
     <g
        transform="matrix(0.4,0,0,0.4,-56.741854,-154.45687)"
@@ -12038,7 +11913,7 @@
          line-height="125%"
          font-size="40px"
          font-weight="normal"
-         style="font-size:40px;font-style:normal;font-weight:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;font-family:Sans"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff"
          id="text9963"><tspan
            x="1363.6637"
            y="1415.5746"
@@ -12052,7 +11927,7 @@
          font-size="100px"
          xml:space="preserve"
          font-weight="normal"
-         style="font-size:100px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;font-family:Sans"
+         style="font-style:normal;font-weight:normal;font-size:100px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000"
          id="text4849"><tspan
            style="font-size:40px;fill:#ffffff"
            x="1291.984"
@@ -12119,7 +11994,7 @@
          line-height="125%"
          font-size="40px"
          font-weight="normal"
-         style="font-size:40px;font-style:normal;font-weight:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;font-family:Sans"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff"
          id="text9963-1"><tspan
            x="1367.399"
            y="1415.5746"
@@ -12133,7 +12008,7 @@
          font-size="100px"
          xml:space="preserve"
          font-weight="normal"
-         style="font-size:100px;font-style:normal;font-weight:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;font-family:Sans"
+         style="font-style:normal;font-weight:normal;font-size:100px;line-height:125%;font-family:Sans;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000"
          id="text4849-5"><tspan
            x="1368.0533"
            y="1500.4048"
@@ -12178,7 +12053,7 @@
          id="99">
         <text
            id="text9734-24"
-           style="font-size:56px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;font-family:Sans"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:56px;line-height:125%;font-family:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff"
            line-height="125%"
            font-weight="bold"
            font-size="56px"
@@ -12200,7 +12075,7 @@
       </g>
       <text
          id="text9734-24-4"
-         style="font-size:22.39999962px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;font-family:Sans"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.39999962px;line-height:125%;font-family:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000"
          line-height="125%"
          font-weight="bold"
          font-size="56px"
@@ -12208,13 +12083,13 @@
          font-stretch="normal"
          font-variant="normal"
          y="231.77097"
-         x="388.01819"
+         x="389.41827"
          xml:space="preserve"
          sodipodi:linespacing="125%"><tspan
            style="font-size:16px;fill:#000000"
            id="tspan9736-5-2"
            y="231.77097"
-           x="388.01819">(8)</tspan></text>
+           x="389.41827">(8)</tspan></text>
       <path
          id="path8856-1-8"
          d="m 287.14974,140.67177 102,0.484 0.54,30.76 24.2,-0.0247"

--- a/ground/gcs/src/plugins/setupwizard/connectiondiagram.cpp
+++ b/ground/gcs/src/plugins/setupwizard/connectiondiagram.cpp
@@ -84,10 +84,6 @@ void ConnectionDiagram::setupGraphicsScene()
 
         QList<QString> elementsToShow;
 
-        Core::IBoardType* type = m_configSource->getControllerType();
-        if (type != NULL)
-            elementsToShow << QString("controller-").append(type->shortName().toLower());
-
         switch (m_configSource->getVehicleType()) {
         case VehicleConfigurationSource::VEHICLE_MULTI:
             switch (m_configSource->getVehicleSubType()) {
@@ -140,6 +136,10 @@ void ConnectionDiagram::setupGraphicsScene()
         default:
             break;
         }
+
+        Core::IBoardType* type = m_configSource->getControllerType();
+        if (type != NULL)
+            elementsToShow << QString("controller-").append(type->shortName().toLower());
 
         setupGraphicsSceneItems(elementsToShow);
 


### PR DESCRIPTION
This is a potential solution to #545. I added a small white box to the Revo board object that covers the (8) drawn when PPM is selected. To make this work I then raised the z-index of the board object so it appears above the PPM object (and all other objects). The downside of this is we can no longer have anything drawn over top of the board, e.g. wires going to pins in the middle of the board. Do we think we will need to do that? The only example I can think of off-hand is the telemetry pins on the Naze32.

Also removes OpenPilot branding from the vehicle images in the diagram.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/546)

<!-- Reviewable:end -->

edit: fixes #545
