### PR TITLE
Sparky2: Fix ADC config

### DIFF
--- a/flight/targets/sparky2/board-info/board_hw_defs.c
+++ b/flight/targets/sparky2/board-info/board_hw_defs.c
@@ -7,25 +7,29 @@
  *
  * @file       pios_board.c 
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
- * @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @author     dRonin, http://dronin.org Copyright (C) 2015-2016
  * @brief      Board specific hardware configuration file
  * @see        The GNU Public License (GPL) Version 3
  *
  *****************************************************************************/
-/* 
- * This program is free software; you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation; either version 3 of the License, or 
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
- * 
- * You should have received a copy of the GNU General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 #include <pios_config.h>
 #include <pios_board_info.h>
@@ -1810,8 +1814,8 @@ struct pios_internal_adc_cfg pios_adc_cfg = {
 	.half_flag = DMA_IT_HTIF4,
 	.full_flag = DMA_IT_TCIF4,
 	.adc_pins = {                                                                               \
-		{GPIOC, GPIO_Pin_3,     ADC_Channel_13},                /* Current sensor */            \
-		{GPIOC, GPIO_Pin_2,     ADC_Channel_12},                /* Voltage sensor */            \
+		{GPIOC, GPIO_Pin_2,     ADC_Channel_12},                /* Current sensor */            \
+		{GPIOC, GPIO_Pin_3,     ADC_Channel_13},                /* Voltage sensor */            \
 		{GPIOA, GPIO_Pin_4,     ADC_Channel_4},                 /* DAC pin        */            \
 		{NULL,  0,              ADC_Channel_Vrefint},           /* Voltage reference */         \
 		{NULL,  0,              ADC_Channel_TempSensor}         /* Temperature sensor */        \


### PR DESCRIPTION
ADC channels swapped. Checked against schematic, gerber, and tested.

@henn1001 The labels weren't wrong, just the channels. ;)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/572)

<!-- Reviewable:end -->
