### PR TITLE
Centralize stabilization, flight switch, and flight mode options in shared UAVO

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -140,13 +140,18 @@ int32_t ActuatorInitialize()
 }
 MODULE_INITCALL(ActuatorInitialize, ActuatorStart);
 
-static float get_curve2_source(ActuatorDesiredData *desired, MixerSettingsCurve2SourceOptions source)
+static float get_curve2_source(ActuatorDesiredData *desired, SystemSettingsAirframeTypeOptions airframe_type, MixerSettingsCurve2SourceOptions source)
 {
 	float tmp;
 
 	switch (source) {
 	case MIXERSETTINGS_CURVE2SOURCE_THROTTLE:
-		return desired->Throttle;
+		if(airframe_type == SYSTEMSETTINGS_AIRFRAMETYPE_HELICP)
+		{
+			ManualControlCommandThrottleGet(&tmp);
+			return tmp;
+		}
+		return desired->Thrust;
 		break;
 	case MIXERSETTINGS_CURVE2SOURCE_ROLL:
 		return desired->Roll;
@@ -158,6 +163,10 @@ static float get_curve2_source(ActuatorDesiredData *desired, MixerSettingsCurve2
 		return desired->Yaw;
 		break;
 	case MIXERSETTINGS_CURVE2SOURCE_COLLECTIVE:
+		if (airframe_type == SYSTEMSETTINGS_AIRFRAMETYPE_HELICP)
+		{
+			return desired->Thrust;
+		}
 		ManualControlCommandCollectiveGet(&tmp);
 		return tmp;
 		break;
@@ -202,6 +211,9 @@ static void actuator_task(void* parameters)
 	ActuatorDesiredData desired;
 	MixerStatusData mixerStatus;
 	FlightStatusData flightStatus;
+	ManualControlCommandData manual_control_command;
+
+	SystemSettingsAirframeTypeOptions airframe_type;
 
 	/* Read initial values of ActuatorSettings */
 	settings_updated = true;
@@ -217,6 +229,7 @@ static void actuator_task(void* parameters)
 			ActuatorSettingsGet(&actuatorSettings);
 			actuator_update_rate_if_changed(false);
 			MixerSettingsGet(&mixerSettings);
+			SystemSettingsAirframeTypeGet(&airframe_type);
 		}
 
 		if (rc != true) {
@@ -247,6 +260,7 @@ static void actuator_task(void* parameters)
 		FlightStatusGet(&flightStatus);
 		ActuatorDesiredGet(&desired);
 		ActuatorCommandGet(&command);
+		ManualControlCommandGet(&manual_control_command);
 
 #if defined(MIXERSTATUS_DIAGNOSTICS)
 		MixerStatusGet(&mixerStatus);
@@ -266,14 +280,16 @@ static void actuator_task(void* parameters)
 		AlarmsClear(SYSTEMALARMS_ALARM_ACTUATOR);
 
 		bool armed = flightStatus.Armed == FLIGHTSTATUS_ARMED_ARMED;
-		bool positiveThrottle = desired.Throttle >= 0.00f;
+		bool positiveThrottle = desired.Thrust >= 0.00f;
 		bool spinWhileArmed = actuatorSettings.MotorsSpinWhileArmed == ACTUATORSETTINGS_MOTORSSPINWHILEARMED_TRUE;
 
-		float curve1 = throt_curve(desired.Throttle, mixerSettings.ThrottleCurve1, MIXERSETTINGS_THROTTLECURVE1_NUMELEM);
+		float const throttle_source = (airframe_type == SYSTEMSETTINGS_AIRFRAMETYPE_HELICP) ? manual_control_command.Throttle : desired.Thrust;
+
+		float curve1 = throt_curve(throttle_source, mixerSettings.ThrottleCurve1, MIXERSETTINGS_THROTTLECURVE1_NUMELEM);
 
 		//The source for the secondary curve is selectable
 		float curve2 = collective_curve(
-				get_curve2_source(&desired, mixerSettings.Curve2Source),
+				get_curve2_source(&desired, airframe_type, mixerSettings.Curve2Source),
 				mixerSettings.ThrottleCurve2,
 				MIXERSETTINGS_THROTTLECURVE2_NUMELEM);
 

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -4,17 +4,17 @@
  * @{
  * @addtogroup ActuatorModule Actuator Module
  * @{
+ *
+ * @file       actuator.c
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2015
+ * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
+ * @brief      Actuator module. Drives the actuators (servos, motors etc).
  * @brief      Take the values in @ref ActuatorDesired and mix to set the outputs
  *
  * This module ultimately controls the outputs.  The values from @ref ActuatorDesired
  * are combined based on the values in @ref MixerSettings and then scaled by the
  * values in @ref ActuatorSettings to create the output PWM times.
- *
- * @file       actuator.c
- * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2015
- * @author     dRonin, http://dronin.org Copyright (C) 2015
- * @brief      Actuator module. Drives the actuators (servos, motors etc).
  *
  * @see        The GNU Public License (GPL) Version 3
  *
@@ -33,6 +33,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "openpilot.h"

--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -6,6 +6,7 @@
  * @{
  *
  * @file       altitudehold.c
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
  * @brief      This module runs an EKF to estimate altitude from just a barometric
  *             sensor and controls throttle to hold a fixed altitude
@@ -27,6 +28,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 /**

--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -159,7 +159,7 @@ static void altitudeHoldTask(void *parameters)
 
 			if (flight_mode == FLIGHTSTATUS_FLIGHTMODE_ALTITUDEHOLD && !engaged) {
 				// Copy the current throttle as a starting point for integral
-				StabilizationDesiredThrottleGet(&velocity_pid.iAccumulator);
+				StabilizationDesiredThrustGet(&velocity_pid.iAccumulator);
 				engaged = true;
 
 				// Make sure this uses a valid AltitudeHoldDesired. No delay is really required here
@@ -214,7 +214,7 @@ static void altitudeHoldTask(void *parameters)
 			altitudeHoldState.AngleGain = 1.0f;
 
 			if (altitudeHoldSettings.AttitudeComp > 0) {
-				// Throttle desired is at this point the mount desired in the up direction, we can
+				// Thrust desired is at this point the mount desired in the up direction, we can
 				// account for the attitude if desired
 				AttitudeActualData attitudeActual;
 				AttitudeActualGet(&attitudeActual);
@@ -239,11 +239,11 @@ static void altitudeHoldTask(void *parameters)
 				altitudeHoldState.AngleGain = 1.0f / fraction;
 			}
 
-			altitudeHoldState.Throttle = throttle_desired;
+			altitudeHoldState.Thrust = throttle_desired;
 			AltitudeHoldStateSet(&altitudeHoldState);
 
 			StabilizationDesiredGet(&stabilizationDesired);
-			stabilizationDesired.Throttle = bound_min_max(throttle_desired, min_throttle, 1.0f);
+			stabilizationDesired.Thrust = bound_min_max(throttle_desired, min_throttle, 1.0f);
 
 			if (landing) {
 				stabilizationDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;

--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -49,6 +49,7 @@
 #include "systemident.h"
 #include <pios_board_info.h>
 #include "pios_thread.h"
+#include "systemsettings.h"
 
 #include "circqueue.h"
 
@@ -167,7 +168,7 @@ static void at_new_gyro_data(UAVObjEvent * ev, void *ctx, void *obj, int len) {
 	q_item->u[1] = actuators.Pitch;
 	q_item->u[2] = actuators.Yaw;
 
-	q_item->throttle = actuators.Throttle;
+	q_item->throttle = actuators.Thrust;
 
 	if (circ_queue_advance_write(at_queue) != 0) {
 		last_sample_unpushed = true;
@@ -214,13 +215,15 @@ static void UpdateStabilizationDesired(bool doingIdent) {
 	StabilizationSettingsPitchMaxGet(&pitchMax);
 	StabilizationSettingsManualRateGet(manualRate);
 
-	ManualControlCommandRollGet(&stabDesired.Roll);
-	stabDesired.Roll *= rollMax;
-	ManualControlCommandPitchGet(&stabDesired.Pitch);
-	stabDesired.Pitch *= pitchMax;
+	SystemSettingsAirframeTypeOptions airframe_type;
+	SystemSettingsAirframeTypeGet(&airframe_type);
 
-	ManualControlCommandYawGet(&stabDesired.Yaw);
-	stabDesired.Yaw *= manualRate[STABILIZATIONSETTINGS_MANUALRATE_YAW];
+	ManualControlCommandData manual_control_command;
+	ManualControlCommandGet(&manual_control_command);
+
+	stabDesired.Roll = manual_control_command.Roll * rollMax;
+	stabDesired.Pitch = manual_control_command.Pitch * pitchMax;
+	stabDesired.Yaw = manual_control_command.Yaw * manualRate[STABILIZATIONSETTINGS_MANUALRATE_YAW];
 
 	if (doingIdent) {
 		stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL]  = STABILIZATIONDESIRED_STABILIZATIONMODE_SYSTEMIDENT;
@@ -232,8 +235,7 @@ static void UpdateStabilizationDesired(bool doingIdent) {
 		stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_RATE;
 	}
 
-	ManualControlCommandThrottleGet(&stabDesired.Throttle);
-
+	stabDesired.Thrust = (airframe_type == SYSTEMSETTINGS_AIRFRAMETYPE_HELICP) ? manual_control_command.Collective : manual_control_command.Throttle;
 	StabilizationDesiredSet(&stabDesired);
 }
 

--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -6,7 +6,7 @@
  * @{
  *
  * @file       autotune.c
- * @author     dRonin, http://dRonin.org, Copyright (C) 2015-2016
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2012.
  * @brief      State machine to run autotuning. Low level work done by @ref
@@ -30,9 +30,9 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  *
-* Additional note on redistribution: The copyright and license notices above
-* must be maintained in each individual source file that is a derivative work
-* of this source file; otherwise redistribution is prohibited.
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "openpilot.h"

--- a/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
+++ b/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
@@ -538,7 +538,7 @@ static uint8_t updateFixedDesiredAttitude()
 	fixedwingpathfollowerStatus.Command[FIXEDWINGPATHFOLLOWERSTATUS_COMMAND_POWER] = powerCommand;
 
 	// set throttle
-	stabDesired.Throttle = powerCommand;
+	stabDesired.Thrust = powerCommand;
 
 	// Error condition: plane cannot hold altitude at current speed.
 	fixedwingpathfollowerStatus.Errors[FIXEDWINGPATHFOLLOWERSTATUS_ERRORS_LOWPOWER] = 0;
@@ -652,7 +652,7 @@ static uint8_t updateFixedDesiredAttitude()
 	stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;
 	stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_MANUAL;
 	
-	if (isnan(stabDesired.Roll) || isnan(stabDesired.Pitch) || isnan(stabDesired.Yaw) || isnan(stabDesired.Throttle)) {
+	if (isnan(stabDesired.Roll) || isnan(stabDesired.Pitch) || isnan(stabDesired.Yaw) || isnan(stabDesired.Thrust)) {
 		northVelIntegral = 0;
 		eastVelIntegral = 0;
 		downVelIntegral = 0;

--- a/flight/Modules/GroundPathFollower/groundpathfollower.c
+++ b/flight/Modules/GroundPathFollower/groundpathfollower.c
@@ -6,11 +6,13 @@
  * @{
  *
  * @file       groundpathfollower.c
- * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2012.
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
- * @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2012.
  * @brief      Perform the path segment requested by @ref PathDesired
-
+ *
+ * @see        The GNU Public License (GPL) Version 3
+ *
  *****************************************************************************/
 /*
  * This program is free software; you can redistribute it and/or modify
@@ -26,6 +28,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 /**

--- a/flight/Modules/GroundPathFollower/groundpathfollower.c
+++ b/flight/Modules/GroundPathFollower/groundpathfollower.c
@@ -234,7 +234,7 @@ static void groundPathFollowerTask(void *parameters)
 				// Track throttle before engaging this mode.  Cheap system ident
 				StabilizationDesiredData stabDesired;
 				StabilizationDesiredGet(&stabDesired);
-				throttleOffset = stabDesired.Throttle;
+				throttleOffset = stabDesired.Thrust;
 
 				break;
 		}
@@ -392,7 +392,7 @@ static void updateGroundDesiredAttitude()
 	// Calculate direction from velocityDesired and set stabDesired.Yaw
 	stabDesired.Yaw = atan2f( velocityDesired.East, velocityDesired.North ) * RAD2DEG;
 
-	// Calculate throttle and set stabDesired.Throttle
+	// Calculate throttle and set stabDesired.Thrust
 	float velDesired = sqrtf(powf(velocityDesired.East,2) + powf(velocityDesired.North,2));
 	float velActual = sqrtf(powf(eastVel,2) + powf(northVel,2));
 	ManualControlCommandData manualControlData;
@@ -400,24 +400,24 @@ static void updateGroundDesiredAttitude()
 	switch (guidanceSettings.ThrottleControl) {
 		case GROUNDPATHFOLLOWERSETTINGS_THROTTLECONTROL_MANUAL:
 		{
-			stabDesired.Throttle = manualControlData.Throttle;
+			stabDesired.Thrust = manualControlData.Throttle;
 			break;
 		}
 		case GROUNDPATHFOLLOWERSETTINGS_THROTTLECONTROL_PROPORTIONAL:
 		{
 			float velRatio = velDesired / guidanceSettings.HorizontalVelMax;
-			stabDesired.Throttle = guidanceSettings.MaxThrottle * velRatio;
+			stabDesired.Thrust = guidanceSettings.MaxThrottle * velRatio;
 			if (guidanceSettings.ManualOverride == GROUNDPATHFOLLOWERSETTINGS_MANUALOVERRIDE_TRUE) {
-				stabDesired.Throttle = stabDesired.Throttle * manualControlData.Throttle;
+				stabDesired.Thrust = stabDesired.Thrust * manualControlData.Throttle;
 			}
 			break;
 		}
 		case GROUNDPATHFOLLOWERSETTINGS_THROTTLECONTROL_AUTO:
 		{
 			float velError = velDesired - velActual;
-			stabDesired.Throttle = pid_apply(&ground_pids[VELOCITY], velError, dT) + velDesired * guidanceSettings.VelocityFeedforward;
+			stabDesired.Thrust = pid_apply(&ground_pids[VELOCITY], velError, dT) + velDesired * guidanceSettings.VelocityFeedforward;
 			if (guidanceSettings.ManualOverride == GROUNDPATHFOLLOWERSETTINGS_MANUALOVERRIDE_TRUE) {
-				stabDesired.Throttle = stabDesired.Throttle * manualControlData.Throttle;
+				stabDesired.Thrust = stabDesired.Thrust * manualControlData.Throttle;
 			}
 			break;
 		}
@@ -429,7 +429,7 @@ static void updateGroundDesiredAttitude()
 	}
 
 	// Limit throttle as per settings
-	stabDesired.Throttle = bound_min_max(stabDesired.Throttle, 0, guidanceSettings.MaxThrottle);
+	stabDesired.Thrust = bound_min_max(stabDesired.Thrust, 0, guidanceSettings.MaxThrottle);
 
 	// Set StabilizationDesired object
 	stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;

--- a/flight/Modules/ManualControl/failsafe_control.c
+++ b/flight/Modules/ManualControl/failsafe_control.c
@@ -73,23 +73,28 @@ int32_t failsafe_control_select(bool reset_controller)
 		FlightStatusFlightModeSet(&flight_status);
 	}
 
-#ifdef GIMBAL
-	// Gimbals do not need failsafe
 	StabilizationDesiredData stabilization_desired;
 	StabilizationDesiredGet(&stabilization_desired);
+
+	// use mode-specific to tell stabilization that values are pre-scaled here
+	stabilization_desired.ThrustUnit = SHAREDDEFS_POSITIONUNIT_MODESPECIFIC;
+	stabilization_desired.RollUnit = SHAREDDEFS_ORIENTATIONUNIT_MODESPECIFIC;
+	stabilization_desired.PitchUnit = SHAREDDEFS_ORIENTATIONUNIT_MODESPECIFIC;
+	stabilization_desired.YawUnit = SHAREDDEFS_ORIENTATIONUNIT_MODESPECIFIC;
+#ifdef GIMBAL
+	// Gimbals do not need failsafe
+
 	stabilization_desired.Thrust = -1;
 	stabilization_desired.Roll = 0;
 	stabilization_desired.Pitch = 0;
 	stabilization_desired.Yaw = 0;
-	stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_POI;
-	stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = STABILIZATIONDESIRED_STABILIZATIONMODE_POI;
-	stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_AXISLOCK;
-	StabilizationDesiredSet(&stabilization_desired);
+
+	stabilization_desired.StabilizationMode.Roll = STABILIZATIONDESIRED_STABILIZATIONMODE_POI;
+	stabilization_desired.StabilizationMode.Pitch = STABILIZATIONDESIRED_STABILIZATIONMODE_POI;
+	stabilization_desired.StabilizationMode.Yaw = STABILIZATIONDESIRED_STABILIZATIONMODE_AXISLOCK;
 #else
 	// Pick default values that will roughly cause a plane to circle down
 	// and a quad to fall straight down
-	StabilizationDesiredData stabilization_desired;
-	StabilizationDesiredGet(&stabilization_desired);
 
 	if (!armed_when_enabled) {
 		/* disable stabilization so outputs do not move when system was not armed */
@@ -97,6 +102,7 @@ int32_t failsafe_control_select(bool reset_controller)
 		stabilization_desired.Roll  = 0;
 		stabilization_desired.Pitch = 0;
 		stabilization_desired.Yaw   = 0;
+
 		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_MANUAL;
 		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = STABILIZATIONDESIRED_STABILIZATIONMODE_MANUAL;
 		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_MANUAL;
@@ -107,6 +113,7 @@ int32_t failsafe_control_select(bool reset_controller)
 		stabilization_desired.Roll = -10;
 		stabilization_desired.Pitch = 0;
 		stabilization_desired.Yaw = -5;
+
 		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;
 		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;
 		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_RATE;

--- a/flight/Modules/ManualControl/failsafe_control.c
+++ b/flight/Modules/ManualControl/failsafe_control.c
@@ -77,7 +77,7 @@ int32_t failsafe_control_select(bool reset_controller)
 	// Gimbals do not need failsafe
 	StabilizationDesiredData stabilization_desired;
 	StabilizationDesiredGet(&stabilization_desired);
-	stabilization_desired.Throttle = -1;
+	stabilization_desired.Thrust = -1;
 	stabilization_desired.Roll = 0;
 	stabilization_desired.Pitch = 0;
 	stabilization_desired.Yaw = 0;
@@ -93,7 +93,7 @@ int32_t failsafe_control_select(bool reset_controller)
 
 	if (!armed_when_enabled) {
 		/* disable stabilization so outputs do not move when system was not armed */
-		stabilization_desired.Throttle = -1;
+		stabilization_desired.Thrust = -1;
 		stabilization_desired.Roll  = 0;
 		stabilization_desired.Pitch = 0;
 		stabilization_desired.Yaw   = 0;
@@ -103,7 +103,7 @@ int32_t failsafe_control_select(bool reset_controller)
 	} else {
 		/* Pick default values that will roughly cause a plane to circle down and */
 		/* a quad to fall straight down */
-		stabilization_desired.Throttle = -1;
+		stabilization_desired.Thrust = -1;
 		stabilization_desired.Roll = -10;
 		stabilization_desired.Pitch = 0;
 		stabilization_desired.Yaw = -5;

--- a/flight/Modules/ManualControl/geofence_control.c
+++ b/flight/Modules/ManualControl/geofence_control.c
@@ -79,12 +79,19 @@ int32_t geofence_control_select(bool reset_controller)
 	StabilizationDesiredData stabilization_desired;
 	StabilizationDesiredGet(&stabilization_desired);
 
+	// use mode-specific to tell stabilization that values are pre-scaled here
+	stabilization_desired.ThrustUnit = SHAREDDEFS_POSITIONUNIT_MODESPECIFIC;
+	stabilization_desired.RollUnit = SHAREDDEFS_ORIENTATIONUNIT_MODESPECIFIC;
+	stabilization_desired.PitchUnit = SHAREDDEFS_ORIENTATIONUNIT_MODESPECIFIC;
+	stabilization_desired.YawUnit = SHAREDDEFS_ORIENTATIONUNIT_MODESPECIFIC;
+
 	if (!geofence_armed_when_enabled) {
 		/* disable stabilization so outputs do not move when system was not armed */
 		stabilization_desired.Thrust = -1;
 		stabilization_desired.Roll  = 0;
 		stabilization_desired.Pitch = 0;
 		stabilization_desired.Yaw   = 0;
+
 		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_MANUAL;
 		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = STABILIZATIONDESIRED_STABILIZATIONMODE_MANUAL;
 		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_MANUAL;

--- a/flight/Modules/ManualControl/geofence_control.c
+++ b/flight/Modules/ManualControl/geofence_control.c
@@ -81,7 +81,7 @@ int32_t geofence_control_select(bool reset_controller)
 
 	if (!geofence_armed_when_enabled) {
 		/* disable stabilization so outputs do not move when system was not armed */
-		stabilization_desired.Throttle = -1;
+		stabilization_desired.Thrust = -1;
 		stabilization_desired.Roll  = 0;
 		stabilization_desired.Pitch = 0;
 		stabilization_desired.Yaw   = 0;
@@ -91,7 +91,7 @@ int32_t geofence_control_select(bool reset_controller)
 	} else {
 		/* Pick default values that will roughly cause a plane to circle down and */
 		/* a quad to fall straight down */
-		stabilization_desired.Throttle = -1;
+		stabilization_desired.Thrust = -1;
 		stabilization_desired.Roll = -10;
 		stabilization_desired.Pitch = 0;
 		stabilization_desired.Yaw = -5;

--- a/flight/Modules/ManualControl/tablet_control.c
+++ b/flight/Modules/ManualControl/tablet_control.c
@@ -6,8 +6,8 @@
  * @{
  *
  * @file       tablet_control.c
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2015
- * @author     dRonin, http://dronin.org Copyright (C) 2015
  * @brief      Use tablet for control source
  *
  * @see        The GNU Public License (GPL) Version 3
@@ -27,6 +27,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "openpilot.h"

--- a/flight/Modules/ManualControl/tablet_control.c
+++ b/flight/Modules/ManualControl/tablet_control.c
@@ -100,7 +100,7 @@ int32_t tablet_control_select(bool reset_controller)
 			LoiterCommandData loiterCommand;
 			loiterCommand.Pitch = 0;
 			loiterCommand.Roll = 0;
-			loiterCommand.Throttle = 0.5f;
+			loiterCommand.Thrust = 0.5f;
 			loiterCommand.Frame = LOITERCOMMAND_FRAME_BODY;
 			LoiterCommandSet(&loiterCommand);
 

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -1011,55 +1011,23 @@ static void update_stabilization_desired(ManualControlCommandData * manual_contr
 			return;
 	}
 
+	stabilization.ThrustUnit = SHAREDDEFS_POSITIONUNIT_EFFORT;
+	stabilization.RollUnit = SHAREDDEFS_ORIENTATIONUNIT_EFFORT;
+	stabilization.PitchUnit = SHAREDDEFS_ORIENTATIONUNIT_EFFORT;
+	stabilization.YawUnit = SHAREDDEFS_ORIENTATIONUNIT_EFFORT;
+
 	// TOOD: Add assumption about order of stabilization desired and manual control stabilization mode fields having same order
 	stabilization.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL]  = stab_settings[0];
 	stabilization.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = stab_settings[1];
 	stabilization.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW]   = stab_settings[2];
 
-	stabilization.Roll = (stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_DISABLED) ? 0 :
-		(stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_MANUAL) ? manual_control_command->Roll :
-		(stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_RATE) ? expo3(manual_control_command->Roll, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_ROLL]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_ROLL] :
-		(stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_ACROPLUS) ? expo3(manual_control_command->Roll, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_ROLL]) :
-		(stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_WEAKLEVELING) ? expo3(manual_control_command->Roll, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_ROLL]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_ROLL]:
-		(stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE) ? expo3(manual_control_command->Roll, stabSettings.AttitudeExpo[STABILIZATIONSETTINGS_ATTITUDEEXPO_ROLL]) * stabSettings.RollMax :
-		(stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_AXISLOCK) ? expo3(manual_control_command->Roll, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_ROLL]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_ROLL] :
-		(stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_VIRTUALBAR) ? manual_control_command->Roll :
-		(stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_HORIZON) ? expo3(manual_control_command->Roll, stabSettings.HorizonExpo[STABILIZATIONSETTINGS_HORIZONEXPO_ROLL]) :
-		(stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_MWRATE) ? expo3(manual_control_command->Roll, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_ROLL]) :
-		(stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_SYSTEMIDENT) ? manual_control_command->Roll * stabSettings.RollMax :
-		(stab_settings[0] == STABILIZATIONDESIRED_STABILIZATIONMODE_COORDINATEDFLIGHT) ? manual_control_command->Roll :
-		0; // this is an invalid mode
-
-	stabilization.Pitch = (stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_DISABLED) ? 0 :
-		(stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_MANUAL) ? manual_control_command->Pitch :
-		(stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_RATE) ? expo3(manual_control_command->Pitch, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_PITCH]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_PITCH] :
-		(stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_ACROPLUS) ? expo3(manual_control_command->Pitch, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_PITCH]) :
-		(stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_WEAKLEVELING) ? expo3(manual_control_command->Pitch, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_PITCH]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_PITCH] :
-		(stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE) ? expo3(manual_control_command->Pitch, stabSettings.AttitudeExpo[STABILIZATIONSETTINGS_ATTITUDEEXPO_PITCH]) * stabSettings.PitchMax :
-		(stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_AXISLOCK) ? expo3(manual_control_command->Pitch, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_PITCH]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_PITCH] :
-		(stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_VIRTUALBAR) ? manual_control_command->Pitch :
-		(stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_HORIZON) ? expo3(manual_control_command->Pitch, stabSettings.HorizonExpo[STABILIZATIONSETTINGS_HORIZONEXPO_PITCH]):
-		(stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_MWRATE) ? expo3(manual_control_command->Pitch, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_PITCH]) :
-		(stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_SYSTEMIDENT) ? manual_control_command->Pitch * stabSettings.PitchMax :
-		(stab_settings[1] == STABILIZATIONDESIRED_STABILIZATIONMODE_COORDINATEDFLIGHT) ? manual_control_command->Pitch :
-		0; // this is an invalid mode
-
-	stabilization.Yaw = (stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_DISABLED) ? 0 :
-		(stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_MANUAL) ? manual_control_command->Yaw :
-		(stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_RATE) ? expo3(manual_control_command->Yaw, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_YAW]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_YAW] :
-		(stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_ACROPLUS) ? expo3(manual_control_command->Yaw, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_YAW]) :
-		(stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_WEAKLEVELING) ? expo3(manual_control_command->Yaw, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_YAW]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_YAW] :
-		(stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE) ? expo3(manual_control_command->Yaw, stabSettings.AttitudeExpo[STABILIZATIONSETTINGS_ATTITUDEEXPO_YAW]) * stabSettings.YawMax :
-		(stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_AXISLOCK) ? expo3(manual_control_command->Yaw, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_YAW]) * stabSettings.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_YAW] :
-		(stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_VIRTUALBAR) ? manual_control_command->Yaw :
-		(stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_HORIZON) ? expo3(manual_control_command->Yaw, stabSettings.HorizonExpo[STABILIZATIONSETTINGS_HORIZONEXPO_YAW]) :
-		(stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_MWRATE) ? expo3(manual_control_command->Yaw, stabSettings.RateExpo[STABILIZATIONSETTINGS_RATEEXPO_YAW]) :
-		(stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_SYSTEMIDENT) ? manual_control_command->Yaw * stabSettings.YawMax :
-		(stab_settings[2] == STABILIZATIONDESIRED_STABILIZATIONMODE_COORDINATEDFLIGHT) ? manual_control_command->Yaw :
-		0; // this is an invalid mode
+	stabilization.Roll = manual_control_command->Roll;
+	stabilization.Pitch = manual_control_command->Pitch;
+	stabilization.Yaw = manual_control_command->Yaw;
 
 	float const thrust_source = (airframe_type == SYSTEMSETTINGS_AIRFRAMETYPE_HELICP) ? manual_control_command->Collective : manual_control_command->Throttle;
 	stabilization.Thrust = (thrust_source < 0) ? -1 : thrust_source;
+
 	StabilizationDesiredSet(&stabilization);
 }
 

--- a/flight/Modules/Sensors/simulated/sensors.c
+++ b/flight/Modules/Sensors/simulated/sensors.c
@@ -6,8 +6,9 @@
  * @{
  *
  * @file       sensors.c
- * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
+ * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @brief      Update available sensors registered with @ref PIOS_Sensors
  *
  * @see        The GNU Public License (GPL) Version 3
@@ -27,6 +28,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "pios.h"

--- a/flight/Modules/Sensors/simulated/sensors.c
+++ b/flight/Modules/Sensors/simulated/sensors.c
@@ -336,7 +336,7 @@ static void simulateModelQuadcopter()
 	ActuatorDesiredData actuatorDesired;
 	ActuatorDesiredGet(&actuatorDesired);
 
-	float thrust = (flightStatus.Armed == FLIGHTSTATUS_ARMED_ARMED) ? actuatorDesired.Throttle * MAX_THRUST : 0;
+	float thrust = (flightStatus.Armed == FLIGHTSTATUS_ARMED_ARMED) ? actuatorDesired.Thrust * MAX_THRUST : 0;
 	if (thrust < 0)
 		thrust = 0;
 	
@@ -577,7 +577,7 @@ static void simulateModelAirplane()
 	ActuatorDesiredData actuatorDesired;
 	ActuatorDesiredGet(&actuatorDesired);
 	
-	float thrust = (flightStatus.Armed == FLIGHTSTATUS_ARMED_ARMED) ? actuatorDesired.Throttle * MAX_THRUST : 0;
+	float thrust = (flightStatus.Armed == FLIGHTSTATUS_ARMED_ARMED) ? actuatorDesired.Thrust * MAX_THRUST : 0;
 	if (thrust < 0)
 		thrust = 0;
 	
@@ -869,7 +869,7 @@ static void simulateModelCar()
 	ActuatorDesiredData actuatorDesired;
 	ActuatorDesiredGet(&actuatorDesired);
 	
-	float thrust = (flightStatus.Armed == FLIGHTSTATUS_ARMED_ARMED) ? actuatorDesired.Throttle * MAX_THRUST : 0;
+	float thrust = (flightStatus.Armed == FLIGHTSTATUS_ARMED_ARMED) ? actuatorDesired.Thrust * MAX_THRUST : 0;
 	if (thrust < 0)
 		thrust = 0;
 	

--- a/flight/Modules/UAVOMavlinkBridge/UAVOMavlinkBridge.c
+++ b/flight/Modules/UAVOMavlinkBridge/UAVOMavlinkBridge.c
@@ -1,14 +1,15 @@
 /**
  ******************************************************************************
  * @addtogroup TauLabsModules TauLabs Modules
- * @{ 
+ * @{
  * @addtogroup UAVOMavlinkBridge UAVO to Mavlink Bridge Module
- * @{ 
+ * @{
  *
  * @file       UAVOMavlinkBridge.c
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
- * @author     dRonin, http://dronin.org Copyright (C) 2015
  * @brief      Bridges selected UAVObjects to Mavlink
+ *
  * @see        The GNU Public License (GPL) Version 3
  *
  *****************************************************************************/
@@ -26,6 +27,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 // ****************

--- a/flight/Modules/UAVOMavlinkBridge/UAVOMavlinkBridge.c
+++ b/flight/Modules/UAVOMavlinkBridge/UAVOMavlinkBridge.c
@@ -395,7 +395,7 @@ static void uavoMavlinkBridgeTask(void *parameters) {
 					// heading Current heading in degrees, in compass units (0..360, 0=north)
 					heading,
 					// throttle Current throttle setting in integer percent, 0 to 100
-					actDesired.Throttle * 100,
+					actDesired.Thrust * 100,
 					// alt Current altitude (MSL), in meters
 					altitude,
 					// climb Current climb rate in meters/second

--- a/flight/Modules/VtolPathFollower/vtol_follower_control.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_control.c
@@ -6,9 +6,12 @@
  * @{
  *
  * @file       vtol_follower_control.c
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
- * @author     dRonin, http://dronin.org Copyright (C) 2015
  * @brief      Control algorithms for the vtol follower
+ *
+ * @see        The GNU Public License (GPL) Version 3
+ *
  *****************************************************************************/
 /*
  * This program is free software; you can redistribute it and/or modify
@@ -24,6 +27,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "openpilot.h"

--- a/flight/Modules/VtolPathFollower/vtol_follower_control.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_control.c
@@ -52,6 +52,7 @@
 #include "velocitydesired.h"
 #include "velocityactual.h"
 #include "vtolpathfollowersettings.h"
+#include "systemsettings.h"
 
 // Private variables
 static VtolPathFollowerSettingsData guidanceSettings;
@@ -401,7 +402,7 @@ static float vtol_follower_control_altitude(float downCommand) {
 	altitudeHoldState.AngleGain = 1.0f;
 
 	if (altitudeHoldSettings.AttitudeComp > 0) {
-		// Throttle desired is at this point the mount desired in the up direction, we can
+		// Thrust desired is at this point the mount desired in the up direction, we can
 		// account for the attitude if desired
 		AttitudeActualData attitudeActual;
 		AttitudeActualGet(&attitudeActual);
@@ -426,7 +427,7 @@ static float vtol_follower_control_altitude(float downCommand) {
 		altitudeHoldState.AngleGain = 1.0f / fraction;
 	}
 
-	altitudeHoldState.Throttle = downCommand;
+	altitudeHoldState.Thrust = downCommand;
 	AltitudeHoldStateSet(&altitudeHoldState);
 
 	return downCommand;
@@ -457,6 +458,12 @@ int32_t vtol_follower_control_attitude(float dT, const float *att_adj)
 	StabilizationSettingsData stabSet;
 	StabilizationSettingsGet(&stabSet);
 
+	SystemSettingsData system_settings;
+	SystemSettingsGet( &system_settings );
+
+	ManualControlCommandData manual_control_command;
+	ManualControlCommandGet( &manual_control_command );
+
 	float northCommand = accelDesired.North;
 	float eastCommand = accelDesired.East;
 
@@ -481,11 +488,11 @@ int32_t vtol_follower_control_attitude(float dT, const float *att_adj)
 
 	// Calculate the throttle setting or use pass through from transmitter
 	if (guidanceSettings.ThrottleControl == VTOLPATHFOLLOWERSETTINGS_THROTTLECONTROL_FALSE) {
-		ManualControlCommandThrottleGet(&stabDesired.Throttle);
+		stabDesired.Thrust = (system_settings.AirframeType == SYSTEMSETTINGS_AIRFRAMETYPE_HELICP) ? manual_control_command.Collective : manual_control_command.Throttle;
 	} else {
 		float downCommand = vtol_follower_control_altitude(accelDesired.Down);
 
-		stabDesired.Throttle = bound_min_max(downCommand, 0, 1);
+		stabDesired.Thrust = bound_min_max(downCommand, 0, 1);
 	}
 	
 	// Various ways to control the yaw that are essentially manual passthrough. However, because we do not have a fine
@@ -493,19 +500,16 @@ int32_t vtol_follower_control_attitude(float dT, const float *att_adj)
 	switch(guidanceSettings.YawMode) {
 	case VTOLPATHFOLLOWERSETTINGS_YAWMODE_RATE:
 		/* This is awkward.  This allows the transmitter to control the yaw while flying navigation */
-		ManualControlCommandYawGet(&yaw);
-		stabDesired.Yaw = stabSet.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_YAW] * yaw;
+		stabDesired.Yaw = stabSet.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_YAW] * manual_control_command.Yaw;
 		stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_RATE;
 		break;
 	case VTOLPATHFOLLOWERSETTINGS_YAWMODE_AXISLOCK:
-		ManualControlCommandYawGet(&yaw);
-		stabDesired.Yaw = stabSet.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_YAW] * yaw;
+		stabDesired.Yaw = stabSet.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_YAW] * manual_control_command.Yaw;
 		stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_AXISLOCK;
 		break;
 	case VTOLPATHFOLLOWERSETTINGS_YAWMODE_ATTITUDE:
 	{
-		ManualControlCommandYawGet(&yaw);
-		stabDesired.Yaw = stabSet.YawMax * yaw;
+		stabDesired.Yaw = stabSet.YawMax * manual_control_command.Yaw;
 		stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;
 	}
 		break;
@@ -589,7 +593,7 @@ bool vtol_follower_control_loiter(float dT, float *hold_pos, float *att_adj,
 		// Inverted because we want units in "Down" frame
 		// Doubled to recenter to 1 to -1 scale from 0-1.
 		// loiter_deadband clips appropriately.
-		down_cmd = loiter_deadband(1 - (cmd.Throttle * 2),
+		down_cmd = loiter_deadband(1 - (cmd.Thrust * 2),
 				altitudeHoldSettings.Deadband / 100.0f,
 				altitudeHoldSettings.Expo);
 	}

--- a/flight/Modules/VtolPathFollower/vtolpathfollower.c
+++ b/flight/Modules/VtolPathFollower/vtolpathfollower.c
@@ -210,7 +210,7 @@ static void vtolPathFollowerTask(void *parameters)
 				pid_zero(&vtol_pids[i]);
 		
 			// Track throttle before engaging this mode.  Cheap system ident
-			StabilizationDesiredThrottleGet(&vtol_pids[DOWN_VELOCITY].iAccumulator);
+			StabilizationDesiredThrustGet(&vtol_pids[DOWN_VELOCITY].iAccumulator);
 			// Note the negative sign because this is the accumulation for down.
 			vtol_pids[DOWN_VELOCITY].iAccumulator *= -1;
 		}

--- a/flight/Modules/VtolPathFollower/vtolpathfollower.c
+++ b/flight/Modules/VtolPathFollower/vtolpathfollower.c
@@ -6,12 +6,15 @@
  * @{
  *
  * @file       vtolpathfollower.c
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
- * @author     dRonin, http://dronin.org Copyright (C) 2015
  * @brief      Compute attitude to achieve a path for VTOL aircrafts
  *
  * Runs the VTOL follower FSM which then calls the lower VTOL navigation
  * control algorithms as appropriate.
+ *
+ * @see        The GNU Public License (GPL) Version 3
+ *
  *****************************************************************************/
 /*
  * This program is free software; you can redistribute it and/or modify
@@ -27,6 +30,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "openpilot.h"

--- a/ground/gcs/src/plugins/hitl/fgsimulator.cpp
+++ b/ground/gcs/src/plugins/hitl/fgsimulator.cpp
@@ -162,7 +162,7 @@ void FGSimulator::transmitUpdate()
         ailerons = actData.Roll;
         elevator = -actData.Pitch;
         rudder = actData.Yaw;
-        throttle = actData.Throttle;
+        throttle = actData.Thrust;
     }
 
     int allowableDifference = 10;
@@ -204,7 +204,7 @@ void FGSimulator::transmitUpdate()
         actData.Roll = ailerons;
         actData.Pitch = -elevator;
         actData.Yaw = rudder;
-        actData.Throttle = throttle;
+        actData.Thrust = throttle;
         actDesired->setData(actData);
     }
 }

--- a/ground/gcs/src/plugins/hitl/xplanesimulator.cpp
+++ b/ground/gcs/src/plugins/hitl/xplanesimulator.cpp
@@ -108,7 +108,7 @@ void XplaneSimulator::transmitUpdate()
         float ailerons = actData.Roll;
         float elevator = actData.Pitch;
         float rudder = actData.Yaw;
-        float throttle = actData.Throttle > 0? actData.Throttle : 0;
+        float throttle = actData.Thrust > 0? actData.Thrust : 0;
         float none = -999;
         //quint32 none = *((quint32*)&tmp); // get float as 4 bytes
         

--- a/ground/gcs/src/plugins/hitl/xplanesimulator.cpp
+++ b/ground/gcs/src/plugins/hitl/xplanesimulator.cpp
@@ -1,17 +1,18 @@
 /**
  ******************************************************************************
- *
- * @file       xplanesimulator.cpp
- * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
- * @brief
- * @see        The GNU Public License (GPL) Version 3
- *
  * @addtogroup GCSPlugins GCS Plugins
  * @{
  * @addtogroup HITLPlugin HITL Plugin
  * @{
- * @brief The Hardware In The Loop plugin
+ *
+ * @file       xplanesimulator.cpp
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
+ * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
+ * @brief      The Hardware In The Loop plugin
+ *
+ * @see        The GNU Public License (GPL) Version 3
+ *
  *****************************************************************************/
 /*
  * This program is free software; you can redistribute it and/or modify
@@ -27,6 +28,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 /**

--- a/shared/uavobjectdefinition/actuatordesired.xml
+++ b/shared/uavobjectdefinition/actuatordesired.xml
@@ -4,7 +4,7 @@
         <field name="Roll" units="% / 100" type="float" elements="1"/>
         <field name="Pitch" units="% / 100" type="float" elements="1"/>
         <field name="Yaw" units="% / 100" type="float" elements="1"/>
-        <field name="Throttle" units="% / 100" type="float" elements="1"/>
+        <field name="Thrust" units="% / 100" type="float" elements="1"/>
         <field name="UpdateTime" units="ms" type="float" elements="1"/>
         <field name="NumLongUpdates" units="ms" type="float" elements="1"/>
         <access gcs="readwrite" flight="readwrite"/>

--- a/shared/uavobjectdefinition/altitudeholdstate.xml
+++ b/shared/uavobjectdefinition/altitudeholdstate.xml
@@ -4,7 +4,7 @@
         <field name="VelocityDesired" units="m/s" type="float" elements="1"/>
         <field name="Integral" units="" type="float" elements="1"/>
         <field name="AngleGain" units="" type="float" elements="1"/>
-        <field name="Throttle" units="" type="float" elements="1"/>
+        <field name="Thrust" units="" type="float" elements="1"/>
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="false" updatemode="manual" period="0"/>
         <telemetryflight acked="false" updatemode="periodic" period="0"/>

--- a/shared/uavobjectdefinition/camerastabsettings.xml
+++ b/shared/uavobjectdefinition/camerastabsettings.xml
@@ -6,7 +6,7 @@
         <field name="InputRate" units="deg/s" type="uint8" elementnames="Roll,Pitch,Yaw" defaultvalue="50"/>
         <field name="OutputRange" units="deg" type="uint8" elementnames="Roll,Pitch,Yaw" defaultvalue="20"/>
         <field name="FeedForward" units="" type="uint8" elementnames="Roll,Pitch,Yaw" defaultvalue="0"/>
-        <field name="StabilizationMode" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Attitude,AxisLock" defaultvalue="Attitude"/>
+        <field name="StabilizationMode" units="" type="enum" elementnames="Roll,Pitch,Yaw" parent="SharedDefs.StabilizationMode" options="Attitude,AxisLock" defaultvalue="Attitude"/>
         <field name="MaxAxisLockRate" units="deg/s" type="float" elements="1" defaultvalue="1"/>
         <field name="AttitudeFilter" units="ms" type="uint8" elements="1" defaultvalue="0"/>
         <field name="InputFilter" units="ms" type="uint8" elements="1" defaultvalue="0"/>

--- a/shared/uavobjectdefinition/flightstatus.xml
+++ b/shared/uavobjectdefinition/flightstatus.xml
@@ -4,27 +4,7 @@
 		<field name="Armed" units="" type="enum" elements="1" options="Disarmed,Arming,Armed" defaultvalue="Disarmed"/>
 
 		<!-- Note these enumerated values should be the same as ManualControlSettings -->
-		<field name="FlightMode" units="" type="enum" elements="1">
-			 <options>
-				<option>Manual</option>
-				<option>Acro</option>
-				<option>Leveling</option>
-				<option>MWRate</option>
-				<option>Horizon</option>
-				<option>AxisLock</option>
-				<option>VirtualBar</option>
-				<option>Stabilized1</option>
-				<option>Stabilized2</option>
-				<option>Stabilized3</option>
-				<option>Autotune</option>
-				<option>AltitudeHold</option>
-				<option>PositionHold</option>
-				<option>ReturnToHome</option>
-				<option>PathPlanner</option>
-				<option>TabletControl</option>
-				<option>AcroPlus</option>
-			</options>
-		</field>
+		<field name="FlightMode" units="" type="enum" elements="1" parent="SharedDefs.FlightMode" />
 
 		<!-- Indicate what submodule is in control -->
 		<field name="ControlSource" units="" type="enum" elements="1" options="Geofence,Failsafe,Transmitter,Tablet" defaultvalue="Failsafe"/>

--- a/shared/uavobjectdefinition/loitercommand.xml
+++ b/shared/uavobjectdefinition/loitercommand.xml
@@ -3,7 +3,7 @@
 		<description>Requested movement while in loiter mode</description>
 		<field name="Pitch" units="" type="float" elements="1"/>
 		<field name="Roll" units="" type="float" elements="1"/>
-		<field name="Throttle" units="" type="float" elements="1"/>
+		<field name="Thrust" units="" type="float" elements="1"/>
 		<field name="Frame" units="" type="enum" elements="1" options="Body,Earth" default="Body"/>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="false" updatemode="manual" period="0"/>

--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -129,7 +129,7 @@
 
 		<!-- Note these options values should be identical to those defined in FlightMode -->
 		<field name="FlightModeNumber" units="" type="uint8" elements="1" defaultvalue="3"/>
-		<field name="FlightModePosition" units="" type="enum" elements="6" options="Manual,Acro,Leveling,MWRate,Horizon,AxisLock,VirtualBar,Stabilized1,Stabilized2,Stabilized3,Autotune,AltitudeHold,PositionHold,ReturnToHome,PathPlanner,TabletControl,AcroPlus" defaultvalue="Leveling,Leveling,Leveling,Horizon,ReturnToHome,PositionHold"/>
+		<field name="FlightModePosition" units="" type="enum" elements="6" parent="SharedDefs.FlightMode" defaultvalue="Leveling,Leveling,Leveling,Horizon,ReturnToHome,PositionHold"/>
 
 		<!-- This option prevents timing out arming when disabled and in autonomous modes.
                      It is enabled by default for additional safety to prevent flyaways -->

--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -123,9 +123,9 @@
 		<field name="DisarmTime" units="ms" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="1000"/>
  
 		<!-- Note these options should be identical to those in StabilizationDesired.StabilizationMode -->
-		<field name="Stabilization1Settings" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,MWRate,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled" defaultvalue="Attitude,Attitude,Rate"/>
-		<field name="Stabilization2Settings" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,MWRate,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled" defaultvalue="Attitude,Attitude,Rate"/>
-		<field name="Stabilization3Settings" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,MWRate,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled" defaultvalue="Attitude,Attitude,Rate"/>
+		<field name="Stabilization1Settings" units="" type="enum" elementnames="Roll,Pitch,Yaw" parent="SharedDefs.StabilizationMode" defaultvalue="Attitude,Attitude,Rate"/>
+		<field name="Stabilization2Settings" units="" type="enum" elementnames="Roll,Pitch,Yaw" parent="SharedDefs.StabilizationMode" defaultvalue="Attitude,Attitude,Rate"/>
+		<field name="Stabilization3Settings" units="" type="enum" elementnames="Roll,Pitch,Yaw" parent="SharedDefs.StabilizationMode" defaultvalue="Attitude,Attitude,Rate"/>
 
 		<!-- Note these options values should be identical to those defined in FlightMode -->
 		<field name="FlightModeNumber" units="" type="uint8" elements="1" defaultvalue="3"/>

--- a/shared/uavobjectdefinition/shareddefs.xml
+++ b/shared/uavobjectdefinition/shareddefs.xml
@@ -1,0 +1,14 @@
+<xml>
+	<object name="SharedDefs" singleinstance="true" settings="false">
+		<description>Templates for common enums.</description>
+		<field name="FlightMode" units="" type="enum" elements="1" options="Manual,Acro,Leveling,MWRate,Horizon,AxisLock,VirtualBar,Stabilized1,Stabilized2,Stabilized3,Autotune,AltitudeHold,PositionHold,ReturnToHome,PathPlanner,TabletControl,AcroPlus" />
+		<field name="StabilizationMode" units="" type="enum" elements="1" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,MWRate,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled" />
+		<!-- Effort -> Emulate direct stick input; ModeSpecific -> Assume values are pre-scaled with some knowledge about given mode, do not scale -->
+		<field name="OrientationUnit" units="" type="enum" elements="1" options="Effort,ModeSpecific,Degrees,DegreesPerSec,DegreesPerSec2" />
+		<field name="PositionUnit" units="" type="enum" elements="1" options="Effort,ModeSpecific,Meters,MetersPerSec,MetersPerSec2" />
+		<access gcs="readwrite" flight="readwrite"/>
+		<telemetrygcs acked="false" updatemode="manual" period="0"/>
+		<telemetryflight acked="false" updatemode="periodic" period="0"/>
+		<logging updatemode="periodic" period="0"/>
+	</object>
+</xml>

--- a/shared/uavobjectdefinition/stabilizationdesired.xml
+++ b/shared/uavobjectdefinition/stabilizationdesired.xml
@@ -4,7 +4,7 @@
 		<field name="Roll" units="degrees" type="float" elements="1"/>
 		<field name="Pitch" units="degrees" type="float" elements="1"/>
 		<field name="Yaw" units="degrees" type="float" elements="1"/>
-		<field name="Throttle" units="%" type="float" elements="1"/>
+		<field name="Thrust" units="%" type="float" elements="1"/>
 		<!-- These values should match those in ManualControlCommand.Stabilization{1,2,3}Settings -->
 		<field name="StabilizationMode" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,MWRate,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled"/>
 		<access gcs="readwrite" flight="readwrite"/>

--- a/shared/uavobjectdefinition/stabilizationdesired.xml
+++ b/shared/uavobjectdefinition/stabilizationdesired.xml
@@ -1,12 +1,16 @@
 <xml>
 	<object name="StabilizationDesired" singleinstance="true" settings="false">
 		<description>The desired attitude that @ref StabilizationModule will try and achieve if FlightMode is Stabilized.  Comes from @ref ManaulControlModule.</description>
-		<field name="Roll" units="degrees" type="float" elements="1"/>
-		<field name="Pitch" units="degrees" type="float" elements="1"/>
-		<field name="Yaw" units="degrees" type="float" elements="1"/>
-		<field name="Thrust" units="%" type="float" elements="1"/>
+		<field name="Roll" units="" type="float" elements="1"/>
+		<field name="Pitch" units="" type="float" elements="1"/>
+		<field name="Yaw" units="" type="float" elements="1"/>
+		<field name="Thrust" units="" type="float" elements="1"/>
+		<field name="RollUnit" units="" type="enum" elements="1" parent="SharedDefs.OrientationUnit" default="ModeSpecific" />
+		<field name="PitchUnit" units="" type="enum" elements="1" parent="SharedDefs.OrientationUnit" default="ModeSpecific" />
+		<field name="YawUnit" units="" type="enum" elements="1" parent="SharedDefs.OrientationUnit" default="ModeSpecific" />
+		<field name="ThrustUnit" units="" type="enum" elements="1" parent="SharedDefs.PositionUnit" default="ModeSpecific" />
 		<!-- These values should match those in ManualControlCommand.Stabilization{1,2,3}Settings -->
-		<field name="StabilizationMode" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,MWRate,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled"/>
+		<field name="StabilizationMode" units="" type="enum" elementnames="Roll,Pitch,Yaw" parent="SharedDefs.StabilizationMode" />
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="false" updatemode="manual" period="0"/>
 		<telemetryflight acked="false" updatemode="periodic" period="1000"/>


### PR DESCRIPTION
Adding flight modes and stabilization modes is a pain, as it's necessary to ensure several redundant/identical fields in UAVOs are up-to-date. This PR centralizes stabilization and flight mode enums into a shared UAVO which is referenced by the other duplicate UAVOs.

Note: depends on #569 and #581

edit by MPL: fixes #640 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/585)

<!-- Reviewable:end -->
