### PR TITLE
flight: OpenLog selectable baudrate

### DIFF
--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -92,6 +92,7 @@ static void register_object(UAVObjHandle obj);
 static void register_default_profile();
 static void logSettings(UAVObjHandle obj);
 static void writeHeader();
+static void updateSettings();
 
 // Local variables
 static uintptr_t logging_com_id;
@@ -113,6 +114,7 @@ int32_t LoggingInitialize(void)
 	if (PIOS_COM_OPENLOG) {
 		logging_com_id = PIOS_COM_OPENLOG;
 		destination_spi_flash = false;
+		updateSettings();
 	}
 	else if (PIOS_COM_SPIFLASH) {
 		logging_com_id = PIOS_COM_SPIFLASH;
@@ -628,6 +630,26 @@ static void writeHeader()
 	}
 	tmp_str[pos++] = '\n';
 	send_data((uint8_t*)tmp_str, pos);
+}
+
+static void updateSettings()
+{
+	if (logging_com_id) {
+
+		// Retrieve settings
+		uint8_t speed;
+		ModuleSettingsOpenLogSpeedGet(&speed);
+
+		// Set port speed
+		switch (speed) {
+		case MODULESETTINGS_OPENLOGSPEED_115200:
+			PIOS_COM_ChangeBaud(logging_com_id, 115200);
+			break;
+		case MODULESETTINGS_OPENLOGSPEED_250000:
+			PIOS_COM_ChangeBaud(logging_com_id, 250000);
+			break;
+		}
+	}
 }
 
 /**

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -552,7 +552,6 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 #if defined(PIOS_INCLUDE_OPENLOG)
 			PIOS_HAL_ConfigureCom(usart_port_cfg, 0, PIOS_COM_OPENLOG_TX_BUF_LEN, com_driver, &port_driver_id);
 			target = &pios_com_openlog_logging_id;
-			PIOS_COM_ChangeBaud(port_driver_id, 115200);
 #endif /* PIOS_INCLUDE_OPENLOG */
 		break;
 

--- a/shared/uavobjectdefinition/modulesettings.xml
+++ b/shared/uavobjectdefinition/modulesettings.xml
@@ -95,6 +95,8 @@
 		<!-- FrSky telemetry Module Settings -->
 		<field name="FrskyAccelData" units="" type="enum" elements="1" options="Accels,NEDAccels, NEDVelocity, AttitudeAngles" defaultvalue="Accels"/>
 
+		<field name="OpenLogSpeed" units="bps" type="enum" elements="1" options="115200,250000" defaultvalue="115200"/>
+
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
Seems to "work" for me at 250k Baud. Should i add more rates?

Note that i´m using this special firmware: 
https://github.com/cleanflight/blackbox-firmware

Can´t really fly much at the moment but this is a really short log while armed without props. Custom profile and gyro log rate at 1000hz.
[Matlab.zip](https://github.com/d-ronin/dRonin/files/112347/Matlab.zip)

```
wrongSyncByte instances:            85
wrongMessageByte instances:          0

Completed bytes:    245542 of    283010
Est. time remaining, 00h:00m:01s 
Unknown object ID: 0x0457E4D6 appeared 1 times.
Unknown object ID: 0x420A42B9 appeared 1 times.
Unknown object ID: 0x0A5832F6 appeared 1 times.
Unknown object ID: 0xFE418AF6 appeared 1 times.
Unknown object ID: 0x43408D74 appeared 1 times.
283010 records in 1.93 seconds.
```

By the way, is there a limit of bytes which the matlab file can parse? completed bytes x of y ...

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/586)

<!-- Reviewable:end -->
