### PR TITLE
Flight: Make external mag handling consistent across targets

### DIFF
--- a/flight/Modules/Sensors/sensors.c
+++ b/flight/Modules/Sensors/sensors.c
@@ -116,7 +116,7 @@ static float z_accel_offset = 0;
 static float Rsb[3][3] = {{0}}; //! Rotation matrix that transforms from the body frame to the sensor board frame
 static int8_t rotate = 0;
 
-#if defined (AQ32)
+#if defined(SUPPORTS_EXTERNAL_MAG)
 // indicates whether the external mag works
 extern bool external_mag_fail;
 #endif
@@ -300,7 +300,7 @@ static void SensorsTask(void *parameters)
 #endif /* PIOS_INCLUDE_RANGEFINDER */
 
 		bool test_good_run = good_runs > REQUIRED_GOOD_CYCLES;
-		#if defined(AQ32)
+		#if defined(SUPPORTS_EXTERNAL_MAG)
 		test_good_run = test_good_run && !external_mag_fail;
 		#endif
 

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -26,6 +26,7 @@
  */
 #include <pios.h>
 #include <pios_hal.h>
+#include <openpilot.h>
 
 #include <pios_com_priv.h>
 #include <pios_rcvr_priv.h>
@@ -391,12 +392,15 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 	switch (port_type) {
 	case HWSHARED_PORTTYPES_I2C:
 #if defined(PIOS_INCLUDE_I2C)
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_OK);
+		
 		if (i2c_id && i2c_cfg) {
 			if (PIOS_I2C_Init(i2c_id, i2c_cfg)) {
 				PIOS_Assert(0);
+				AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 			}
 			if (PIOS_I2C_CheckClear(*i2c_id) != 0)
-				PIOS_HAL_Panic(led_id, 6);
+				AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
 		}
 #endif  /* PIOS_INCLUDE_I2C */
 		break;

--- a/flight/PiOS/inc/pios_mpu60x0.h
+++ b/flight/PiOS/inc/pios_mpu60x0.h
@@ -182,8 +182,9 @@ struct pios_mpu60x0_cfg {
 	uint8_t Pwr_mgmt_clk;			/* Power management and clock selection (See datasheet page 32 for more details) */
 	enum pios_mpu60x0_filter default_filter;
 	enum pios_mpu60x0_orientation orientation;
-	uint8_t use_internal_mag;		/* Flag to indicate whether or not to use the internal mag on MPU9x50 devices */
 };
+
+extern bool use_mpu_mag;
 
 #endif /* PIOS_MPU60X0_H */
 

--- a/flight/PiOS/inc/pios_mpu9150.h
+++ b/flight/PiOS/inc/pios_mpu9150.h
@@ -40,7 +40,7 @@
 #define PIOS_MPU9150_I2C_ADD_A0_HIGH      0x69
 
 /* Public Functions */
-extern int32_t PIOS_MPU9150_Init(uint32_t i2c_id, uint8_t i2c_addr, const struct pios_mpu60x0_cfg * new_cfg);
+extern int32_t PIOS_MPU9150_Init(uint32_t i2c_id, uint8_t i2c_addr, const struct pios_mpu60x0_cfg * new_cfg, bool use_internal_mag);
 extern uint8_t PIOS_MPU9150_Test();
 extern int32_t PIOS_MPU9150_Probe(uint32_t i2c_id, uint8_t i2c_addr);
 extern int32_t PIOS_MPU9150_SetGyroRange(enum pios_mpu60x0_range);

--- a/flight/targets/aq32/fw/pios_board.c
+++ b/flight/targets/aq32/fw/pios_board.c
@@ -210,14 +210,6 @@ void PIOS_Board_Init(void) {
     PIOS_LED_Init(led_cfg);
 #endif    /* PIOS_INCLUDE_LED */
 
-#if defined(PIOS_INCLUDE_I2C)
-    if (PIOS_I2C_Init(&pios_i2c_internal_id, &pios_i2c_internal_cfg)) {
-        PIOS_DEBUG_Assert(0);
-    }
-    if (PIOS_I2C_CheckClear(pios_i2c_internal_id) != 0)
-        panic(8);
-#endif
-
 #if defined(PIOS_INCLUDE_SPI)
     if (PIOS_SPI_Init(&pios_spi_internal_id, &pios_spi_internal_cfg)) {
         PIOS_Assert(0);
@@ -381,6 +373,23 @@ void PIOS_Board_Init(void) {
 #endif    /* PIOS_INCLUDE_USB */
 
     /* Configure the IO ports */
+
+    PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_I2C,  // port type protocol
+            NULL,                                   // usart_port_cfg
+            NULL,                                   // frsky usart_port_cfg
+            NULL,                                   // com_driver
+            &pios_i2c_internal_id,                  // i2c_id
+            &pios_i2c_internal_cfg,                 // i2c_cfg
+            NULL,                                   // ppm_cfg
+            NULL,                                   // pwm_cfg
+            PIOS_LED_ALARM,                         // led_id
+            NULL,                                   // usart_dsm_hsum_cfg
+            NULL,                                   // dsm_cfg
+            0,                                      // dsm_mode
+            NULL,                                   // sbus_rcvr_cfg
+            NULL,                                   // sbus_cfg    
+            false);                                 // sbus_toggle
+
     HwAQ32DSMxModeOptions hw_DSMxMode;
     HwAQ32DSMxModeGet(&hw_DSMxMode);
 
@@ -623,15 +632,21 @@ void PIOS_Board_Init(void) {
 
     if (Magnetometer == HWAQ32_MAGNETOMETER_EXTERNAL)
     {
-        AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_OK);
-            
-        if (PIOS_I2C_Init(&pios_i2c_external_id, &pios_i2c_external_cfg)) {
-            PIOS_DEBUG_Assert(0);
-            AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);
-        }
-        
-        if (PIOS_I2C_CheckClear(pios_i2c_external_id) != 0)
-            AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_CRITICAL);;
+		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_I2C,  // port type protocol
+				NULL,                                   // usart_port_cfg
+				NULL,                                   // frsky usart_port_cfg
+				NULL,                                   // com_driver
+				&pios_i2c_external_id,                  // i2c_id
+				&pios_i2c_external_cfg,                 // i2c_cfg
+				NULL,                                   // ppm_cfg
+				NULL,                                   // pwm_cfg
+				PIOS_LED_ALARM,                         // led_id
+				NULL,                                   // usart_dsm_hsum_cfg
+				NULL,                                   // dsm_cfg
+				0,                                      // dsm_mode
+				NULL,                                   // sbus_rcvr_cfg
+				NULL,                                   // sbus_cfg    
+				false);                                 // sbus_toggle
     
         if (PIOS_HMC5883_Init(pios_i2c_external_id, &pios_hmc5883_external_cfg) == 0) {
             if (PIOS_HMC5883_Test() == 0) {

--- a/flight/targets/aq32/fw/pios_config.h
+++ b/flight/targets/aq32/fw/pios_config.h
@@ -125,7 +125,8 @@
 #define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (9873737)
 
 #define REVOLUTION
-#define AQ32
+
+#define SUPPORTS_EXTERNAL_MAG
 
 #endif /* PIOS_CONFIG_H */
 /**

--- a/flight/targets/sparky/fw/pios_board.c
+++ b/flight/targets/sparky/fw/pios_board.c
@@ -217,22 +217,6 @@ void PIOS_Board_Init(void)
 	PIOS_LED_Init(led_cfg);
 #endif	/* PIOS_INCLUDE_LED */
 
-	PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_I2C,  // port type protocol
-	        NULL,                                   // usart_port_cfg
-	        NULL,                                   // frsky usart_port_cfg
-	        NULL,                                   // com_driver
-	        &pios_i2c_internal_id,                  // i2c_id
-	        &pios_i2c_internal_cfg,                 // i2c_cfg 
-	        NULL,                                   // ppm_cfg
-	        NULL,                                   // pwm_cfg
-	        PIOS_LED_ALARM,                         // led_id
-	        NULL,                                   // usart_dsm_hsum_cfg
-	        NULL,                                   // dsm_cfg
-	        0,                                      // dsm_mode
-	        NULL,                                   // sbus_rcvr_cfg
-	        NULL,                                   // sbus_cfg
-            false);                                 // sbus_toggle
-
 #if defined(PIOS_INCLUDE_CAN)
 	if (PIOS_CAN_Init(&pios_can_id, &pios_can_cfg) != 0)
 		panic(6);
@@ -376,6 +360,23 @@ void PIOS_Board_Init(void)
 #endif	/* PIOS_INCLUDE_USB */
 
 	/* Configure the IO ports */
+	
+	PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_I2C,  // port type protocol
+	        NULL,                                   // usart_port_cfg
+	        NULL,                                   // frsky usart_port_cfg
+	        NULL,                                   // com_driver
+	        &pios_i2c_internal_id,                  // i2c_id
+	        &pios_i2c_internal_cfg,                 // i2c_cfg 
+	        NULL,                                   // ppm_cfg
+	        NULL,                                   // pwm_cfg
+	        PIOS_LED_ALARM,                         // led_id
+	        NULL,                                   // usart_dsm_hsum_cfg
+	        NULL,                                   // dsm_cfg
+	        0,                                      // dsm_mode
+	        NULL,                                   // sbus_rcvr_cfg
+	        NULL,                                   // sbus_cfg
+            false);                                 // sbus_toggle
+
 	HwSparkyDSMxModeOptions hw_DSMxMode;
 	HwSparkyDSMxModeGet(&hw_DSMxMode);
 

--- a/flight/targets/sparky/fw/pios_board.c
+++ b/flight/targets/sparky/fw/pios_board.c
@@ -141,7 +141,7 @@ static const struct pios_exti_cfg pios_exti_mpu9150_cfg __exti_config = {
 	},
 };
 
-static struct pios_mpu60x0_cfg pios_mpu9150_cfg = {
+static const struct pios_mpu60x0_cfg pios_mpu9150_cfg = {
 	.exti_cfg = &pios_exti_mpu9150_cfg,
 	.default_samplerate = 500,
 	.interrupt_cfg = PIOS_MPU60X0_INT_CLR_ANYRD,
@@ -150,7 +150,6 @@ static struct pios_mpu60x0_cfg pios_mpu9150_cfg = {
 	.Pwr_mgmt_clk = PIOS_MPU60X0_PWRMGMT_PLL_Z_CLK,
 	.default_filter = PIOS_MPU60X0_LOWPASS_256_HZ,
 	.orientation = PIOS_MPU60X0_TOP_180DEG,
-	.use_internal_mag = true
 };
 #endif /* PIOS_INCLUDE_MPU9150 */
 
@@ -172,10 +171,7 @@ static const struct pios_hmc5883_cfg pios_hmc5883_external_cfg = {
 #define PIOS_COM_CAN_RX_BUF_LEN 256
 #define PIOS_COM_CAN_TX_BUF_LEN 256
 
-#if defined(PIOS_INCLUDE_DEBUG_CONSOLE)
-#define PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN 40
-uintptr_t pios_com_debug_id;
-#endif	/* PIOS_INCLUDE_DEBUG_CONSOLE */
+bool external_mag_fail;
 
 uintptr_t pios_com_aux_id;
 uintptr_t pios_com_can_id;
@@ -221,13 +217,21 @@ void PIOS_Board_Init(void)
 	PIOS_LED_Init(led_cfg);
 #endif	/* PIOS_INCLUDE_LED */
 
-#if defined(PIOS_INCLUDE_I2C)
-	if (PIOS_I2C_Init(&pios_i2c_internal_id, &pios_i2c_internal_cfg)) {
-		PIOS_DEBUG_Assert(0);
-	}
-	if (PIOS_I2C_CheckClear(pios_i2c_internal_id) != 0)
-		panic(3);
-#endif
+	PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_I2C,  // port type protocol
+	        NULL,                                   // usart_port_cfg
+	        NULL,                                   // frsky usart_port_cfg
+	        NULL,                                   // com_driver
+	        &pios_i2c_internal_id,                  // i2c_id
+	        &pios_i2c_internal_cfg,                 // i2c_cfg 
+	        NULL,                                   // ppm_cfg
+	        NULL,                                   // pwm_cfg
+	        PIOS_LED_ALARM,                         // led_id
+	        NULL,                                   // usart_dsm_hsum_cfg
+	        NULL,                                   // dsm_cfg
+	        0,                                      // dsm_mode
+	        NULL,                                   // sbus_rcvr_cfg
+	        NULL,                                   // sbus_cfg
+            false);                                 // sbus_toggle
 
 #if defined(PIOS_INCLUDE_CAN)
 	if (PIOS_CAN_Init(&pios_can_id, &pios_can_cfg) != 0)
@@ -261,6 +265,10 @@ void PIOS_Board_Init(void)
 		panic(5);
 	if (PIOS_FLASHFS_Logfs_Init(&pios_waypoints_settings_fs_id, &flashfs_internal_waypoints_cfg, FLASH_PARTITION_LABEL_WAYPOINTS) != 0)
 		panic(5);
+
+#if defined(ERASE_FLASH)
+	PIOS_FLASHFS_Format(pios_uavo_settings_fs_id);
+#endif
 
 #endif	/* PIOS_INCLUDE_FLASH */
 
@@ -527,13 +535,13 @@ void PIOS_Board_Init(void)
 		HwSparkyMagnetometerGet(&Magnetometer);
 
 		if (Magnetometer == HWSPARKY_MAGNETOMETER_INTERNAL)
-			pios_mpu9150_cfg.use_internal_mag = true;
+			use_mpu_mag = true;
 		else
-			pios_mpu9150_cfg.use_internal_mag = false;
+			use_mpu_mag = false;
 
 
 		int retval;
-		retval = PIOS_MPU9150_Init(pios_i2c_internal_id, PIOS_MPU9150_I2C_ADD_A0_LOW, &pios_mpu9150_cfg);
+		retval = PIOS_MPU9150_Init(pios_i2c_internal_id, PIOS_MPU9150_I2C_ADD_A0_LOW, &pios_mpu9150_cfg, use_mpu_mag);
 		if (retval == -10)
 			panic(1); // indicate missing IRQ separately
 		if (retval != 0)
@@ -662,35 +670,34 @@ void PIOS_Board_Init(void)
 		uint8_t Magnetometer;
 		HwSparkyMagnetometerGet(&Magnetometer);
 
+		external_mag_fail = false;
+		
 		if (Magnetometer == HWSPARKY_MAGNETOMETER_EXTERNALI2CFLEXIPORT) {
-			// setup sensor orientation
-			uint8_t ExtMagOrientation;
-			HwSparkyExtMagOrientationGet(&ExtMagOrientation);
+			if (PIOS_HMC5883_Init(pios_i2c_flexi_id, &pios_hmc5883_external_cfg) == 0) {
+				if (PIOS_HMC5883_Test() == 0) {
+					// External mag configuration was successful
 
-			if (Magnetometer == HWSPARKY_MAGNETOMETER_EXTERNALI2CFLEXIPORT) {
-				// init sensor
-				pios_mpu9150_cfg.use_internal_mag = false;
+					// setup sensor orientation
+					uint8_t ExtMagOrientation;
+					HwSparkyExtMagOrientationGet(&ExtMagOrientation);
 
-				//I2C is slow, sensor init as well, reset watchdog to prevent reset here
-				PIOS_WDG_Clear();
-
-				if (PIOS_HMC5883_Init(pios_i2c_flexi_id, &pios_hmc5883_external_cfg) != 0)
-					panic(11);
-				if (PIOS_HMC5883_Test() != 0)
-					panic(11);
+					enum pios_hmc5883_orientation hmc5883_externalOrientation = \
+						(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP0DEGCW)      ? PIOS_HMC5883_TOP_0DEG      : \
+						(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP90DEGCW)     ? PIOS_HMC5883_TOP_90DEG     : \
+						(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP180DEGCW)    ? PIOS_HMC5883_TOP_180DEG    : \
+						(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP270DEGCW)    ? PIOS_HMC5883_TOP_270DEG    : \
+						(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM0DEGCW)   ? PIOS_HMC5883_BOTTOM_0DEG   : \
+						(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM90DEGCW)  ? PIOS_HMC5883_BOTTOM_90DEG  : \
+						(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM180DEGCW) ? PIOS_HMC5883_BOTTOM_180DEG : \
+						(ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM270DEGCW) ? PIOS_HMC5883_BOTTOM_270DEG : \
+						pios_hmc5883_external_cfg.Default_Orientation;
+					PIOS_HMC5883_SetOrientation(hmc5883_externalOrientation);
+				}
+				else
+					external_mag_fail = true;  // External HMC5883 Test Failed
 			}
-
-			enum pios_hmc5883_orientation hmc5883_orientation = \
-			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP0DEGCW)      ? PIOS_HMC5883_TOP_0DEG      : \
-			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP90DEGCW)     ? PIOS_HMC5883_TOP_90DEG     : \
-			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP180DEGCW)    ? PIOS_HMC5883_TOP_180DEG    : \
-			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_TOP270DEGCW)    ? PIOS_HMC5883_TOP_270DEG    : \
-			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM0DEGCW)   ? PIOS_HMC5883_BOTTOM_0DEG   : \
-			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM90DEGCW)  ? PIOS_HMC5883_BOTTOM_90DEG  : \
-			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM180DEGCW) ? PIOS_HMC5883_BOTTOM_180DEG : \
-			        (ExtMagOrientation == HWSPARKY_EXTMAGORIENTATION_BOTTOM270DEGCW) ? PIOS_HMC5883_BOTTOM_270DEG : \
-			        pios_hmc5883_external_cfg.Default_Orientation;
-			PIOS_HMC5883_SetOrientation(hmc5883_orientation);
+			else
+				external_mag_fail = true;  // External HMC5883 Init Failed
 		}
 	}
 #endif /* PIOS_INCLUDE_HMC5883 */

--- a/flight/targets/sparky/fw/pios_config.h
+++ b/flight/targets/sparky/fw/pios_config.h
@@ -67,6 +67,7 @@
 #define PIOS_MPU6050_ACCEL
 #define PIOS_MPU6050_SIMPLE_INIT_SEQUENCE
 #define PIOS_INCLUDE_MPU9150
+#define PIOS_INCLUDE_HMC5883
 #define FLASH_FREERTOS
 
 /* Com systems to include */
@@ -130,6 +131,8 @@
 #define CAMERASTAB_POI_MODE
 
 #define PIOS_INCLUDE_FASTHEAP
+
+#define SUPPORTS_EXTERNAL_MAG
 
 #endif /* PIOS_CONFIG_H */
 /**

--- a/shared/uavobjectdefinition/hwaq32.xml
+++ b/shared/uavobjectdefinition/hwaq32.xml
@@ -116,7 +116,7 @@
 		<field name="MPU6000Rate" units="" type="enum" elements="1" options="200,333,500,666,1000,2000,4000,8000" defaultvalue="500"/>
 		<field name="MPU6000DLPF" units="" type="enum" elements="1" options="256,188,98,42,20,10,5" defaultvalue="188"/>
 	
-		<field name="Magnetometer" units="function" type="enum" elements="1" options="Internal,External" defaultvalue="Internal"/>
+		<field name="Magnetometer" units="function" type="enum" elements="1" options="Disabled,Internal,External" defaultvalue="Internal"/>
 		<field name="ExtMagOrientation" units="function" type="enum" elements="1" options="Top0degCW,Top90degCW,Top180degCW,Top270degCW,Bottom0degCW,Bottom90degCW,Bottom180degCW,Bottom270degCW" defaultvalue="Top0degCW" />
 	
 		<access gcs="readwrite" flight="readwrite"/>

--- a/shared/uavobjectdefinition/hwsparky.xml
+++ b/shared/uavobjectdefinition/hwsparky.xml
@@ -72,7 +72,7 @@
 		<field name="MPU9150DLPF" units="" type="enum" elements="1" options="256,188,98,42,20,10,5" defaultvalue="188"/>
 		<field name="MPU9150Rate" units="" type="enum" elements="1" options="200,333,500,666,1000,2000,4000,8000" defaultvalue="500"/>
 
-		<field name="Magnetometer" units="function" type="enum" elements="1" options="Internal,ExternalI2CFlexiPort" defaultvalue="Internal"/>
+		<field name="Magnetometer" units="function" type="enum" elements="1" options="Disabled,Internal,ExternalI2CFlexiPort" defaultvalue="Internal"/>
 		<field name="ExtMagOrientation" units="function" type="enum" elements="1" parent="HwShared.MagOrientation" defaultvalue="Top0degCW" />
 
 		<access gcs="readwrite" flight="readwrite"/>


### PR DESCRIPTION
The external mag handling is not consistent across targets  This PR will change the external mag handling to be as follows:

1)I2C initialization will no longer generate a panic code upon failure.  Successful initialization will be indicated by the I2C WCA box being displayed in green.  Either an init failure or a checkclear failure will turn the I2C WCA box red.  Both internal and external I2C ports will adhere to this.  One deficiency is that if an I2C bus fails initialization, it will be hard to tell whether the internal or external bus is at fault.  A mitigation here is to disable any active external I2C buses and see if the error condition clears,

2)A failure of the external mag to initialize will no longer generate a panic code upon initialization or test failure, it will turn the sensor WCA box red.

3)An option to disable the use of mag inputs completely will be added.

This initial set of commits moves Sparky to this paradigm.  Other targets to follow.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/589)

<!-- Reviewable:end -->
