### PR TITLE
revomini: default to no telemetry on mainport

### DIFF
--- a/shared/uavobjectdefinition/hwrevomini.xml
+++ b/shared/uavobjectdefinition/hwrevomini.xml
@@ -12,7 +12,7 @@
 			 <option>Outputs</option>
 		</options>
 		</field>		
-		<field name="MainPort" units="function" type="enum" elements="1"  parent="HwShared.PortTypes" defaultvalue="Telemetry">
+		<field name="MainPort" units="function" type="enum" elements="1"  parent="HwShared.PortTypes" defaultvalue="Disabled">
 			<options>
 				<option>Disabled</option>
 				<option>Telemetry</option>


### PR DESCRIPTION
fixes #568

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/590)

<!-- Reviewable:end -->
