### PR TITLE
gcs: usability improvements

### DIFF
--- a/ground/gcs/share/default_configurations/developer.xml
+++ b/ground/gcs/share/default_configurations/developer.xml
@@ -4,7 +4,7 @@
     <AutoSelect>true</AutoSelect>
     <Description>Developer</Description>
     <Details>Developer mode configuration</Details>
-    <ExpertMode>true</ExpertMode>
+    <ExpertMode>false</ExpertMode>
     <OverrideLanguage>en_US</OverrideLanguage>
     <SaveSettingsOnExit>true</SaveSettingsOnExit>
     <StyleSheet>default</StyleSheet>

--- a/ground/gcs/share/default_configurations/netbook.xml
+++ b/ground/gcs/share/default_configurations/netbook.xml
@@ -4,7 +4,7 @@
     <AutoSelect>true</AutoSelect>
     <Description>Netbook configuration</Description>
     <Details>Laptop configuration built to work on standard laptop screen sizes</Details>
-    <ExpertMode>true</ExpertMode>
+    <ExpertMode>false</ExpertMode>
     <OverrideLanguage>en_US</OverrideLanguage>
     <SaveSettingsOnExit>true</SaveSettingsOnExit>
     <StyleSheet>default</StyleSheet>

--- a/ground/gcs/src/plugins/config/attitude.ui
+++ b/ground/gcs/src/plugins/config/attitude.ui
@@ -1202,7 +1202,7 @@ new home location unless it is in indoor mode.</string>
         <string>Load default CameraStabilization settings except output channels into GCS.
 
 Loaded settings are not applied automatically. You have to click the
-Apply or Save button afterwards.</string>
+Save button afterwards.</string>
        </property>
        <property name="text">
         <string>Reset To Defaults</string>
@@ -1235,7 +1235,7 @@ from board into GCS. Useful if you have accidentally changed some
 settings.
 
 Loaded settings are not applied automatically. You have to click the
-Apply or Save button afterwards.</string>
+Save button afterwards.</string>
        </property>
        <property name="text">
         <string>Reload Board Data</string>

--- a/ground/gcs/src/plugins/config/autotune.ui
+++ b/ground/gcs/src/plugins/config/autotune.ui
@@ -81,23 +81,22 @@ p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.Helvetica Neue DeskInterface'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:20pt; font-weight:600; color:#ff0000;&quot;&gt;WARNING:&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Lucida Grande';&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande';&quot;&gt;This is an advanced plugin for the GCS that is going to make your UAV twitch automatically, so test in a large open area and be cautious of the values that it creates.&lt;br /&gt;&lt;br /&gt;Please read and understand all of the following steps for autotuning before attempting an autotune.&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande';&quot;&gt;This is an advanced plugin for the GCS that is going to make your UAV wiggle automatically, so test in a large open area and be cautious of the values that it creates.&lt;br /&gt;&lt;br /&gt;Please read and understand all of the following steps before attempting an autotune.&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;
 &lt;ol style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Go to https://vimeo.com/104806460 and watch the autotuning tutorial.&lt;/li&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:1; text-indent:0px; font-family:'Lucida Grande';&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;On the &lt;span style=&quot; font-style:italic;&quot;&gt;Input configuration &lt;/span&gt;page, &lt;span style=&quot; font-style:italic;&quot;&gt;Flight Mode Switch Settings tab&lt;/span&gt;, set one of your flight modes to &amp;quot;Autotune&amp;quot;.&lt;/li&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:1; text-indent:0px; font-family:'Lucida Grande';&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Click the &lt;span style=&quot; font-style:italic;&quot;&gt;Enable Autotune Module&lt;/span&gt; checkbox below this text, click S&lt;span style=&quot; font-style:italic;&quot;&gt;ave,&lt;/span&gt; and reboot the flight controller.&lt;br /&gt;&lt;/li&gt;
-&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Take off, and when stable, change flight mode to autotune. Focus on keeping the UAV in the air while it's twitching.&lt;/li&gt;
+&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Take off, and when stable, change flight mode to autotune. Focus on keeping the UAV in the air while it's wiggling.&lt;/li&gt;
 &lt;ol type=&quot;a&quot; style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 2;&quot;&gt;&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;In the first few seconds, nothing will happen...&lt;/li&gt;
-&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The the UAV will start twitching for approximately 60 seconds. It will continue to respond to your inputs, and moving the sticks won't negatively affect the tune.&lt;/li&gt;
-&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When the twitching stops, the tuning phase is completed.&lt;/li&gt;&lt;/ol&gt;
+&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The the UAV will start wiggling for approximately 60 seconds. It will continue to respond to your inputs, and moving the sticks won't negatively affect the tune.&lt;/li&gt;
+&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When the wiggling stops, the measurement phase is completed.&lt;/li&gt;&lt;/ol&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:1; text-indent:0px; font-family:'Lucida Grande';&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Land and disarm leaving the Autotune mode enabled. At this point, the settings are saved. Power down the UAV, unless it is connected to GCS via bluetooth.&lt;br /&gt;&lt;/li&gt;
-&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Connect to GCS and check the values on the &lt;span style=&quot; font-style:italic;&quot;&gt;Autotune Setup&lt;/span&gt; page against the values on the &lt;span style=&quot; font-style:italic;&quot;&gt;Stabilization&lt;/span&gt; page. If they are vastly different, this is an indication to be wary, and indicates that a subsequent autotune should be run to get more accurate values. &lt;span style=&quot; font-weight:600;&quot;&gt;For extreme values a prompt will ask if you want to continue. Check your settings carefully in this case.&lt;/span&gt;&lt;br /&gt;&lt;/li&gt;
+&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Land and disarm; the system then saves the measured properties. &lt;br /&gt;&lt;/li&gt;
+&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Connect to GCS and check the values on the &lt;span style=&quot; font-style:italic;&quot;&gt;Autotune Setup&lt;/span&gt; page. &lt;br /&gt;&lt;/li&gt;
 &lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Adjust the values as necessary with the &lt;span style=&quot; font-style:italic;&quot;&gt;Damping&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Noise sensitivity&lt;/span&gt; sliders until they appear to be reasonable. When satisfied, click the &lt;span style=&quot; font-style:italic;&quot;&gt;Apply Computed Values&lt;/span&gt; button at the bottom right.&lt;br /&gt;&lt;/li&gt;
-&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Return to the &lt;span style=&quot; font-style:italic;&quot;&gt;Stabilization&lt;/span&gt; page and click &lt;span style=&quot; font-style:italic;&quot;&gt;apply&lt;/span&gt; to enable the new settings. The &lt;span style=&quot; font-style:italic;&quot;&gt;save&lt;/span&gt; button must also be pressed if the flight controller is to be powered down prior to the next flight.&lt;br /&gt;&lt;/li&gt;
-&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ensure that a normal flight mode (not Autotune) is selected prior to the next flight.  If Autotune is left as the active mode, it is likely that the flight controller will not arm.&lt;/li&gt;
-&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If the UAV performs well, then the process is complete.  If it does not, the &lt;span style=&quot; font-style:italic;&quot;&gt;Damping&lt;/span&gt; and &lt;span style=&quot; font-style:italic;&quot;&gt;Noise sensitivity&lt;/span&gt; sliders may be adjusted, settings reapplied, saved and tested again.&lt;/li&gt;&lt;/ol&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Return to the &lt;span style=&quot; font-style:italic;&quot;&gt;Stabilization&lt;/span&gt; page and click &lt;span style=&quot; font-style:italic;&quot;&gt;save&lt;/span&gt; to enable the new settings. &lt;br /&gt;&lt;/li&gt;
+&lt;li style=&quot; font-family:'Lucida Grande';&quot; style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ensure that a normal flight mode (not Autotune) is selected prior to the next flight.  If Autotune is left as the active mode, the flight controller will not arm.&lt;/li&gt;&lt;/ol&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
@@ -138,55 +137,6 @@ p, li { white-space: pre-wrap; }
                </size>
               </property>
              </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="stabilizationReloadBoardData_6">
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Reloads the saved settings into GCS. Useful if you have accidentally changed some settings.</string>
-              </property>
-              <property name="styleSheet">
-               <string notr="true"/>
-              </property>
-              <property name="text">
-               <string>Reload Board Data</string>
-              </property>
-              <property name="objrelation" stdset="0">
-               <stringlist>
-                <string>button:reload</string>
-                <string>buttongroup:10</string>
-               </stringlist>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="saveStabilizationToRAM_6">
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>Send settings to the board but do not save to the non-volatile memory</string>
-              </property>
-              <property name="styleSheet">
-               <string notr="true"/>
-              </property>
-              <property name="text">
-               <string>Apply</string>
-              </property>
-              <property name="objrelation" stdset="0">
-               <stringlist>
-                <string>button:apply</string>
-               </stringlist>
-              </property>
-             </widget>
             </item>
             <item>
              <widget class="QPushButton" name="saveStabilizationToSD_6">
@@ -316,8 +266,8 @@ p, li { white-space: pre-wrap; }
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>808</width>
-            <height>710</height>
+            <width>429</width>
+            <height>726</height>
            </rect>
           </property>
           <property name="sizePolicy">

--- a/ground/gcs/src/plugins/config/configattitudewidget.cpp
+++ b/ground/gcs/src/plugins/config/configattitudewidget.cpp
@@ -105,6 +105,10 @@ ConfigAttitudeWidget::ConfigAttitudeWidget(QWidget *parent) :
         }
     }
 
+    Core::Internal::GeneralSettings *settings = pm->getObject<Core::Internal::GeneralSettings>();
+    if (!settings->useExpertMode())
+	m_ui->applyButton->setVisible(false);
+
     // Must set up the UI (above) before setting up the UAVO mappings or refreshWidgetValues
     // will be dealing with some null pointers
     addUAVObject("AttitudeSettings");

--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -76,6 +76,11 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     PicoCSettings picoCSettings;
     QString picoCSettingsName = picoCSettings.getName();
 
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+    Core::Internal::GeneralSettings *settings = pm->getObject<Core::Internal::GeneralSettings>();
+    if (!settings->useExpertMode())
+       ui->saveRAM->setVisible(false);
+
     // Link the checkboxes
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbAirspeed, ModuleSettings::ADMINSTATE_AIRSPEED);
     addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbAltitudeHold, ModuleSettings::ADMINSTATE_ALTITUDEHOLD);

--- a/ground/gcs/src/plugins/config/configstabilizationwidget.cpp
+++ b/ground/gcs/src/plugins/config/configstabilizationwidget.cpp
@@ -3,6 +3,8 @@
  *
  * @file       configstabilizationwidget.h
  * @author     E. Lafargue & The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
+ *
  * @addtogroup GCSPlugins GCS Plugins
  * @{
  * @addtogroup ConfigPlugin Config Plugin
@@ -23,6 +25,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 #include "configstabilizationwidget.h"
 #include "convertmwrate.h"
@@ -50,11 +56,10 @@ ConfigStabilizationWidget::ConfigStabilizationWidget(QWidget *parent) : ConfigTa
 
     ExtensionSystem::PluginManager *pm=ExtensionSystem::PluginManager::instance();
     Core::Internal::GeneralSettings * settings=pm->getObject<Core::Internal::GeneralSettings>();
-    if(!settings->useExpertMode() || true)
-        m_stabilization->saveStabilizationToRAM_6->setVisible(false);
-    m_stabilization->saveStabilizationToRAM_6->setVisible(true);
 
-    
+    if (!settings->useExpertMode())
+        m_stabilization->saveStabilizationToRAM_6->setVisible(false);
+
 
     autoLoadWidgets();
     realtimeUpdates=new QTimer(this);

--- a/ground/gcs/src/plugins/config/defaulthwsettingswidget.cpp
+++ b/ground/gcs/src/plugins/config/defaulthwsettingswidget.cpp
@@ -3,6 +3,7 @@
  * @file       DefaultHwSettingsWidget.cpp
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2013
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
  * @addtogroup GCSPlugins GCS Plugins
  * @{
  * @addtogroup ConfigPlugin Config Plugin
@@ -23,6 +24,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 #include "defaulthwsettingswidget.h"
 #include "hwfieldselector.h"
@@ -50,6 +55,11 @@ DefaultHwSettingsWidget::DefaultHwSettingsWidget(QWidget *parent, bool autopilot
     //generic elements based on the hardware UAVO.
     fieldWidgets.clear();
 
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+    Core::Internal::GeneralSettings *settings = pm->getObject<Core::Internal::GeneralSettings>();
+    if (!settings->useExpertMode())
+        defaultHWSettingsWidget->applyButton->setVisible(false);
+
     bool unknown_board = true;
     if (autopilotConnected){
         addApplySaveButtons(defaultHWSettingsWidget->applyButton,defaultHWSettingsWidget->saveButton);
@@ -57,21 +67,18 @@ DefaultHwSettingsWidget::DefaultHwSettingsWidget(QWidget *parent, bool autopilot
 
         // Query the board plugin for the connected board to get the specific
         // hw settings object
-        ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-        if (pm != NULL) {
-             UAVObjectUtilManager* uavoUtilManager = pm->getObject<UAVObjectUtilManager>();
-             Core::IBoardType* board = uavoUtilManager->getBoardType();
-             if (board != NULL) {
-                 QString hwSwettingsObject = board->getHwUAVO();
+        UAVObjectUtilManager* uavoUtilManager = pm->getObject<UAVObjectUtilManager>();
+        Core::IBoardType* board = uavoUtilManager->getBoardType();
+        if (board != NULL) {
+            QString hwSwettingsObject = board->getHwUAVO();
 
-                 UAVObject *obj = getObjectManager()->getObject(hwSwettingsObject);
-                 if (obj != NULL) {
-                     unknown_board = false;
-                     qDebug() << "Checking object " << obj->getName();
-                     connect(obj,SIGNAL(transactionCompleted(UAVObject*,bool)), this, SLOT(settingsUpdated(UAVObject*,bool)));
-                     obj->requestUpdate();
-                 }
-             }
+            UAVObject *obj = getObjectManager()->getObject(hwSwettingsObject);
+            if (obj != NULL) {
+                unknown_board = false;
+                qDebug() << "Checking object " << obj->getName();
+                connect(obj,SIGNAL(transactionCompleted(UAVObject*,bool)), this, SLOT(settingsUpdated(UAVObject*,bool)));
+                obj->requestUpdate();
+            }
         }
     }
 

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -3037,7 +3037,7 @@ Apply or Save button afterwards.</string>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="camerastabilizationSaveRAM">
+      <widget class="QPushButton" name="saveRAM">
        <property name="minimumSize">
         <size>
          <width>0</width>


### PR DESCRIPTION
- Enable "expert mode" in default configs.  Fixes #405
- Eliminate "apply" button on a few more tabs when expert mode is not set.  Fix up associated instruction text.
- Improve autotune instructions in GCS to be a little more minimal/clear.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/592)

<!-- Reviewable:end -->
