### PR TITLE
sparky: remove vibration analysis

### DIFF
--- a/flight/targets/sparky/fw/Makefile
+++ b/flight/targets/sparky/fw/Makefile
@@ -51,7 +51,6 @@ OPTMODULES += AltitudeHold
 OPTMODULES += PathPlanner
 OPTMODULES += VtolPathFollower
 OPTMODULES += FixedWingPathFollower
-OPTMODULES += VibrationAnalysis
 OPTMODULES += UAVOMavlinkBridge
 OPTMODULES += UAVOMSPBridge
 OPTMODULES += UAVOLighttelemetryBridge 


### PR DESCRIPTION
We're just way too down to the wire on flash space on Sparky1, and this
is a very infrequently used feature that uses a ton of space.

before:

`-rw-r--r--  1 mlyle  staff  211268 Feb  2 11:21 build/fw_sparky/fw_sparky.tlfw`

after:

`-rw-r--r--  1 mlyle  staff  193004 Feb  2 11:20 build/fw_sparky/fw_sparky.tlfw`

fixes #527

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/595)

<!-- Reviewable:end -->
