### PR TITLE
flight / telemetry serial configuration work

### DIFF
--- a/flight/Modules/ComUsbBridge/ComUsbBridge.c
+++ b/flight/Modules/ComUsbBridge/ComUsbBridge.c
@@ -123,10 +123,6 @@ static int32_t comUsbBridgeInitialize(void)
 	}
 #endif
 
-	if (module_enabled) {
-		updateSettings();
-	}
-
 	return 0;
 }
 MODULE_INITCALL(comUsbBridgeInitialize, comUsbBridgeStart)
@@ -157,6 +153,8 @@ static void com2UsbBridgeTask(void *parameters)
 
 static void usb2ComBridgeTask(void * parameters)
 {
+	updateSettings();
+
 	/* Handle vcp -> usart direction */
 	volatile uint32_t tx_errors = 0;
 	while (1) {
@@ -179,7 +177,6 @@ static void usb2ComBridgeTask(void * parameters)
 static void updateSettings()
 {
 	if (usart_port) {
-
 		// Retrieve settings
 		uint8_t speed;
 		ModuleSettingsComUsbBridgeSpeedGet(&speed);

--- a/flight/Modules/ComUsbBridge/ComUsbBridge.c
+++ b/flight/Modules/ComUsbBridge/ComUsbBridge.c
@@ -8,6 +8,8 @@
  * @file       ComUsbBridge.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2011.
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
+ *
  * @brief      Bridges selected Com Port to the USB VCP emulated serial port
  * @see        The GNU Public License (GPL) Version 3
  *
@@ -26,6 +28,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 // ****************
@@ -34,6 +40,7 @@
 
 #include "modulesettings.h"
 #include "pios_thread.h"
+#include <pios_hal.h>
 
 #include <stdbool.h>
 
@@ -177,31 +184,7 @@ static void updateSettings()
 		uint8_t speed;
 		ModuleSettingsComUsbBridgeSpeedGet(&speed);
 
-		// Set port speed
-		switch (speed) {
-		case MODULESETTINGS_COMUSBBRIDGESPEED_2400:
-			PIOS_COM_ChangeBaud(usart_port, 2400);
-			break;
-		case MODULESETTINGS_COMUSBBRIDGESPEED_4800:
-			PIOS_COM_ChangeBaud(usart_port, 4800);
-			break;
-		case MODULESETTINGS_COMUSBBRIDGESPEED_9600:
-			PIOS_COM_ChangeBaud(usart_port, 9600);
-			break;
-		case MODULESETTINGS_COMUSBBRIDGESPEED_19200:
-			PIOS_COM_ChangeBaud(usart_port, 19200);
-			break;
-		case MODULESETTINGS_COMUSBBRIDGESPEED_38400:
-			PIOS_COM_ChangeBaud(usart_port, 38400);
-			break;
-		case MODULESETTINGS_COMUSBBRIDGESPEED_57600:
-			PIOS_COM_ChangeBaud(usart_port, 57600);
-			break;
-		case MODULESETTINGS_COMUSBBRIDGESPEED_115200:
-			PIOS_COM_ChangeBaud(usart_port, 115200);
-			break;
-		}
-
+		PIOS_HAL_ConfigureSerialSpeed(usart_port, speed);
 	}
 }
 

--- a/flight/Modules/GPS/GPS.c
+++ b/flight/Modules/GPS/GPS.c
@@ -2,12 +2,14 @@
  ******************************************************************************
  * @addtogroup TauLabsModules Tau Labs Modules
  * @{ 
- * @addtogroup GSPModule GPS Module
+ * @addtogroup GPSModule GPS Module
  * @{ 
  *
  * @file       GPS.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
+ *
  * @brief      GPS module, handles UBX and NMEA streams from GPS
  * @see        The GNU Public License (GPL) Version 3
  *
@@ -26,6 +28,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 // ****************
@@ -45,6 +51,8 @@
 #include "NMEA.h"
 #include "UBX.h"
 #include "ubx_cfg.h"
+
+#include <pios_hal.h>
 
 #if defined(PIOS_GPS_PROVIDES_AIRSPEED)
 #include "gps_airspeed.h"
@@ -325,32 +333,7 @@ static void updateSettings()
 		ModuleSettingsGPSSpeedGet(&speed);
 
 		// Set port speed
-		switch (speed) {
-		case MODULESETTINGS_GPSSPEED_2400:
-			PIOS_COM_ChangeBaud(gpsPort, 2400);
-			break;
-		case MODULESETTINGS_GPSSPEED_4800:
-			PIOS_COM_ChangeBaud(gpsPort, 4800);
-			break;
-		case MODULESETTINGS_GPSSPEED_9600:
-			PIOS_COM_ChangeBaud(gpsPort, 9600);
-			break;
-		case MODULESETTINGS_GPSSPEED_19200:
-			PIOS_COM_ChangeBaud(gpsPort, 19200);
-			break;
-		case MODULESETTINGS_GPSSPEED_38400:
-			PIOS_COM_ChangeBaud(gpsPort, 38400);
-			break;
-		case MODULESETTINGS_GPSSPEED_57600:
-			PIOS_COM_ChangeBaud(gpsPort, 57600);
-			break;
-		case MODULESETTINGS_GPSSPEED_115200:
-			PIOS_COM_ChangeBaud(gpsPort, 115200);
-			break;
-		case MODULESETTINGS_GPSSPEED_230400:
-			PIOS_COM_ChangeBaud(gpsPort, 230400);
-			break;
-		}
+		PIOS_HAL_ConfigureSerialSpeed(gpsPort, speed);
 	}
 }
 

--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -208,17 +208,19 @@ static void loggingTask(void *parameters)
 	// Get settings automatically for now on
 	LoggingSettingsConnectCopy(&settings);
 
-
 	LoggingStatsGet(&loggingData);
 	loggingData.BytesLogged = 0;
 	
 #if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)
-	if (destination_spi_flash)
-	{
+	if (destination_spi_flash) {
 		loggingData.MinFileId = PIOS_STREAMFS_MinFileId(streamfs_id);
 		loggingData.MaxFileId = PIOS_STREAMFS_MaxFileId(streamfs_id);
 	}
 #endif
+
+	if (!destination_spi_flash) {
+		updateSettings();
+	}
 
 	if (settings.LogBehavior == LOGGINGSETTINGS_LOGBEHAVIOR_LOGONSTART) {
 		loggingData.Operation = LOGGINGSTATS_OPERATION_INITIALIZING;

--- a/flight/Modules/PicoC/picoc_module.c
+++ b/flight/Modules/PicoC/picoc_module.c
@@ -7,6 +7,8 @@
  *
  * @file       picoc_module.c
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2014
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
+ *
  * @brief      c-interpreter module for autonomous user programmed tasks
  *             picoc module task
  * @see        The GNU Public License (GPL) Version 3
@@ -26,6 +28,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 
@@ -40,6 +46,8 @@
 #include "flightstatus.h"
 #include "modulesettings.h"
 #include "pios_thread.h"
+
+#include <pios_hal.h>
 
 // Global variables
 extern uintptr_t pios_waypoints_settings_fs_id;	/* use the waypoint filesystem */
@@ -292,30 +300,7 @@ static void updateSettings()
 {
 	// if there is a com port, setup its speed.
 	if (picocPort) {
-		// set port speed
-		switch (picocsettings.ComSpeed) {
-		case PICOCSETTINGS_COMSPEED_2400:
-			PIOS_COM_ChangeBaud(picocPort, 2400);
-			break;
-		case PICOCSETTINGS_COMSPEED_4800:
-			PIOS_COM_ChangeBaud(picocPort, 4800);
-			break;
-		case PICOCSETTINGS_COMSPEED_9600:
-			PIOS_COM_ChangeBaud(picocPort, 9600);
-			break;
-		case PICOCSETTINGS_COMSPEED_19200:
-			PIOS_COM_ChangeBaud(picocPort, 19200);
-			break;
-		case PICOCSETTINGS_COMSPEED_38400:
-			PIOS_COM_ChangeBaud(picocPort, 38400);
-			break;
-		case PICOCSETTINGS_COMSPEED_57600:
-			PIOS_COM_ChangeBaud(picocPort, 57600);
-			break;
-		case PICOCSETTINGS_COMSPEED_115200:
-			PIOS_COM_ChangeBaud(picocPort, 115200);
-			break;
-		}
+		PIOS_HAL_ConfigureSerialSpeed(picocPort, picocsettings.ComSpeed);
 	}
 }
 

--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -156,7 +156,6 @@ static int32_t RadioComBridgeStart(void)
 		// Configure the UAVObject callbacks
 		ObjectPersistenceConnectCallback(&objectPersistenceUpdatedCb);
 
-		updateSettings();
 		// Start the primary tasks for receiving/sending UAVTalk packets from the GCS.
 		data->telemetryTxTaskHandle = PIOS_Thread_Create(telemetryTxTask, "telemetryTxTask", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 		data->telemetryRxTaskHandle = PIOS_Thread_Create(telemetryRxTask, "telemetryRxTask", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
@@ -306,6 +305,8 @@ static void telemetryTxTask( __attribute__ ((unused))
 			    void *parameters)
 {
 	UAVObjEvent ev;
+
+	updateSettings();
 
 	// Loop forever
 	while (1) {

--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -171,7 +171,6 @@ static int32_t RadioComBridgeStart(void)
 
 		// Register the watchdog timers.
 #ifdef PIOS_INCLUDE_WDG
-		PIOS_WDG_RegisterFlag(PIOS_WDG_TELEMETRYTX);
 		PIOS_WDG_RegisterFlag(PIOS_WDG_TELEMETRYRX);
 		PIOS_WDG_RegisterFlag(PIOS_WDG_RADIOTX);
 		PIOS_WDG_RegisterFlag(PIOS_WDG_RADIORX);
@@ -307,6 +306,8 @@ static void telemetryTxTask( __attribute__ ((unused))
 	UAVObjEvent ev;
 
 	updateSettings();
+
+	PIOS_WDG_RegisterFlag(PIOS_WDG_TELEMETRYTX);
 
 	// Loop forever
 	while (1) {

--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -391,7 +391,7 @@ static void radioRxTask( __attribute__ ((unused))
 		PIOS_WDG_UpdateFlag(PIOS_WDG_RADIORX);
 #endif
 		if (PIOS_COM_RFM22B) {
-			uint8_t serial_data[1];
+			uint8_t serial_data[32];
 			uint16_t bytes_to_process =
 			    PIOS_COM_ReceiveBuffer(PIOS_COM_RFM22B,
 						   serial_data,
@@ -407,7 +407,7 @@ static void radioRxTask( __attribute__ ((unused))
 				}
 			}
 		} else {
-			PIOS_Thread_Sleep(5);
+			PIOS_Thread_Sleep(3);
 		}
 	}
 }
@@ -433,7 +433,7 @@ static void telemetryRxTask( __attribute__ ((unused))
 		}
 #endif /* PIOS_INCLUDE_USB */
 		if (inputPort) {
-			uint8_t serial_data[1];
+			uint8_t serial_data[32];
 			uint16_t bytes_to_process =
 			    PIOS_COM_ReceiveBuffer(inputPort, serial_data,
 						   sizeof(serial_data),

--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -8,7 +8,7 @@
  * @file       RadioComBridge.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2012.
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
- * @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @author     dRonin, http://dronin.org Copyright (C) 2015-2016
  * @brief      Bridges from RFM22b comm channel to another PIOS_COM channel
  *             has the ability to hook and process UAVO packets for the radio
  *             board (e.g. TauLink)
@@ -28,7 +28,11 @@
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
- * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USAa
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 // ****************
@@ -64,7 +68,6 @@
 #define RETRY_TIMEOUT_MS  20
 #define EVENT_QUEUE_SIZE  10
 #define MAX_PORT_DELAY    200
-#define SERIAL_RX_BUF_LEN 100
 #define PPM_INPUT_TIMEOUT 100
 
 // ****************
@@ -77,7 +80,6 @@ typedef struct {
 	struct pios_thread *radioTxTaskHandle;
 	struct pios_thread *radioRxTaskHandle;
 	struct pios_thread *PPMInputTaskHandle;
-	struct pios_thread *serialRxTaskHandle;
 
 	// The UAVTalk connection on the com side.
 	UAVTalkConnection telemUAVTalkCon;
@@ -87,18 +89,12 @@ typedef struct {
 	struct pios_queue *uavtalkEventQueue;
 	struct pios_queue *radioEventQueue;
 
-	// The raw serial Rx buffer
-	uint8_t serialRxBuf[SERIAL_RX_BUF_LEN];
-
 	// Error statistics.
 	uint32_t telemetryTxRetries;
 	uint32_t radioTxRetries;
 
 	// Is this modem the coordinator
 	bool isCoordinator;
-
-	// Should we parse UAVTalk?
-	bool parseUAVTalk;
 } RadioComBridgeData;
 
 // ****************
@@ -106,7 +102,6 @@ typedef struct {
 
 static void telemetryTxTask(void *parameters);
 static void telemetryRxTask(void *parameters);
-static void serialRxTask(void *parameters);
 static void radioTxTask(void *parameters);
 static void radioRxTask(void *parameters);
 static void PPMInputTask(void *parameters);
@@ -138,9 +133,6 @@ static int32_t RadioComBridgeStart(void)
 		// Check if this is the coordinator modem
 		data->isCoordinator = PIOS_RFM22B_IsCoordinator(PIOS_COM_RFM22B);
 
-		// Parse UAVTalk out of the link
-		data->parseUAVTalk = true;
-
 		// Configure our UAVObjects for updates.
 		UAVObjConnectQueue(UAVObjGetByID(RFM22BSTATUS_OBJID), data->uavtalkEventQueue,
 				   EV_UPDATED | EV_UPDATED_MANUAL | EV_UPDATE_REQ);
@@ -168,13 +160,6 @@ static int32_t RadioComBridgeStart(void)
 			data->PPMInputTaskHandle = PIOS_Thread_Create(PPMInputTask, "PPMInputTask",STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 #ifdef PIOS_INCLUDE_WDG
 			PIOS_WDG_RegisterFlag(PIOS_WDG_PPMINPUT);
-#endif
-		}
-		if (!data->parseUAVTalk) {
-			// If the user wants raw serial communication, we need to spawn another thread to handle it.
-			data->serialRxTaskHandle = PIOS_Thread_Create(serialRxTask, "serialRxTask", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
-#ifdef PIOS_INCLUDE_WDG
-			PIOS_WDG_RegisterFlag(PIOS_WDG_SERIALRX);
 #endif
 		}
 		data->radioTxTaskHandle = PIOS_Thread_Create(radioTxTask, "radioTxTask", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
@@ -223,8 +208,6 @@ static int32_t RadioComBridgeInitialize(void)
 	// Initialize the statistics.
 	data->telemetryTxRetries = 0;
 	data->radioTxRetries = 0;
-
-	data->parseUAVTalk = true;
 
 	return 0;
 }
@@ -394,30 +377,12 @@ static void radioRxTask( __attribute__ ((unused))
 						   sizeof(serial_data),
 						   MAX_PORT_DELAY);
 			if (bytes_to_process > 0) {
-				if (data->parseUAVTalk) {
-					// Pass the data through the UAVTalk parser.
-					for (uint8_t i = 0;
-					     i < bytes_to_process; i++) {
-						ProcessRadioStream(data->
-								   radioUAVTalkCon,
-								   data->
-								   telemUAVTalkCon,
-								   serial_data
-								   [i]);
-					}
-				} else if (PIOS_COM_TELEMETRY) {
-					// Send the data straight to the telemetry port.
-					// Following call can fail with -2 error code (buffer full) or -3 error code (could not acquire send mutex)
-					// It is the caller responsibility to retry in such cases...
-					int32_t ret = -2;
-					uint8_t count = 5;
-					while (count-- > 0 && ret < -1) {
-						ret =
-						    PIOS_COM_SendBufferNonBlocking
-						    (PIOS_COM_TELEMETRY,
-						     serial_data,
-						     bytes_to_process);
-					}
+				// Pass the data through the UAVTalk parser.
+				for (uint8_t i = 0;
+				     i < bytes_to_process; i++) {
+					ProcessRadioStream(data->radioUAVTalkCon,
+							   data->telemUAVTalkCon,
+							   serial_data[i]);
 				}
 			}
 		} else {
@@ -436,8 +401,7 @@ static void telemetryRxTask( __attribute__ ((unused))
 {
 	// Task loop
 	while (1) {
-		uint32_t inputPort =
-		    data->parseUAVTalk ? PIOS_COM_TELEMETRY : 0;
+		uint32_t inputPort = PIOS_COM_TELEMETRY;
 #ifdef PIOS_INCLUDE_WDG
 		PIOS_WDG_UpdateFlag(PIOS_WDG_TELEMETRYRX);
 #endif
@@ -499,49 +463,6 @@ static void PPMInputTask( __attribute__ ((unused))
 }
 
 /**
- * @brief Receive raw serial data from the USB/COM port.
- *
- * @param[in] parameters  The task parameters
- */
-static void serialRxTask( __attribute__ ((unused))
-			 void *parameters)
-{
-	// Task loop
-	while (1) {
-		uint32_t inputPort = PIOS_COM_TELEMETRY;
-#ifdef PIOS_INCLUDE_WDG
-		PIOS_WDG_UpdateFlag(PIOS_WDG_SERIALRX);
-#endif
-		if (inputPort && PIOS_COM_RFM22B) {
-			// Receive some data.
-			uint16_t bytes_to_process =
-			    PIOS_COM_ReceiveBuffer(inputPort,
-						   data->serialRxBuf,
-						   sizeof(data->
-							  serialRxBuf),
-						   MAX_PORT_DELAY);
-
-			if (bytes_to_process > 0) {
-				// Send the data over the radio link.
-				// Following call can fail with -2 error code (buffer full) or -3 error code (could not acquire send mutex)
-				// It is the caller responsibility to retry in such cases...
-				int32_t ret = -2;
-				uint8_t count = 5;
-				while (count-- > 0 && ret < -1) {
-					ret =
-					    PIOS_COM_SendBufferNonBlocking
-					    (PIOS_COM_RFM22B,
-					     data->serialRxBuf,
-					     bytes_to_process);
-				}
-			}
-		} else {
-			PIOS_Thread_Sleep(5);
-		}
-	}
-}
-
-/**
  * @brief Transmit data buffer to the com port.
  *
  * @param[in] buf Data buffer to send
@@ -552,7 +473,7 @@ static void serialRxTask( __attribute__ ((unused))
 static int32_t UAVTalkSendHandler(uint8_t * buf, int32_t length)
 {
 	int32_t ret;
-	uint32_t outputPort = data->parseUAVTalk ? PIOS_COM_TELEMETRY : 0;
+	uint32_t outputPort = PIOS_COM_TELEMETRY;
 
 #if defined(PIOS_INCLUDE_USB)
 	// Determine output port (USB takes priority over telemetry port)
@@ -560,6 +481,7 @@ static int32_t UAVTalkSendHandler(uint8_t * buf, int32_t length)
 		outputPort = PIOS_COM_TELEM_USB;
 	}
 #endif /* PIOS_INCLUDE_USB */
+
 	if (outputPort) {
 		// Following call can fail with -2 error code (buffer full) or -3 error code (could not acquire send mutex)
 		// It is the caller responsibility to retry in such cases...
@@ -586,9 +508,6 @@ static int32_t UAVTalkSendHandler(uint8_t * buf, int32_t length)
  */
 static int32_t RadioSendHandler(uint8_t * buf, int32_t length)
 {
-	if (!data->parseUAVTalk) {
-		return length;
-	}
 	uint32_t outputPort = PIOS_COM_RFM22B;
 
 	// Don't send any data unless the radio port is available.

--- a/flight/Modules/Telemetry/telemetry.c
+++ b/flight/Modules/Telemetry/telemetry.c
@@ -8,7 +8,7 @@
  * @file       telemetry.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
- * @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @author     dRonin, http://dronin.org Copyright (C) 2015-2016
  * @brief      Telemetry module, handles telemetry and UAVObject updates
  * @see        The GNU Public License (GPL) Version 3
  *
@@ -27,6 +27,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "openpilot.h"
@@ -555,14 +559,9 @@ static void updateTelemetryStats()
 
 /**
  * Update the telemetry settings, called on startup.
- * FIXME: This should be in the TelemetrySettings object. But objects
- * have too much overhead yet. Also the telemetry has no any specific
- * settings, etc. Thus the ModuleSettings object which contains the
- * telemetry port speed is used for now.
  */
 static void updateSettings()
 {
-	
 	if (PIOS_COM_TELEM_RF) {
 		// Retrieve settings
 		uint8_t speed;
@@ -588,6 +587,9 @@ static void updateSettings()
 		case MODULESETTINGS_TELEMETRYSPEED_57600:
 			PIOS_COM_ChangeBaud(PIOS_COM_TELEM_RF, 57600);
 			break;
+		case MODULESETTINGS_TELEMETRYSPEED_INIT_HC06:
+		case MODULESETTINGS_TELEMETRYSPEED_INIT_HM10:
+			/* XXX TODO: Initialize appropriately */
 		case MODULESETTINGS_TELEMETRYSPEED_115200:
 			PIOS_COM_ChangeBaud(PIOS_COM_TELEM_RF, 115200);
 			break;

--- a/flight/Modules/Telemetry/telemetry.c
+++ b/flight/Modules/Telemetry/telemetry.c
@@ -116,11 +116,6 @@ int32_t TelemetryStart(void)
 	TaskMonitorAdd(TASKINFO_RUNNING_TELEMETRYTX, telemetryTxTaskHandle);
 	TaskMonitorAdd(TASKINFO_RUNNING_TELEMETRYRX, telemetryRxTaskHandle);
 
-#if defined(PIOS_TELEM_PRIORITY_QUEUE)
-	telemetryTxPriTaskHandle = PIOS_Thread_Create(telemetryTxPriTask, "TelPriTx", STACK_SIZE_BYTES, NULL, TASK_PRIORITY_TXPRI);
-	TaskMonitorAdd(TASKINFO_RUNNING_TELEMETRYTXPRI, telemetryTxPriTaskHandle);
-#endif
-
 	return 0;
 }
 
@@ -142,9 +137,6 @@ int32_t TelemetryInitialize(void)
 #if defined(PIOS_TELEM_PRIORITY_QUEUE)
 	priorityQueue = PIOS_Queue_Create(MAX_QUEUE_SIZE, sizeof(UAVObjEvent));
 #endif
-
-	// Update telemetry settings
-	updateSettings();
 
 	// Initialise UAVTalk
 	uavTalkCon = UAVTalkInitialize(&transmitData);
@@ -363,6 +355,14 @@ static void processObjEvent(UAVObjEvent * ev)
  */
 static void telemetryTxTask(void *parameters)
 {
+	// Update telemetry settings
+	updateSettings();
+
+#if defined(PIOS_TELEM_PRIORITY_QUEUE)
+	telemetryTxPriTaskHandle = PIOS_Thread_Create(telemetryTxPriTask, "TelPriTx", STACK_SIZE_BYTES, NULL, TASK_PRIORITY_TXPRI);
+	TaskMonitorAdd(TASKINFO_RUNNING_TELEMETRYTXPRI, telemetryTxPriTaskHandle);
+#endif
+
 	UAVObjEvent ev;
 
 	// Loop forever

--- a/flight/Modules/Telemetry/telemetry.c
+++ b/flight/Modules/Telemetry/telemetry.c
@@ -406,7 +406,7 @@ static void telemetryRxTask(void *parameters)
 
 		if (inputPort) {
 			// Block until data are available
-			uint8_t serial_data[1];
+			uint8_t serial_data[16];
 			uint16_t bytes_to_process;
 
 			bytes_to_process = PIOS_COM_ReceiveBuffer(inputPort, serial_data, sizeof(serial_data), 500);
@@ -416,7 +416,7 @@ static void telemetryRxTask(void *parameters)
 				}
 			}
 		} else {
-			PIOS_Thread_Sleep(5);
+			PIOS_Thread_Sleep(3);
 		}
 	}
 }

--- a/flight/Modules/Telemetry/telemetry.c
+++ b/flight/Modules/Telemetry/telemetry.c
@@ -41,6 +41,8 @@
 #include "pios_thread.h"
 #include "pios_queue.h"
 
+#include "pios_hal.h"
+
 // Private constants
 #define MAX_QUEUE_SIZE   TELEM_QUEUE_SIZE
 #define STACK_SIZE_BYTES PIOS_TELEM_STACK_SIZE
@@ -565,39 +567,15 @@ static void updateTelemetryStats()
  */
 static void updateSettings()
 {
+#ifndef SIM_POSIX
 	if (PIOS_COM_TELEM_RF) {
 		// Retrieve settings
 		uint8_t speed;
 		ModuleSettingsTelemetrySpeedGet(&speed);
 
-		// Set port speed
-		switch (speed) {
-		case MODULESETTINGS_TELEMETRYSPEED_2400:
-			PIOS_COM_ChangeBaud(PIOS_COM_TELEM_RF, 2400);
-			break;
-		case MODULESETTINGS_TELEMETRYSPEED_4800:
-			PIOS_COM_ChangeBaud(PIOS_COM_TELEM_RF, 4800);
-			break;
-		case MODULESETTINGS_TELEMETRYSPEED_9600:
-			PIOS_COM_ChangeBaud(PIOS_COM_TELEM_RF, 9600);
-			break;
-		case MODULESETTINGS_TELEMETRYSPEED_19200:
-			PIOS_COM_ChangeBaud(PIOS_COM_TELEM_RF, 19200);
-			break;
-		case MODULESETTINGS_TELEMETRYSPEED_38400:
-			PIOS_COM_ChangeBaud(PIOS_COM_TELEM_RF, 38400);
-			break;
-		case MODULESETTINGS_TELEMETRYSPEED_57600:
-			PIOS_COM_ChangeBaud(PIOS_COM_TELEM_RF, 57600);
-			break;
-		case MODULESETTINGS_TELEMETRYSPEED_INIT_HC06:
-		case MODULESETTINGS_TELEMETRYSPEED_INIT_HM10:
-		/* XXX TODO: Initialize appropriately */
-		case MODULESETTINGS_TELEMETRYSPEED_115200:
-			PIOS_COM_ChangeBaud(PIOS_COM_TELEM_RF, 115200);
-			break;
-		}
+		PIOS_HAL_ConfigureSerialSpeed(PIOS_COM_TELEM_RF, speed);
 	}
+#endif
 }
 
 /**

--- a/flight/Modules/Telemetry/telemetry.c
+++ b/flight/Modules/Telemetry/telemetry.c
@@ -1,9 +1,9 @@
 /**
  ******************************************************************************
  * @addtogroup TauLabsModules Tau Labs Modules
- * @{ 
+ * @{
  * @addtogroup TelemetryModule Telemetry Module
- * @{ 
+ * @{
  *
  * @file       telemetry.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
@@ -86,7 +86,7 @@ static void gcsTelemetryStatsUpdated();
 static void updateSettings();
 static uintptr_t getComPort();
 static void session_managing_updated(UAVObjEvent * ev, void *ctx, void *obj,
-	int len);
+		int len);
 static void update_object_instances(uint32_t obj_id, uint32_t inst_id);
 static void check_pause_periodic_updates_timeout();
 
@@ -99,7 +99,7 @@ int32_t TelemetryStart(void)
 {
 	// Process all registered objects and connect queue for updates
 	UAVObjIterate(&registerObject);
-    
+
 	// Create periodic event that will be used to update the telemetry stats
 	UAVObjEvent ev;
 	memset(&ev, 0, sizeof(UAVObjEvent));
@@ -107,7 +107,7 @@ int32_t TelemetryStart(void)
 
 	// Listen to objects of interest
 	GCSTelemetryStatsConnectQueue(priorityQueue);
-    
+
 	// Start telemetry tasks
 	telemetryTxTaskHandle = PIOS_Thread_Create(telemetryTxTask, "TelTx", STACK_SIZE_BYTES, NULL, TASK_PRIORITY_TX);
 	telemetryRxTaskHandle = PIOS_Thread_Create(telemetryRxTask, "TelRx", STACK_SIZE_BYTES, NULL, TASK_PRIORITY_RX);
@@ -143,10 +143,10 @@ int32_t TelemetryInitialize(void)
 
 	// Update telemetry settings
 	updateSettings();
-    
+
 	// Initialise UAVTalk
 	uavTalkCon = UAVTalkInitialize(&transmitData);
-    
+
 	SessionManagingInitialize();
 	SessionManagingConnectCallback(session_managing_updated);
 
@@ -177,7 +177,7 @@ static void registerObject(UAVObjHandle obj)
 
 		/* Only create a periodic event for objects that are periodic */
 		if ((updateMode == UPDATEMODE_PERIODIC) ||
-			(updateMode == UPDATEMODE_THROTTLED)) {
+				(updateMode == UPDATEMODE_THROTTLED)) {
 			// Setup object for periodic updates
 			UAVObjEvent ev = {
 				.obj    = obj,
@@ -245,9 +245,9 @@ static void updateObject(UAVObjHandle obj, int32_t eventType)
 				// Once setting EV_UPDATED_THROTTLED_DIRTY, there is no need to listen for EV_UPDATED.
 				eventMask = EV_UPDATED_PERIODIC | EV_UPDATE_REQ | EV_UPDATED_THROTTLED_DIRTY;
 			} else { //If periodic is not set then we just received an object
-				// update so switch to periodic for the timeout period to prevent
-				// sending more updates.  Listen to the EV_UPDATED flag still to
-				// catch any updates that would overwise never get sent.
+				 // update so switch to periodic for the timeout period to prevent
+				 // sending more updates.  Listen to the EV_UPDATED flag still to
+				 // catch any updates that would overwise never get sent.
 				eventMask = EV_UPDATED_PERIODIC | EV_UPDATED | EV_UPDATED_MANUAL | EV_UPDATE_REQ;
 			}
 		}
@@ -287,16 +287,18 @@ static void processObjEvent(UAVObjEvent * ev)
 		// Act on event
 		retries = 0;
 		success = -1;
-		if (ev->event == EV_UPDATED || ev->event == EV_UPDATED_MANUAL || ((ev->event == EV_UPDATED_PERIODIC) && (updateMode != UPDATEMODE_THROTTLED))) {
+		if (ev->event == EV_UPDATED || ev->event == EV_UPDATED_MANUAL ||
+				((ev->event == EV_UPDATED_PERIODIC) && (updateMode != UPDATEMODE_THROTTLED))) {
 			// Send update to GCS (with retries)
 			if (pausePeriodicUpdates) {
 				check_pause_periodic_updates_timeout();
 			}
 			while (retries < MAX_RETRIES && success == -1) {
-				if((ev->obj !=FlightTelemetryStatsHandle()) && (ev->event == EV_UPDATED_PERIODIC) && pausePeriodicUpdates) {
+				if ((ev->obj !=FlightTelemetryStatsHandle()) && (ev->event == EV_UPDATED_PERIODIC) && pausePeriodicUpdates) {
 					success = 0;
 				} else {
-					success = UAVTalkSendObject(uavTalkCon, ev->obj, ev->instId, UAVObjGetTelemetryAcked(&metadata), REQ_TIMEOUT_MS);	// call blocks until ack is received or timeout
+					success = UAVTalkSendObject(uavTalkCon, ev->obj, ev->instId, UAVObjGetTelemetryAcked(
+										&metadata), REQ_TIMEOUT_MS);                                                    // call blocks until ack is received or timeout
 				}
 				++retries;
 			}
@@ -308,7 +310,7 @@ static void processObjEvent(UAVObjEvent * ev)
 		} else if (ev->event == EV_UPDATE_REQ) {
 			// Request object update from GCS (with retries)
 			while (retries < MAX_RETRIES && success == -1) {
-				success = UAVTalkSendObjectRequest(uavTalkCon, ev->obj, ev->instId, REQ_TIMEOUT_MS);	// call blocks until update is received or timeout
+				success = UAVTalkSendObjectRequest(uavTalkCon, ev->obj, ev->instId, REQ_TIMEOUT_MS);    // call blocks until update is received or timeout
 				++retries;
 			}
 			// Update stats
@@ -330,7 +332,8 @@ static void processObjEvent(UAVObjEvent * ev)
 					if (pausePeriodicUpdates) {
 						success = 0;
 					} else {
-						success = UAVTalkSendObject(uavTalkCon, ev->obj, ev->instId, UAVObjGetTelemetryAcked(&metadata), REQ_TIMEOUT_MS);	// call blocks until ack is received or timeout
+						success = UAVTalkSendObject(uavTalkCon, ev->obj, ev->instId, UAVObjGetTelemetryAcked(
+											&metadata), REQ_TIMEOUT_MS);                                                    // call blocks until ack is received or timeout
 					}
 					++retries;
 				}
@@ -343,7 +346,7 @@ static void processObjEvent(UAVObjEvent * ev)
 		}
 		// If this is a metaobject then make necessary telemetry updates
 		if (UAVObjIsMetaobject(ev->obj)) {
-			updateObject(UAVObjGetLinkedObj(ev->obj), EV_NONE);	// linked object will be the actual object the metadata are for
+			updateObject(UAVObjGetLinkedObj(ev->obj), EV_NONE);     // linked object will be the actual object the metadata are for
 		} else {
 			if (updateMode == UPDATEMODE_THROTTLED) {
 				// If this is UPDATEMODE_THROTTLED, the event mask changes on every event.
@@ -589,7 +592,7 @@ static void updateSettings()
 			break;
 		case MODULESETTINGS_TELEMETRYSPEED_INIT_HC06:
 		case MODULESETTINGS_TELEMETRYSPEED_INIT_HM10:
-			/* XXX TODO: Initialize appropriately */
+		/* XXX TODO: Initialize appropriately */
 		case MODULESETTINGS_TELEMETRYSPEED_115200:
 			PIOS_COM_ChangeBaud(PIOS_COM_TELEM_RF, 115200);
 			break;
@@ -598,18 +601,19 @@ static void updateSettings()
 }
 
 /**
- * Determine input/output com port as highest priority available 
+ * Determine input/output com port as highest priority available
  */
-static uintptr_t getComPort() {
+static uintptr_t getComPort()
+{
 #if defined(PIOS_INCLUDE_USB)
-	if ( PIOS_COM_Available(PIOS_COM_TELEM_USB) )
+	if (PIOS_COM_Available(PIOS_COM_TELEM_USB) )
 		return PIOS_COM_TELEM_USB;
 	else
 #endif /* PIOS_INCLUDE_USB */
-		if ( PIOS_COM_Available(PIOS_COM_TELEM_RF) )
-			return PIOS_COM_TELEM_RF;
-		else
-			return 0;
+	if (PIOS_COM_Available(PIOS_COM_TELEM_RF) )
+		return PIOS_COM_TELEM_RF;
+	else
+		return 0;
 }
 
 /**

--- a/flight/Modules/UAVOLighttelemetryBridge/UAVOLighttelemetryBridge.c
+++ b/flight/Modules/UAVOLighttelemetryBridge/UAVOLighttelemetryBridge.c
@@ -112,14 +112,6 @@ int32_t uavoLighttelemetryBridgeInitialize()
 		{ 
 			// Update telemetry settings
 			ltm_scheduler = 1;
-			updateSettings();
-			uint8_t speed;
-			ModuleSettingsLightTelemetrySpeedGet(&speed);
-			if (speed == MODULESETTINGS_LIGHTTELEMETRYSPEED_1200)
-				ltm_slowrate = 1;
-			else 
-				ltm_slowrate = 0;
-	
 			module_enabled = true; 
 			return 0;
 		}
@@ -154,6 +146,8 @@ MODULE_INITCALL(uavoLighttelemetryBridgeInitialize, uavoLighttelemetryBridgeStar
 
 static void uavoLighttelemetryBridgeTask(void *parameters)
 {
+	updateSettings();
+	
 	uint32_t lastSysTime;
 
 	// Main task loop
@@ -388,6 +382,11 @@ static void updateSettings()
 		ModuleSettingsLightTelemetrySpeedGet(&speed);
 
 		PIOS_HAL_ConfigureSerialSpeed(lighttelemetryPort, speed);
+
+		if (speed == MODULESETTINGS_LIGHTTELEMETRYSPEED_1200)
+			ltm_slowrate = 1;
+		else 
+			ltm_slowrate = 0;
 	}
 }
 #endif //end define lighttelemetry

--- a/flight/Modules/UAVOLighttelemetryBridge/UAVOLighttelemetryBridge.c
+++ b/flight/Modules/UAVOLighttelemetryBridge/UAVOLighttelemetryBridge.c
@@ -6,7 +6,9 @@
  * @{ 
  *
  * @file	   UAVOLighttelemetryBridge.c
+ * @author         dRonin, http://dRonin.org/, Copyright (C) 2016
  * @author	   Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
+ *
  * @brief	   Bridges selected UAVObjects to a minimal one way telemetry 
  *			   protocol for really low bitrates (1200/2400 bauds). This can be 
  *			   used with FSK audio modems or increase range for serial telemetry.
@@ -41,6 +43,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 #include "openpilot.h"
 #include "modulesettings.h"
@@ -55,6 +61,8 @@
 #include "manualcontrolcommand.h"
 #include "flightstatus.h"
 #include "pios_thread.h"
+
+#include <pios_hal.h>
 
 #if defined(PIOS_INCLUDE_LIGHTTELEMETRY)
 // Private constants
@@ -378,33 +386,8 @@ static void updateSettings()
 		// Retrieve settings
 		uint8_t speed;
 		ModuleSettingsLightTelemetrySpeedGet(&speed);
-		// Set port speed
-		switch (speed) {
-		case MODULESETTINGS_LIGHTTELEMETRYSPEED_1200:
-			PIOS_COM_ChangeBaud(lighttelemetryPort, 1200);
-			break;
-		case MODULESETTINGS_LIGHTTELEMETRYSPEED_2400:
-			PIOS_COM_ChangeBaud(lighttelemetryPort, 2400);
-			break;
-		case MODULESETTINGS_LIGHTTELEMETRYSPEED_4800:
-			PIOS_COM_ChangeBaud(lighttelemetryPort, 4800);
-			break;
-		case MODULESETTINGS_LIGHTTELEMETRYSPEED_9600:
-			PIOS_COM_ChangeBaud(lighttelemetryPort, 9600);
-			break;
-		case MODULESETTINGS_LIGHTTELEMETRYSPEED_19200:
-			PIOS_COM_ChangeBaud(lighttelemetryPort, 19200);
-			break;
-		case MODULESETTINGS_LIGHTTELEMETRYSPEED_38400:
-			PIOS_COM_ChangeBaud(lighttelemetryPort, 38400);
-			break;
-		case MODULESETTINGS_LIGHTTELEMETRYSPEED_57600:
-			PIOS_COM_ChangeBaud(lighttelemetryPort, 57600);
-			break;
-		case MODULESETTINGS_LIGHTTELEMETRYSPEED_115200:
-			PIOS_COM_ChangeBaud(lighttelemetryPort, 115200);
-			break;
-		}
+
+		PIOS_HAL_ConfigureSerialSpeed(lighttelemetryPort, speed);
 	}
 }
 #endif //end define lighttelemetry

--- a/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
+++ b/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
@@ -733,8 +733,6 @@ static int32_t uavoMSPBridgeInitialize(void)
 
 			msp->com = pios_com_msp_id;
 
-			setMSPSpeed(msp);
-
 			module_enabled = true;
 			return 0;
 		}
@@ -752,6 +750,8 @@ MODULE_INITCALL(uavoMSPBridgeInitialize, uavoMSPBridgeStart)
  */
 static void uavoMSPBridgeTask(void *parameters)
 {
+	setMSPSpeed(msp);
+
 	while (1) {
 		uint8_t b = 0;
 		uint16_t count = PIOS_COM_ReceiveBuffer(msp->com, &b, 1, PIOS_QUEUE_TIMEOUT_MAX);

--- a/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
+++ b/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
@@ -7,7 +7,7 @@
  *
  * @file       uavomspbridge.c
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015
- * @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @author     dRonin, http://dronin.org Copyright (C) 2015-2016
  * @brief      Bridges selected UAVObjects to MSP for MWOSD and the like.
  *
  * @see        The GNU Public License (GPL) Version 3
@@ -27,6 +27,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "openpilot.h"
@@ -54,6 +58,8 @@
 #include "flightbatterystate.h"
 #include "gpsposition.h"
 #include "modulesettings.h"
+
+#include <pios_hal.h>
 
 #if defined(PIOS_INCLUDE_MSP_BRIDGE)
 
@@ -705,29 +711,7 @@ static void setMSPSpeed(struct msp_bridge *m)
 		uint8_t speed;
 		ModuleSettingsMSPSpeedGet(&speed);
 
-		switch (speed) {
-		case MODULESETTINGS_MSPSPEED_2400:
-			PIOS_COM_ChangeBaud(m->com, 2400);
-			break;
-		case MODULESETTINGS_MSPSPEED_4800:
-			PIOS_COM_ChangeBaud(m->com, 4800);
-			break;
-		case MODULESETTINGS_MSPSPEED_9600:
-			PIOS_COM_ChangeBaud(m->com, 9600);
-			break;
-		case MODULESETTINGS_MSPSPEED_19200:
-			PIOS_COM_ChangeBaud(m->com, 19200);
-			break;
-		case MODULESETTINGS_MSPSPEED_38400:
-			PIOS_COM_ChangeBaud(m->com, 38400);
-			break;
-		case MODULESETTINGS_MSPSPEED_57600:
-			PIOS_COM_ChangeBaud(m->com, 57600);
-			break;
-		case MODULESETTINGS_MSPSPEED_115200:
-			PIOS_COM_ChangeBaud(m->com, 115200);
-			break;
-		}
+		PIOS_HAL_ConfigureSerialSpeed(m->com, speed);
 	}
 }
 

--- a/flight/Modules/UAVOMavlinkBridge/UAVOMavlinkBridge.c
+++ b/flight/Modules/UAVOMavlinkBridge/UAVOMavlinkBridge.c
@@ -50,6 +50,8 @@
 #include "mavlink.h"
 #include "pios_thread.h"
 
+#include <pios_hal.h>
+
 #include "custom_types.h"
 
 // ****************
@@ -499,30 +501,7 @@ static void updateSettings()
 		uint8_t speed;
 		ModuleSettingsMavlinkSpeedGet(&speed);
 
-		// Set port speed
-		switch (speed) {
-		case MODULESETTINGS_MAVLINKSPEED_2400:
-			PIOS_COM_ChangeBaud(mavlink_port, 2400);
-			break;
-		case MODULESETTINGS_MAVLINKSPEED_4800:
-			PIOS_COM_ChangeBaud(mavlink_port, 4800);
-			break;
-		case MODULESETTINGS_MAVLINKSPEED_9600:
-			PIOS_COM_ChangeBaud(mavlink_port, 9600);
-			break;
-		case MODULESETTINGS_MAVLINKSPEED_19200:
-			PIOS_COM_ChangeBaud(mavlink_port, 19200);
-			break;
-		case MODULESETTINGS_MAVLINKSPEED_38400:
-			PIOS_COM_ChangeBaud(mavlink_port, 38400);
-			break;
-		case MODULESETTINGS_MAVLINKSPEED_57600:
-			PIOS_COM_ChangeBaud(mavlink_port, 57600);
-			break;
-		case MODULESETTINGS_MAVLINKSPEED_115200:
-			PIOS_COM_ChangeBaud(mavlink_port, 115200);
-			break;
-		}
+		PIOS_HAL_ConfigureSerialSpeed(mavlink_port, speed);
 	}
 }
 /**

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -848,8 +848,8 @@ void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
 }
 #endif /* PIOS_INCLUDE_RFM22B */
 
-/* Needs some safety margin over 500. */
-#define BT_COMMAND_DELAY 575
+/* Needs some safety margin over 1000. */
+#define BT_COMMAND_DELAY 1100
 
 void PIOS_HAL_ConfigureSerialSpeed(uintptr_t com_id,
 		HwSharedSpeedBpsOptions speed) {
@@ -878,7 +878,7 @@ void PIOS_HAL_ConfigureSerialSpeed(uintptr_t com_id,
 		case HWSHARED_SPEEDBPS_INITHM10:
 			PIOS_COM_ChangeBaud(com_id, 9600);
 
-			/* 3.75 seconds, ouch. */
+			/* 8 seconds, ouch. */
 			PIOS_Thread_Sleep(BT_COMMAND_DELAY / 2);
 			PIOS_COM_SendString(com_id,"AT+NAMEdRonin");
 			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
@@ -899,32 +899,34 @@ void PIOS_HAL_ConfigureSerialSpeed(uintptr_t com_id,
 			/* Some modules default to 38400, some to 9600.
 			 * Best effort to work with 38400. */
 
-			/* 2.3 second init time. */
+			/* ~4.5 second init time. */
 			PIOS_COM_ChangeBaud(com_id, 38400);
-			PIOS_COM_SendString(com_id,"AT+BAUD4"); // 9600
+			PIOS_COM_SendString(com_id,"AT+BAUD8"); // 115200
 			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
-			PIOS_COM_ChangeBaud(com_id, 9600);
 
+			PIOS_COM_ChangeBaud(com_id, 9600);
+			PIOS_COM_SendString(com_id,"AT+BAUD8"); 
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
+
+			PIOS_COM_ChangeBaud(com_id, 115200); 
 			PIOS_COM_SendString(com_id,"AT+NAMEdRonin");
 			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
 			PIOS_COM_SendString(com_id,"AT+PIN0000");
 			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
-			PIOS_COM_SendString(com_id,"AT+BAUD8"); // 115200
-			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
-			PIOS_COM_ChangeBaud(com_id, 115200);
 			break;
 
 		case HWSHARED_SPEEDBPS_INITHC05:
 			/* Some modules default to 38400, some to 9600.
 			 * Best effort to work with 38400. */
 
-			/* 1.7 second init time; not silence delimited */
+			/* Not silence delimited; but usually requires you to
+			 * push a button at magical timing */
 			PIOS_COM_ChangeBaud(com_id, 38400);
 			PIOS_COM_SendString(com_id,"AT+UART=115200,0,0\r\n"); // 9600
-			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY/2);
 			PIOS_COM_ChangeBaud(com_id, 9600);
 			PIOS_COM_SendString(com_id,"AT+UART=115200,0,0\r\n"); // 9600
-			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY/2);
 
 			PIOS_COM_ChangeBaud(com_id, 115200);
 

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -914,6 +914,27 @@ void PIOS_HAL_ConfigureSerialSpeed(uintptr_t com_id,
 			PIOS_COM_ChangeBaud(com_id, 115200);
 			break;
 
+		case HWSHARED_SPEEDBPS_INITHC05:
+			/* Some modules default to 38400, some to 9600.
+			 * Best effort to work with 38400. */
+
+			/* 1.7 second init time; not silence delimited */
+			PIOS_COM_ChangeBaud(com_id, 38400);
+			PIOS_COM_SendString(com_id,"AT+UART=115200,0,0\r\n"); // 9600
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
+			PIOS_COM_ChangeBaud(com_id, 9600);
+			PIOS_COM_SendString(com_id,"AT+UART=115200,0,0\r\n"); // 9600
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
+
+			PIOS_COM_ChangeBaud(com_id, 115200);
+
+			PIOS_COM_SendString(com_id,"AT+NAME=dRonin\r\n");
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY/2);
+			PIOS_COM_SendString(com_id,"AT+PSWD=0000\r\n");
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY/2);
+
+			break;
+
 		case HWSHARED_SPEEDBPS_115200:
 			PIOS_COM_ChangeBaud(com_id, 115200);
 			break;

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -848,6 +848,9 @@ void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
 }
 #endif /* PIOS_INCLUDE_RFM22B */
 
+/* Needs some safety margin over 500. */
+#define BT_COMMAND_DELAY 575
+
 void PIOS_HAL_ConfigureSerialSpeed(uintptr_t com_id,
 		HwSharedSpeedBpsOptions speed) {
 	switch (speed) {
@@ -875,27 +878,39 @@ void PIOS_HAL_ConfigureSerialSpeed(uintptr_t com_id,
 		case HWSHARED_SPEEDBPS_INITHM10:
 			PIOS_COM_ChangeBaud(com_id, 9600);
 
-			/* XXX TODO Need appropriate delays between these. */
-
+			/* 3.75 seconds, ouch. */
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY / 2);
 			PIOS_COM_SendString(com_id,"AT+NAMEdRonin");
-			PIOS_COM_SendString(com_id,"AT+PIN:000000");
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
+			PIOS_COM_SendString(com_id,"AT+PIN000000");
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
 			PIOS_COM_SendString(com_id,"AT+MODE0");
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
 			PIOS_COM_SendString(com_id,"AT+SHOW1");
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
 			PIOS_COM_SendString(com_id,"AT+RESET");
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
 			PIOS_COM_SendString(com_id,"AT+BAUD4"); // 115200
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
 			PIOS_COM_ChangeBaud(com_id, 115200);
 			break;
 
 		case HWSHARED_SPEEDBPS_INITHC06:
+			/* Some modules default to 38400, some to 9600.
+			 * Best effort to work with 38400. */
+
+			/* 2.3 second init time. */
 			PIOS_COM_ChangeBaud(com_id, 38400);
 			PIOS_COM_SendString(com_id,"AT+BAUD4"); // 9600
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
 			PIOS_COM_ChangeBaud(com_id, 9600);
 
-			/* XXX TODO Need appropriate delays between these. */
-
 			PIOS_COM_SendString(com_id,"AT+NAMEdRonin");
-			PIOS_COM_SendString(com_id,"AT+PIN:0000");
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
+			PIOS_COM_SendString(com_id,"AT+PIN0000");
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
 			PIOS_COM_SendString(com_id,"AT+BAUD8"); // 115200
+			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
 			PIOS_COM_ChangeBaud(com_id, 115200);
 			break;
 

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -177,11 +177,11 @@ uintptr_t pios_com_debug_id;
 #endif
 
 #ifndef PIOS_COM_RFM22B_RF_RX_BUF_LEN
-#define PIOS_COM_RFM22B_RF_RX_BUF_LEN 512
+#define PIOS_COM_RFM22B_RF_RX_BUF_LEN 640
 #endif
 
 #ifndef PIOS_COM_RFM22B_RF_TX_BUF_LEN
-#define PIOS_COM_RFM22B_RF_TX_BUF_LEN 512
+#define PIOS_COM_RFM22B_RF_TX_BUF_LEN 640
 #endif
 
 /**

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -873,7 +873,7 @@ void PIOS_HAL_ConfigureSerialSpeed(uintptr_t com_id,
 			PIOS_COM_ChangeBaud(com_id, 38400);
 			break;
 		case HWSHARED_SPEEDBPS_57600:
-			PIOS_COM_ChangeBaud(com_id, 115200);
+			PIOS_COM_ChangeBaud(com_id, 57600);
 			break;
 		case HWSHARED_SPEEDBPS_INITHM10:
 			PIOS_COM_ChangeBaud(com_id, 9600);

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -851,6 +851,8 @@ void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
 /* Needs some safety margin over 1000. */
 #define BT_COMMAND_DELAY 1100
 
+#define BT_COMMAND_QDELAY 350
+
 void PIOS_HAL_ConfigureSerialSpeed(uintptr_t com_id,
 		HwSharedSpeedBpsOptions speed) {
 	switch (speed) {
@@ -878,21 +880,20 @@ void PIOS_HAL_ConfigureSerialSpeed(uintptr_t com_id,
 		case HWSHARED_SPEEDBPS_INITHM10:
 			PIOS_COM_ChangeBaud(com_id, 9600);
 
-			/* 8 seconds, ouch. */
-			PIOS_Thread_Sleep(BT_COMMAND_DELAY / 2);
-			PIOS_COM_SendString(com_id,"AT+NAMEdRonin");
-			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
-			PIOS_COM_SendString(com_id,"AT+PIN000000");
-			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
-			PIOS_COM_SendString(com_id,"AT+MODE0");
-			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
-			PIOS_COM_SendString(com_id,"AT+SHOW1");
-			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
-			PIOS_COM_SendString(com_id,"AT+RESET");
-			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
 			PIOS_COM_SendString(com_id,"AT+BAUD4"); // 115200
-			PIOS_Thread_Sleep(BT_COMMAND_DELAY);
+			PIOS_Thread_Sleep(BT_COMMAND_QDELAY);
+
 			PIOS_COM_ChangeBaud(com_id, 115200);
+
+			PIOS_Thread_Sleep(BT_COMMAND_QDELAY);
+			PIOS_COM_SendString(com_id,"AT+NAMEdRonin");
+			PIOS_Thread_Sleep(BT_COMMAND_QDELAY);
+			PIOS_COM_SendString(com_id,"AT+PASS000000");
+			PIOS_Thread_Sleep(BT_COMMAND_QDELAY);
+			PIOS_COM_SendString(com_id,"AT+POWE3");
+			PIOS_Thread_Sleep(BT_COMMAND_QDELAY);
+			PIOS_COM_SendString(com_id,"AT+RESET");
+			PIOS_Thread_Sleep(BT_COMMAND_QDELAY);
 			break;
 
 		case HWSHARED_SPEEDBPS_INITHC06:

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -2,7 +2,7 @@
  ******************************************************************************
  * @file       pios_hal.c
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2015
- * @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @author     dRonin, http://dronin.org Copyright (C) 2015-2016
  * @addtogroup PIOS PIOS Core hardware abstraction layer
  * @{
  * @addtogroup PIOS_HAL Hardware abstraction layer files
@@ -23,7 +23,12 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
+
 #include <pios.h>
 #include <pios_hal.h>
 #include <openpilot.h>
@@ -842,3 +847,64 @@ void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
 	RFM22BStatusInstSet(status_inst, &rfm22bstatus);
 }
 #endif /* PIOS_INCLUDE_RFM22B */
+
+void PIOS_HAL_ConfigureSerialSpeed(uintptr_t com_id,
+		HwSharedSpeedBpsOptions speed) {
+	switch (speed) {
+		case HWSHARED_SPEEDBPS_1200:
+			PIOS_COM_ChangeBaud(com_id, 2400);
+			break;
+		case HWSHARED_SPEEDBPS_2400:
+			PIOS_COM_ChangeBaud(com_id, 2400);
+			break;
+		case HWSHARED_SPEEDBPS_4800:
+			PIOS_COM_ChangeBaud(com_id, 4800);
+			break;
+		case HWSHARED_SPEEDBPS_9600:
+			PIOS_COM_ChangeBaud(com_id, 9600);
+			break;
+		case HWSHARED_SPEEDBPS_19200:
+			PIOS_COM_ChangeBaud(com_id, 19200);
+			break;
+		case HWSHARED_SPEEDBPS_38400:
+			PIOS_COM_ChangeBaud(com_id, 38400);
+			break;
+		case HWSHARED_SPEEDBPS_57600:
+			PIOS_COM_ChangeBaud(com_id, 115200);
+			break;
+		case HWSHARED_SPEEDBPS_INITHM10:
+			PIOS_COM_ChangeBaud(com_id, 9600);
+
+			/* XXX TODO Need appropriate delays between these. */
+
+			PIOS_COM_SendString(com_id,"AT+NAMEdRonin");
+			PIOS_COM_SendString(com_id,"AT+PIN:000000");
+			PIOS_COM_SendString(com_id,"AT+MODE0");
+			PIOS_COM_SendString(com_id,"AT+SHOW1");
+			PIOS_COM_SendString(com_id,"AT+RESET");
+			PIOS_COM_SendString(com_id,"AT+BAUD4"); // 115200
+			PIOS_COM_ChangeBaud(com_id, 115200);
+			break;
+
+		case HWSHARED_SPEEDBPS_INITHC06:
+			PIOS_COM_ChangeBaud(com_id, 38400);
+			PIOS_COM_SendString(com_id,"AT+BAUD4"); // 9600
+			PIOS_COM_ChangeBaud(com_id, 9600);
+
+			/* XXX TODO Need appropriate delays between these. */
+
+			PIOS_COM_SendString(com_id,"AT+NAMEdRonin");
+			PIOS_COM_SendString(com_id,"AT+PIN:0000");
+			PIOS_COM_SendString(com_id,"AT+BAUD8"); // 115200
+			PIOS_COM_ChangeBaud(com_id, 115200);
+			break;
+
+		case HWSHARED_SPEEDBPS_115200:
+			PIOS_COM_ChangeBaud(com_id, 115200);
+			break;
+
+		case HWSHARED_SPEEDBPS_230400:
+			PIOS_COM_ChangeBaud(com_id, 230400);
+			break;
+	}
+}

--- a/flight/PiOS/inc/pios_hal.h
+++ b/flight/PiOS/inc/pios_hal.h
@@ -79,4 +79,7 @@ void PIOS_HAL_ConfigureRFM22B(HwSharedRadioPortOptions radio_type,
 		int status_inst);
 #endif /* PIOS_INCLUDE_RFM22B */
 
+void PIOS_HAL_ConfigureSerialSpeed(uintptr_t com_id,
+		                HwSharedSpeedBpsOptions speed);
+
 #endif

--- a/flight/targets/pipxtreme/fw/pios_board.c
+++ b/flight/targets/pipxtreme/fw/pios_board.c
@@ -5,27 +5,27 @@
  * @addtogroup PipXtreme OpenPilot PipXtreme support files
  * @{
  *
- * @file       pios_board.c 
+ * @file       pios_board.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2011.
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
  * @author     dRonin, http://dronin.org Copyright (C) 2015
  * @brief      The board specific initialization routines
  * @see        The GNU Public License (GPL) Version 3
- * 
+ *
  *****************************************************************************/
-/* 
- * This program is free software; you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation; either version 3 of the License, or 
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
- * 
- * You should have received a copy of the GNU General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
@@ -55,7 +55,8 @@ uintptr_t pios_uavo_settings_fs_id;
  * initializes all the core subsystems on this specific hardware
  * called from System/openpilot.c
  */
-void PIOS_Board_Init(void) {
+void PIOS_Board_Init(void)
+{
 
 	/* Delay system */
 	PIOS_DELAY_Init();
@@ -80,10 +81,10 @@ void PIOS_Board_Init(void) {
 #if defined(PIOS_LED_HEARTBEAT)
 	PIOS_LED_Off(PIOS_LED_HEARTBEAT);
 #endif /* PIOS_LED_HEARTBEAT */
-	while (1) ;
+	while (1);
 #endif
 
-#endif	/* PIOS_INCLUDE_FLASH && PIOS_INCLUDE_LOGFS_SETTINGS */
+#endif  /* PIOS_INCLUDE_FLASH && PIOS_INCLUDE_LOGFS_SETTINGS */
 
 	/* Initialize the task monitor library */
 	TaskMonitorInitialize();
@@ -113,7 +114,7 @@ void PIOS_Board_Init(void) {
 
 #if defined(PIOS_INCLUDE_LED)
 	PIOS_LED_Init(&pios_led_cfg);
-#endif	/* PIOS_INCLUDE_LED */
+#endif  /* PIOS_INCLUDE_LED */
 
 #if defined(PIOS_INCLUDE_TIM)
 	/* Set up pulse timers */
@@ -121,7 +122,7 @@ void PIOS_Board_Init(void) {
 	PIOS_TIM_InitClock(&tim_2_cfg);
 	PIOS_TIM_InitClock(&tim_3_cfg);
 	PIOS_TIM_InitClock(&tim_4_cfg);
-#endif	/* PIOS_INCLUDE_TIM */
+#endif  /* PIOS_INCLUDE_TIM */
 
 	/* Initialize board specific USB data */
 	PIOS_USB_BOARD_DATA_Init();
@@ -152,8 +153,7 @@ void PIOS_Board_Init(void) {
 
 	/* Configure the USB virtual com port (VCP) */
 #if defined(PIOS_INCLUDE_USB_CDC)
-	if (usb_cdc_present)
-	{
+	if (usb_cdc_present) {
 		PIOS_HAL_ConfigureCDC(hwTauLink.VCPPort, pios_usb_id, &pios_usb_cdc_cfg);
 	}
 #endif
@@ -171,7 +171,7 @@ void PIOS_Board_Init(void) {
 			NULL,                                // dsm_cfg
 			0,                                   // dsm_mode
 			NULL,                                // sbus_rcvr_cfg
-			NULL,                                // sbus_cfg    
+			NULL,                                // sbus_cfg
 			false);                              // sbus_toggle
 
 	// Update the com baud rate.
@@ -199,10 +199,10 @@ void PIOS_Board_Init(void) {
 
 	const struct pios_rfm22b_cfg *rfm22b_cfg = PIOS_BOARD_HW_DEFS_GetRfm22Cfg(bdinfo->board_rev);
 	PIOS_HAL_ConfigureRFM22B(hwTauLink.Radio, bdinfo->board_type,
-	    bdinfo->board_rev, hwTauLink.MaxRfPower,
-	    hwTauLink.MaxRfSpeed, hwTauLink.RfBand, NULL, rfm22b_cfg,
-	    hwTauLink.MinChannel, hwTauLink.MaxChannel,
-	    hwTauLink.CoordID, 0);
+			bdinfo->board_rev, hwTauLink.MaxRfPower,
+			hwTauLink.MaxRfSpeed, hwTauLink.RfBand, NULL, rfm22b_cfg,
+			hwTauLink.MinChannel, hwTauLink.MaxChannel,
+			hwTauLink.CoordID, 0);
 
 	if (bdinfo->board_rev == TAULINK_VERSION_MODULE) {
 		// Configure the main serial port function
@@ -220,8 +220,8 @@ void PIOS_Board_Init(void) {
 			PIOS_Assert(rx_buffer);
 			PIOS_Assert(tx_buffer);
 			if (PIOS_COM_Init(&pios_com_telem_uart_bluetooth_id, &pios_usart_com_driver, pios_usart2_id,
-												rx_buffer, PIOS_COM_TELEM_RX_BUF_LEN,
-												tx_buffer, PIOS_COM_TELEM_TX_BUF_LEN)) {
+					rx_buffer, PIOS_COM_TELEM_RX_BUF_LEN,
+					tx_buffer, PIOS_COM_TELEM_TX_BUF_LEN)) {
 				PIOS_Assert(0);
 			}
 
@@ -238,7 +238,7 @@ void PIOS_Board_Init(void) {
 			PIOS_COM_ChangeBaud(pios_com_telem_uart_bluetooth_id, 115200);
 			pios_com_telem_serial_id = pios_com_telem_uart_bluetooth_id;
 		}
-			break;
+		break;
 		case HWTAULINK_BTPORT_COMBRIDGE:
 		{
 			// Note: if the main port is also on telemetry the bluetooth
@@ -252,8 +252,8 @@ void PIOS_Board_Init(void) {
 			PIOS_Assert(rx_buffer);
 			PIOS_Assert(tx_buffer);
 			if (PIOS_COM_Init(&pios_com_telem_uart_bluetooth_id, &pios_usart_com_driver, pios_usart2_id,
-												rx_buffer, PIOS_COM_TELEM_RX_BUF_LEN,
-												tx_buffer, PIOS_COM_TELEM_TX_BUF_LEN)) {
+					rx_buffer, PIOS_COM_TELEM_RX_BUF_LEN,
+					tx_buffer, PIOS_COM_TELEM_TX_BUF_LEN)) {
 				PIOS_Assert(0);
 			}
 
@@ -262,81 +262,83 @@ void PIOS_Board_Init(void) {
 			ModuleSettingsInitialize();
 			ModuleSettingsData moduleSettings;
 			ModuleSettingsGet(&moduleSettings);
-			switch(comBaud) {
-				case 4800:
-					moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_4800;
-					break;
-				case 9600:
-					moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_9600;
-					break;
-				case 19200:
-					moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_19200;
-					break;
-				case 38400:
-					moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_38400;
-					break;
-				case 57600:
-					moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_57600;
-					break;
-				case 115200:
-					moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_115200;
-					break;
-				default:
-					moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_9600;
+			switch (comBaud) {
+			case 4800:
+				moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_4800;
+				break;
+			case 9600:
+				moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_9600;
+				break;
+			case 19200:
+				moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_19200;
+				break;
+			case 38400:
+				moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_38400;
+				break;
+			case 57600:
+				moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_57600;
+				break;
+			case 115200:
+				moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_115200;
+				break;
+			default:
+				moduleSettings.ComUsbBridgeSpeed = MODULESETTINGS_COMUSBBRIDGESPEED_9600;
 			}
 			ModuleSettingsSet(&moduleSettings);
 
 			PIOS_COM_ChangeBaud(pios_com_telem_uart_bluetooth_id, comBaud);
 			pios_com_bridge_id = pios_com_telem_uart_bluetooth_id;
 		}
-			break;
+		break;
 		case HWTAULINK_MAINPORT_DISABLED:
 			break;
 		}
 	}
 
-    // Configure the flexi port
-    switch (hwTauLink.PPMPort) {
-    case HWTAULINK_PPMPORT_PPM:
-    {
+	// Configure the flexi port
+	switch (hwTauLink.PPMPort) {
+	case HWTAULINK_PPMPORT_PPM:
+	{
 #if defined(PIOS_INCLUDE_PPM)
-				/* PPM input is configured on the coordinator modem and sent in the RFM22BReceiver UAVO. */
-				uintptr_t pios_ppm_id;
-				PIOS_PPM_Init(&pios_ppm_id, &pios_ppm_cfg);
+		/* PPM input is configured on the coordinator modem and sent in the RFM22BReceiver UAVO. */
+		uintptr_t pios_ppm_id;
+		PIOS_PPM_Init(&pios_ppm_id, &pios_ppm_cfg);
 
-				if (PIOS_RCVR_Init(&pios_ppm_rcvr_id, &pios_ppm_rcvr_driver, pios_ppm_id)) {
-					PIOS_Assert(0);
-				}
+		if (PIOS_RCVR_Init(&pios_ppm_rcvr_id, &pios_ppm_rcvr_driver, pios_ppm_id)) {
+			PIOS_Assert(0);
+		}
 
 #endif /* PIOS_INCLUDE_PPM */
-        break;
-    }
-    case HWTAULINK_PPMPORT_SPORT:
+		break;
+	}
+	case HWTAULINK_PPMPORT_SPORT:
 #if defined(PIOS_INCLUDE_TARANIS_SPORT)
-        PIOS_HAL_ConfigureCom(&pios_usart_sport_cfg, 0, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sport_id);
+		PIOS_HAL_ConfigureCom(&pios_usart_sport_cfg, 0, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver,
+				&pios_com_frsky_sport_id);
 #endif /* PIOS_INCLUDE_TARANIS_SPORT */
-        break;
-    case HWTAULINK_PPMPORT_PPMSPORT:
-    {
+		break;
+	case HWTAULINK_PPMPORT_PPMSPORT:
+	{
 #if defined(PIOS_INCLUDE_TARANIS_SPORT)
-        PIOS_HAL_ConfigureCom(&pios_usart_sport_cfg, 0, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver, &pios_com_frsky_sport_id);
+		PIOS_HAL_ConfigureCom(&pios_usart_sport_cfg, 0, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, &pios_usart_com_driver,
+				&pios_com_frsky_sport_id);
 #endif /* PIOS_INCLUDE_TARANIS_SPORT */
 #if defined(PIOS_INCLUDE_PPM)
-        /* PPM input is configured on the coordinator modem and sent in the RFM22BReceiver UAVO. */
-        uintptr_t pios_ppm_id;
-        PIOS_PPM_Init(&pios_ppm_id, &pios_ppm_cfg);
+		/* PPM input is configured on the coordinator modem and sent in the RFM22BReceiver UAVO. */
+		uintptr_t pios_ppm_id;
+		PIOS_PPM_Init(&pios_ppm_id, &pios_ppm_cfg);
 
-        if (PIOS_RCVR_Init(&pios_ppm_rcvr_id, &pios_ppm_rcvr_driver, pios_ppm_id)) {
-            PIOS_Assert(0);
-        }
+		if (PIOS_RCVR_Init(&pios_ppm_rcvr_id, &pios_ppm_rcvr_driver, pios_ppm_id)) {
+			PIOS_Assert(0);
+		}
 
 #endif /* PIOS_INCLUDE_PPM */
-        break;
-    }
-    case HWTAULINK_PPMPORT_DISABLED:
-    default:
-        break;
-    }
+		break;
+	}
+	case HWTAULINK_PPMPORT_DISABLED:
+	default:
+		break;
+	}
 
 	if (PIOS_COM_TELEMETRY) {
 		PIOS_COM_ChangeBaud(PIOS_COM_TELEMETRY, comBaud);

--- a/flight/targets/pipxtreme/fw/pios_board.c
+++ b/flight/targets/pipxtreme/fw/pios_board.c
@@ -215,8 +215,8 @@ void PIOS_Board_Init(void)
 			if (PIOS_USART_Init(&pios_usart2_id, &pios_usart_bluetooth_cfg)) {
 				PIOS_Assert(0);
 			}
-			uint8_t *rx_buffer = (uint8_t *)PIOS_malloc(128);
-			uint8_t *tx_buffer = (uint8_t *)PIOS_malloc(256);
+			uint8_t *rx_buffer = (uint8_t *)PIOS_malloc(PIOS_COM_TELEM_RX_BUF_LEN);
+			uint8_t *tx_buffer = (uint8_t *)PIOS_malloc(PIOS_COM_TELEM_TX_BUF_LEN);
 			PIOS_Assert(rx_buffer);
 			PIOS_Assert(tx_buffer);
 			if (PIOS_COM_Init(&pios_com_telem_uart_bluetooth_id, &pios_usart_com_driver, pios_usart2_id,
@@ -290,7 +290,7 @@ void PIOS_Board_Init(void)
 			pios_com_bridge_id = pios_com_telem_uart_bluetooth_id;
 		}
 		break;
-		case HWTAULINK_MAINPORT_DISABLED:
+		case HWTAULINK_BTPORT_DISABLED:
 			break;
 		}
 	}

--- a/flight/targets/pipxtreme/fw/pios_board.c
+++ b/flight/targets/pipxtreme/fw/pios_board.c
@@ -44,11 +44,9 @@ uintptr_t pios_ppm_rcvr_id;
 
 uintptr_t pios_uavo_settings_fs_id;
 
-#define PIOS_COM_TELEM_RX_BUF_LEN 256
-#define PIOS_COM_TELEM_TX_BUF_LEN 256
-#define PIOS_COM_RFM22B_RF_RX_BUF_LEN 256
-#define PIOS_COM_RFM22B_RF_TX_BUF_LEN 256
-#define PIOS_COM_FRSKYSPORT_TX_BUF_LEN 16
+#define PIOS_COM_TELEM_RX_BUF_LEN 450
+#define PIOS_COM_TELEM_TX_BUF_LEN 450
+#define PIOS_COM_FRSKYSPORT_TX_BUF_LEN 24
 
 /**
  * PIOS_Board_Init()

--- a/ground/gcs/src/plugins/serialconnection/serialpluginconfiguration.cpp
+++ b/ground/gcs/src/plugins/serialconnection/serialpluginconfiguration.cpp
@@ -2,13 +2,14 @@
  ******************************************************************************
  *
  * @file       serialpluginconfiguration.cpp
+ * @author     dRonin, http://dRonin.org Copyright (C) 2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @see        The GNU Public License (GPL) Version 3
  * @addtogroup GCSPlugins GCS Plugins
  * @{
  * @addtogroup SerialPlugin Serial Connection Plugin
  * @{
- * @brief Impliments serial connection to the flight hardware for Telemetry
+ * @brief Implements serial connection to the flight hardware for Telemetry
  *****************************************************************************/
 /*
  * This program is free software; you can redistribute it and/or modify
@@ -24,6 +25,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "serialpluginconfiguration.h"
@@ -36,7 +41,7 @@
  */
 SerialPluginConfiguration::SerialPluginConfiguration(QString classId, QSettings* qSettings, QObject *parent) :
     IUAVGadgetConfiguration(classId, parent),
-    m_speed("57600"), m_reconnect(true)
+    m_speed("115200"), m_reconnect(true)
 {
     Q_UNUSED(qSettings);
 
@@ -64,10 +69,10 @@ void SerialPluginConfiguration::saveConfig(QSettings* settings) const {
 }
 void SerialPluginConfiguration::restoresettings()
 {
-    settings->beginGroup(QLatin1String("SerialConnection"));
+    settings->beginGroup(QLatin1String("SerialConn"));
     QString str=(settings->value(QLatin1String("speed"), tr("")).toString());
     if(str.isEmpty())
-        m_speed="57600";
+        m_speed="115200";
     else
         m_speed=str;
     m_reconnect = settings->value(QLatin1String("reconnect"), tr("")).toBool();
@@ -76,7 +81,7 @@ void SerialPluginConfiguration::restoresettings()
 }
 void SerialPluginConfiguration::savesettings() const
 {
-    settings->beginGroup(QLatin1String("SerialConnection"));
+    settings->beginGroup(QLatin1String("SerialConn"));
     settings->setValue(QLatin1String("speed"), m_speed);
     settings->setValue(QLatin1String("reconnect"), m_reconnect);
     settings->endGroup();

--- a/python/dronin/telemetry.py
+++ b/python/dronin/telemetry.py
@@ -576,6 +576,7 @@ def get_telemetry_by_args(desc="Process telemetry", service_in_iter=True,
     parser.add_argument("-b", "--baudrate",
                         action  = "store",
                         dest    = "baud",
+                        default = "115200",
                         help    = "baud rate for serial communications")
 
     parser.add_argument("source",

--- a/python/get_config.py
+++ b/python/get_config.py
@@ -11,7 +11,7 @@ import os
 import sys
 sys.path.insert(1, os.path.dirname(sys.path[0]))
 
-from taulabs import uavo, telemetry, uavo_collection
+from dronin import uavo, telemetry, uavo_collection
 
 #-------------------------------------------------------------------------------
 USAGE = "%(prog)s"

--- a/shared/uavobjectdefinition/hwshared.xml
+++ b/shared/uavobjectdefinition/hwshared.xml
@@ -40,6 +40,7 @@
 				<option>57600</option>
 				<option>115200</option>
 				<option>230400</option>
+				<option>Init HC05</option>
 				<option>Init HC06</option>
 				<option>Init HM10</option>
 			</options>

--- a/shared/uavobjectdefinition/hwshared.xml
+++ b/shared/uavobjectdefinition/hwshared.xml
@@ -29,6 +29,22 @@
 			</options>
 		</field>
 
+		<field name="SpeedBps" units="bps" type="enum" elements="1" defaultvalue="115200">
+			<options>
+				<option>1200</option>
+				<option>2400</option>
+				<option>4800</option>
+				<option>9600</option>
+				<option>19200</option>
+				<option>38400</option>
+				<option>57600</option>
+				<option>115200</option>
+				<option>230400</option>
+				<option>Init HC06</option>
+				<option>Init HM10</option>
+			</options>
+		</field>
+
 		<field name="MagOrientation" units="function" type="enum" elements="1" options="Top0degCW,Top90degCW,Top180degCW,Top270degCW,Bottom0degCW,Bottom90degCW,Bottom180degCW,Bottom270degCW" defaultvalue="Top0degCW" />
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" options="USBTelemetry,Disabled" defaultvalue="USBTelemetry"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" options="USBTelemetry,ComBridge,DebugConsole,PicoC,Disabled" defaultvalue="Disabled"/>

--- a/shared/uavobjectdefinition/hwtaulink.xml
+++ b/shared/uavobjectdefinition/hwtaulink.xml
@@ -16,7 +16,19 @@
 		<!-- Whenever port is on PPM_IN that data will be sent to remove side -->
 		<field name="PPMPort" units="" type="enum" elements="1" options="Disabled,PPM,SPORT,PPM+SPORT" defaultvalue="PPM+SPORT"/>
 		<field name="VCPPort" units="" type="enum" elements="1" parent="HwShared.USB_VCPPort" defaultvalue="Disabled"/>
-		<field name="ComSpeed" units="bps" type="enum" elements="1" options="4800,9600,19200,38400,57600,115200" defaultvalue="57600"/>
+		<field name="ComSpeed" units="bps" type="enum" parent="HwShared.SpeedBps" elements="1" defaultvalue="Init HM10">
+			<option>1200</option>
+			<option>2400</option>
+			<option>4800</option>
+			<option>9600</option>
+			<option>19200</option>
+			<option>38400</option>
+			<option>57600</option>
+			<option>115200</option>
+			<option>230400</option>
+			<option>Init HC06</option>
+			<option>Init HM10</option>
+		</field>
 
 		<!-- radio settings -->
 		<field name="MaxRfSpeed" units="bps" type="enum" elements="1" parent="HwShared.MaxRfSpeed" defaultvalue="64000"/>

--- a/shared/uavobjectdefinition/modulesettings.xml
+++ b/shared/uavobjectdefinition/modulesettings.xml
@@ -31,7 +31,7 @@
 		</field>
 
 		<!-- Telemetry Module Settings -->
-		<field name="TelemetrySpeed" units="bps" type="enum" elements="1" defaultvalue="57600">
+		<field name="TelemetrySpeed" units="bps" type="enum" elements="1" defaultvalue="Init HM-10">
 			<options>
 				<option>2400</option>
 				<option>4800</option>
@@ -40,6 +40,8 @@
 				<option>38400</option>
 				<option>57600</option>
 				<option>115200</option>
+				<option>Init HC06</option>
+				<option>Init HM10</option>
 			</options>
 		</field>
 

--- a/shared/uavobjectdefinition/modulesettings.xml
+++ b/shared/uavobjectdefinition/modulesettings.xml
@@ -77,17 +77,6 @@
 			</options>
 		</field>
 
-		<!-- GenericI2CSensor Module Settings -->
-		<field name="I2CVMProgramSelect" units="" type="enum" elements="1" defaultvalue="None">
-			<options>
-				<option>EndianTest</option>
-				<option>MathTest</option>
-				<option>None</option>
-				<option>OPBaroAltimeter</option>
-				<option>User</option>
-			</options>
-		</field>
-		
 		<!-- Mavlink Module Settings -->
 		<field name="MavlinkSpeed" units="bps" type="enum" elements="1" options="2400,4800,9600,19200,38400,57600,115200" defaultvalue="57600"/>
 		<field name="MSPSpeed" units="bps" type="enum" elements="1" options="2400,4800,9600,19200,38400,57600,115200" defaultvalue="115200"/>

--- a/shared/uavobjectdefinition/modulesettings.xml
+++ b/shared/uavobjectdefinition/modulesettings.xml
@@ -31,22 +31,21 @@
 		</field>
 
 		<!-- Telemetry Module Settings -->
-		<field name="TelemetrySpeed" units="bps" type="enum" elements="1" defaultvalue="Init HM-10">
+		<field name="TelemetrySpeed" units="bps" type="enum" elements="1" defaultvalue="115200" parent="HwShared.SpeedBps">
 			<options>
-				<option>2400</option>
-				<option>4800</option>
 				<option>9600</option>
 				<option>19200</option>
 				<option>38400</option>
 				<option>57600</option>
 				<option>115200</option>
+				<option>230400</option>
 				<option>Init HC06</option>
 				<option>Init HM10</option>
 			</options>
 		</field>
 
 		<!-- GPS Module Settings -->
-		<field name="GPSSpeed" units="bps" type="enum" elements="1" defaultvalue="57600">
+		<field name="GPSSpeed" units="bps" type="enum" elements="1" defaultvalue="57600" parent="HwShared.SpeedBps">
 			<options>
 				<option>2400</option>
 				<option>4800</option>
@@ -65,23 +64,13 @@
 		<field name="GPSDynamicsMode" units="" type="enum" elements="1" options="Portable, Pedestrian, Automotive, Airborne1G, Airborne2G, Airborne4G" defaultvalue="Airborne2G"/>
 
 		<!-- ComUsbBridge Module Settings -->
-		<field name="ComUsbBridgeSpeed" units="bps" type="enum" elements="1" defaultvalue="57600">
-			<options>
-				<option>2400</option>
-				<option>4800</option>
-				<option>9600</option>
-				<option>19200</option>
-				<option>38400</option>
-				<option>57600</option>
-				<option>115200</option>
-			</options>
-		</field>
+		<field name="ComUsbBridgeSpeed" units="bps" type="enum" elements="1" parent="HwShared.SpeedBps" defaultvalue="57600"/>
 
 		<!-- Mavlink Module Settings -->
-		<field name="MavlinkSpeed" units="bps" type="enum" elements="1" options="2400,4800,9600,19200,38400,57600,115200" defaultvalue="57600"/>
-		<field name="MSPSpeed" units="bps" type="enum" elements="1" options="2400,4800,9600,19200,38400,57600,115200" defaultvalue="115200"/>
+		<field name="MavlinkSpeed" units="bps" type="enum" elements="1" parent="HwShared.SpeedBps" options="2400,4800,9600,19200,38400,57600,115200" defaultvalue="57600"/>
+		<field name="MSPSpeed" units="bps" type="enum" elements="1" parent="HwShared.SpeedBps" options="2400,4800,9600,19200,38400,57600,115200" defaultvalue="115200"/>
 		<!-- LightTelemetry Module Settings -->
-		<field name="LightTelemetrySpeed" units="bps" type="enum" elements="1" options="1200,2400,4800,9600,19200,38400,57600,115200" defaultvalue="2400"/>
+		<field name="LightTelemetrySpeed" units="bps" type="enum" elements="1" parent="HwShared.SpeedBps" options="1200,2400,4800,9600,19200,38400,57600,115200" defaultvalue="2400"/>
 
 		<!-- FrSky telemetry Module Settings -->
 		<field name="FrskyAccelData" units="" type="enum" elements="1" options="Accels,NEDAccels, NEDVelocity, AttitudeAngles" defaultvalue="Accels"/>

--- a/shared/uavobjectdefinition/modulesettings.xml
+++ b/shared/uavobjectdefinition/modulesettings.xml
@@ -39,6 +39,7 @@
 				<option>57600</option>
 				<option>115200</option>
 				<option>230400</option>
+				<option>Init HC05</option>
 				<option>Init HC06</option>
 				<option>Init HM10</option>
 			</options>

--- a/shared/uavobjectdefinition/picocsettings.xml
+++ b/shared/uavobjectdefinition/picocsettings.xml
@@ -20,7 +20,7 @@
 				<option>File</option>
 			</options>
 		</field>
-		<field name="ComSpeed" units="bps" type="enum" elements="1" defaultvalue="115200">
+		<field name="ComSpeed" units="bps" type="enum" parent="HwShared.SpeedBps" elements="1" defaultvalue="115200">
 			<options>
 				<option>2400</option>
 				<option>4800</option>


### PR DESCRIPTION
Fixes #600 
- Correct pipxtreme buffer size and case statement
- Make a common parent type for almost all baud rate information.
- Increase default telemetry rate to 115200 in both flight and telemetry
- Factor baud rate management into PIOS_HAL from UAVOMSPBridge, UAVOMavlinkBridge, UAVOLightTelemetryBridge, Telemetry, PicoC, GPS, and ComUsbBridge.
- Teach baud rate management code how to initialize COTS bluetooth modules
- Adjust pipxtreme to always project a virtual "modulesettings"
- Eliminate raw-passthrough mode that is unused in radiocombridge

Also removes some i2c vm items that were missed and unused.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/607)

<!-- Reviewable:end -->
