### PR TITLE
Add Installation UUID to Usage Data reports

### DIFF
--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -294,17 +294,6 @@ int main(int argc, char **argv)
         overrideSettings(parser, settings);
         locale = settings->value("General/OverrideLanguage", locale).toString();
 
-        //Check the Installation UUID and Generate a new one if required
-        QUuid *installationUUID = new QUuid(settings->value(QLatin1String("General/InstallationUUID"),"").toString());
-        if(installationUUID == NULL){ //Create new UUID
-            QString uuid = QUuid::createUuid().toString();
-            displayError(QString("Error parsing Installation UUID. Generated new UUID: ") + uuid);
-            settings->setValue(QLatin1String("General/InstallationUUID"), uuid);
-            settings->sync();
-        }else{ //UUID OK
-            delete installationUUID;
-        }
-
         settingsFilename = settings->fileName();
         delete settings;
     }

--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -60,6 +60,7 @@
 #include <QBitmap>
 #include <QCommandLineParser>
 #include <QCommandLineOption>
+#include <QUuid>
 
 #include "libcrashreporter-qt/libcrashreporter-handler/Handler.h"
 
@@ -292,6 +293,18 @@ int main(int argc, char **argv)
         }
         overrideSettings(parser, settings);
         locale = settings->value("General/OverrideLanguage", locale).toString();
+
+        //Check the Installation UUID and Generate a new one if required
+        QUuid *installationUUID = new QUuid(settings->value(QLatin1String("General/InstallationUUID"),"").toString());
+        if(installationUUID == NULL){ //Create new UUID
+            QString uuid = QUuid::createUuid().toString();
+            displayError(QString("Error parsing Installation UUID. Generated new UUID: ") + uuid);
+            settings->setValue(QLatin1String("General/InstallationUUID"), uuid);
+            settings->sync();
+        }else{ //UUID OK
+            delete installationUUID;
+        }
+
         settingsFilename = settings->fileName();
         delete settings;
     }

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsoptionpage.cpp
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsoptionpage.cpp
@@ -45,6 +45,7 @@ QWidget *UsageStatsOptionPage::createPage(QWidget *parent)
     m_page->setupUi(w);
     m_page->cb_AllowSending->setChecked(m_config->getSendUsageStats());
     m_page->cb_AllowPrivate->setChecked(m_config->getSendPrivateData());
+    m_page->label_UUID->setText(QString("UUID: ")+m_config->getInstallationUUID());
     return w;
 }
 

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsoptionpage.ui
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsoptionpage.ui
@@ -14,6 +14,16 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_AllowPrivate">
+     <property name="text">
+      <string>Allow sending private data (IP, FC CPU numbers):</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="1">
     <widget class="QCheckBox" name="cb_AllowSending">
      <property name="sizePolicy">
@@ -59,13 +69,10 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_AllowPrivate">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_UUID">
      <property name="text">
-      <string>Allow sending private data (IP, FC CPU numbers):</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+      <string>&lt;UUID&gt;</string>
      </property>
     </widget>
    </item>

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.cpp
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.cpp
@@ -65,6 +65,8 @@ void UsageStatsPlugin::readConfig(QSettings *qSettings, Core::UAVConfigInfo *con
     sendUsageStats = (qSettings->value(QLatin1String("SendUsageStats"), sendUsageStats).toBool());
     sendPrivateData = (qSettings->value(QLatin1String("SendPrivateData"), sendPrivateData).toBool());
     qSettings->endGroup();
+
+    installationUUID = (qSettings->value(QLatin1String("General/InstallationUUID"), installationUUID).toString());
 }
 
 void UsageStatsPlugin::saveConfig(QSettings *qSettings, Core::UAVConfigInfo *configInfo)
@@ -235,6 +237,7 @@ QByteArray UsageStatsPlugin::processJson() {
     json["currentOS"] = QSysInfo::prettyProductName();
     json["currentArch"] = QSysInfo::currentCpuArchitecture();
     json["buildInfo"] = QSysInfo::buildAbi();
+    json["installationUUID"] = installationUUID;
     QJsonArray boardArray;
     foreach (boardLog board, boardLogList) {
         QJsonObject b;

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.cpp
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.cpp
@@ -47,7 +47,7 @@
 #include <QSysInfo>
 #include "usagestatsoptionpage.h"
 
-UsageStatsPlugin::UsageStatsPlugin(): sendUsageStats(true), sendPrivateData(true)
+UsageStatsPlugin::UsageStatsPlugin(): sendUsageStats(true), sendPrivateData(true), installationUUID("")
 {
     loop = new QEventLoop(this);
     connect(&netMngr, SIGNAL(finished(QNetworkReply*)), loop, SLOT(quit()));
@@ -64,9 +64,15 @@ void UsageStatsPlugin::readConfig(QSettings *qSettings, Core::UAVConfigInfo *con
     qSettings->beginGroup(QLatin1String("UsageStatistics"));
     sendUsageStats = (qSettings->value(QLatin1String("SendUsageStats"), sendUsageStats).toBool());
     sendPrivateData = (qSettings->value(QLatin1String("SendPrivateData"), sendPrivateData).toBool());
-    qSettings->endGroup();
 
-    installationUUID = (qSettings->value(QLatin1String("General/InstallationUUID"), installationUUID).toString());
+    //Check the Installation UUID and Generate a new one if required
+    installationUUID = QUuid(qSettings->value(QLatin1String("InstallationUUID"),"").toString());
+    if(installationUUID.isNull()){ //Create new UUID
+        installationUUID = QUuid::createUuid();
+        qSettings->setValue(QLatin1String("InstallationUUID"), installationUUID.toString());
+    }
+
+    qSettings->endGroup();
 }
 
 void UsageStatsPlugin::saveConfig(QSettings *qSettings, Core::UAVConfigInfo *configInfo)
@@ -237,7 +243,10 @@ QByteArray UsageStatsPlugin::processJson() {
     json["currentOS"] = QSysInfo::prettyProductName();
     json["currentArch"] = QSysInfo::currentCpuArchitecture();
     json["buildInfo"] = QSysInfo::buildAbi();
-    json["installationUUID"] = installationUUID;
+
+    if(!installationUUID.isNull())
+        json["installationUUID"] = installationUUID.toString().remove(QRegExp("[{}]*"));
+
     QJsonArray boardArray;
     foreach (boardLog board, boardLogList) {
         QJsonObject b;
@@ -302,6 +311,10 @@ void UsageStatsPlugin::setSendUsageStats(bool value)
 }
 
 
+QString UsageStatsPlugin::getInstallationUUID() const
+{
+    return installationUUID.toString().remove(QRegExp("[{}]*"));
+}
 
 AppCloseHook::AppCloseHook(UsageStatsPlugin *parent) : Core::ICoreListener(parent), m_parent(parent)
 {

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.h
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.h
@@ -87,6 +87,7 @@ private:
     QEventLoop *loop;
     bool sendUsageStats;
     bool sendPrivateData;
+    QString installationUUID;
 private slots:
     void pluginsLoadEnded();
     void addNewBoardSeen(deviceInfo, deviceDescriptorStruct);

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.h
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.h
@@ -38,6 +38,7 @@
 #include <QNetworkReply>
 #include <QNetworkAccessManager>
 #include <QEventLoop>
+#include <QUuid>
 
 using namespace uploader;
 struct boardLog
@@ -75,6 +76,8 @@ public:
 
     bool getSendPrivateData() const;
     void setSendPrivateData(bool value);
+
+    QString getInstallationUUID() const;
 public slots:
     void updateSettings();
 private:
@@ -87,7 +90,7 @@ private:
     QEventLoop *loop;
     bool sendUsageStats;
     bool sendPrivateData;
-    QString installationUUID;
+    QUuid installationUUID;
 private slots:
     void pluginsLoadEnded();
     void addNewBoardSeen(deviceInfo, deviceDescriptorStruct);


### PR DESCRIPTION
Creates an installation UUID in the configuration file and reports this UUID together with usage data. The UUID should be constant over different builds as long as settings are not erased.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/612)

<!-- Reviewable:end -->

edit by MPL: Fixes #493
