### PR TITLE
Add target to get SDL to the tools directory in OS X and fix package install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,8 @@ help:
 	@echo "     gtest_install        - Install the google unit test suite"
 	@echo "     uncrustify_install   - Install the uncrustify code formatter"
 	@echo "     openssl_install      - Install the openssl libraries on windows machines"	
+	@echo "     sdl_install          - Install the SDL libraries"
+
 	@echo
 	@echo "   [Big Hammer]"
 	@echo "     all                  - Generate UAVObjects, build openpilot firmware and gcs"

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -611,3 +611,24 @@ breakpad_install: breakpad_clean
 breakpad_clean:
 	$(V0) @echo " CLEAN        $(BREAKPAD_DIR)"
 	$(V1) [ ! -d "$(BREAKPAD_DIR)" ] || $(RM) -rf $(BREAKPAD_DIR)
+
+
+.PHONY: sdl_install
+
+# SDL download URL
+SDL_DIR  := $(TOOLS_DIR)/SDL.framework
+SDL_URL  := https://www.libsdl.org/release/SDL-1.2.15.dmg
+SDL_FILE := SDL-1.2.15.dmg
+
+ifdef MACOSX
+sdl_install:
+	$(V0) @echo " DOWNLOAD $(SDL_URL) "
+	$(V1) curl -L -k -o "$(DL_DIR)/$(SDL_FILE)" "$(SDL_URL)"
+	$(V1) hdiutil attach $(DL_DIR)/$(SDL_FILE);
+	$(V1) cp -r /Volumes/SDL/SDL.framework $(TOOLS_DIR);
+	$(V1) hdiutil detach /Volumes/SDL;
+	$(V1) rm $(DL_DIR)/$(SDL_FILE);
+endif
+
+
+

--- a/package/osx/libraries
+++ b/package/osx/libraries
@@ -25,8 +25,12 @@ cd ${CWD}
 
 # Copy SDL files
 echo "Copying SDL"
-cp -r "/Library/Frameworks/SDL.framework" "${APP}/Contents/Frameworks/"
 
+if [ -d "../tools/SDL.framework" ]; then
+	cp -r "../tools/SDL.framework" "${APP}/Contents/Frameworks/"
+else
+	cp -r "/Library/Frameworks/SDL.framework" "${APP}/Contents/Frameworks/"
+fi
 # these are optional
 echo "Changing package identification of SDL"
 install_name_tool -id \


### PR DESCRIPTION
Store SDL in the tools directory.
When doing package_installer, if the tools directory contains the SDL framework this will be used.

Only in OS X as I cannot test other systems.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/615)

<!-- Reviewable:end -->

edit by MPL: fixes #614
