### PR TITLE
Flight - MSP Bridge stack space overflows causing reset.

### DIFF
--- a/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
+++ b/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
@@ -150,7 +150,7 @@ struct msp_bridge {
 #if defined(PIOS_MSP_STACK_SIZE)
 #define STACK_SIZE_BYTES PIOS_MSP_STACK_SIZE
 #else
-#define STACK_SIZE_BYTES 672
+#define STACK_SIZE_BYTES 768
 #endif
 #define TASK_PRIORITY               PIOS_THREAD_PRIO_LOW
 


### PR DESCRIPTION
During bench testing of latest next plus #403, resets were observed when both GPS and MSP modules were enabled.  Cause of reset traced to insufficient MSP bridge stack space, likely due to new comp GPS calculations.  With MSP bridge stack size increased to 768 bytes, reset no longer observed, and free stack space of ~80 bytes indicated.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/618)

<!-- Reviewable:end -->
