### PR TITLE
GCS:Config: Add Acro+ insanity factor to expert stab page

### DIFF
--- a/ground/gcs/src/plugins/config/stabilization.ui
+++ b/ground/gcs/src/plugins/config/stabilization.ui
@@ -615,8 +615,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>935</width>
-            <height>814</height>
+            <width>937</width>
+            <height>820</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -10498,8 +10498,8 @@ border-radius: 5;</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>951</width>
-            <height>967</height>
+            <width>923</width>
+            <height>996</height>
            </rect>
           </property>
           <property name="autoFillBackground">
@@ -29361,8 +29361,8 @@ value as the Kp.</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>625</width>
-            <height>1430</height>
+            <width>923</width>
+            <height>1521</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -34550,6 +34550,110 @@ border-radius: 5;</string>
                    </item>
                   </layout>
                  </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="gbAcroPlus">
+               <property name="title">
+                <string>Acro+</string>
+               </property>
+               <layout class="QGridLayout" name="gridLayout_31">
+                <item row="0" column="1">
+                 <widget class="QLabel" name="lblInsanityFactor">
+                  <property name="minimumSize">
+                   <size>
+                    <width>150</width>
+                    <height>16</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Insanity Factor (%)</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="3">
+                 <widget class="QDoubleSpinBox" name="sbInsanityFactor">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>103</width>
+                    <height>22</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>217</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                  <property name="decimals">
+                   <number>0</number>
+                  </property>
+                  <property name="objrelation" stdset="0">
+                   <stringlist>
+                    <string>objname:StabilizationSettings</string>
+                    <string>fieldname:AcroInsanityFactor</string>
+                    <string>haslimits:yes</string>
+                    <string>scale:1</string>
+                    <string>buttongroup:10</string>
+                   </stringlist>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="4">
+                 <spacer name="horizontalSpacer_21">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item row="0" column="2">
+                 <spacer name="horizontalSpacer_23">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>10</width>
+                    <height>10</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item row="0" column="0">
+                 <spacer name="horizontalSpacer_25">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
                 </item>
                </layout>
               </widget>

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -45,7 +45,9 @@
 
 	<field name="CoordinatedFlightYawPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="0,0.1,0.5" limits="%BE:0:1,%BE:0:1, "/>
 
-	<field name="AcroInsanityFactor" units="percent" type="float" elements="1" defaultvalue="40" limits="%BE:0:100"/>
+	<field name="AcroInsanityFactor" units="percent" type="float" elements="1" defaultvalue="40" limits="%BE:0:100">
+		<description>Only applicable to Acro+ flight mode. Controls the amount of stick input fed directly to the actuators (AKA "gyro suppression"), 100% results in full manual control at full stick deflection. Note: the rate settings are no longer directly applicable, especially with high insanity factors.</description>
+	</field>
 
 	<field name="CameraTilt" units="deg" type="float" elements="1" defaultvalue="0" limits="%BE:0:85"/>
   


### PR DESCRIPTION
As per title. Adds description to UAVO field too.

Note: this doesn't currently have a tooltip but I will soon submit another PR which uses the UAVO description as tooltip when the UI files don't already have one, applicable to all UAVO->widget relations.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/624)

<!-- Reviewable:end -->
