### PR TITLE
Config: Use UAVO field descriptions for widget tooltips

### DIFF
--- a/ground/gcs/src/plugins/uavobjectbrowser/treeitem.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/treeitem.h
@@ -113,10 +113,8 @@ public:
     QVariant data(int column = 1) const;
     QString description() { return m_description; }
     void setDescription(QString d) {
-        if(d.trimmed().isEmpty()) {
-            m_description = QString();
-        }
-        else {
+        d = d.trimmed().toHtmlEscaped();
+        if(!d.isEmpty()) {
             // insert html tags to make this rich text so Qt will take care of wrapping
             d.prepend("<span style='font-style: normal'>");
             d.remove("@Ref", Qt::CaseInsensitive);

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
@@ -1314,7 +1314,7 @@ bool ConfigTaskWidget::setWidgetFromField(QWidget * widget,UAVObjectField * fiel
 
     // use UAVO field description as tooltip if the widget doesn't already have one
     if (!widget->toolTip().length()) {
-        QString desc = field->getDescription().trimmed();
+        QString desc = field->getDescription().trimmed().toHtmlEscaped();
         if (desc.length()) {
             // insert html tags to make this rich text so Qt will take care of wrapping
             desc.prepend("<span style='font-style: normal'>");

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
@@ -1311,6 +1311,19 @@ bool ConfigTaskWidget::setWidgetFromField(QWidget * widget,UAVObjectField * fiel
 {
     if(!widget || !field)
         return false;
+
+    // use UAVO field description as tooltip if the widget doesn't already have one
+    if (!widget->toolTip().length()) {
+        QString desc = field->getDescription().trimmed();
+        if (desc.length()) {
+            // insert html tags to make this rich text so Qt will take care of wrapping
+            desc.prepend("<span style='font-style: normal'>");
+            desc.remove("@Ref", Qt::CaseInsensitive);
+            desc.append("</span>");
+        }
+        widget->setToolTip(desc);
+    }
+
     if(QComboBox * cb=qobject_cast<QComboBox *>(widget))
     {
         if(cb->count()==0)


### PR DESCRIPTION
When widgets don't already have a tooltip defined.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/625)

<!-- Reviewable:end -->
