### PR TITLE
makefile: ef:  don't ask for bin (it's implied)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -736,7 +736,7 @@ endef
 # $(4) = yes for bootloader, no for no bootloader
 define EF_TEMPLATE
 .PHONY: ef_$(1)
-ef_$(1): ef_$(1)_bin ef_$(1)_hex
+ef_$(1): ef_$(1)_hex
 
 FW_FILES += $(BUILD_DIR)/ef_$(1)/ef_$(1).hex
 


### PR DESCRIPTION
Prevents this:

```
/var/lib/jenkins/jobs/dron/workspace/Nodes/master/tools/gcc-arm-none-eabi-5_2-2015q4/bin/arm-none-eabi-objcopy: error: the input file '/var/lib/jenkins/jobs/dron/workspace/Nodes/master/build/ef_pipxtreme/ef_pipxtreme.bin' is empty
```

which is seen intermittently in jenkins, from two attempts to do the .bin stuff at once.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/632)

<!-- Reviewable:end -->
