### PR TITLE
AH throttle_desired integral calculation error

### DIFF
--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -168,6 +168,7 @@ static void altitudeHoldTask(void *parameters)
 			timeout = engaged ? dt_ms : 100;
 
 			continue;
+
 		} else if (ev.obj == AltitudeHoldSettingsHandle()) {
 			AltitudeHoldSettingsGet(&altitudeHoldSettings);
 

--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -134,7 +134,6 @@ static void altitudeHoldTask(void *parameters)
 	struct pid velocity_pid;
 
 	// Listen for object updates.
-	AltitudeHoldDesiredConnectQueue(queue);
 	AltitudeHoldSettingsConnectQueue(queue);
 	FlightStatusConnectQueue(queue);
 
@@ -145,7 +144,7 @@ static void altitudeHoldTask(void *parameters)
 	AlarmsSet(SYSTEMALARMS_ALARM_ALTITUDEHOLD, SYSTEMALARMS_ALARM_OK);
 
 	// Main task loop
-	const uint32_t dt_ms = 5;
+	const uint32_t dt_ms = 20;
 	const float dt_s = dt_ms * 0.001f;
 	uint32_t timeout = dt_ms;
 
@@ -162,25 +161,19 @@ static void altitudeHoldTask(void *parameters)
 				StabilizationDesiredThrottleGet(&velocity_pid.iAccumulator);
 				engaged = true;
 
-				// Make sure this uses a valid AltitudeHoldDesired. No delay is really required here
-				// because ManualControl sets AltitudeHoldDesired first before the FlightStatus, but
-				// this is just to be conservative at 1ms when engaging will not bother the pilot.
-				PIOS_Thread_Sleep(1);
-				AltitudeHoldDesiredGet(&altitudeHoldDesired);
-
 			} else if (flight_mode != FLIGHTSTATUS_FLIGHTMODE_ALTITUDEHOLD)
 				engaged = false;
 
 			// Run loop at 20 Hz when engaged otherwise just slowly wait for it to be engaged
 			timeout = engaged ? dt_ms : 100;
 
-		} else if (ev.obj == AltitudeHoldDesiredHandle()) {
-			AltitudeHoldDesiredGet(&altitudeHoldDesired);
+			continue;
 		} else if (ev.obj == AltitudeHoldSettingsHandle()) {
 			AltitudeHoldSettingsGet(&altitudeHoldSettings);
 
 			pid_configure(&velocity_pid, altitudeHoldSettings.VelocityKp,
 				          altitudeHoldSettings.VelocityKi, 0.0f, 1.0f);
+			continue;
 		}
 
 		bool landing = altitudeHoldDesired.Land == ALTITUDEHOLDDESIRED_LAND_TRUE;
@@ -199,6 +192,7 @@ static void altitudeHoldTask(void *parameters)
 			velocity_z = -velocity_z; // Use positive up convention
 
 			// Compute the altitude error
+			AltitudeHoldDesiredGet(&altitudeHoldDesired);
 			altitude_error = altitudeHoldDesired.Altitude - position_z;
 
 			// Velocity desired is from the outer controller plus the set point

--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -147,6 +147,7 @@ static void altitudeHoldTask(void *parameters)
 	// Main task loop
 	const uint32_t dt_ms = 20;
 	uint32_t timeout = dt_ms;
+	uint32_t timeval = PIOS_DELAY_GetRaw();
 
 	while (1) {
 		if (PIOS_Queue_Receive(queue, &ev, timeout) != true) {
@@ -160,7 +161,7 @@ static void altitudeHoldTask(void *parameters)
 				// Copy the current throttle as a starting point for integral
 				StabilizationDesiredThrottleGet(&velocity_pid.iAccumulator);
 				engaged = true;
-				uint32_t timeval = PIOS_DELAY_GetRaw();
+				timeval = PIOS_DELAY_GetRaw();
 
 			} else if (flight_mode != FLIGHTSTATUS_FLIGHTMODE_ALTITUDEHOLD)
 				engaged = false;

--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -6,6 +6,7 @@
  * @{
  *
  * @file       altitudehold.c
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
  * @brief      This module runs an EKF to estimate altitude from just a barometric
  *             sensor and controls throttle to hold a fixed altitude
@@ -145,7 +146,6 @@ static void altitudeHoldTask(void *parameters)
 
 	// Main task loop
 	const uint32_t dt_ms = 20;
-	const float dt_s = dt_ms * 0.001f;
 	uint32_t timeout = dt_ms;
 
 	while (1) {
@@ -160,6 +160,7 @@ static void altitudeHoldTask(void *parameters)
 				// Copy the current throttle as a starting point for integral
 				StabilizationDesiredThrottleGet(&velocity_pid.iAccumulator);
 				engaged = true;
+				uint32_t timeval = PIOS_DELAY_GetRaw();
 
 			} else if (flight_mode != FLIGHTSTATUS_FLIGHTMODE_ALTITUDEHOLD)
 				engaged = false;
@@ -197,11 +198,13 @@ static void altitudeHoldTask(void *parameters)
 			altitude_error = altitudeHoldDesired.Altitude - position_z;
 
 			// Velocity desired is from the outer controller plus the set point
+			float dT = PIOS_DELAY_DiffuS(timeval) * 1.0e-6f;
+			timeval = PIOS_DELAY_GetRaw();
 			float velocity_desired = altitude_error * altitudeHoldSettings.PositionKp + altitudeHoldDesired.ClimbRate;
 			float throttle_desired = pid_apply_antiwindup(&velocity_pid, 
 			                    velocity_desired - velocity_z,
 			                    min_throttle, 1.0f, // positive limits since this is throttle
-			                    dt_s);
+			                    dT);
 
 			AltitudeHoldStateData altitudeHoldState;
 			altitudeHoldState.VelocityDesired = velocity_desired;


### PR DESCRIPTION
The current altitude hold loop has two active paths which allow control to be passed to the throttle_desired pid_apply_antiwindup() function during flight. The first is the loop timeout specified by dt_ms and the second is changes to the AltitudeHoldDesired object. The latter occurs every 20 ms as defined by the ManualControl task rate. Unfortunately, when the AltitudeHoldeDesired object is updated, regardless of whether the throttle changed or not, the pid_apply_antiwindup is called at some time interval less than dt_ms. Therfore a velocity error is computed for this shortened time interval yet pid_apply_antiwindup is still passed the dt_ms time value, resulting in a throttle_desired PID integral calculation error.

I am opening this up for the experts to weigh in on this proposed change where the ManualControl and AltitudeHold task be performed independent of each other, where altitudeHoldTask will sample AltitudeHoldDesired only when the dt_ms timer expires. This proposed change eliminates the integral calculation error associated with the incorrect velocity error calculated off cycle from dt_ms. I further suggest this change allows the AH task to run at a more reasonable loop rate (20ms or longer), thereby freeing up cpu resources.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/633)

<!-- Reviewable:end -->
