### PR TITLE
GCS:Autotune: Correct damping display, add reset button

### DIFF
--- a/ground/gcs/src/plugins/config/autotune.ui
+++ b/ground/gcs/src/plugins/config/autotune.ui
@@ -591,7 +591,7 @@ p, li { white-space: pre-wrap; }
               <item row="1" column="2">
                <widget class="QLabel" name="lblDamp">
                 <property name="text">
-                 <string>1.1</string>
+                 <string>1.10</string>
                 </property>
                </widget>
               </item>
@@ -661,7 +661,14 @@ p, li { white-space: pre-wrap; }
               <item row="2" column="2">
                <widget class="QLabel" name="lblNoise">
                 <property name="text">
-                 <string>1.0</string>
+                 <string>1.0 %</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2">
+               <widget class="QPushButton" name="btnResetSliders">
+                <property name="text">
+                 <string>Reset Sliders</string>
                 </property>
                </widget>
               </item>

--- a/ground/gcs/src/plugins/config/configautotunewidget.cpp
+++ b/ground/gcs/src/plugins/config/configautotunewidget.cpp
@@ -92,8 +92,12 @@ ConfigAutotuneWidget::ConfigAutotuneWidget(QWidget *parent) :
     connect(m_autotune->useComputedValues, SIGNAL(pressed()), this, SLOT(saveStabilization()));
 
     connect(m_autotune->shareDataPB, SIGNAL(pressed()),this, SLOT(onShareData()));
+    connect(m_autotune->btnResetSliders, SIGNAL(pressed()), this, SLOT(resetSliders()));
 
     setNotMandatory(systemIdent->getName());
+
+    // force defaults in-case somebody tries to change them in UI and forgets to update this func
+    resetSliders();
 }
 
 /**
@@ -392,8 +396,8 @@ void ConfigAutotuneWidget::recomputeStabilization()
     m_autotune->rollTau->setText(QString::number(tau,'g',3));
     m_autotune->pitchTau->setText(QString::number(tau,'g',3));
     m_autotune->wn->setText(QString::number(wn / 2 / M_PI, 'f', 1));
-    m_autotune->lblDamp->setText(QString::number(damp, 'g', 2));
-    m_autotune->lblNoise->setText(QString::number(ghf * 100, 'g', 2) + " %");
+    m_autotune->lblDamp->setText(QString::number(damp, 'f', 2));
+    m_autotune->lblNoise->setText(QString::number(ghf * 100, 'f', 1) + " %");
 
 }
 
@@ -626,4 +630,10 @@ QJsonDocument ConfigAutotuneWidget::getResultsJson()
     json["rawSettings"] = rawSettings;
 
     return QJsonDocument(json);
+}
+
+void ConfigAutotuneWidget::resetSliders()
+{
+    m_autotune->rateDamp->setValue(110);
+    m_autotune->rateNoise->setValue(10);
 }

--- a/ground/gcs/src/plugins/config/configautotunewidget.h
+++ b/ground/gcs/src/plugins/config/configautotunewidget.h
@@ -66,6 +66,7 @@ signals:
 public slots:
     void refreshWidgetsValues(UAVObject *obj);
     void updateObjectsFromWidgets();
+    void resetSliders();
 private slots:
     void recomputeStabilization();
     void saveStabilization();


### PR DESCRIPTION
Now correctly displays 2 D.P. for damping slider. Reset button resets both sliders. See #634.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/636)

<!-- Reviewable:end -->
