### PR TITLE
gcs: uavobjbrowser: adjust event filter on combo boxes

### DIFF
--- a/ground/gcs/src/plugins/uavobjectbrowser/browseritemdelegate.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/browseritemdelegate.cpp
@@ -63,11 +63,8 @@ bool BrowserItemDelegate::eventFilter(QObject *object, QEvent *event)
             return true;
         }
     }
-    else
-    {
-        return QStyledItemDelegate::eventFilter( object, event );
-    }
-    return false;
+
+    return QStyledItemDelegate::eventFilter( object, event );
 }
 
 void BrowserItemDelegate::setEditorData(QWidget *editor,

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
@@ -4,6 +4,7 @@
  * @file       uavobjectbrowserwidget.cpp
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
+ * @author     dRonin, http://dRonin.org, Copyright (C) 2016
  * @addtogroup GCSPlugins GCS Plugins
  * @{
  * @addtogroup UAVObjectBrowserPlugin UAVObject Browser Plugin
@@ -24,7 +25,12 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
+
 #include "uavobjectbrowserwidget.h"
 #include "uavobjecttreemodel.h"
 #include "browseritemdelegate.h"
@@ -663,9 +669,9 @@ void UAVOBrowserTreeView::updateTimerPeriod(unsigned int val)
     else
     {
         // If the UAVO has a very fast data rate, then don't go the full speed.
-        if (val < 100)
+        if (val < 125)
         {
-            val = 100- powf((100-val),0.914); //This drives the throttled speed exponentially toward 30Hz.
+            val = 125; // Don't try to draw the browser faster than 8Hz.
         }
         m_updateViewTimer.start(val);
     }


### PR DESCRIPTION
This allows the proper thing to happen when you click 'save' in the
uavobjbrowser with a combobox selected.  It gets deselected and the
proper value gets saved.

Fixes #559

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/650)

<!-- Reviewable:end -->
