### PR TITLE
gcs: config tab selection: behavior improvements

### DIFF
--- a/ground/gcs/src/libs/utils/mytabbedstackwidget.cpp
+++ b/ground/gcs/src/libs/utils/mytabbedstackwidget.cpp
@@ -25,7 +25,12 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
+
 #include "mytabbedstackwidget.h"
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -140,3 +145,13 @@ void MyTabbedStackWidget::insertCornerWidget(int index, QWidget *widget)
     widget->hide();
 }
 
+void MyTabbedStackWidget::setHidden(int index, bool hide)
+{
+    QListWidgetItem *i = m_listWidget->item(index);
+
+    if (!i) {
+        return;
+    }
+
+    i->setHidden(hide);
+}

--- a/ground/gcs/src/libs/utils/mytabbedstackwidget.h
+++ b/ground/gcs/src/libs/utils/mytabbedstackwidget.h
@@ -2,6 +2,7 @@
  ******************************************************************************
  *
  * @file       mytabbedstackwidget.h
+ * @author     dRonin, http://dRonin.org Copyright (C) 2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  *             Parts by Nokia Corporation (qt-info@nokia.com) Copyright (C) 2009.
  * @brief
@@ -24,6 +25,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #ifndef MYTABBEDSTACKWIDGET_H
@@ -52,6 +57,8 @@ public:
     int currentIndex() const;
 
     void insertCornerWidget(int index, QWidget *widget);
+    void setHidden(int index, bool hide);
+
     QWidget * currentWidget(){return m_stackWidget->currentWidget();}
     QWidget * getWidget(int index) {return m_stackWidget->widget(index);}
 

--- a/ground/gcs/src/plugins/config/configgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.cpp
@@ -230,6 +230,7 @@ void ConfigGadgetWidget::onAutopilotDisconnect() {
     icon->addFile(":/configgadget/images/hardware_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     QWidget *qwd = new DefaultHwSettingsWidget(this, false);
     ftw->insertTab(ConfigGadgetWidget::hardware, qwd, *icon, QString("Hardware"));
+    lastTabIndex = ftw->currentIndex();
     ftw->setCurrentIndex(ConfigGadgetWidget::hardware);
 
     emit autopilotDisconnected();
@@ -280,7 +281,7 @@ void ConfigGadgetWidget::onAutopilotConnect() {
     icon->addFile(":/configgadget/images/ins_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new ConfigAttitudeWidget(this);
     ftw->insertTab(ConfigGadgetWidget::sensors, qwd, *icon, QString("Attitude"));
-
+    ftw->setCurrentIndex(lastTabIndex);
     emit autopilotConnected();
 }
 

--- a/ground/gcs/src/plugins/config/configgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.cpp
@@ -4,7 +4,7 @@
  * @file       configgadgetwidget.cpp
  * @author     E. Lafargue & The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
- * @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @author     dRonin, http://dronin.org Copyright (C) 2015-2016
  * @addtogroup GCSPlugins GCS Plugins
  * @{
  * @addtogroup ConfigPlugin Config Plugin
@@ -25,6 +25,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "configgadgetwidget.h"
@@ -166,6 +170,8 @@ void ConfigGadgetWidget::deferredLoader()
     icon->addFile(":/configgadget/images/osd_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new ConfigOsdWidget(this);
     ftw->insertTab(ConfigGadgetWidget::osd, qwd, *icon, QString("OSD"));
+    // Hide OSD if not applicable, else show
+    ftw->setHidden(ConfigGadgetWidget::osd, true);
     break;
 
         case 12:
@@ -241,6 +247,8 @@ void ConfigGadgetWidget::onAutopilotConnect() {
     QIcon* icon;
     QWidget* qwd;
 
+    bool hasOSD = true;
+
     qDebug()<<"ConfigGadgetWidget onAutopilotConnect";
     // First of all, check what Board type we are talking to, and
     // if necessary, remove/add tabs in the config gadget:
@@ -261,12 +269,14 @@ void ConfigGadgetWidget::onAutopilotConnect() {
             QLabel *txt = new QLabel(this);
             txt->setText(tr("Board detected, but of unknown type. This could be because either your GCS or firmware is out of date."));
             qwd = txt;
-        }
-        else {
+        } else {
             qwd = board->getBoardConfiguration();
             if (qwd == NULL) {
                 qwd = new DefaultHwSettingsWidget(this, true);
-            } else {
+            }
+
+            if (!board->queryCapabilities(Core::IBoardType::BOARD_CAPABILITIES_OSD)) {
+                hasOSD = false;
             }
         }
 
@@ -282,6 +292,10 @@ void ConfigGadgetWidget::onAutopilotConnect() {
     qwd = new ConfigAttitudeWidget(this);
     ftw->insertTab(ConfigGadgetWidget::sensors, qwd, *icon, QString("Attitude"));
     ftw->setCurrentIndex(lastTabIndex);
+
+    // Hide OSD if not applicable, else show
+    ftw->setHidden(ConfigGadgetWidget::osd, !hasOSD);
+
     emit autopilotConnected();
 }
 

--- a/ground/gcs/src/plugins/config/configgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.cpp
@@ -285,6 +285,10 @@ void ConfigGadgetWidget::onAutopilotConnect() {
 
             if (!board->queryCapabilities(Core::IBoardType::BOARD_CAPABILITIES_OSD)) {
                 hasOSD = false;
+
+                if (lastTabIndex == ConfigGadgetWidget::osd) {
+                    lastTabIndex = ConfigGadgetWidget::hardware;
+                }
             }
         }
 

--- a/ground/gcs/src/plugins/config/configgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.cpp
@@ -69,6 +69,7 @@ ConfigGadgetWidget::ConfigGadgetWidget(QWidget *parent) : QWidget(parent)
 
     help = 0;
     chunk = 0;
+    lastTabIndex = ConfigGadgetWidget::hardware;
 
     QTimer::singleShot(500, this, SLOT(deferredLoader()));
 }
@@ -228,6 +229,8 @@ void ConfigGadgetWidget::resizeEvent(QResizeEvent *event)
 }
 
 void ConfigGadgetWidget::onAutopilotDisconnect() {
+    lastTabIndex = ftw->currentIndex();
+
     ftw->setCurrentIndex(ConfigGadgetWidget::hardware);
     ftw->removeTab(ConfigGadgetWidget::hardware);
 
@@ -236,7 +239,6 @@ void ConfigGadgetWidget::onAutopilotDisconnect() {
     icon->addFile(":/configgadget/images/hardware_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     QWidget *qwd = new DefaultHwSettingsWidget(this, false);
     ftw->insertTab(ConfigGadgetWidget::hardware, qwd, *icon, QString("Hardware"));
-    lastTabIndex = ftw->currentIndex();
     ftw->setCurrentIndex(ConfigGadgetWidget::hardware);
 
     emit autopilotDisconnected();
@@ -248,6 +250,12 @@ void ConfigGadgetWidget::onAutopilotConnect() {
     QWidget* qwd;
 
     bool hasOSD = true;
+
+    int index = ftw->currentIndex();
+
+    if (index != ConfigGadgetWidget::hardware) {
+        lastTabIndex = index;
+    }
 
     qDebug()<<"ConfigGadgetWidget onAutopilotConnect";
     // First of all, check what Board type we are talking to, and
@@ -291,10 +299,11 @@ void ConfigGadgetWidget::onAutopilotConnect() {
     icon->addFile(":/configgadget/images/ins_selected.png", QSize(), QIcon::Selected, QIcon::Off);
     qwd = new ConfigAttitudeWidget(this);
     ftw->insertTab(ConfigGadgetWidget::sensors, qwd, *icon, QString("Attitude"));
-    ftw->setCurrentIndex(lastTabIndex);
 
     // Hide OSD if not applicable, else show
     ftw->setHidden(ConfigGadgetWidget::osd, !hasOSD);
+
+    ftw->setCurrentIndex(lastTabIndex);
 
     emit autopilotConnected();
 }

--- a/ground/gcs/src/plugins/config/configgadgetwidget.h
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.h
@@ -67,6 +67,13 @@ protected:
         void resizeEvent(QResizeEvent * event);
         void paintEvent(QPaintEvent * event);
         MyTabbedStackWidget *ftw;
+
+private:
+        UAVDataObject* oplinkStatusObj;
+        int lastTabIndex;
+        // A timer that timesout the connction to the OPLink.
+        QTimer *oplinkTimeout;
+        bool oplinkConnected;
 };
 
 #endif // CONFIGGADGETWIDGET_H


### PR DESCRIPTION
1. Remember the "current tab" so that we "get back to" where the user was last on connection.  Inherited from an unmerged @guilhermito changeset.
2. Hide the OSD config tab if we don't have that board capability.

Tested on brain and sparky2 several cycles.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/652)

<!-- Reviewable:end -->
