### PR TITLE
Allow more autonomous flight modes for helicp

### DIFF
--- a/flight/Modules/ManualControl/geofence_control.c
+++ b/flight/Modules/ManualControl/geofence_control.c
@@ -42,6 +42,7 @@
 #include "geofencesettings.h"
 #include "stabilizationdesired.h"
 #include "systemalarms.h"
+#include "systemsettings.h"
 
 //! Initialize the geofence controller
 int32_t geofence_control_initialize()
@@ -74,30 +75,28 @@ int32_t geofence_control_select(bool reset_controller)
 		FlightStatusFlightModeSet(&flight_status);
 	}
 
+	SystemSettingsAirframeTypeOptions airframe_type;
+	SystemSettingsAirframeTypeGet(&airframe_type);
+
 	// Pick default values that will roughly cause a plane to circle down
 	// and a quad to fall straight down
 	StabilizationDesiredData stabilization_desired;
 	StabilizationDesiredGet(&stabilization_desired);
+	StabilizationDesiredGet(&stabilization_desired);
+	stabilization_desired.Thrust = (airframe_type == SYSTEMSETTINGS_AIRFRAMETYPE_HELICP) ? 0 : -1;
+	stabilization_desired.Roll = 0;
+	stabilization_desired.Pitch = 0;
+	stabilization_desired.Yaw   = 0;
 
 	if (!geofence_armed_when_enabled) {
 		/* disable stabilization so outputs do not move when system was not armed */
-		stabilization_desired.Thrust = -1;
-		stabilization_desired.Roll  = 0;
-		stabilization_desired.Pitch = 0;
-		stabilization_desired.Yaw   = 0;
-		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_MANUAL;
-		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = STABILIZATIONDESIRED_STABILIZATIONMODE_MANUAL;
-		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_MANUAL;
+		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_DISABLED;
+		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = STABILIZATIONDESIRED_STABILIZATIONMODE_DISABLED;
+		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_DISABLED;
 	} else {
-		/* Pick default values that will roughly cause a plane to circle down and */
-		/* a quad to fall straight down */
-		stabilization_desired.Thrust = -1;
-		stabilization_desired.Roll = -10;
-		stabilization_desired.Pitch = 0;
-		stabilization_desired.Yaw = -5;
-		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;
-		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;
-		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_RATE;
+		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_FAILSAFE;
+		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = STABILIZATIONDESIRED_STABILIZATIONMODE_FAILSAFE;
+		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_FAILSAFE;
 	}
 
 	StabilizationDesiredSet(&stabilization_desired);

--- a/flight/Modules/VtolPathFollower/vtolpathfollower.c
+++ b/flight/Modules/VtolPathFollower/vtolpathfollower.c
@@ -160,7 +160,8 @@ static void vtolPathFollowerTask(void *parameters)
 			(systemSettings.AirframeType != SYSTEMSETTINGS_AIRFRAMETYPE_OCTOV) &&
 			(systemSettings.AirframeType != SYSTEMSETTINGS_AIRFRAMETYPE_OCTOCOAXP) &&
 			(systemSettings.AirframeType != SYSTEMSETTINGS_AIRFRAMETYPE_OCTOCOAXX) &&
-			(systemSettings.AirframeType != SYSTEMSETTINGS_AIRFRAMETYPE_TRI) )
+			(systemSettings.AirframeType != SYSTEMSETTINGS_AIRFRAMETYPE_TRI) &&
+			(systemSettings.AirframeType != SYSTEMSETTINGS_AIRFRAMETYPE_HELICP) )
 		{
 			// This should be a critical alarm since the system will not attempt to
 			// control in this situation.


### PR DESCRIPTION
- Various non-critical helicp-specific fixes
  - GeoFence will go collective-neutral instead of full-negative, which will result in an only slightly less dramatic fall-out-of-the-sky crash; probably shouldn't use it on any heli you are fond of
- Various small fixes to enable helicopters to use more autonomous flight modes including:
  - PositionHold
  - ReturnToHome
  - PathPlanner

Testing progress
- [ ] Test for regressions on multis
- [x] Bench-test PositionHold on 480-size heli with GPS
  - behavior appears sane
- [x] Bench-test ReturnToHome on 480-size heli with GPS
  - difficult to verify behavior
- [x] Bench-test PathPlanner on 480-size heli with GPS
  - difficult to verify behavior
- [x] Flight-test PositionHold on 480-size heli with GPS
  - success; seemed a bit aggressive but definitely held position
  - thrust axis was in manual in PH; need to verify whether this is correct behavior
- [x] Flight-test loiter on 480-size heli with GPS
  - seems to work as expected
  - probably need to tweak some gains for position + velocity
- ~~Flight-test ReturnToHome on 480-size heli with GPS~~
- ~~Flight-test PathPlanner on 480-size heli with GPS~~

480-size testing platform with GPS (in foreground) for reference:
![20151211_131353-small](https://cloud.githubusercontent.com/assets/666500/12969261/d26ab942-d032-11e5-9915-b0635f370f87.jpg)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/653)

<!-- Reviewable:end -->
