### PR TITLE
GCS: Adds Select All/None buttons to UAV import dialog

### DIFF
--- a/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.cpp
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.cpp
@@ -26,6 +26,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
+#include <QSignalMapper>
 #include "importsummary.h"
 
 ImportSummaryDialog::ImportSummaryDialog( QWidget *parent) :
@@ -46,6 +47,16 @@ ImportSummaryDialog::ImportSummaryDialog( QWidget *parent) :
 
    connect( ui->closeButton, SIGNAL(clicked()), this, SLOT(close()));
    connect(ui->saveToFlash, SIGNAL(clicked()), this, SLOT(doTheSaving()));
+
+   // Connect the Select All/None buttons
+   QSignalMapper* signalMapper = new QSignalMapper (this) ;
+
+   connect(ui->btnSelectAll, SIGNAL(clicked()), signalMapper, SLOT(map()));
+   connect(ui->btnSelectNone, SIGNAL(clicked()), signalMapper, SLOT(map()));
+   signalMapper->setMapping(ui->btnSelectAll, 1);
+   signalMapper->setMapping(ui->btnSelectNone, 0);
+
+   connect (signalMapper, SIGNAL(mapped(int)), this, SLOT(setCheckedState(int)));
 
    // Connect the help button
    connect(ui->helpButton, SIGNAL(clicked()), this, SLOT(openHelp()));
@@ -92,6 +103,18 @@ void ImportSummaryDialog::addLine(QString uavObjectName, QString text, bool stat
 
    this->repaint();
    this->showEvent(NULL);
+}
+
+/*
+  Sets or unsets every UAVObjet in the list
+  */
+void ImportSummaryDialog::setCheckedState(int state)
+{
+    for(int i=0; i < ui->importSummaryList->rowCount(); i++) {
+        QCheckBox *box = dynamic_cast<QCheckBox*>(ui->importSummaryList->cellWidget(i,0));
+        if(box->isEnabled())
+            box->setChecked((state == 1 ? true : false));
+    }
 }
 
 /*

--- a/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.cpp
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.cpp
@@ -49,14 +49,14 @@ ImportSummaryDialog::ImportSummaryDialog( QWidget *parent) :
    connect(ui->saveToFlash, SIGNAL(clicked()), this, SLOT(doTheSaving()));
 
    // Connect the Select All/None buttons
-   QSignalMapper* signalMapper = new QSignalMapper (this) ;
+   QSignalMapper* signalMapper = new QSignalMapper (this);
 
    connect(ui->btnSelectAll, SIGNAL(clicked()), signalMapper, SLOT(map()));
    connect(ui->btnSelectNone, SIGNAL(clicked()), signalMapper, SLOT(map()));
    signalMapper->setMapping(ui->btnSelectAll, 1);
    signalMapper->setMapping(ui->btnSelectNone, 0);
 
-   connect (signalMapper, SIGNAL(mapped(int)), this, SLOT(setCheckedState(int)));
+   connect(signalMapper, SIGNAL(mapped(int)), this, SLOT(setCheckedState(int)));
 
    // Connect the help button
    connect(ui->helpButton, SIGNAL(clicked()), this, SLOT(openHelp()));
@@ -110,8 +110,8 @@ void ImportSummaryDialog::addLine(QString uavObjectName, QString text, bool stat
   */
 void ImportSummaryDialog::setCheckedState(int state)
 {
-    for(int i=0; i < ui->importSummaryList->rowCount(); i++) {
-        QCheckBox *box = dynamic_cast<QCheckBox*>(ui->importSummaryList->cellWidget(i,0));
+    for(int i = 0; i < ui->importSummaryList->rowCount(); i++) {
+        QCheckBox *box = dynamic_cast<QCheckBox*>(ui->importSummaryList->cellWidget(i, 0));
         if(box->isEnabled())
             box->setChecked((state == 1 ? true : false));
     }

--- a/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.h
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.h
@@ -63,6 +63,7 @@ public slots:
     void updateSaveCompletion();
 
 private slots:
+    void setCheckedState(int state);
     void doTheSaving();
     void openHelp();
 

--- a/ground/gcs/src/plugins/uavsettingsimportexport/importsummarydialog.ui
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/importsummarydialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>544</width>
     <height>377</height>
    </rect>
   </property>
@@ -55,6 +55,26 @@
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="btnSelectAll">
+       <property name="text">
+        <string>Select All</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnSelectNone">
+       <property name="text">
+        <string>Select None</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
@@ -120,6 +140,7 @@ then close the dialog.</string>
   </layout>
  </widget>
  <resources>
+  <include location="../coreplugin/core.qrc"/>
   <include location="../coreplugin/core.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
In order to solve issue  #631 this patch will allow to rapidly select/deselect all settings loaded from a UAV file.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/655)

<!-- Reviewable:end -->
