### PR TITLE
GCS:Config: Add voltage ratio box

### DIFF
--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -131,6 +131,10 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     addUAVObjectToWidgetRelation(batteryStateName, "ConsumedEnergy", ui->le_liveConsumedEnergy);
     addUAVObjectToWidgetRelation(batteryStateName, "EstimatedFlightTime", ui->le_liveEstimatedFlightTime);
 
+    // connect the voltage ratio and factor boxes so they update each other when edited
+    connect(ui->sb_voltageRatio, SIGNAL(valueChanged(double)), this, SLOT(updateVoltageRatio(double)));
+    connect(ui->sb_voltageFactor, SIGNAL(valueChanged(double)), this, SLOT(updateVoltageFactor(double)));
+
     addUAVObjectToWidgetRelation(vibrationAnalysisSettingsName, "SampleRate", ui->sb_sampleRate);
     addUAVObjectToWidgetRelation(vibrationAnalysisSettingsName, "FFTWindowSize", ui->cb_windowSize);
 
@@ -751,6 +755,16 @@ void ConfigModuleWidget::refreshAdcNames(void)
         if (i < ui->cbCurrentPin->count())
             ui->cbCurrentPin->setItemText(i, name);
     }
+}
+
+void ConfigModuleWidget::updateVoltageRatio(double value)
+{
+    ui->sb_voltageFactor->setValue(1000.0 / value);
+}
+
+void ConfigModuleWidget::updateVoltageFactor(double value)
+{
+    ui->sb_voltageRatio->setValue(1000.0 / value);
 }
 
 /**

--- a/ground/gcs/src/plugins/config/configmodulewidget.h
+++ b/ground/gcs/src/plugins/config/configmodulewidget.h
@@ -52,6 +52,8 @@ private slots:
     void toggleVibrationTest();
     void toggleBatteryMonitoringPin();
     void toggleBatteryMonitoringGb();
+    void updateVoltageRatio(double value);
+    void updateVoltageFactor(double value);
 
     void recheckTabs();
     void objectUpdated(UAVObject * obj, bool success);

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>448</width>
-    <height>697</height>
+    <height>828</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <property name="tabsClosable">
       <bool>false</bool>
@@ -487,18 +487,18 @@
              <double>1000.000000000000000</double>
             </property>
             <property name="singleStep">
-             <double>0.000010000000000</double>
+             <double>0.010000000000000</double>
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="label_11">
             <property name="text">
              <string>Low voltage alarm:</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="6" column="1">
            <widget class="QDoubleSpinBox" name="sb_lowVoltageAlarm">
             <property name="suffix">
              <string>V</string>
@@ -511,14 +511,14 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="7" column="0">
            <widget class="QLabel" name="label_12">
             <property name="text">
              <string>Low voltage warning:</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="7" column="1">
            <widget class="QDoubleSpinBox" name="sb_lowVoltageWarning">
             <property name="suffix">
              <string>V</string>
@@ -531,14 +531,14 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="label_31">
             <property name="text">
              <string>Calibration offset:</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="5" column="1">
            <widget class="QDoubleSpinBox" name="sb_voltageOffSet">
             <property name="suffix">
              <string>V</string>
@@ -568,6 +568,20 @@
            <widget class="QComboBox" name="cbVoltagePin">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select an ADC pin to measure the voltage. Pins not available with the current board configuration are labeled &amp;quot;Disabled&amp;quot;. These pins may be enabled by settings on the &amp;quot;Hardware&amp;quot; tab. Pins labeled &amp;quot;N/A&amp;quot; are not available due to the board hardware design.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>or</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QDoubleSpinBox" name="sb_voltageRatio">
+            <property name="suffix">
+             <string>:1 ratio</string>
             </property>
            </widget>
           </item>
@@ -1069,8 +1083,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>339</width>
-            <height>594</height>
+            <width>353</width>
+            <height>864</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout">

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -501,7 +501,7 @@
           <item row="6" column="1">
            <widget class="QDoubleSpinBox" name="sb_lowVoltageAlarm">
             <property name="suffix">
-             <string>V</string>
+             <string> V</string>
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
@@ -521,7 +521,7 @@
           <item row="7" column="1">
            <widget class="QDoubleSpinBox" name="sb_lowVoltageWarning">
             <property name="suffix">
-             <string>V</string>
+             <string> V</string>
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
@@ -541,7 +541,7 @@
           <item row="5" column="1">
            <widget class="QDoubleSpinBox" name="sb_voltageOffSet">
             <property name="suffix">
-             <string>V</string>
+             <string> V</string>
             </property>
             <property name="decimals">
              <number>4</number>
@@ -650,7 +650,7 @@
           <item row="6" column="1">
            <widget class="QDoubleSpinBox" name="sb_currentOffSet">
             <property name="suffix">
-             <string>A</string>
+             <string> A</string>
             </property>
             <property name="decimals">
              <number>4</number>
@@ -700,7 +700,7 @@
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Raise an alarm when the remaining flight time (calculated based on battery capacity and current consumed) is below this threshold. Set to 0s to disable.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="suffix">
-             <string>s</string>
+             <string> s</string>
             </property>
             <property name="maximum">
              <number>255</number>
@@ -713,7 +713,7 @@
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Issue a warning when the remaining flight time (calculated based on battery capacity and current consumed) is below this threshold. Set to 0s to disable.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="suffix">
-             <string>s</string>
+             <string> s</string>
             </property>
             <property name="maximum">
              <number>255</number>
@@ -1083,7 +1083,7 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>353</width>
+            <width>376</width>
             <height>864</height>
            </rect>
           </property>


### PR DESCRIPTION
Connected to voltage factor box so changing one will update the other.

<img width="488" alt="divided" src="https://cloud.githubusercontent.com/assets/9995998/13026186/b6c7d316-d283-11e5-98f0-cd3e955f0dff.png">

Also changed step size for the voltage factor spinbox from 0.00001 to 0.01 mV/V for sanity purposes.

Fixes #658.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/659)

<!-- Reviewable:end -->
