### PR TITLE
GCS:Config: Add MWRate deprecation notice

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -321,6 +321,20 @@ ConfigInputWidget::ConfigInputWidget(QWidget *parent) : ConfigTaskWidget(parent)
                         ManualControlSettings::CHANNELGROUPS_ACCESSORY1 <<
                         ManualControlSettings::CHANNELGROUPS_ACCESSORY2 <<
                         ManualControlSettings::CHANNELGROUPS_ARMING;
+
+    for (int i = 1; i <= 6; i++) {
+        QComboBox *child = this->findChild<QComboBox *>(QString("fmsModePos%1").arg(i));
+        if (child)
+            connect(child, SIGNAL(currentTextChanged(QString)), this, SLOT(checkFlightMode(QString)));
+    }
+    const QStringList axes({"Roll", "Pitch", "Yaw"});
+    for (int i = 1; i <= 3; i++) {
+        foreach (const QString &axis, axes) {
+            QComboBox *child = this->findChild<QComboBox *>(QString("fmsSsPos%1%2").arg(i).arg(axis));
+            if (child)
+                connect(child, SIGNAL(currentTextChanged(QString)), this, SLOT(checkFlightMode(QString)));
+        }
+    }
 }
 void ConfigInputWidget::resetTxControls()
 {
@@ -1745,4 +1759,26 @@ void ConfigInputWidget::checkArmingConfig(QString option)
         m_config->lblThrottleCheckWarn->hide();
     else
         m_config->lblThrottleCheckWarn->show();
+}
+
+void ConfigInputWidget::checkFlightMode(QString option)
+{
+    Q_UNUSED(option);
+    // show multiwii deprecation notice if required
+    m_config->lblMultiwii->hide();
+
+    for (int i = 1; i <= m_config->fmsPosNum->value(); i++) {
+        QComboBox *child = this->findChild<QComboBox *>(QString("fmsModePos%1").arg(i));
+        if (child && child->currentText().contains("MWRate"))
+            m_config->lblMultiwii->show();
+    }
+
+    const QStringList axes({"Roll", "Pitch", "Yaw"});
+    for (int i = 1; i <= 3; i++) {
+        foreach (const QString &axis, axes) {
+            QComboBox *child = this->findChild<QComboBox *>(QString("fmsSsPos%1%2").arg(i).arg(axis));
+            if (child && child->currentText().contains("MWRate"))
+                m_config->lblMultiwii->show();
+        }
+    }
 }

--- a/ground/gcs/src/plugins/config/configinputwidget.h
+++ b/ground/gcs/src/plugins/config/configinputwidget.h
@@ -196,6 +196,7 @@ private slots:
         void simpleCalibration(bool state);
         void updateCalibration();
         void checkArmingConfig(QString option);
+        void checkFlightMode(QString option);
 
 protected:
         void resizeEvent(QResizeEvent *event);

--- a/ground/gcs/src/plugins/config/input.ui
+++ b/ground/gcs/src/plugins/config/input.ui
@@ -1228,6 +1228,16 @@ channel value for each flight mode.</string>
                   </property>
                  </widget>
                 </item>
+                <item row="2" column="0">
+                 <widget class="QLabel" name="lblMultiwii">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:12pt; font-weight:600; color:#ff0000;&quot;&gt;Note:&lt;/span&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt; Multiwii flight mode is deprecated, it will be &lt;/span&gt;&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;&gt;removed&lt;/span&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt; in a future release! Consider Acro+ instead.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="wordWrap">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
                </layout>
               </item>
               <item row="2" column="1">
@@ -1395,7 +1405,7 @@ channel value for each flight mode.</string>
             <x>0</x>
             <y>0</y>
             <width>838</width>
-            <height>737</height>
+            <height>794</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -1699,6 +1709,7 @@ Applies and Saves all settings to SD</string>
   <tabstop>saveRCInputToSD</tabstop>
  </tabstops>
  <resources>
+  <include location="../coreplugin/core.qrc"/>
   <include location="../coreplugin/core.qrc"/>
  </resources>
  <connections/>

--- a/ground/gcs/src/plugins/config/stabilization.ui
+++ b/ground/gcs/src/plugins/config/stabilization.ui
@@ -25739,7 +25739,7 @@ border-radius: 5;</string>
        <item>
         <widget class="QLabel" name="label_3">
          <property name="text">
-          <string>This mode attempts to replicate the feel of the control loop used in MultiWii / baseflight. The units are different for the settings, but you can use the calculate button below to translate from one system to the other. To use this, you use a Stabilization# flight mode with the roll and pitch (optionally yaw) axes set to MWRate (selected in the input configuration page).</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This mode attempts to replicate the feel of the control loop used in MultiWii / baseflight. The units are different for the settings, but you can use the calculate button below to translate from one system to the other. To use this, you use a Stabilization# flight mode with the roll and pitch (optionally yaw) axes set to MWRate (selected in the input configuration page).&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:14pt; font-weight:600; color:#ff0000;&quot;&gt;Note:&lt;/span&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt; Multiwii flight mode is deprecated, it will be &lt;/span&gt;&lt;span style=&quot; font-size:14pt; font-weight:600;&quot;&gt;removed&lt;/span&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt; in a future release! Consider Acro+ instead.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>


### PR DESCRIPTION
The flight mode settings notice only displays if MWRate is selected.

![screenshot from 2016-02-14 15 38 28](https://cloud.githubusercontent.com/assets/9995998/13031364/206c9a24-d331-11e5-9c94-42e8a84b81b8.png)
![screenshot from 2016-02-14 15 38 43](https://cloud.githubusercontent.com/assets/9995998/13031365/206d8948-d331-11e5-9529-1ad758a0b6f3.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/663)

<!-- Reviewable:end -->

Action item from #56.
