### PR TITLE
GCS: Do not automatically apply UAV settings with import

### DIFF
--- a/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.cpp
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.cpp
@@ -186,17 +186,14 @@ void ImportSummaryDialog::doTheApplySaving(int op)
         QCheckBox *box = dynamic_cast<QCheckBox*>(ui->importSummaryList->cellWidget(i,0));
         if (box->isChecked()) {
             UAVObject* importedObj = importedObjects->getObject(uavObjectName);
+            UAVObject* boardObj = boardObjManager->getObject(uavObjectName);
 
-            if(op & UAVSettingsAction::apply) {
-                UAVObject* boardObj = boardObjManager->getObject(uavObjectName);
+            quint8* data = new quint8[importedObj->getNumBytes()];
+            importedObj->pack(data);
+            boardObj->unpack(data);
+            delete data;
 
-                quint8* data = new quint8[importedObj->getNumBytes()];
-                importedObj->pack(data);
-                boardObj->unpack(data);
-                delete data;
-
-                boardObj->updated();
-            }
+            boardObj->updated();
 
             if(op & UAVSettingsAction::save) {
                 utilManager->saveObjectToFlash(importedObj);

--- a/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.cpp
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.cpp
@@ -35,14 +35,6 @@
 #include <QSignalMapper>
 #include "importsummary.h"
 
-#define UAV_SETIMPEXP_APPLY 1
-#define UAV_SETIMPEXP_SAVE 2
-
-enum UAVSettingsAction{
-    apply = 1,
-    save = 2
-};
-
 ImportSummaryDialog::ImportSummaryDialog( QWidget *parent) :
     QDialog(parent),
     ui(new Ui::ImportSummaryDialog),
@@ -61,23 +53,14 @@ ImportSummaryDialog::ImportSummaryDialog( QWidget *parent) :
    ui->progressBar->setValue(0);
 
    connect( ui->closeButton, SIGNAL(clicked()), this, SLOT(close()));
+   connect(ui->btnSaveToFlash, SIGNAL(clicked()), this, SLOT(doTheApplySaving()));
 
    // Connect the Select All/None buttons
-   QSignalMapper* signalMapper = new QSignalMapper(this);
-
-   connect(ui->btnSaveToFlash, SIGNAL(clicked()), signalMapper, SLOT(map()));
-   connect(ui->btnApply, SIGNAL(clicked()), signalMapper, SLOT(map()));
-
-   signalMapper->setMapping(ui->btnSaveToFlash, UAVSettingsAction::save);
-   signalMapper->setMapping(ui->btnApply, UAVSettingsAction::apply);
-
-   connect(signalMapper, SIGNAL(mapped(int)), this, SLOT(doTheApplySaving(int)));
-
-   // Connect the Select All/None buttons
-   signalMapper = new QSignalMapper (this);
+   QSignalMapper* signalMapper = new QSignalMapper (this);
 
    connect(ui->btnSelectAll, SIGNAL(clicked()), signalMapper, SLOT(map()));
    connect(ui->btnSelectNone, SIGNAL(clicked()), signalMapper, SLOT(map()));
+
    signalMapper->setMapping(ui->btnSelectAll, 1);
    signalMapper->setMapping(ui->btnSelectNone, 0);
 
@@ -153,9 +136,9 @@ void ImportSummaryDialog::setCheckedState(int state)
 }
 
 /*
-  Apply or saves every checked UAVObjet in the list to Flash
+  Apply and saves every checked UAVObjet in the list to Flash
   */
-void ImportSummaryDialog::doTheApplySaving(int op)
+void ImportSummaryDialog::doTheApplySaving()
 {
     if(!importedObjects)
         return;
@@ -175,7 +158,6 @@ void ImportSummaryDialog::doTheApplySaving(int op)
     if(itemCount==0)
         return;
 
-    ui->btnApply->setEnabled(false);
     ui->btnSaveToFlash->setEnabled(false);
     ui->closeButton->setEnabled(false);
 
@@ -195,9 +177,7 @@ void ImportSummaryDialog::doTheApplySaving(int op)
 
             boardObj->updated();
 
-            if(op & UAVSettingsAction::save) {
-                utilManager->saveObjectToFlash(importedObj);
-            }
+            utilManager->saveObjectToFlash(boardObj);
 
             updateCompletion();
             this->repaint();
@@ -211,7 +191,6 @@ void ImportSummaryDialog::updateCompletion()
     ui->progressBar->setValue(ui->progressBar->value()+1);
     if(ui->progressBar->value()==ui->progressBar->maximum())
     {
-        ui->btnApply->setEnabled(true);
         ui->btnSaveToFlash->setEnabled(true);
         ui->closeButton->setEnabled(true);
     }

--- a/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.h
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.h
@@ -51,6 +51,7 @@ public:
     ImportSummaryDialog(QWidget *parent=0);
     ~ImportSummaryDialog();
     void addLine(QString objectName, QString text, bool status);
+    void setUAVOSettings(UAVObjectManager* obj);
 
 protected:
     void showEvent(QShowEvent *event);
@@ -58,12 +59,13 @@ protected:
 
 private:
     Ui::ImportSummaryDialog *ui;
+    UAVObjectManager* importedObjects;
 
 public slots:
-    void updateSaveCompletion();
+    void updateCompletion();
 
 private slots:
-    void doTheSaving();
+    void doTheApplySaving(int op);
     void openHelp();
 
 };

--- a/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.h
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.h
@@ -65,7 +65,7 @@ public slots:
     void updateCompletion();
 
 private slots:
-    void doTheApplySaving(int op);
+    void doTheApplySaving();
     void setCheckedState(int state);
     void openHelp();
 

--- a/ground/gcs/src/plugins/uavsettingsimportexport/importsummarydialog.ui
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/importsummarydialog.ui
@@ -115,13 +115,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnApply">
-       <property name="text">
-        <string>Apply</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QPushButton" name="btnSaveToFlash">
        <property name="toolTip">
         <string>Save all settings checked above to persistent board storage,

--- a/ground/gcs/src/plugins/uavsettingsimportexport/importsummarydialog.ui
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/importsummarydialog.ui
@@ -95,13 +95,20 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="saveToFlash">
+      <widget class="QPushButton" name="btnApply">
+       <property name="text">
+        <string>Apply</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnSaveToFlash">
        <property name="toolTip">
         <string>Save all settings checked above to persistent board storage,
 then close the dialog.</string>
        </property>
        <property name="text">
-        <string>Save to Board Flash</string>
+        <string>Save</string>
        </property>
       </widget>
      </item>
@@ -120,6 +127,7 @@ then close the dialog.</string>
   </layout>
  </widget>
  <resources>
+  <include location="../coreplugin/core.qrc"/>
   <include location="../coreplugin/core.qrc"/>
  </resources>
  <connections/>

--- a/ground/gcs/src/plugins/uavsettingsimportexport/uavsettingsimportexportfactory.cpp
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/uavsettingsimportexportfactory.cpp
@@ -139,7 +139,9 @@ void UAVSettingsImportExportFactory::importUAVSettings()
     ImportSummaryDialog swui((QWidget*)Core::ICore::instance()->mainWindow());
 
     ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *objManager = pm->getObject<UAVObjectManager>();
+    UAVObjectManager *boardObjManager = pm->getObject<UAVObjectManager>();
+    UAVObjectManager *importedObjectManager = new UAVObjectManager();
+
     swui.show();
 
     QDomNode node = root.firstChild();
@@ -152,7 +154,7 @@ void UAVSettingsImportExportFactory::importUAVSettings()
             uint uavObjectID = e.attribute("id").toUInt(NULL,16);
 
             // Sanity Check:
-            UAVObject *obj = objManager->getObject(uavObjectName);
+            UAVObject *obj = boardObjManager->getObject(uavObjectName);
             UAVDataObject *dobj = dynamic_cast<UAVDataObject*>(obj);
             if (obj == NULL) {
                 // This object is unknown!
@@ -163,13 +165,15 @@ void UAVSettingsImportExportFactory::importUAVSettings()
             } else {
                 //  - Update each field
                 //  - Issue and "updated" command
+                UAVDataObject *newObj = dobj->clone();
+
                 bool error = false;
                 bool setError = false;
                 QDomNode field = node.firstChild();
                 while(!field.isNull()) {
                     QDomElement f = field.toElement();
                     if (f.tagName() == "field") {
-                        UAVObjectField *uavfield = obj->getField(f.attribute("name"));
+                        UAVObjectField *uavfield = newObj->getField(f.attribute("name"));
                         if (uavfield) {
                             QStringList list = f.attribute("values").split(",");
                             if (list.length() == 1) {
@@ -199,23 +203,25 @@ void UAVSettingsImportExportFactory::importUAVSettings()
                     }
                     field = field.nextSibling();
                 }
-                obj->updated();
+                newObj->updated();
 
                 if (error) {
                     swui.addLine(uavObjectName, "Warning (Object field unknown)", true);
-                } else if (uavObjectID != obj->getObjID()) {
-                    qDebug() << "Mismatch for Object " << uavObjectName << uavObjectID << " - " << obj->getObjID();
+                } else if (uavObjectID != newObj->getObjID()) {
+                    qDebug() << "Mismatch for Object " << uavObjectName << uavObjectID << " - " << newObj->getObjID();
                     swui.addLine(uavObjectName, "Warning (ObjectID mismatch)", true);
                 } else if (setError) {
                     swui.addLine(uavObjectName, "Warning (Objects field value(s) invalid)", false);
                 } else {
                     swui.addLine(uavObjectName, "OK", true);
                 }
+                importedObjectManager->registerObject(newObj);
             }
         }
         node = node.nextSibling();
     }
     qDebug() << "End import";
+    swui.setUAVOSettings(importedObjectManager);
     swui.exec();
 }
 

--- a/ground/gcs/src/plugins/uavsettingsimportexport/uavsettingsimportexportfactory.h
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/uavsettingsimportexportfactory.h
@@ -29,6 +29,9 @@
 #include "uavsettingsimportexport_global.h"
 #include "uavobjectutil/uavobjectutilmanager.h"
 #include "../../../../../build/ground/gcs/gcsversioninfo.h"
+
+class QDomNode;
+
 class UAVSETTINGSIMPORTEXPORT_EXPORT UAVSettingsImportExportFactory : public QObject
 {
     Q_OBJECT
@@ -36,6 +39,7 @@ class UAVSETTINGSIMPORTEXPORT_EXPORT UAVSettingsImportExportFactory : public QOb
 public:
     UAVSettingsImportExportFactory(QObject *parent = 0);
     ~UAVSettingsImportExportFactory();
+    static bool updateObject(UAVObject *obj, QDomNode * node);
 
 private:
     enum storedData { Settings, Data, Both };


### PR DESCRIPTION
This will import all settings to a temporary object, but nothing will be modified in the FC without user intervention. The apply button will make settings temporarily active (apply to ram), while the save button will save settings to the persistent memory (flash)

Fixes #668

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/669)

<!-- Reviewable:end -->
