### PR TITLE
Throttle curve dilutes AH/PH altitude control

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -440,6 +440,15 @@ float process_mixer(const int index, const float curve1, const float curve2,
  */
 static float throt_curve(float const input, float const * curve, uint8_t num_points)
 {
+        uint8_t flightMode;
+        FlightStatusFlightModeGet(&flightMode);
+
+        // don't use the throttle curve during altitude/position hold to avoid desensitizing
+	// the compensation being applied to maintain altitiude
+        if( flightMode == FLIGHTSTATUS_FLIGHTMODE_ALTITUDEHOLD
+                        || flightMode == FLIGHTSTATUS_FLIGHTMODE_POSITIONHOLD )
+                return input;
+
 	return linear_interpolate(input, curve, num_points, 0.0f, 1.0f);
 }
 


### PR DESCRIPTION
During altitude hold and position hold, throttle_desired is used to
maintain the current altitude. However, the throttle_desired value is
desensitized when the throttle curve is applied in actuator.c. In an
attempt to overcome this desensitizes, one can crank up the attitude
compensation as well as the Kp/Kd terms which make uav setup different
between similar crafts with and without throttle curves. Furthermore, when
the user exceeds their throttle curve knees, due to controlled altitude
change with the stick or under strong winds conditions, the altitude change
can be drastic and unexpected due to the higher AH settings.

This change simply disables the throttle curve during AH and PH
flightmodes. Not sure if the proposed change is the best solution, so
interested in any feedback.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/671)

<!-- Reviewable:end -->
