### PR TITLE
STM32F4 USART: Add single wire mode

### DIFF
--- a/flight/PiOS/STM32F4xx/pios_usart.c
+++ b/flight/PiOS/STM32F4xx/pios_usart.c
@@ -219,6 +219,12 @@ int32_t PIOS_USART_Init(uintptr_t * usart_id, const struct pios_usart_cfg * cfg)
 	if (usart_dev->cfg->tx.gpio != 0)
 		GPIO_Init(usart_dev->cfg->tx.gpio, (GPIO_InitTypeDef *)&usart_dev->cfg->tx.init);
 
+	/* Enable single wire mode if requested */
+	if (usart_dev->cfg->single_wire == true)
+		USART_HalfDuplexCmd(usart_dev->cfg->regs, ENABLE);
+	else
+		USART_HalfDuplexCmd(usart_dev->cfg->regs, DISABLE);
+
 	/* Configure the USART */
 	USART_Init(usart_dev->cfg->regs, (USART_InitTypeDef *)&usart_dev->cfg->init);
 


### PR DESCRIPTION
Support single wire mode for UART on STM32F4. This is e.g. useful for S.Port telemetry, but it requires an external bi-directional inverter as the F4 doesn't have built-in inverters.

Status: bench tested to be working.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/672)

<!-- Reviewable:end -->
