### PR TITLE
Low power stabilization

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -310,7 +310,7 @@ static void actuator_task(void* parameters)
 			// Could consider stabilizing on a positive arming edge,
 			// but this seems problematic.
 		} else if (last_pos_throttle_time) {
-			if ((this_systime - last_pos_throttle_time) >
+			if ((this_systime - last_pos_throttle_time) <
 					1000.0f * actuatorSettings.LowPowerStabilizationMaxTime) {
 				stabilize_now = true;
 				throttle_source = 0.0f;

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -298,7 +298,7 @@ static void actuator_task(void* parameters)
 			throttle_source = desired.Thrust;
 		}
 
-		bool stabilize_now = throttle_source >= 0.00f;
+		bool stabilize_now = throttle_source >= 0.0f;
 
 		static uint32_t last_pos_throttle_time = 0;
 
@@ -314,6 +314,7 @@ static void actuator_task(void* parameters)
 			if ((this_systime - last_pos_throttle_time) >
 					1000.0f * actuatorSettings.LowPowerStabilizationMaxTime) {
 				stabilize_now = true;
+				throttle_source = 0.0f;
 			} else {
 				last_pos_throttle_time = 0;
 			}
@@ -363,8 +364,8 @@ static void actuator_task(void* parameters)
 
 			offset = 1.0f - max_chan;
 		} else if (min_chan < 0.0f) {
-			/* Low power stabilization--- how much power are we
-			 * willing to add??? */
+			/* Low-side clip management-- how much power are we
+			 * willing to add??? XXX TODO */
 		}
 
 		for (int ct = 0; ct < MAX_MIX_ACTUATORS; ct++) {

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -366,8 +366,10 @@ static void stabilizationTask(void* parameters)
 			float raw_input = (&stabDesired.Roll)[i];
 
 			if (mode == STABILIZATIONDESIRED_STABILIZATIONMODE_FAILSAFE) {
-				// helicp needs everything zeroed
-				if (airframe_type == SYSTEMSETTINGS_AIRFRAMETYPE_HELICP) {
+				// Everything except planes should drop straight down
+				if ((airframe_type != SYSTEMSETTINGS_AIRFRAMETYPE_FIXEDWING) &&
+						(airframe_type != SYSTEMSETTINGS_AIRFRAMETYPE_FIXEDWINGELEVON) &&
+						(airframe_type != SYSTEMSETTINGS_AIRFRAMETYPE_FIXEDWINGVTAIL)) {
 					actuatorDesired.Thrust = 0.0f;
 					switch (i) {
 						case 0: /* Roll */

--- a/flight/targets/cc3d/fw/pios_config.h
+++ b/flight/targets/cc3d/fw/pios_config.h
@@ -99,7 +99,7 @@
 #define CPULOAD_LIMIT_CRITICAL		95
 
 /* Task stack sizes */
-#define PIOS_ACTUATOR_STACK_SIZE        600
+#define PIOS_ACTUATOR_STACK_SIZE        624
 #define PIOS_MANUAL_STACK_SIZE          700
 #define PIOS_SYSTEM_STACK_SIZE          660
 #define PIOS_STABILIZATION_STACK_SIZE   624

--- a/flight/targets/naze32/fw/pios_config.h
+++ b/flight/targets/naze32/fw/pios_config.h
@@ -98,7 +98,7 @@
 #define CPULOAD_LIMIT_CRITICAL		95
 
 /* Task stack sizes */
-#define PIOS_ACTUATOR_STACK_SIZE        600
+#define PIOS_ACTUATOR_STACK_SIZE        624
 #define PIOS_MANUAL_STACK_SIZE          700
 #define PIOS_SYSTEM_STACK_SIZE          660
 #define PIOS_STABILIZATION_STACK_SIZE   624

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -22,11 +22,11 @@
         <field name="MotorsSpinWhileArmed" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE">
             <description>When enabled, the motors will spin at the ChannelNeutral command when armed with zero throttle.</description>
         </field>
-        <field name="LowPowerStabilizationMaxPowerAdd" units="" type="float" elements="1" defaultvalue="0">
-            <description>Maximum power to add to ensure stabilization at low power.  The value 0 prevents adding power at low throttle for stabilization.</description>
+        <field name="LowPowerStabilizationMaxPowerAdd" units="" type="float" elements="1" defaultvalue="0.07">
+            <description>Maximum power to add to ensure stabilization at low power.  Always select a value well under hover power.</description>
         </field>
-        <field name="LowPowerStabilizationMaxTime" units="s" type="float" elements="1" defaultvalue="5">
-            <description>Maximum time in seconds to add power to ensure stabilization at low power.  A value of 0 prevents adding power at all.</description>
+        <field name="LowPowerStabilizationMaxTime" units="s" type="float" elements="1" defaultvalue="0">
+            <description>Maximum time in seconds to add power when at zero throttle to ensure stabilization.  Choosing 0 prevents adding power at zero throttle.</description>
         </field>
 
         <field name="MotorInputOutputCurveFit" units="-" type="float" elements="1" defaultvalue="1">

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -22,6 +22,12 @@
         <field name="MotorsSpinWhileArmed" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE">
             <description>When enabled, the motors will spin at the ChannelNeutral command when armed with zero throttle.</description>
         </field>
+        <field name="LowPowerStabilizationMaxPowerAdd" units="" type="float" elements="1" defaultvalue="0">
+            <description>Maximum power to add to ensure stabilization at low power.  The value 0 prevents adding power at low throttle for stabilization.</description>
+        </field>
+        <field name="LowPowerStabilizationMaxTime" units="s" type="float" elements="1" defaultvalue="5">
+            <description>Maximum time in seconds to add power to ensure stabilization at low power.  A value of 0 prevents adding power at all.</description>
+        </field>
 
         <field name="MotorInputOutputCurveFit" units="-" type="float" elements="1" defaultvalue="1">
             <description>Actuator mapping of input in [-1,1] to output on [-1,1], using power equation of type x^value.</description>


### PR DESCRIPTION
Fixes #228
- [x] Basic infrastructure for low power stabilization
- [x] Corrections to timer math for safety -- this was actually OK (proper windowed unsigned int subtraction)
- [x] Negative-side clip management implementation -- right now control authority is limited in that case
- ~~Need to give thought to integrator wind-up considerations in clipping scenarios~~ [issueopened]
- ~~Consider adding default actuator curve fit value = 0.85 or 0.9~~ [issueopened]
- ~~Consider adding actuator curve fit to UI~~ [issueopened]
- ~~Consider adding lowpower stab settings to UI~~ [issueopened]

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/676)

<!-- Reviewable:end -->
