### PR TITLE
flight/receiver activity: double activity detection range

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -76,7 +76,7 @@
 #define CONNECTION_OFFSET          250
 
 #define RCVR_ACTIVITY_MONITOR_CHANNELS_PER_GROUP 12
-#define RCVR_ACTIVITY_MONITOR_MIN_RANGE 10
+#define RCVR_ACTIVITY_MONITOR_MIN_RANGE 20
 
 /* All channels must have at least this many counts on each side of neutral.
  * (Except throttle which must have this many on the positive side).  This is


### PR DESCRIPTION
Make things less likely to grab the wrong channel as an interim measure
for Tanto release.

Fixes #68

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/683)

<!-- Reviewable:end -->
