### PR TITLE
gcs: shortcutsettings: remove import/export functionality

### DIFF
--- a/ground/gcs/src/plugins/coreplugin/dialogs/shortcutsettings.cpp
+++ b/ground/gcs/src/plugins/coreplugin/dialogs/shortcutsettings.cpp
@@ -2,6 +2,7 @@
  ******************************************************************************
  *
  * @file       shortcutsettings.cpp
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  *             Parts by Nokia Corporation (qt-info@nokia.com) Copyright (C) 2009.
  * @addtogroup GCSPlugins GCS Plugins
@@ -24,6 +25,10 @@
  * You should have received a copy of the GNU General Public License along 
  * with this program; if not, write to the Free Software Foundation, Inc., 
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "shortcutsettings.h"
@@ -37,11 +42,9 @@
 #include "uniqueidmanager.h"
 #include <utils/treewidgetcolumnstretcher.h>
 
-
 #include <QKeyEvent>
 #include <QShortcut>
 #include <QHeaderView>
-#include <QFileDialog>
 #include <QtDebug>
 
 Q_DECLARE_METATYPE(Core::Internal::ShortcutItem*)
@@ -95,10 +98,6 @@ QWidget *ShortcutSettings::createPage(QWidget *parent)
         this, SLOT(resetKeySequence()));
     connect(m_page->removeButton, SIGNAL(clicked()),
         this, SLOT(removeKeySequence()));
-    connect(m_page->exportButton, SIGNAL(clicked()),
-        this, SLOT(exportAction()));
-    connect(m_page->importButton, SIGNAL(clicked()),
-        this, SLOT(importAction()));
     connect(m_page->defaultButton, SIGNAL(clicked()),
         this, SLOT(defaultAction()));
 
@@ -230,29 +229,6 @@ void ShortcutSettings::removeKeySequence()
     m_page->shortcutEdit->clear();
 }
 
-void ShortcutSettings::importAction()
-{
-    UniqueIDManager *uidm = UniqueIDManager::instance();
-
-    QString fileName = QFileDialog::getOpenFileName(0, tr("Import Keyboard Mapping Scheme"),
-        ICore::instance()->resourcePath() + "/schemes/",
-        tr("Keyboard Mapping Scheme (*.kms)"));
-    if (!fileName.isEmpty()) {
-        CommandsFile cf(fileName);
-        QMap<QString, QKeySequence> mapping = cf.importCommands();
-
-        foreach (ShortcutItem *item, m_scitems) {
-            QString sid = uidm->stringForUniqueIdentifier(item->m_cmd->id());
-            if (mapping.contains(sid)) {
-                item->m_key = mapping.value(sid);
-                item->m_item->setText(2, item->m_key.toString());
-                if (item->m_item == m_page->commandList->currentItem())
-                    commandChanged(item->m_item);
-            }
-        }
-    }
-}
-
 void ShortcutSettings::defaultAction()
 {
     foreach (ShortcutItem *item, m_scitems) {
@@ -261,21 +237,6 @@ void ShortcutSettings::defaultAction()
         if (item->m_item == m_page->commandList->currentItem())
             commandChanged(item->m_item);
     }
-}
-
-void ShortcutSettings::exportAction()
-{
-#if 0
-    QString fileName = ICore::instance()->fileManager()->getSaveFileNameWithExtension(
-        tr("Export Keyboard Mapping Scheme"),
-        ICore::instance()->resourcePath() + "/schemes/",
-        tr("Keyboard Mapping Scheme (*.kms)"),
-        ".kms");
-    if (!fileName.isEmpty()) {
-        CommandsFile cf(fileName);
-        cf.exportCommands(m_scitems);
-    }
-#endif
 }
 
 void ShortcutSettings::initialize()

--- a/ground/gcs/src/plugins/coreplugin/dialogs/shortcutsettings.h
+++ b/ground/gcs/src/plugins/coreplugin/dialogs/shortcutsettings.h
@@ -2,6 +2,7 @@
  ******************************************************************************
  *
  * @file       shortcutsettings.h
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  *             Parts by Nokia Corporation (qt-info@nokia.com) Copyright (C) 2009.
  * @addtogroup GCSPlugins GCS Plugins
@@ -24,6 +25,10 @@
  * You should have received a copy of the GNU General Public License along 
  * with this program; if not, write to the Free Software Foundation, Inc., 
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #ifndef SHORTCUTSETTINGS_H
@@ -84,8 +89,6 @@ private slots:
     void keyChanged();
     void resetKeySequence();
     void removeKeySequence();
-    void importAction();
-    void exportAction();
     void defaultAction();
 
 private:

--- a/ground/gcs/src/plugins/coreplugin/dialogs/shortcutsettings.ui
+++ b/ground/gcs/src/plugins/coreplugin/dialogs/shortcutsettings.ui
@@ -65,13 +65,6 @@
       <item>
        <layout class="QHBoxLayout">
         <item>
-         <widget class="QPushButton" name="defaultButton">
-          <property name="text">
-           <string>Defaults</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <spacer>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -85,16 +78,9 @@
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="importButton">
+         <widget class="QPushButton" name="defaultButton">
           <property name="text">
-           <string>Import...</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="exportButton">
-          <property name="text">
-           <string>Export...</string>
+           <string>Restore defaults</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
The 'export' functionality wasn't functional; we no longer ship keyboard
shortcut sets, etc.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/690)

<!-- Reviewable:end -->
