### PR TITLE
flight/manualcontrol: separate failsafe-disarm timer

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -715,9 +715,21 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 		bool low_throttle = cmd->Throttle < 0;
 
 		// Check for arming timeout if transmitter invalid or throttle is low and checked
-		if (!valid || (low_throttle && check_throttle)) {
-			if ((settings->ArmedTimeout != 0) && (timeDifferenceMs(armedDisarmStart, lastSysTime) > settings->ArmedTimeout))
+		if (!valid) {
+			/* This is a separate armed timeout for invalid input only.
+			 * It defaults to 0 for now (in which case we still check the below
+			 * low-throttle-or-invalid-input timeout */
+			if ((settings->InvalidArmedTimeout != 0) && (timeDifferenceMs(armedDisarmStart, lastSysTime) > settings->InvalidArmedTimeout)) {
 				arm_state = ARM_STATE_DISARMED;
+				break;
+			}
+		}
+
+		if (!valid || (low_throttle && check_throttle)) {
+			if ((settings->ArmedTimeout != 0) && (timeDifferenceMs(armedDisarmStart, lastSysTime) > settings->ArmedTimeout)) {
+				arm_state = ARM_STATE_DISARMED;
+				break;
+			}
 		} else {
 			armedDisarmStart = lastSysTime;
  		}

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -719,7 +719,7 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 			/* This is a separate armed timeout for invalid input only.
 			 * It defaults to 0 for now (in which case we still check the below
 			 * low-throttle-or-invalid-input timeout */
-			if ((settings->InvalidArmedTimeout != 0) && (timeDifferenceMs(armedDisarmStart, lastSysTime) > settings->InvalidArmedTimeout)) {
+			if ((settings->InvalidRXArmedTimeout != 0) && (timeDifferenceMs(armedDisarmStart, lastSysTime) > settings->InvalidRXArmedTimeout)) {
 				arm_state = ARM_STATE_DISARMED;
 				break;
 			}

--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -135,6 +135,7 @@
                      It is enabled by default for additional safety to prevent flyaways -->
 		<field name="ArmTimeoutAutonomous" units="" type="enum" elements="1" options="DISABLED,ENABLED" defaultvalue="ENABLED"/>
 		<field name="ArmedTimeout" units="ms" type="uint16" elements="1" defaultvalue="30000"/>
+		<field name="InvalidArmedTimeout" units="ms" type="uint16" elements="1" defaultvalue="0"/>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>

--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -135,7 +135,7 @@
                      It is enabled by default for additional safety to prevent flyaways -->
 		<field name="ArmTimeoutAutonomous" units="" type="enum" elements="1" options="DISABLED,ENABLED" defaultvalue="ENABLED"/>
 		<field name="ArmedTimeout" units="ms" type="uint16" elements="1" defaultvalue="30000"/>
-		<field name="InvalidArmedTimeout" units="ms" type="uint16" elements="1" defaultvalue="0"/>
+		<field name="InvalidRXArmedTimeout" units="ms" type="uint16" elements="1" defaultvalue="0"/>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
Defaults to off / just using the low throttle mechanism

No UI yet.  Fixes #424, but a new post-tanto issue should be opened for changing the
default and creating UI.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/691)

<!-- Reviewable:end -->
