### PR TITLE
gcs: make hangtime/actuator curve fit configurable

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -310,7 +310,7 @@ static void actuator_task(void* parameters)
 			// Could consider stabilizing on a positive arming edge,
 			// but this seems problematic.
 		} else if (last_pos_throttle_time) {
-			if ((this_systime - last_pos_throttle_time) >
+			if ((this_systime - last_pos_throttle_time) <
 					1000.0f * actuatorSettings.LowPowerStabilizationMaxTime) {
 				stabilize_now = true;
 				throttle_source = 0.0f;

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -298,7 +298,7 @@ static void actuator_task(void* parameters)
 			throttle_source = desired.Thrust;
 		}
 
-		bool stabilize_now = throttle_source >= 0.00f;
+		bool stabilize_now = throttle_source >= 0.0f;
 
 		static uint32_t last_pos_throttle_time = 0;
 
@@ -314,6 +314,7 @@ static void actuator_task(void* parameters)
 			if ((this_systime - last_pos_throttle_time) >
 					1000.0f * actuatorSettings.LowPowerStabilizationMaxTime) {
 				stabilize_now = true;
+				throttle_source = 0.0f;
 			} else {
 				last_pos_throttle_time = 0;
 			}
@@ -363,8 +364,8 @@ static void actuator_task(void* parameters)
 
 			offset = 1.0f - max_chan;
 		} else if (min_chan < 0.0f) {
-			/* Low power stabilization--- how much power are we
-			 * willing to add??? */
+			/* Low-side clip management-- how much power are we
+			 * willing to add??? XXX TODO */
 		}
 
 		for (int ct = 0; ct < MAX_MIX_ACTUATORS; ct++) {

--- a/flight/targets/cc3d/fw/pios_config.h
+++ b/flight/targets/cc3d/fw/pios_config.h
@@ -99,7 +99,7 @@
 #define CPULOAD_LIMIT_CRITICAL		95
 
 /* Task stack sizes */
-#define PIOS_ACTUATOR_STACK_SIZE        600
+#define PIOS_ACTUATOR_STACK_SIZE        624
 #define PIOS_MANUAL_STACK_SIZE          700
 #define PIOS_SYSTEM_STACK_SIZE          660
 #define PIOS_STABILIZATION_STACK_SIZE   624

--- a/flight/targets/naze32/fw/pios_config.h
+++ b/flight/targets/naze32/fw/pios_config.h
@@ -98,7 +98,7 @@
 #define CPULOAD_LIMIT_CRITICAL		95
 
 /* Task stack sizes */
-#define PIOS_ACTUATOR_STACK_SIZE        600
+#define PIOS_ACTUATOR_STACK_SIZE        624
 #define PIOS_MANUAL_STACK_SIZE          700
 #define PIOS_SYSTEM_STACK_SIZE          660
 #define PIOS_STABILIZATION_STACK_SIZE   624

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -3,7 +3,7 @@
  *
  * @file       configoutputwidget.cpp
  * @author     E. Lafargue & The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
- * @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @author     dRonin, http://dronin.org Copyright (C) 2015-2016
  * @addtogroup GCSPlugins GCS Plugins
  * @{
  * @addtogroup ConfigPlugin Config Plugin
@@ -24,6 +24,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "configoutputwidget.h"
@@ -165,6 +169,7 @@ void ConfigOutputWidget::enableControls(bool enable)
         m_config->channelOutTest->setChecked(false);
     m_config->channelOutTest->setEnabled(enable);
     m_config->calibrateESC->setEnabled(enable);
+    m_config->motorCurveFit->setEnabled(enable);
 }
 
 ConfigOutputWidget::~ConfigOutputWidget()
@@ -476,6 +481,8 @@ void ConfigOutputWidget::refreshWidgetsValues(UAVObject * obj)
         }
     }
 
+    m_config->motorCurveFit->setValue(actuatorSettingsData.MotorInputOutputCurveFit);
+
     // Get Channel ranges:
     QList<OutputChannelForm*> outputChannelForms = findChildren<OutputChannelForm*>();
     foreach(OutputChannelForm *outputChannelForm, outputChannelForms)
@@ -593,6 +600,8 @@ void ConfigOutputWidget::updateObjectsFromWidgets()
         actuatorSettingsData.TimerPwmResolution[3] = m_config->cb_outputResolution4->currentIndex();
         actuatorSettingsData.TimerPwmResolution[4] = m_config->cb_outputResolution5->currentIndex();
         actuatorSettingsData.TimerPwmResolution[5] = m_config->cb_outputResolution6->currentIndex();
+
+        actuatorSettingsData.MotorInputOutputCurveFit = m_config->motorCurveFit->value();
 
         if(m_config->spinningArmed->isChecked() == true)
             actuatorSettingsData.MotorsSpinWhileArmed = ActuatorSettings::MOTORSSPINWHILEARMED_TRUE;

--- a/ground/gcs/src/plugins/config/configstabilizationwidget.cpp
+++ b/ground/gcs/src/plugins/config/configstabilizationwidget.cpp
@@ -62,9 +62,6 @@ ConfigStabilizationWidget::ConfigStabilizationWidget(QWidget *parent) : ConfigTa
 
 
     autoLoadWidgets();
-    realtimeUpdates=new QTimer(this);
-    connect(m_stabilization->realTimeUpdates_6,SIGNAL(stateChanged(int)),this,SLOT(realtimeUpdatesSlot(int)));
-    connect(realtimeUpdates,SIGNAL(timeout()),this,SLOT(apply()));
 
     connect(m_stabilization->checkBox_7,SIGNAL(stateChanged(int)),this,SLOT(linkCheckBoxes(int)));
     connect(m_stabilization->checkBox_2,SIGNAL(stateChanged(int)),this,SLOT(linkCheckBoxes(int)));
@@ -129,15 +126,6 @@ ConfigStabilizationWidget::ConfigStabilizationWidget(QWidget *parent) : ConfigTa
 ConfigStabilizationWidget::~ConfigStabilizationWidget()
 {
     // Do nothing
-}
-
-void ConfigStabilizationWidget::realtimeUpdatesSlot(int value)
-{
-    m_stabilization->realTimeUpdates_6->setCheckState((Qt::CheckState)value);
-    if(value==Qt::Checked && !realtimeUpdates->isActive())
-        realtimeUpdates->start(300);
-    else if(value==Qt::Unchecked)
-        realtimeUpdates->stop();
 }
 
 void ConfigStabilizationWidget::linkCheckBoxes(int value)

--- a/ground/gcs/src/plugins/config/configstabilizationwidget.cpp
+++ b/ground/gcs/src/plugins/config/configstabilizationwidget.cpp
@@ -30,6 +30,7 @@
  * must be maintained in each individual source file that is a derivative work
  * of this source file; otherwise redistribution is prohibited.
  */
+
 #include "configstabilizationwidget.h"
 #include "convertmwrate.h"
 

--- a/ground/gcs/src/plugins/config/configstabilizationwidget.h
+++ b/ground/gcs/src/plugins/config/configstabilizationwidget.h
@@ -48,7 +48,6 @@ public:
 
 private:
     Ui_StabilizationWidget *m_stabilization;
-    QTimer * realtimeUpdates;
 
     struct UpdateExpoFlags {
       bool RateRoll;
@@ -66,7 +65,6 @@ private:
     } update_exp;
 
 private slots:
-    void realtimeUpdatesSlot(int);
     void linkCheckBoxes(int value);
     void processLinkedWidgets(QWidget*);
     void applyRateLimits();

--- a/ground/gcs/src/plugins/config/output.ui
+++ b/ground/gcs/src/plugins/config/output.ui
@@ -1204,7 +1204,7 @@ Leave at 50Hz for fixed wing.</string>
                  </widget>
                 </item>
                 <item>
-                 <widget class="QDoubleSpinBox" name="motorCurveFIt">
+                 <widget class="QDoubleSpinBox" name="motorCurveFit">
                   <property name="minimum">
                    <double>0.500000000000000</double>
                   </property>
@@ -1217,12 +1217,6 @@ Leave at 50Hz for fixed wing.</string>
                   <property name="value">
                    <double>1.000000000000000</double>
                   </property>
-                   <property name="objrelation" stdset="0">
-                    <stringlist>
-                     <string>objname:ActuatorSettings</string>
-                     <string>fieldname:MotorInputOutputCurveFit</string>
-                    </stringlist>
-                   </property>
                  </widget>
                 </item>
                 <item>

--- a/ground/gcs/src/plugins/config/output.ui
+++ b/ground/gcs/src/plugins/config/output.ui
@@ -1206,7 +1206,7 @@ Leave at 50Hz for fixed wing.</string>
                 <item>
                  <widget class="QDoubleSpinBox" name="motorCurveFit">
                   <property name="toolTip">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Motor curve fit can be used for correct for nonlinearity in&lt;/p&gt;&lt;p&gt;motor output.  If you experience oscillation at high power&lt;/p&gt;&lt;p&gt;but are otherwise well-tuned, consider lowering motor curve&lt;/p&gt;&lt;p&gt;fit some.  Values between 0.5 (square-root) and 1.0 (no&lt;/p&gt;&lt;p&gt;linearization) are sensible.  This is a more rational subtitute&lt;/p&gt;&lt;p&gt;for Throttle PID Attenutation (TPA).&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Note that some re-tuning may be required after changing &lt;/p&gt;&lt;p&gt;this value.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Motor curve fit can be used for correct for nonlinearity in motor output.  If you experience oscillation at high power but are otherwise well-tuned, consider lowering motor curve fit some.  Values between 0.5 (square-root) and 1.0 (no linearization) are sensible.  This is a more rational subtitute for Throttle PID Attenutation (TPA).&lt;/p&gt;&lt;p&gt;Note that some re-tuning may be required after changing &lt;/p&gt;&lt;p&gt;this value.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                   <property name="minimum">
                    <double>0.500000000000000</double>

--- a/ground/gcs/src/plugins/config/output.ui
+++ b/ground/gcs/src/plugins/config/output.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>698</width>
-    <height>754</height>
+    <width>868</width>
+    <height>751</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -134,8 +134,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>811</width>
-            <height>654</height>
+            <width>838</width>
+            <height>650</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -1106,15 +1106,23 @@ Leave at 50Hz for fixed wing.</string>
                  <number>12</number>
                 </property>
                 <item>
-                 <widget class="QCheckBox" name="spinningArmed">
+                 <widget class="QCheckBox" name="channelOutTest">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
                   <property name="minimumSize">
                    <size>
-                    <width>519</width>
+                    <width>105</width>
                     <height>0</height>
                    </size>
                   </property>
+                  <property name="toolTip">
+                   <string>Move the servos using the sliders. Two important things:
+- Take extra care if the output is connected to an motor controller!
+- Will only work if the RC receiver is working (failsafe)</string>
+                  </property>
                   <property name="text">
-                   <string>Motors spin at neutral output when armed and throttle below zero (be careful)</string>
+                   <string>Test outputs</string>
                   </property>
                  </widget>
                 </item>
@@ -1130,6 +1138,19 @@ Leave at 50Hz for fixed wing.</string>
                    </size>
                   </property>
                  </spacer>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="spinningArmed">
+                  <property name="minimumSize">
+                   <size>
+                    <width>519</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Motors spin at neutral output when armed and throttle below zero</string>
+                  </property>
+                 </widget>
                 </item>
                </layout>
               </item>
@@ -1176,24 +1197,32 @@ Leave at 50Hz for fixed wing.</string>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_3">
                 <item>
-                 <widget class="QCheckBox" name="channelOutTest">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>105</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="toolTip">
-                   <string>Move the servos using the sliders. Two important things:
-- Take extra care if the output is connected to an motor controller!
-- Will only work if the RC receiver is working (failsafe)</string>
-                  </property>
+                 <widget class="QLabel" name="label">
                   <property name="text">
-                   <string>Test outputs</string>
+                   <string>Motor curve fit:</string>
                   </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QDoubleSpinBox" name="motorCurveFIt">
+                  <property name="minimum">
+                   <double>0.500000000000000</double>
+                  </property>
+                  <property name="maximum">
+                   <double>1.000000000000000</double>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.010000000000000</double>
+                  </property>
+                  <property name="value">
+                   <double>1.000000000000000</double>
+                  </property>
+                   <property name="objrelation" stdset="0">
+                    <stringlist>
+                     <string>objname:ActuatorSettings</string>
+                     <string>fieldname:MotorInputOutputCurveFit</string>
+                    </stringlist>
+                   </property>
                  </widget>
                 </item>
                 <item>

--- a/ground/gcs/src/plugins/config/output.ui
+++ b/ground/gcs/src/plugins/config/output.ui
@@ -1205,6 +1205,9 @@ Leave at 50Hz for fixed wing.</string>
                 </item>
                 <item>
                  <widget class="QDoubleSpinBox" name="motorCurveFit">
+                  <property name="toolTip">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Motor curve fit can be used for correct for nonlinearity in&lt;/p&gt;&lt;p&gt;motor output.  If you experience oscillation at high power&lt;/p&gt;&lt;p&gt;but are otherwise well-tuned, consider lowering motor curve&lt;/p&gt;&lt;p&gt;fit some.  Values between 0.5 (square-root) and 1.0 (no&lt;/p&gt;&lt;p&gt;linearization) are sensible.  This is a more rational subtitute&lt;/p&gt;&lt;p&gt;for Throttle PID Attenutation (TPA).&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Note that some re-tuning may be required after changing &lt;/p&gt;&lt;p&gt;this value.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
                   <property name="minimum">
                    <double>0.500000000000000</double>
                   </property>

--- a/ground/gcs/src/plugins/config/stabilization.ui
+++ b/ground/gcs/src/plugins/config/stabilization.ui
@@ -34585,7 +34585,7 @@ border-radius: 5;</string>
                    </sizepolicy>
                   </property>
                   <property name="toolTip">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This specifies the maximum amount of power to add when&lt;/p&gt;&lt;p&gt;stabilization needs more total power than on the throttle&lt;/p&gt;&lt;p&gt;stick.  This is used during HangTime and other maneuvers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This specifies the maximum amount of power to add when stabilization needs more total power than specified by the throttle input.  This is used during HangTime and other maneuvers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -34698,7 +34698,7 @@ border-radius: 5;</string>
                    </size>
                   </property>
                   <property name="toolTip">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In the Acro+ flight mode, this selects how much&lt;/p&gt;&lt;p&gt;effort to apply to actuators at full stick deflection&lt;/p&gt;&lt;p&gt;(and how much gyro suppression should occur).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In the Acro+ flight mode, this selects how much effort to apply to actuators at full stick deflection (and how much gyro suppression should occur).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -34729,7 +34729,7 @@ border-radius: 5;</string>
                    </sizepolicy>
                   </property>
                   <property name="toolTip">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HangTime allows stabilization of the flight controller during&lt;/p&gt;&lt;p&gt;brief maneuvers at zero throttle.  This specifies the maximum&lt;/p&gt;&lt;p&gt;length of time to add power for stabilization at zero throttle.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HangTime allows stabilization of the flight controller during brief maneuvers at zero throttle.  This specifies the maximum length of time to add power for stabilization at zero throttle.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/ground/gcs/src/plugins/config/stabilization.ui
+++ b/ground/gcs/src/plugins/config/stabilization.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>965</width>
-    <height>908</height>
+    <width>1036</width>
+    <height>984</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -615,8 +615,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>935</width>
-            <height>807</height>
+            <width>1006</width>
+            <height>883</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -10498,7 +10498,7 @@ border-radius: 5;</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>930</width>
+            <width>980</width>
             <height>1019</height>
            </rect>
           </property>
@@ -29361,8 +29361,8 @@ value as the Kp.</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>909</width>
-            <height>1470</height>
+            <width>980</width>
+            <height>1473</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -32111,7 +32111,7 @@ border-radius: 5;</string>
                 </size>
                </property>
                <property name="title">
-                <string>Throttle PID attenuation</string>
+                <string>Throttle PID Attenuation (deprecated; please consider using MotorCurveFit in output settings) </string>
                </property>
                <layout class="QGridLayout" name="gridLayout_14">
                 <property name="leftMargin">
@@ -34560,7 +34560,78 @@ border-radius: 5;</string>
                 <string>Advanced Acro Settings</string>
                </property>
                <layout class="QGridLayout" name="gridLayout_31">
-                <item row="0" column="1">
+                <item row="0" column="5">
+                 <spacer name="horizontalSpacer_23">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>10</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item row="0" column="10">
+                 <widget class="QDoubleSpinBox" name="sbHungPower">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="toolTip">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This specifies the maximum amount of power to add when&lt;/p&gt;&lt;p&gt;stabilization needs more total power than on the throttle&lt;/p&gt;&lt;p&gt;stick.  This is used during HangTime and other maneuvers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                  <property name="suffix">
+                   <string>%</string>
+                  </property>
+                  <property name="decimals">
+                   <number>1</number>
+                  </property>
+                  <property name="maximum">
+                   <double>15.000000000000000</double>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.500000000000000</double>
+                  </property>
+                  <property name="value">
+                   <double>0.000000000000000</double>
+                  </property>
+                  <property name="objrelation" stdset="0">
+                   <stringlist>
+                    <string>objname:ActuatorSettings</string>
+                    <string>fieldname:LowPowerStabilizationMaxPowerAdd</string>
+                    <string>scale:.01</string>
+                    <string>buttongroup:10</string>
+                   </stringlist>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="9">
+                 <spacer name="horizontalSpacer_25">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>10</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item row="0" column="0">
                  <widget class="QLabel" name="lblInsanityFactor">
                   <property name="minimumSize">
                    <size>
@@ -34569,26 +34640,56 @@ border-radius: 5;</string>
                    </size>
                   </property>
                   <property name="text">
-                   <string>Acro+ Insanity Factor (%)</string>
+                   <string>Acro+ Insanity Factor</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                   </property>
                  </widget>
                 </item>
-                <item row="0" column="3">
+                <item row="0" column="1">
+                 <spacer name="horizontalSpacer_21">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>10</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item row="0" column="4">
+                 <widget class="QLabel" name="label_4">
+                  <property name="text">
+                   <string>HangTime Maximum Duration</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="8">
+                 <widget class="QLabel" name="label_5">
+                  <property name="text">
+                   <string>Maximum Power Add</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="2">
                  <widget class="QDoubleSpinBox" name="sbInsanityFactor">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>103</width>
-                    <height>22</height>
-                   </size>
                   </property>
                   <property name="maximumSize">
                    <size>
@@ -34596,8 +34697,14 @@ border-radius: 5;</string>
                     <height>16777215</height>
                    </size>
                   </property>
+                  <property name="toolTip">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In the Acro+ flight mode, this selects how much&lt;/p&gt;&lt;p&gt;effort to apply to actuators at full stick deflection&lt;/p&gt;&lt;p&gt;(and how much gyro suppression should occur).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
                   <property name="alignment">
                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                  <property name="suffix">
+                   <string>%</string>
                   </property>
                   <property name="decimals">
                    <number>0</number>
@@ -34613,8 +34720,40 @@ border-radius: 5;</string>
                   </property>
                  </widget>
                 </item>
-                <item row="0" column="4">
-                 <spacer name="horizontalSpacer_21">
+                <item row="0" column="6">
+                 <widget class="QDoubleSpinBox" name="sbHangtime">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="toolTip">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HangTime allows stabilization of the flight controller during&lt;/p&gt;&lt;p&gt;brief maneuvers at zero throttle.  This specifies the maximum&lt;/p&gt;&lt;p&gt;length of time to add power for stabilization at zero throttle.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                  <property name="suffix">
+                   <string> s</string>
+                  </property>
+                  <property name="maximum">
+                   <double>4.500000000000000</double>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.250000000000000</double>
+                  </property>
+                  <property name="objrelation" stdset="0">
+                   <stringlist>
+                    <string>objname:ActuatorSettings</string>
+                    <string>fieldname:LowPowerStabilizationMaxTime</string>
+                    <string>buttongroup:10</string>
+                   </stringlist>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="3">
+                 <spacer name="horizontalSpacer_35">
                   <property name="orientation">
                    <enum>Qt::Horizontal</enum>
                   </property>
@@ -34626,30 +34765,14 @@ border-radius: 5;</string>
                   </property>
                  </spacer>
                 </item>
-                <item row="0" column="2">
-                 <spacer name="horizontalSpacer_23">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Fixed</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>10</width>
-                    <height>10</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item row="0" column="0">
-                 <spacer name="horizontalSpacer_25">
+                <item row="0" column="7">
+                 <spacer name="horizontalSpacer_40">
                   <property name="orientation">
                    <enum>Qt::Horizontal</enum>
                   </property>
                   <property name="sizeHint" stdset="0">
                    <size>
-                    <width>40</width>
+                    <width>0</width>
                     <height>20</height>
                    </size>
                   </property>
@@ -34707,60 +34830,6 @@ border-radius: 5;</string>
                 <property name="horizontalSpacing">
                  <number>6</number>
                 </property>
-                <item row="0" column="0">
-                 <spacer name="horizontalSpacer_36">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Preferred</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>632</width>
-                    <height>27</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item row="0" column="1">
-                 <widget class="QPushButton" name="pushButton_9">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>0</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                  <property name="toolTip">
-                   <string>Reset all values to GCS defaults</string>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true"/>
-                  </property>
-                  <property name="text">
-                   <string>Default</string>
-                  </property>
-                  <property name="objrelation" stdset="0">
-                   <stringlist>
-                    <string>objname:StabilizationSettings</string>
-                    <string>button:default</string>
-                    <string>buttongroup:13</string>
-                   </stringlist>
-                  </property>
-                 </widget>
-                </item>
                 <item row="1" column="0" colspan="2">
                  <widget class="QGroupBox" name="groupBox_10">
                   <property name="minimumSize">
@@ -37096,6 +37165,60 @@ border-radius: 5;</string>
                   </layout>
                  </widget>
                 </item>
+                <item row="0" column="0">
+                 <spacer name="horizontalSpacer_36">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Preferred</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>632</width>
+                    <height>27</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QPushButton" name="pushButton_9">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>16777215</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>Reset all values to GCS defaults</string>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true"/>
+                  </property>
+                  <property name="text">
+                   <string>Default</string>
+                  </property>
+                  <property name="objrelation" stdset="0">
+                   <stringlist>
+                    <string>objname:StabilizationSettings</string>
+                    <string>button:default</string>
+                    <string>buttongroup:13</string>
+                   </stringlist>
+                  </property>
+                 </widget>
+                </item>
                </layout>
               </widget>
              </item>
@@ -38232,6 +38355,22 @@ border-radius: 5;</string>
                      <property name="horizontalSpacing">
                       <number>6</number>
                      </property>
+                     <item row="0" column="0">
+                      <spacer name="horizontalSpacer_65">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeType">
+                        <enum>QSizePolicy::Preferred</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>632</width>
+                         <height>27</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
                      <item row="1" column="0" colspan="2">
                       <widget class="QGroupBox" name="RateStabilizationGroup_20">
                        <property name="sizePolicy">
@@ -40615,22 +40754,6 @@ border-radius: 5;</string>
                         </stringlist>
                        </property>
                       </widget>
-                     </item>
-                     <item row="0" column="0">
-                      <spacer name="horizontalSpacer_65">
-                       <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                       </property>
-                       <property name="sizeType">
-                        <enum>QSizePolicy::Preferred</enum>
-                       </property>
-                       <property name="sizeHint" stdset="0">
-                        <size>
-                         <width>632</width>
-                         <height>27</height>
-                        </size>
-                       </property>
-                      </spacer>
                      </item>
                     </layout>
                    </widget>

--- a/ground/gcs/src/plugins/config/stabilization.ui
+++ b/ground/gcs/src/plugins/config/stabilization.ui
@@ -615,8 +615,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>937</width>
-            <height>820</height>
+            <width>935</width>
+            <height>807</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -10498,8 +10498,8 @@ border-radius: 5;</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>923</width>
-            <height>996</height>
+            <width>930</width>
+            <height>1019</height>
            </rect>
           </property>
           <property name="autoFillBackground">
@@ -29361,8 +29361,8 @@ value as the Kp.</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>923</width>
-            <height>1521</height>
+            <width>909</width>
+            <height>1470</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -34557,7 +34557,7 @@ border-radius: 5;</string>
              <item>
               <widget class="QGroupBox" name="gbAcroPlus">
                <property name="title">
-                <string>Acro+</string>
+                <string>Advanced Acro Settings</string>
                </property>
                <layout class="QGridLayout" name="gridLayout_31">
                 <item row="0" column="1">
@@ -34569,7 +34569,7 @@ border-radius: 5;</string>
                    </size>
                   </property>
                   <property name="text">
-                   <string>Insanity Factor (%)</string>
+                   <string>Acro+ Insanity Factor (%)</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -37101,75 +37101,6 @@ border-radius: 5;</string>
              </item>
              <item>
               <spacer name="verticalSpacer_7">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>10</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="groupBox_3">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>60</height>
-                </size>
-               </property>
-               <property name="title">
-                <string>Real Time Updates</string>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_13">
-                <property name="leftMargin">
-                 <number>4</number>
-                </property>
-                <property name="rightMargin">
-                 <number>4</number>
-                </property>
-                <item>
-                 <widget class="QCheckBox" name="realTimeUpdates_6">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>136</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                  <property name="toolTip">
-                   <string>If you check this, the GCS will udpate the stabilization factors
-automatically every 300ms, which will help for fast tuning.</string>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true"/>
-                  </property>
-                  <property name="text">
-                   <string>Update in real time</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <spacer name="verticalSpacer_12">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>
                </property>
@@ -41633,7 +41564,6 @@ Useful if you have accidentally changed some settings.</string>
   <tabstop>AttitudeRollILimit</tabstop>
   <tabstop>AttitudePitchILimit_2</tabstop>
   <tabstop>AttitudeYawILimit</tabstop>
-  <tabstop>realTimeUpdates_6</tabstop>
  </tabstops>
  <resources>
   <include location="../coreplugin/core.qrc"/>

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -29,7 +29,7 @@
             <description>Maximum time in seconds to add power when at zero throttle to ensure stabilization.  Choosing 0 prevents adding power at zero throttle.</description>
         </field>
 
-        <field name="MotorInputOutputCurveFit" units="-" type="float" elements="1" defaultvalue="1">
+        <field name="MotorInputOutputCurveFit" units="-" type="float" elements="1" defaultvalue="0.9">
             <description>Actuator mapping of input in [-1,1] to output on [-1,1], using power equation of type x^value.</description>
         </field>
 

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -22,11 +22,11 @@
         <field name="MotorsSpinWhileArmed" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE">
             <description>When enabled, the motors will spin at the ChannelNeutral command when armed with zero throttle.</description>
         </field>
-        <field name="LowPowerStabilizationMaxPowerAdd" units="" type="float" elements="1" defaultvalue="0">
-            <description>Maximum power to add to ensure stabilization at low power.  The value 0 prevents adding power at low throttle for stabilization.</description>
+        <field name="LowPowerStabilizationMaxPowerAdd" units="" type="float" elements="1" defaultvalue="0.07">
+            <description>Maximum power to add to ensure stabilization at low power.  Always select a value well under hover power.</description>
         </field>
-        <field name="LowPowerStabilizationMaxTime" units="s" type="float" elements="1" defaultvalue="5">
-            <description>Maximum time in seconds to add power to ensure stabilization at low power.  A value of 0 prevents adding power at all.</description>
+        <field name="LowPowerStabilizationMaxTime" units="s" type="float" elements="1" defaultvalue="0">
+            <description>Maximum time in seconds to add power when at zero throttle to ensure stabilization.  Choosing 0 prevents adding power at zero throttle.</description>
         </field>
 
         <field name="MotorInputOutputCurveFit" units="-" type="float" elements="1" defaultvalue="1">

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -22,6 +22,12 @@
         <field name="MotorsSpinWhileArmed" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE">
             <description>When enabled, the motors will spin at the ChannelNeutral command when armed with zero throttle.</description>
         </field>
+        <field name="LowPowerStabilizationMaxPowerAdd" units="" type="float" elements="1" defaultvalue="0">
+            <description>Maximum power to add to ensure stabilization at low power.  The value 0 prevents adding power at low throttle for stabilization.</description>
+        </field>
+        <field name="LowPowerStabilizationMaxTime" units="s" type="float" elements="1" defaultvalue="5">
+            <description>Maximum time in seconds to add power to ensure stabilization at low power.  A value of 0 prevents adding power at all.</description>
+        </field>
 
         <field name="MotorInputOutputCurveFit" units="-" type="float" elements="1" defaultvalue="1">
             <description>Actuator mapping of input in [-1,1] to output on [-1,1], using power equation of type x^value.</description>


### PR DESCRIPTION
Builds upon / requires #676.  Fixes #688 
- Sets the default value of actuator curve fit to 0.9.  This value was chosen to not screw up actually linear actuators / existing setups much, but still provide some degree of correction in all cases.
- Adds UI for actuator curve fit, on motor output pane.
- Adds UI for hangtime on stabilization pane.  Note this will make the stabilization pane save the actuator object (but it makes a lot more sense here than on the stabilization pane.  There's also some rearrangement associated with this.
- Remove "live update" functionality of PIDs.  Requires a telemetry link / is a really wonky thing to try and use / our controls were in the wrong place.
- Adds tooltips, for this functionality and acro+.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/697)

<!-- Reviewable:end -->
