### PR TITLE
stabilization settings: turn up weak leveling rate

### DIFF
--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -38,8 +38,8 @@
 	<field name="MaxAxisLock" units="deg" type="uint8" elements="1" defaultvalue="15"/>
 	<field name="MaxAxisLockRate" units="deg/s" type="uint8" elements="1" defaultvalue="2"/>
 
-	<field name="WeakLevelingKp" units="(deg/s)/deg" type="float" elements="1" defaultvalue="0.1"/>
-	<field name="MaxWeakLevelingRate" units="deg/s" type="uint8" elements="1" defaultvalue="5"/>
+	<field name="WeakLevelingKp" units="(deg/s)/deg" type="float" elements="1" defaultvalue="0.33"/>
+	<field name="MaxWeakLevelingRate" units="deg/s" type="uint8" elements="1" defaultvalue="45"/>
 
 	<field name="LowThrottleZeroIntegral" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="TRUE"/>
 


### PR DESCRIPTION
We suggest using weakleveling a lot to learn rate, but it needs to be
more effective to do so.  The current coefficients do almost nothing--
.1 corresponds to taking out 63% of the pitch/roll in 10 seconds, or 30
seconds to remove 95% of the bank.

New value of .33 takes out 63% of the pitch/roll in 3 seconds, or 9
seconds to get 95% of the way to level.

Put another way, at 45 degree roll, it'll want to initially level at 15
deg/sec.  With 150 deg/sec default full-stick deflection rates, it'll
take 10% deflection to hold that attitude.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/711)

<!-- Reviewable:end -->
