### PR TITLE
naze32: configurable interrupt port for mpu6050

### DIFF
--- a/shared/uavobjectdefinition/hwnaze.xml
+++ b/shared/uavobjectdefinition/hwnaze.xml
@@ -46,6 +46,7 @@
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>
 		<field name="MPU6050Rate" units="" type="enum" elements="1" options="200,333,500" defaultvalue="333"/>
 		<field name="MPU6050DLPF" units="" type="enum" elements="1" options="256,188,98,42,20,10,5" defaultvalue="188"/>
+        <field name="MPU6050IntPin" units="" type="enum" elements="1" options="Auto,PB13,PC13" defaultvalue="Auto"/>
 
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
The port moves about among the various naze incarnations and isn't as
simple to detect as "is this a rev 5?"  Afromini Amaze is effectively a
rev 4, but has the MPU on port C.

This allows the user to override that when the default isn't working
correctly.  My Amaze works now.

Closes #702 

![dronin_gcs](https://cloud.githubusercontent.com/assets/1779/13371681/03faf50c-dce1-11e5-9234-a5ba86029704.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/712)

<!-- Reviewable:end -->
