### PR TITLE
IAP reset: Disable PWM in many cases during reset wait

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -693,12 +693,7 @@ static bool set_channel(uint8_t mixer_channel, float value)
 		return true;
 	}
 	case ACTUATORSETTINGS_CHANNELTYPE_PWM:
-#if defined(PIOS_INCLUDE_HPWM)
-		// The HPWM method will convert from us to the appropriate settings
 		PIOS_Servo_Set(mixer_channel, value, actuatorSettings.ChannelMax[mixer_channel]);
-#else
-		PIOS_Servo_Set(mixer_channel, value, actuatorSettings.ChannelMax[mixer_channel]);
-#endif
 		return true;
 	default:
 		return false;

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -689,11 +689,12 @@ static bool set_channel(uint8_t mixer_channel, float value)
 		}
 		PIOS_Servo_Set(mixer_channel,
 					buzzOn ? actuatorSettings.ChannelMax[mixer_channel] : actuatorSettings.ChannelMin[mixer_channel],
-					actuatorSettings.ChannelMax[mixer_channel]);
+					actuatorSettings.ChannelMax[mixer_channel],
+					actuatorSettings.ChannelMax[mixer_channel] < actuatorSettings.ChannelMin[mixer_channel]);
 		return true;
 	}
 	case ACTUATORSETTINGS_CHANNELTYPE_PWM:
-		PIOS_Servo_Set(mixer_channel, value, actuatorSettings.ChannelMax[mixer_channel]);
+		PIOS_Servo_Set(mixer_channel, value, actuatorSettings.ChannelMax[mixer_channel], actuatorSettings.ChannelMax[mixer_channel] < actuatorSettings.ChannelMin[mixer_channel]);
 		return true;
 	default:
 		return false;

--- a/flight/Modules/FirmwareIAP/firmwareiap.c
+++ b/flight/Modules/FirmwareIAP/firmwareiap.c
@@ -8,7 +8,7 @@
  * @file       firmwareiap.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2014
- * @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
  * @brief      In Application Programming module to support firmware upgrades by
  *             providing a means to enter the bootloader.
  *
@@ -29,6 +29,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 #include <stdint.h>
 
@@ -38,6 +42,7 @@
 #include "firmwareiap.h"
 #include "firmwareiapobj.h"
 #include "flightstatus.h"
+#include "pios_servo.h"
 #include "pios_thread.h"
 
 // Private constants
@@ -188,6 +193,9 @@ static void FirmwareIAPCallback(UAVObjEvent* ev, void *ctx, void *obj, int len)
 					lastResetSysTime = PIOS_Thread_Systime();
 					UAVObjEvent * ev = PIOS_malloc_no_dma(sizeof(UAVObjEvent));
 					memset(ev,0,sizeof(UAVObjEvent));
+
+					PIOS_Servo_PrepareForReset(); // Stop PWM
+
 					EventPeriodicCallbackCreate(ev, resetTask, 100);
 					iap_state = IAP_STATE_RESETTING;
 				} else {

--- a/flight/PiOS.posix/inc/pios_servo.h
+++ b/flight/PiOS.posix/inc/pios_servo.h
@@ -36,6 +36,8 @@ enum pwm_mode {PWM_MODE_1MHZ, PWM_MODE_12MHZ};
 extern void PIOS_Servo_SetMode(const uint16_t * speeds, const uint8_t *pwm_mode, uint8_t banks);
 extern void PIOS_Servo_Set(uint8_t Servo, uint16_t Position);
 
+extern void PIOS_Servo_PrepareForReset();
+
 #endif /* PIOS_SERVO_H */
 
 /**

--- a/flight/PiOS.posix/posix/pios_servo.c
+++ b/flight/PiOS.posix/posix/pios_servo.c
@@ -71,4 +71,7 @@ void PIOS_Servo_Set(uint8_t Servo, uint16_t Position)
 #endif // PIOS_ENABLE_DEBUG_PINS
 }
 
+void PIOS_Servo_PrepareForReset() {
+}
+
 #endif

--- a/flight/PiOS/Common/pios_servo.c
+++ b/flight/PiOS/Common/pios_servo.c
@@ -242,7 +242,6 @@ void PIOS_Servo_SetMode(const uint16_t * speeds, const enum pwm_mode *pwm_mode, 
 * \param[in] Position Servo position in microseconds
 * \param[in] max Maximum pulse length in us for oneshot
 */
-#if defined(PIOS_INCLUDE_HPWM)
 void PIOS_Servo_Set(uint8_t servo, float position, float max)
 {
 	/* Make sure servo exists */
@@ -252,6 +251,7 @@ void PIOS_Servo_Set(uint8_t servo, float position, float max)
 
 	const struct pios_tim_channel * chan = &servo_cfg->channels[servo];
 
+#if defined(PIOS_INCLUDE_HPWM)
 	/* recalculate the position value based on timer clock rate */
 	/* position is in us. Note: if the set of channel resolutions */
 	/* stop all being multiples of 1MHz we might need to refactor */
@@ -284,6 +284,7 @@ void PIOS_Servo_Set(uint8_t servo, float position, float max)
 			return;
 		}
 	}
+#endif
 
 	/* Update the position */
 	switch(chan->timer_chan) {
@@ -301,42 +302,6 @@ void PIOS_Servo_Set(uint8_t servo, float position, float max)
 			break;
 	}
 }
-#else
-/**
-* Set servo position
-* \param[in] Servo Servo number (0-num_channels)
-* \param[in] Position Servo position in microseconds
-*/
-void PIOS_Servo_Set(uint8_t servo, uint16_t position)
-{
-	/* Make sure servo exists */
-	if (!servo_cfg || servo >= servo_cfg->num_channels) {
-		return;
-	}
-
-	const struct pios_tim_channel * chan = &servo_cfg->channels[servo];
-
-	/* recalculate the position value based on timer clock rate */
-	/* position is in us */
-	/* clk_rate is in count per second */
-
-	/* Update the position */
-	switch(chan->timer_chan) {
-		case TIM_Channel_1:
-			TIM_SetCompare1(chan->timer, position);
-			break;
-		case TIM_Channel_2:
-			TIM_SetCompare2(chan->timer, position);
-			break;
-		case TIM_Channel_3:
-			TIM_SetCompare3(chan->timer, position);
-			break;
-		case TIM_Channel_4:
-			TIM_SetCompare4(chan->timer, position);
-			break;
-	}
-}
-#endif /* PIOS_INCLUDE_HPWM */
 
 #if defined(PIOS_INCLUDE_HPWM)
 /**

--- a/flight/PiOS/Common/pios_servo.c
+++ b/flight/PiOS/Common/pios_servo.c
@@ -250,15 +250,16 @@ void PIOS_Servo_PrepareForReset() {
 * \param[in] Servo Servo number (0-num_channels)
 * \param[in] Position Servo position in microseconds
 * \param[in] max Maximum pulse length in us for oneshot
+* \param[in] inverted True if channel inverted (used for reset behavior only)
 */
-void PIOS_Servo_Set(uint8_t servo, float position, float max)
+void PIOS_Servo_Set(uint8_t servo, float position, float max, bool inverted)
 {
 	/* Make sure servo exists */
 	if (!servo_cfg || servo >= servo_cfg->num_channels) {
 		return;
 	}
 
-	if (resetting) {
+	if (resetting && (!inverted)) {
 		/* If we're resetting, drive / hold pin low.  This will
 		 * allow ESCs to disarm.
 		 */

--- a/flight/PiOS/inc/pios_servo.h
+++ b/flight/PiOS/inc/pios_servo.h
@@ -34,12 +34,12 @@
 enum pwm_mode {PWM_MODE_1MHZ, PWM_MODE_12MHZ};
 
 /* Public Functions */
-extern void PIOS_Servo_SetMode(const uint16_t * update_rates, const enum pwm_mode *pwm_mdoe, uint8_t banks);
-#if defined(PIOS_INCLUDE_HPWM)
+void PIOS_Servo_PrepareForReset();
+extern void PIOS_Servo_SetMode(const uint16_t * update_rates, const enum pwm_mode *pwm_mode, uint8_t banks);
 extern void PIOS_Servo_Set(uint8_t servo, float position, float max);
+
+#if defined(PIOS_INCLUDE_HPWM)
 extern void PIOS_Servo_Update();
-#else
-extern void PIOS_Servo_Set(uint8_t Servo, uint16_t Position);
 #endif
 
 #endif /* PIOS_SERVO_H */

--- a/flight/PiOS/inc/pios_servo.h
+++ b/flight/PiOS/inc/pios_servo.h
@@ -36,7 +36,7 @@ enum pwm_mode {PWM_MODE_1MHZ, PWM_MODE_12MHZ};
 /* Public Functions */
 void PIOS_Servo_PrepareForReset();
 extern void PIOS_Servo_SetMode(const uint16_t * update_rates, const enum pwm_mode *pwm_mode, uint8_t banks);
-extern void PIOS_Servo_Set(uint8_t servo, float position, float max);
+extern void PIOS_Servo_Set(uint8_t servo, float position, float max, bool inverted);
 
 #if defined(PIOS_INCLUDE_HPWM)
 extern void PIOS_Servo_Update();


### PR DESCRIPTION
Relates to #642.

When we go to deliberate reset, if the output channel is not inverted, generate all-low PWM.  (Inversion check is there to try and deal better if someone is doing something odd, e.g. P-fet high side switching of brushed motors).

This will let some ESCs disarm during the interval and not be fooled by short pulses.  It will also ensure the channel is low when reset makes us "let go" of it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/720)

<!-- Reviewable:end -->
