### PR TITLE
Config: Add limit exceeded to tooltip, change warning colour

### DIFF
--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
@@ -36,7 +36,7 @@
 /**
  * Constructor
  */
-ConfigTaskWidget::ConfigTaskWidget(QWidget *parent) : QWidget(parent),currentBoard(0),isConnected(false),allowWidgetUpdates(true),smartsave(NULL),dirty(false),outOfLimitsStyle("background-color: rgb(255, 0, 0);"),timeOut(NULL)
+ConfigTaskWidget::ConfigTaskWidget(QWidget *parent) : QWidget(parent),currentBoard(0),isConnected(false),allowWidgetUpdates(true),smartsave(NULL),dirty(false),outOfLimitsStyle("background-color: rgb(255, 180, 0);"),timeOut(NULL)
 {
     pm = ExtensionSystem::PluginManager::instance();
     objManager = pm->getObject<UAVObjectManager>();
@@ -1350,6 +1350,14 @@ void ConfigTaskWidget::checkWidgetsLimits(QWidget * widget,UAVObjectField * fiel
             widget->setProperty("styleBackup",widget->styleSheet());
         widget->setStyleSheet(outOfLimitsStyle);
         widget->setProperty("wasOverLimits",(bool)true);
+        if(!widget->property("toolTipBackup").isValid()) {
+            QString tip = widget->toolTip();
+            if (tip.length() && !tip.startsWith("<"))
+                tip = tip.prepend("<p>").append("</p>");
+            widget->setProperty("toolTipBackup", tip);
+        }
+        widget->setToolTip(widget->property("toolTipBackup").toString() +
+                           tr("<p><strong>Warning:</strong> The value of this field exceeds the recommended limits! Please double-check before flying.</p>"));
         if(QComboBox * cb=qobject_cast<QComboBox *>(widget))
         {
             if(cb->findData(value.toString())==-1)
@@ -1401,6 +1409,12 @@ void ConfigTaskWidget::checkWidgetsLimits(QWidget * widget,UAVObjectField * fiel
                 QString style=widget->property("styleBackup").toString();
                 widget->setStyleSheet(style);
             }
+
+            if(widget->property("toolTipBackup").isValid())
+                widget->setToolTip(widget->property("toolTipBackup").toString());
+            else
+                widget->setToolTip("");
+
             loadWidgetLimits(widget,field,index,hasLimits,scale);
         }
     }


### PR DESCRIPTION
Changed the warning colour from red to orange when limits are exceeded, hopefully slightly friendlier. Also add a description of the warning to the widget tooltip when limits are exceeded.
![screenshot from 2016-03-02 19 20 46](https://cloud.githubusercontent.com/assets/9995998/13452569/d235b73e-e0ad-11e5-9054-75bc4e3e9a75.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/733)

<!-- Reviewable:end -->
