### PR TITLE
F1: Fix halt, by not double-initing board, fix safe boot

### DIFF
--- a/flight/targets/bl/f1/main.c
+++ b/flight/targets/bl/f1/main.c
@@ -90,7 +90,6 @@ int main() {
 	GO_dfu = (USB_connected == true) || (User_DFU_request == true);
 
 	if (GO_dfu == true) {
-		PIOS_Board_Init();
 		if (User_DFU_request == true)
 			DeviceState = DFUidle;
 		else

--- a/flight/targets/bl/f1/op_dfu.c
+++ b/flight/targets/bl/f1/op_dfu.c
@@ -297,7 +297,7 @@ void processComand(uint8_t *xReceive_Buffer) {
 		sendData(Buffer + 1, 63);
 		break;
 	case JumpFW:
-		if (Data == 0x5AFE) {
+		if ((Data & 0xFFFF) == 0x5AFE) {
 			/* Force board into safe mode */
 			PIOS_IAP_WriteBootCount(0xFFFF);
 		}

--- a/flight/targets/cc3d/board-info/board-info.mk
+++ b/flight/targets/cc3d/board-info/board-info.mk
@@ -1,7 +1,8 @@
 BOARD_TYPE          := 0x04
 BOARD_REVISION      := 0x02
-# Previous version was 0x080, 0x081 introduces forced boot from bkp registers
-BOOTLOADER_VERSION  := 0x81
+# Previous version was 0x080, 0x081 introduces forced boot from bkp registers,
+# 0x082 fixes halt (by not double-initing board) 
+BOOTLOADER_VERSION  := 0x82
 HW_TYPE             := 0x01
 
 MCU                 := cortex-m3

--- a/flight/targets/pipxtreme/board-info/board-info.mk
+++ b/flight/targets/pipxtreme/board-info/board-info.mk
@@ -1,7 +1,8 @@
 BOARD_TYPE          := 0x03
 BOARD_REVISION      := 0x02
-# Previous version was 0x080, 0x081 introduces forced boot from bkp registers
-BOOTLOADER_VERSION  := 0x81
+# Previous version was 0x080, 0x081 introduces forced boot from bkp registers,
+# 0x082 fixes halt (by not double-initing board) 
+BOOTLOADER_VERSION  := 0x82
 HW_TYPE             := 0x01
 
 MCU                 := cortex-m3


### PR DESCRIPTION
Introduced here https://github.com/d-ronin/dRonin/blame/f72a42d1311b4a7113fc2395a8f5cb0ea5c9cef9/flight/Bootloaders/CopterControl/main.c#L74

Halt now works reliably for me.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/740)

<!-- Reviewable:end -->
