### PR TITLE
BL: Check for partition erase failure

### DIFF
--- a/flight/targets/bl/common/bl_xfer.c
+++ b/flight/targets/bl/common/bl_xfer.c
@@ -1,6 +1,7 @@
 /**
  ******************************************************************************
  * @file       bl_xfer.c
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013
  * @addtogroup Bootloader
  * @{
@@ -22,6 +23,10 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
  */
 
 #include "pios.h"		/* PIOS_COM_TELEM_USB -- FIXME: include is too coarse */
@@ -249,8 +254,10 @@ bool bl_xfer_write_start(struct xfer_state * xfer, const struct msg_xfer_start *
 	/* Figure out if we need to erase the *selected* partition before writing to it */
 	if (partition_needs_erase) {
 		PIOS_FLASH_start_transaction(xfer->partition_id);
-		PIOS_FLASH_erase_partition(xfer->partition_id);
+		int32_t ret = PIOS_FLASH_erase_partition(xfer->partition_id);
 		PIOS_FLASH_end_transaction(xfer->partition_id);
+		if (ret != 0)
+			return false;
 	}
 
 	xfer->current_partition_offset = xfer->original_partition_offset;


### PR DESCRIPTION
Fixes #147

Will stay in DFU_Idle state causing GCS to error out gracefully if partition erase fails. BL version already bumped for this release by #695 so this will be okay.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/750)

<!-- Reviewable:end -->
