### PR TITLE
BU: Invalidate own metadata, reboot to BL when finished

### DIFF
--- a/flight/targets/bu/common/main.c
+++ b/flight/targets/bu/common/main.c
@@ -104,6 +104,12 @@ int main(void) {
 	const uint32_t zero = 0;
 	PIOS_FLASH_start_transaction(fw_partition_id);
 	PIOS_FLASH_write_data(fw_partition_id, 0, (uint8_t *)&zero, sizeof(zero));
+	/* 
+	 * Invalidate FW metadata so GCS can know FW is invalid
+	 * We replace the 3rd and 4th letters of the TlFw sentinel with 0
+	 */
+	uint32_t offset = pios_board_info_blob.desc_base - pios_board_info_blob.fw_base + 2;
+	PIOS_FLASH_write_data(fw_partition_id, offset, (uint8_t *)&zero, 2);
 	PIOS_FLASH_end_transaction(fw_partition_id);
 	PIOS_LED_Off(PIOS_LED_HEARTBEAT);
 
@@ -117,9 +123,9 @@ int main(void) {
 			PIOS_DELAY_WaitmS(1000);
 	}
 
-	while (1) {
-		PIOS_DELAY_WaitmS(1000);
-	}
+	PIOS_SYS_Reset();
+
+	while(1); // just in case reset fails
 }
 
 void error(int led) {

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -489,12 +489,15 @@ void UploaderGadgetWidget::onBootloaderDetected()
         case uploader::DISCONNECTED:
         {
             QByteArray description = dfu.DownloadDescriptionAsByteArray(dev.SizeOfDesc);
+            // look for completed bootloader update (last 2 chars of TlFw string are nulled)
+            if (QString(description.left(4)) == "Tl")
+                break;
             deviceDescriptorStruct descStructure;
-            if(!UAVObjectUtilManager::descriptionToStructure(description, descStructure))
-                break;
-            if (FirmwareCheckForUpdate(descStructure)) {
-                Core::ModeManager::instance()->activateModeByWorkspaceName("Firmware");
-                break;
+            if (UAVObjectUtilManager::descriptionToStructure(description, descStructure)) {
+                if (FirmwareCheckForUpdate(descStructure)) {
+                    Core::ModeManager::instance()->activateModeByWorkspaceName("Firmware");
+                    break;
+                }
             }
         }
         // fall through to default


### PR DESCRIPTION
@mlyle is planning to make GCS check FW metadata during boot to see if upgrade is needed, will tie nicely into this.

Tested on Sparky2. Might be wise to check Sparky1, and CC3D.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/753)

<!-- Reviewable:end -->
