### PR TITLE
GCS:Uploader: Detect mismatched firmware version, offer update, auto-load correct firmware, stop at BL when firmware metadata invalid

### DIFF
--- a/ground/gcs/src/plugins/uploader/uploader.pro
+++ b/ground/gcs/src/plugins/uploader/uploader.pro
@@ -14,7 +14,9 @@ HEADERS += uploadergadget.h \
     uploader_global.h \
     fileutils.h \
     bl_messages.h \
-    tl_dfu.h
+    tl_dfu.h \
+    ../../../../../build/ground/gcs/gcsversioninfo.h
+
 SOURCES += uploadergadget.cpp \
     uploadergadgetfactory.cpp \
     uploadergadgetwidget.cpp \

--- a/ground/gcs/src/plugins/uploader/uploader.pro
+++ b/ground/gcs/src/plugins/uploader/uploader.pro
@@ -6,6 +6,8 @@ QT += testlib
 include(uploader_dependencies.pri)
 include(../../libs/glc_lib/glc_lib.pri)
 
+CONFIG(release, debug|release):DEFINES += FIRMWARE_RELEASE_CONFIG
+
 INCLUDEPATH *= ../../libs/glc_lib
 HEADERS += uploadergadget.h \
     uploadergadgetfactory.h \

--- a/ground/gcs/src/plugins/uploader/uploader.ui
+++ b/ground/gcs/src/plugins/uploader/uploader.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>822</width>
-    <height>687</height>
+    <height>703</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -50,6 +50,9 @@ Rescue is possible in USB mode only.</string>
        <property name="text">
         <string>Boot</string>
        </property>
+       <property name="autoDefault">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>
@@ -72,6 +75,9 @@ Rescue is possible in USB mode only.</string>
        </property>
        <property name="text">
         <string>Flash</string>
+       </property>
+       <property name="autoDefault">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -474,17 +474,23 @@ void UploaderGadgetWidget::onBootloaderDetected()
     }
     if(dfu.OpenBootloaderComs(devices.first()))
     {
+        tl_dfu::device dev = dfu.findCapabilities();
         switch (uploaderStatus) {
         case uploader::HALTING:
         case uploader::RESCUING:
             break;
+        case uploader::DISCONNECTED:
+        {
+            QByteArray description = dfu.DownloadDescriptionAsByteArray(dev.SizeOfDesc);
+            deviceDescriptorStruct descStructure;
+            if(!UAVObjectUtilManager::descriptionToStructure(description, descStructure))
+                break;
+        }
         default:
             dfu.JumpToApp(false);
             dfu.CloseBootloaderComs();
             return;
         }
-
-        tl_dfu::device dev = dfu.findCapabilities();
 
         //Bootloader has new cap extensions, query partitions and fill out browser
         if(dev.CapExt)

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -360,7 +360,7 @@ void UploaderGadgetWidget::onAutopilotReady()
     DeviceInformationUpdate(board);
     deviceDescriptorStruct device;
     if(utilMngr->getBoardDescriptionStruct(device))
-        FirmwareOnDeviceUpdate(device, QString::number(utilMngr->getFirmwareCRC(), 16));
+        FirmwareOnDeviceUpdate(device, QString::number(utilMngr->getFirmwareCRC()));
     emit newBoardSeen(board, device);
 }
 

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.h
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.h
@@ -115,6 +115,10 @@ private:
     void setStatusInfo(QString str, uploader::StatusIcon ic);
     void ProcessPartitionBundleFlash(bool result, bool start = false);
     void ProcessPartitionBundleSave(bool result, int count = -1);
+    QString getFirmwarePathForBoard(QString boardName);
+    bool FirmwareLoadFromFile(QString filename);
+    bool FirmwareLoadFromFile(QFileInfo filename);
+    bool FirmwareCheckForUpdate(deviceDescriptorStruct device);
 
     Ui_UploaderWidget *m_widget;
     bool telemetryConnected;

--- a/package/osx/package
+++ b/package/osx/package
@@ -26,6 +26,8 @@ device=$(hdiutil attach  "${TEMP_FILE}" | \
 
 # packaging goes here
 mkdir "/Volumes/${VOL_NAME}/Firmware"
+mkdir "${APP_PATH}/${APP_NAME_IN}/Contents/Resources/firmware"
+cp -rp "${FW_DIR}"/* "${APP_PATH}/${APP_NAME_IN}/Contents/Resources/firmware"
 mkdir "/Volumes/${VOL_NAME}/Utilities"
 cp -r "${APP_PATH}/${APP_NAME_IN}" "/Volumes/${VOL_NAME}/${APP_NAME_OUT}"
 cp -rp "${FW_DIR}"/* "/Volumes/${VOL_NAME}/Firmware"


### PR DESCRIPTION
- On device metadata is updated after flashing (see TauLabs/TauLabs#923).
- Progress bar resets to 0 at start of flash, previously it would keep 100% from previous flash during the erase phase.
- Stop in bootloader if firmware metadata is invalid, works great with #753, part of the way to @mlyle's upgrade work.
- Firmware CRC format is consistent (base 10), previously base 16 was used in one place.
- Find correct firmware file for board
- Bundle OSX firmware in app bundle
- Auto-load firmware file when bootloader connects
- Detect incompatible firmware version and offer update, automatically enters bootloader if required, auto-loads file and highlights Flash button

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/755)

<!-- Reviewable:end -->
