### PR TITLE
flight: cc3d: lower settings partition size to 256k

### DIFF
--- a/flight/targets/cc3d/board-info/board_hw_defs.c
+++ b/flight/targets/cc3d/board-info/board_hw_defs.c
@@ -401,18 +401,18 @@ static const struct pios_flash_partition pios_flash_partition_table_m25p16[] = {
 		.label        = FLASH_PARTITION_LABEL_SETTINGS,
 		.chip_desc    = &pios_flash_chip_m25p16,
 		.first_sector = 0,
-		.last_sector  = 15,
+		.last_sector  = 3,
 		.chip_offset  = 0,
-		.size         = (15 - 0 + 1) * FLASH_SECTOR_64KB,
+		.size         = (3 - 0 + 1) * FLASH_SECTOR_64KB,
 	},
 
 	{
-		.label        = FLASH_PARTITION_LABEL_WAYPOINTS,
+		.label        = FLASH_PARTITION_LABEL_LOG,
 		.chip_desc    = &pios_flash_chip_m25p16,
-		.first_sector = 16,
+		.first_sector = 4,
 		.last_sector  = 31,
-		.chip_offset  = (16 * FLASH_SECTOR_64KB),
-		.size         = (31 - 16 + 1) * FLASH_SECTOR_64KB,
+		.chip_offset  = (4 * FLASH_SECTOR_64KB),
+		.size         = (31 - 4 + 1) * FLASH_SECTOR_64KB,
 	},
 #endif	/* PIOS_INCLUDE_FLASH_JEDEC */
 };


### PR DESCRIPTION
Note this has the risk of losing existing settings during upgrade in the
event that there's been a lot of updates and the active arena has spilled
more than 4 times.   But this is a one-time penalty in trade for making
upgrade muuuuuuch faster than downloading a 1MB file, and I don't think
many people will have done the required 1024 object saves to spill that
far.  (figure complete config is ~16 objects on CC3D, so 64 complete
config saves).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/770)

<!-- Reviewable:end -->
