### PR TITLE
MSP: Send meaningful RSSI values at the edges.

### DIFF
--- a/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
+++ b/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
@@ -323,7 +323,13 @@ static void msp_send_analog(struct msp_bridge *m)
 	ManualControlCommandGet(&manualState);
 
 	// MSP RSSI's range is 0-1023
-	data.status.rssi = (manualState.Rssi >= 0 && manualState.Rssi <= 100) ? manualState.Rssi * 10 : 0;
+	if (manualState.Rssi <= 0) {
+		data.status.rssi = 0;
+	} else if (manualState.Rssi >= 100) {
+		data.status.rssi = 1023;
+	} else {
+		data.status.rssi = manualState.Rssi * 10;
+	}
 
 	msp_send(m, MSP_ANALOG, data.buf, sizeof(data));
 }


### PR DESCRIPTION
I ended up quite confused when I'd set my RSSI upper limit just a bit
below the highest value and ended up at ~101% or so, which was showing
up with a blinking 0% on MWOSD.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/771)

<!-- Reviewable:end -->
