### PR TITLE
Use the cloud uavo builder for any subprocess failures

### DIFF
--- a/python/dronin/uavo_collection.py
+++ b/python/dronin/uavo_collection.py
@@ -71,15 +71,19 @@ class UAVOCollection(dict):
         #
         # Grab the exact uavo definition files from the git repo using the header's git hash
         #
-        p = subprocess.Popen(['git', 'archive', githash, '--', 'shared/uavobjectdefinition/'],
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                             cwd=src_dir)
-        # grab the tar file data
-        git_archive_data, git_archive_errors = p.communicate()
+        try:
+            p = subprocess.Popen(['git', 'archive', githash, '--', 'shared/uavobjectdefinition/'],
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                 cwd=src_dir)
+            # grab the tar file data
+            git_archive_data, git_archive_errors = p.communicate()
 
-        if p.returncode == 0:
-            self.from_tar_bytes(git_archive_data)
-            return
+            if p.returncode == 0:
+                self.from_tar_bytes(git_archive_data)
+                return
+        except:
+            # Popen isn't available on GAE, so all of the above fails.
+            pass
 
         #print "Error exit status, falling back to cloud"
 


### PR DESCRIPTION
In this case, there's no subprocess.Popen at all.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/775)

<!-- Reviewable:end -->
