### PR TITLE
flight: brain: remove bootloader update code

### DIFF
--- a/flight/targets/brain/fw/Makefile
+++ b/flight/targets/brain/fw/Makefile
@@ -35,7 +35,6 @@ include $(BOARD_INFO_DIR)/board-info.mk
 # Set developer code and compile options
 # Set to YES for debugging
 DEBUG ?= NO
-EMBED_BL_UPDATE ?= NO
 
 # List of modules to include
 MODULES = Sensors
@@ -122,12 +121,6 @@ SRC += $(OPUAVOBJ)/uavobjectmanager.c
 ifeq ($(DEBUG),YES)
 SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c
 SRC += $(DEBUG_CM3_DIR)/cm3_fault_handlers.c
-endif
-
-ifeq ($(EMBED_BL_UPDATE), YES)
-CDEFS += -DEMBED_BL_UPDATE
-CDEFS += -DBU_PAYLOAD_FILE=$(ROOT_DIR)/build/bl_$(BOARD_NAME)/bl_$(BOARD_NAME).bin
-SRC += $(ROOT_DIR)/flight/targets/bu/common/bu_payload.c
 endif
 
 SRC += $(FLIGHTLIB)/paths.c

--- a/flight/targets/brain/fw/pios_board.c
+++ b/flight/targets/brain/fw/pios_board.c
@@ -47,11 +47,6 @@
 #include "manualcontrolsettings.h"
 #include "onscreendisplaysettings.h"
 
-/* The ADDRESSES of the _bu_payload_* symbols */
-extern const uint32_t _bu_payload_start;
-extern const uint32_t _bu_payload_end;
-extern const uint32_t _bu_payload_size;
-
 /**
  * Configuration for the MPU9250 chip
  */
@@ -267,43 +262,6 @@ void PIOS_Board_Init(void) {
 		PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_FILESYS);
 	if (PIOS_FLASHFS_Logfs_Init(&pios_waypoints_settings_fs_id, &flashfs_waypoints_cfg, FLASH_PARTITION_LABEL_WAYPOINTS) != 0)
 		PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_FILESYS);
-
-#if defined(EMBED_BL_UPDATE)
-	/* Update the bootloader if necessary */
-
-	uintptr_t bl_partition_id;
-	if (PIOS_FLASH_find_partition_id(FLASH_PARTITION_LABEL_BL, &bl_partition_id) != 0){
-		PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_FILESYS);
-	}
-
-	uint32_t bl_crc32 = PIOS_CRC32_updateCRC(0, (uint8_t *)0x08000000, _bu_payload_size);
-	uint32_t bl_new_crc32 = PIOS_CRC32_updateCRC(0, (uint8_t *)&_bu_payload_start, _bu_payload_size);
-
-	if (bl_new_crc32 != bl_crc32 ){
-		/* The bootloader needs to be updated */
-
-		/* Erase the partition */
-		PIOS_LED_On(PIOS_LED_ALARM);
-		PIOS_FLASH_start_transaction(bl_partition_id);
-		PIOS_FLASH_erase_partition(bl_partition_id);
-		PIOS_FLASH_end_transaction(bl_partition_id);
-
-		/* Write in the new bootloader */
-		PIOS_FLASH_start_transaction(bl_partition_id);
-		PIOS_FLASH_write_data(bl_partition_id, 0, (uint8_t *)&_bu_payload_start, _bu_payload_size);
-		PIOS_FLASH_end_transaction(bl_partition_id);
-		PIOS_LED_Off(PIOS_LED_ALARM);
-
-		/* Blink the LED to indicate BL update */
-		for (uint8_t i=0; i<10; i++){
-			PIOS_DELAY_WaitmS(50);
-			PIOS_LED_On(PIOS_LED_ALARM);
-			PIOS_DELAY_WaitmS(50);
-			PIOS_LED_Off(PIOS_LED_ALARM);
-		}
-	}
-#endif /* EMBED_BL_UPDATE */
-
 #endif	/* PIOS_INCLUDE_FLASH */
 
 	RCC_ClearFlag(); // The flags cleared after use


### PR DESCRIPTION
This will be replaced with a different mechanism -- GCS updating
bootloader as appropriate as part of upgrade.

This can sequence/land after that other mechanism lands.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/777)

<!-- Reviewable:end -->
