### PR TITLE
gcs: usbmonitor_mac: fix lock model, work around dup devs

### DIFF
--- a/ground/gcs/src/plugins/rawhid/usbmonitor_mac.cpp
+++ b/ground/gcs/src/plugins/rawhid/usbmonitor_mac.cpp
@@ -136,12 +136,15 @@ void USBMonitor::addDevice(USBPortInfo info) {
     QMutexLocker locker(listMutex);
     for( int i = 0; i < knowndevices.length(); i++) {
 
-        USBPortInfo port = knowndevices.at(i);
-        if(port.serialNumber == info.serialNumber) {
+        USBPortInfo existing = knowndevices.at(i);
+        if (existing.serialNumber.split("+").at(0) ==
+                info.serialNumber.split("+").at(0)) {
             // TODO: Fix hack; don't keep a parallel data structure, re-enumerate
-            qDebug() << "USBMonitor: Duplicate device detected: " << info.serialNumber;
-            emit deviceDiscovered(info);
-            return;
+            qDebug() << "USBMonitor: Duplicate device detected: " << info.serialNumber << " vs. existing: " << existing.serialNumber;
+            knowndevices.removeAt(i);
+            emit deviceRemoved(existing);
+
+            i--;
         }
     }
 

--- a/ground/gcs/src/plugins/rawhid/usbmonitor_mac.cpp
+++ b/ground/gcs/src/plugins/rawhid/usbmonitor_mac.cpp
@@ -138,7 +138,9 @@ void USBMonitor::addDevice(USBPortInfo info) {
 
         USBPortInfo port = knowndevices.at(i);
         if(port.serialNumber == info.serialNumber) {
+            // TODO: Fix hack; don't keep a parallel data structure, re-enumerate
             qDebug() << "USBMonitor: Duplicate device detected: " << info.serialNumber;
+            emit deviceDiscovered(info);
             return;
         }
     }

--- a/ground/gcs/src/plugins/rawhid/usbmonitor_mac.cpp
+++ b/ground/gcs/src/plugins/rawhid/usbmonitor_mac.cpp
@@ -58,7 +58,7 @@ USBMonitor::USBMonitor(QObject *parent): QThread(parent) {
 
     m_instance = this;
 
-    listMutex = new QMutex();
+    listMutex = new QMutex(QMutex::Recursive);
     knowndevices.clear();
 
     hid_manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
@@ -134,6 +134,15 @@ void USBMonitor::detach_callback(void *context, IOReturn r, void *hid_mgr, IOHID
 
 void USBMonitor::addDevice(USBPortInfo info) {
     QMutexLocker locker(listMutex);
+    for( int i = 0; i < knowndevices.length(); i++) {
+
+        USBPortInfo port = knowndevices.at(i);
+        if(port.serialNumber == info.serialNumber) {
+            qDebug() << "USBMonitor: Duplicate device detected: " << info.serialNumber;
+            return;
+        }
+    }
+
     knowndevices.append(info);
     emit deviceDiscovered(info);
 }
@@ -175,7 +184,7 @@ Returns a list of all currently available devices
 */
 QList<USBPortInfo> USBMonitor::availableDevices()
 {
-    //QMutexLocker locker(listMutex);
+    QMutexLocker locker(listMutex);
     return knowndevices;
 }
 


### PR DESCRIPTION
This is slightly hacky.

The hope: it largely fixes #792

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/795)

<!-- Reviewable:end -->
