### PR TITLE
flight/freertos: neuter vTaskDelay when scheduler not running

### DIFF
--- a/flight/PiOS/Common/Libraries/FreeRTOS/Source/tasks.c
+++ b/flight/PiOS/Common/Libraries/FreeRTOS/Source/tasks.c
@@ -723,6 +723,10 @@ tskTCB * pxNewTCB;
 	portTickType xTimeToWake;
 	portBASE_TYPE xAlreadyYielded, xShouldDelay = pdFALSE;
 
+	if (xSchedulerRunning != pdTRUE) {
+		return;
+	}
+
 		configASSERT( pxPreviousWakeTime );
 		configASSERT( ( xTimeIncrement > 0U ) );
 
@@ -794,6 +798,10 @@ tskTCB * pxNewTCB;
 	{
 	portTickType xTimeToWake;
 	signed portBASE_TYPE xAlreadyYielded = pdFALSE;
+
+	if (xSchedulerRunning != pdTRUE) {
+		return;
+	}
 
 		/* A delay time of zero just forces a reschedule. */
 		if( xTicksToDelay > ( portTickType ) 0U )

--- a/flight/targets/cc3d/fw/pios_board.c
+++ b/flight/targets/cc3d/fw/pios_board.c
@@ -103,7 +103,6 @@ static const struct pios_mpu60x0_cfg pios_mpu6000_cfg = {
  * called from System/openpilot.c
  */
 void PIOS_Board_Init(void) {
-
 	/* Delay system */
 	PIOS_DELAY_Init();
 


### PR DESCRIPTION
F1 targets often init hardware and filesystems when the RTOS isn't running.
If they reach a code block that does a PIOS_Thread_Sleep, then they'll
hang forever... e.g. when erasing a fresh flash settings filesystem onto CC3D.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/796)

<!-- Reviewable:end -->
