### PR TITLE
Flight: Add external magnetometer capability to Revolution target.

### DIFF
--- a/flight/targets/revolution/fw/pios_board.c
+++ b/flight/targets/revolution/fw/pios_board.c
@@ -98,6 +98,14 @@ static const struct pios_hmc5883_cfg pios_hmc5883_cfg = {
 	.Mode = PIOS_HMC5883_MODE_CONTINUOUS,
 	.Default_Orientation = PIOS_HMC5883_TOP_270DEG,
 };
+
+static const struct pios_hmc5883_cfg pios_hmc5883_external_cfg = {
+    .M_ODR               = PIOS_HMC5883_ODR_75,
+    .Meas_Conf           = PIOS_HMC5883_MEASCONF_NORMAL,
+    .Gain                = PIOS_HMC5883_GAIN_1_9,
+    .Mode                = PIOS_HMC5883_MODE_SINGLE,
+    .Default_Orientation = PIOS_HMC5883_TOP_270DEG,
+};
 #endif /* PIOS_INCLUDE_HMC5883 */
 
 /**
@@ -164,6 +172,8 @@ static const struct pios_mpu60x0_cfg pios_mpu6000_cfg = {
 #define PIOS_COM_DEBUGCONSOLE_TX_BUF_LEN 40
 uintptr_t pios_com_debug_id;
 #endif	/* PIOS_INCLUDE_DEBUG_CONSOLE */
+
+bool external_mag_fail;
 
 uintptr_t pios_internal_adc_id = 0;
 uintptr_t pios_uavo_settings_fs_id;
@@ -328,10 +338,22 @@ void PIOS_Board_Init(void) {
 #endif	/* PIOS_INCLUDE_USB */
 
 	/* Configure IO ports */
+
+#if defined(PIOS_INCLUDE_I2C)
+	if (PIOS_I2C_Init(&pios_i2c_mag_pressure_adapter_id, &pios_i2c_mag_pressure_adapter_cfg))
+		PIOS_DEBUG_Assert(0);
+
+	if (PIOS_I2C_CheckClear(pios_i2c_mag_pressure_adapter_id) != 0)
+		PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_I2C_INT);
+	else
+		AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_OK);
+#endif  // PIOS_INCLUDE_I2C
+
 	HwRevolutionDSMxModeOptions hw_DSMxMode;
 	HwRevolutionDSMxModeGet(&hw_DSMxMode);
 	
 	/* Configure main USART port */
+
 	uint8_t hw_mainport;
 	HwRevolutionMainPortGet(&hw_mainport);
 
@@ -515,37 +537,12 @@ void PIOS_Board_Init(void) {
 			hwRevoMini.MaxChannel, hwRevoMini.CoordID, 1);
 #endif /* PIOS_INCLUDE_RFM22B */
 
+	/* init sensor queue registration */
+    PIOS_SENSORS_Init();
 
-	if (PIOS_I2C_Init(&pios_i2c_mag_pressure_adapter_id, &pios_i2c_mag_pressure_adapter_cfg)) {
-		PIOS_DEBUG_Assert(0);
-	}
-	
-	PIOS_DELAY_WaitmS(50);
-
-	PIOS_SENSORS_Init();
-
-#if defined(PIOS_INCLUDE_ADC)
-	uint32_t internal_adc_id;
-	PIOS_INTERNAL_ADC_Init(&internal_adc_id, &pios_adc_cfg);
-	PIOS_ADC_Init(&pios_internal_adc_id, &pios_internal_adc_driver, internal_adc_id);
- 
-        // configure the pullup for PA8 (inhibit pullups from current/sonar shared pin)
-        GPIO_Init(pios_current_sonar_pin.gpio, &pios_current_sonar_pin.init);
-#endif
-
-#if defined(PIOS_INCLUDE_HMC5883)
-	if(PIOS_HMC5883_Init(PIOS_I2C_MAIN_ADAPTER, &pios_hmc5883_cfg) != 0)
-		PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_MAG);
-	if (PIOS_HMC5883_Test() != 0)
-		PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_MAG);
-#endif
-	
-#if defined(PIOS_INCLUDE_MS5611)
-	if (PIOS_MS5611_Init(&pios_ms5611_cfg, pios_i2c_mag_pressure_adapter_id) != 0)
-		PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_BARO);
-	if (PIOS_MS5611_Test() != 0)
-		PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_BARO);
-#endif
+    PIOS_WDG_Clear();
+    PIOS_DELAY_WaitmS(200);
+    PIOS_WDG_Clear();
 
 #if defined(PIOS_INCLUDE_MPU6000)
 	if (PIOS_MPU6000_Init(pios_spi_gyro_id,0, &pios_mpu6000_cfg) != 0)
@@ -613,6 +610,77 @@ void PIOS_Board_Init(void) {
 	    (hw_mpu6000_samplerate == HWREVOLUTION_MPU6000RATE_8000) ? 8000 : \
 	    pios_mpu6000_cfg.default_samplerate;
 	PIOS_MPU6000_SetSampleRate(mpu6000_samplerate);
+#endif
+
+#if defined(PIOS_INCLUDE_I2C)
+#if defined(PIOS_INCLUDE_HMC5883)
+	PIOS_WDG_Clear();
+
+	uint8_t magnetometer;
+	HwRevolutionMagnetometerGet(&magnetometer);
+
+	external_mag_fail = false;
+
+	if (magnetometer == HWREVOLUTION_MAGNETOMETER_EXTERNALI2CFLEXIPORT)	{
+		if (PIOS_HMC5883_Init(pios_i2c_flexiport_adapter_id, &pios_hmc5883_external_cfg) == 0) {
+			if (PIOS_HMC5883_Test() == 0) {
+				// External mag configuration was successful
+
+				// setup sensor orientation
+				uint8_t ext_mag_orientation;
+				HwRevolutionExtMagOrientationGet(&ext_mag_orientation);
+
+				enum pios_hmc5883_orientation hmc5883_externalOrientation = \
+					(ext_mag_orientation == HWREVOLUTION_EXTMAGORIENTATION_TOP0DEGCW)      ? PIOS_HMC5883_TOP_0DEG      : \
+					(ext_mag_orientation == HWREVOLUTION_EXTMAGORIENTATION_TOP90DEGCW)     ? PIOS_HMC5883_TOP_90DEG     : \
+					(ext_mag_orientation == HWREVOLUTION_EXTMAGORIENTATION_TOP180DEGCW)    ? PIOS_HMC5883_TOP_180DEG    : \
+					(ext_mag_orientation == HWREVOLUTION_EXTMAGORIENTATION_TOP270DEGCW)    ? PIOS_HMC5883_TOP_270DEG    : \
+					(ext_mag_orientation == HWREVOLUTION_EXTMAGORIENTATION_BOTTOM0DEGCW)   ? PIOS_HMC5883_BOTTOM_0DEG   : \
+					(ext_mag_orientation == HWREVOLUTION_EXTMAGORIENTATION_BOTTOM90DEGCW)  ? PIOS_HMC5883_BOTTOM_90DEG  : \
+					(ext_mag_orientation == HWREVOLUTION_EXTMAGORIENTATION_BOTTOM180DEGCW) ? PIOS_HMC5883_BOTTOM_180DEG : \
+					(ext_mag_orientation == HWREVOLUTION_EXTMAGORIENTATION_BOTTOM270DEGCW) ? PIOS_HMC5883_BOTTOM_270DEG : \
+					pios_hmc5883_external_cfg.Default_Orientation;
+				PIOS_HMC5883_SetOrientation(hmc5883_externalOrientation);
+			}
+			else
+				external_mag_fail = true;  // External HMC5883 Test Failed
+		}
+		else
+			external_mag_fail = true;  // External HMC5883 Init Failed
+	}
+
+	if (magnetometer == HWREVOLUTION_MAGNETOMETER_INTERNAL)
+	{
+		if (PIOS_HMC5883_Init(PIOS_I2C_MAIN_ADAPTER, &pios_hmc5883_cfg) != 0)
+			PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_MAG);
+		if (PIOS_HMC5883_Test() != 0)
+			PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_MAG);
+	}
+
+#endif  // PIOS_INCLUDE_HMC5883
+
+	//I2C is slow, sensor init as well, reset watchdog to prevent reset here
+    PIOS_WDG_Clear();
+
+#if defined(PIOS_INCLUDE_MS5611)
+	if (PIOS_MS5611_Init(&pios_ms5611_cfg, pios_i2c_mag_pressure_adapter_id) != 0)
+		PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_BARO);
+	if (PIOS_MS5611_Test() != 0)
+		PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_BARO);
+#endif
+
+    //I2C is slow, sensor init as well, reset watchdog to prevent reset here
+    PIOS_WDG_Clear();
+
+#endif    /* PIOS_INCLUDE_I2C */
+
+#if defined(PIOS_INCLUDE_ADC)
+	uint32_t internal_adc_id;
+	PIOS_INTERNAL_ADC_Init(&internal_adc_id, &pios_adc_cfg);
+	PIOS_ADC_Init(&pios_internal_adc_id, &pios_internal_adc_driver, internal_adc_id);
+
+        // configure the pullup for PA8 (inhibit pullups from current/sonar shared pin)
+        GPIO_Init(pios_current_sonar_pin.gpio, &pios_current_sonar_pin.init);
 #endif
 
 #if defined(PIOS_INCLUDE_FLASH) && defined(PIOS_INCLUDE_FLASH_JEDEC)

--- a/flight/targets/revolution/fw/pios_config.h
+++ b/flight/targets/revolution/fw/pios_config.h
@@ -146,6 +146,8 @@
  */
 #define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (9870518)
 
+#define SUPPORTS_EXTERNAL_MAG
+
 #endif /* PIOS_CONFIG_H */
 /**
  * @}

--- a/shared/uavobjectdefinition/hwrevolution.xml
+++ b/shared/uavobjectdefinition/hwrevolution.xml
@@ -114,6 +114,9 @@
 		<field name="MPU6000Rate" units="" type="enum" elements="1" options="200,333,500,666,1000,2000,4000,8000" defaultvalue="500"/>
 		<field name="MPU6000DLPF" units="" type="enum" elements="1" options="256,188,98,42,20,10,5" defaultvalue="188"/>
 
+		<field name="Magnetometer" units="function" type="enum" elements="1" options="Disabled,Internal,ExternalI2CFlexiPort" defaultvalue="Internal"/>
+		<field name="ExtMagOrientation" units="function" type="enum" elements="1" options="Top0degCW,Top90degCW,Top180degCW,Top270degCW,Bottom0degCW,Bottom90degCW,Bottom180degCW,Bottom270degCW" defaultvalue="Top0degCW" />
+
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
Adds the capability to use an external I2C magnetometer on the Revolution Flexiport when the Flexiport is configured as an I2C bus.

Needs testing by someone with Revolution hardware and external I2C magnetometer.

~~Addresses #805.~~ edit by mpl: fixes #805

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/806)

<!-- Reviewable:end -->
