### PR TITLE
Watchdog: Change the order of task vs. watchdog initialization

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -7,7 +7,7 @@
  *
  * @file       actuator.c
  * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2015
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @brief      Actuator module. Drives the actuators (servos, motors etc).
  * @brief      Take the values in @ref ActuatorDesired and mix to set the outputs
@@ -110,10 +110,12 @@ static typeof(mixerSettings.Mixer1Vector) *get_mixer_vec(int idx);
  */
 int32_t ActuatorStart()
 {
+	// Watchdog must be registered before starting task
+	PIOS_WDG_RegisterFlag(PIOS_WDG_ACTUATOR);
+
 	// Start main task
 	taskHandle = PIOS_Thread_Create(actuator_task, "Actuator", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 	TaskMonitorAdd(TASKINFO_RUNNING_ACTUATOR, taskHandle);
-	PIOS_WDG_RegisterFlag(PIOS_WDG_ACTUATOR);
 
 	return 0;
 }

--- a/flight/Modules/Attitude/acro/attitude.c
+++ b/flight/Modules/Attitude/acro/attitude.c
@@ -13,7 +13,7 @@
  *
  * @file       attitude.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2015
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2016
  * @author     dRonin, http://dronin.org Copyright (C) 2015-2016
  * @brief      Update attitude for F1 targets
  *
@@ -111,11 +111,12 @@ static float accumulated_gyro[3];
  */
 int32_t AttitudeStart(void)
 {
-	
+	// Watchdog must be registered before starting task
+	PIOS_WDG_RegisterFlag(PIOS_WDG_ATTITUDE);
+
 	// Start main task
 	taskHandle = PIOS_Thread_Create(AttitudeTask, "Attitude", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 	TaskMonitorAdd(TASKINFO_RUNNING_ATTITUDE, taskHandle);
-	PIOS_WDG_RegisterFlag(PIOS_WDG_ATTITUDE);
 	
 	return 0;
 }

--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -14,8 +14,8 @@
  *
  * @file       attitude.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
- * @author     Tau Labs, http://taulabs.org Copyright (C) 2012-2014
- * @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @author     Tau Labs, http://taulabs.org Copyright (C) 2012-2016
+ * @author     dRonin, http://dronin.org Copyright (C) 2015-2016
  * @brief      Full attitude estimation algorithm
  *
  * @see        The GNU Public License (GPL) Version 3
@@ -281,10 +281,12 @@ int32_t AttitudeStart(void)
 	if (GPSVelocityHandle())
 		GPSVelocityConnectQueue(gpsVelQueue);
 
+	// Watchdog must be registered before starting task
+	PIOS_WDG_RegisterFlag(PIOS_WDG_ATTITUDE);
+
 	// Start main task
 	attitudeTaskHandle = PIOS_Thread_Create(AttitudeTask, "Attitude", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 	TaskMonitorAdd(TASKINFO_RUNNING_ATTITUDE, attitudeTaskHandle);
-	PIOS_WDG_RegisterFlag(PIOS_WDG_ATTITUDE);
 
 	return 0;
 }

--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -7,7 +7,7 @@
  *
  * @file       autotune.c
  * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2012.
  * @brief      State machine to run autotuning. Low level work done by @ref
  *             StabilizationModule
@@ -127,10 +127,13 @@ int32_t AutotuneStart(void)
 {
 	// Start main task if it is enabled
 	if(module_enabled) {
+		// Watchdog must be registered before starting task
+		PIOS_WDG_RegisterFlag(PIOS_WDG_AUTOTUNE);
+
+		// Start main task
 		taskHandle = PIOS_Thread_Create(AutotuneTask, "Autotune", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 
 		TaskMonitorAdd(TASKINFO_RUNNING_AUTOTUNE, taskHandle);
-		PIOS_WDG_RegisterFlag(PIOS_WDG_AUTOTUNE);
 	}
 	return 0;
 }

--- a/flight/Modules/ManualControl/manualcontrol.c
+++ b/flight/Modules/ManualControl/manualcontrol.c
@@ -14,7 +14,7 @@
  * transmitter settings come from @ref ManualControlSettings.
  *
  * @file       manualcontrol.c
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2016
  * @brief      ManualControl module. Handles safety R/C link and flight mode.
  *
  * @see        The GNU Public License (GPL) Version 3
@@ -82,10 +82,12 @@ bool ok_to_arm(void);
  */
 int32_t ManualControlStart()
 {
+	// Watchdog must be registered before starting task
+	PIOS_WDG_RegisterFlag(PIOS_WDG_MANUAL);
+
 	// Start main task
 	taskHandle = PIOS_Thread_Create(manualControlTask, "Control", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 	TaskMonitorAdd(TASKINFO_RUNNING_MANUALCONTROL, taskHandle);
-	PIOS_WDG_RegisterFlag(PIOS_WDG_MANUAL);
 
 	return 0;
 }

--- a/flight/Modules/Sensors/sensors.c
+++ b/flight/Modules/Sensors/sensors.c
@@ -7,8 +7,8 @@
  *
  * @file       sensors.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
- * @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2016
+ * @author     dRonin, http://dronin.org Copyright (C) 2015-2016
  * @brief      Acquire sensor data from sensors registered with @ref PIOS_Sensors
  *
  * @see        The GNU Public License (GPL) Version 3
@@ -194,10 +194,12 @@ static int32_t SensorsInitialize(void)
  */
 static int32_t SensorsStart(void)
 {
+	// Watchdog must be registered before starting task
+	PIOS_WDG_RegisterFlag(PIOS_WDG_SENSORS);
+
 	// Start main task
 	sensorsTaskHandle = PIOS_Thread_Create(SensorsTask, "Sensors", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 	TaskMonitorAdd(TASKINFO_RUNNING_SENSORS, sensorsTaskHandle);
-	PIOS_WDG_RegisterFlag(PIOS_WDG_SENSORS);
 
 	return 0;
 }

--- a/flight/Modules/Sensors/simulated/sensors.c
+++ b/flight/Modules/Sensors/simulated/sensors.c
@@ -7,7 +7,7 @@
  *
  * @file       sensors.c
  * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @brief      Update available sensors registered with @ref PIOS_Sensors
  *
@@ -117,10 +117,12 @@ int32_t SensorsInitialize(void)
  */
 int32_t SensorsStart(void)
 {
+	// Watchdog must be registered before starting task
+	PIOS_WDG_RegisterFlag(PIOS_WDG_SENSORS);
+
 	// Start main task
 	sensorsTaskHandle = PIOS_Thread_Create(SensorsTask, "Sensors", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 	TaskMonitorAdd(TASKINFO_RUNNING_SENSORS, sensorsTaskHandle);
-	PIOS_WDG_RegisterFlag(PIOS_WDG_SENSORS);
 
 	return 0;
 }

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -7,7 +7,7 @@
  *
  * @file       stabilization.c
  * @author     dRonin, http://dRonin.org/, Copyright (C) 2015-2016
- * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
+ * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @brief      Control the UAV attitude to @ref StabilizationDesired
  *
@@ -167,10 +167,13 @@ int32_t StabilizationStart()
 	StabilizationSettingsConnectCallback(SettingsUpdatedCb);
 	SubTrimSettingsConnectCallback(SettingsUpdatedCb);
 
+	// Watchdog must be registered before starting task
+	PIOS_WDG_RegisterFlag(PIOS_WDG_STABILIZATION);
+
 	// Start main task
 	taskHandle = PIOS_Thread_Create(stabilizationTask, "Stabilization", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
 	TaskMonitorAdd(TASKINFO_RUNNING_STABILIZATION, taskHandle);
-	PIOS_WDG_RegisterFlag(PIOS_WDG_STABILIZATION);
+
 	return 0;
 }
 


### PR DESCRIPTION
The tasks run immediately after they are created, which means the watchdog
won't have been registered yet before it the UpdateFlag reset function is
called on it. The result was a crash.

This fixes the order of initialization.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/809)

<!-- Reviewable:end -->
