### PR TITLE
gcs: autotune: set minimum damping factor to .85

### DIFF
--- a/ground/gcs/src/plugins/config/autotune.ui
+++ b/ground/gcs/src/plugins/config/autotune.ui
@@ -631,7 +631,7 @@ p, li { white-space: pre-wrap; }
               <item row="1" column="1">
                <widget class="QSlider" name="rateDamp">
                 <property name="minimum">
-                 <number>50</number>
+                 <number>85</number>
                 </property>
                 <property name="maximum">
                  <number>150</number>


### PR DESCRIPTION
Values under 0.8 almost always produce nonsensical results.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/811)

<!-- Reviewable:end -->
