### PR TITLE
GCS:Qwt: Update to 6.1.2

### DIFF
--- a/ground/gcs/src/libs/qwt/qwtconfig.pri
+++ b/ground/gcs/src/libs/qwt/qwtconfig.pri
@@ -9,7 +9,7 @@
 
 #QWT_VER_MAJ      = 6
 #QWT_VER_MIN      = 1
-#QWT_VER_PAT      = 1
+#QWT_VER_PAT      = 2
 #QWT_VERSION      = $${QWT_VER_MAJ}.$${QWT_VER_MIN}.$${QWT_VER_PAT}
 
 ######################################################################

--- a/ground/gcs/src/libs/qwt/src/qwt_color_map.cpp
+++ b/ground/gcs/src/libs/qwt/src/qwt_color_map.cpp
@@ -15,9 +15,10 @@
 class QwtLinearColorMap::ColorStops
 {
 public:
-    ColorStops()
+    ColorStops():
+        d_doAlpha( false )
     {
-        _stops.reserve( 256 );
+        d_stops.reserve( 256 );
     }
 
     void insert( double pos, const QColor &color );
@@ -38,20 +39,50 @@ private:
 
         ColorStop( double p, const QColor &c ):
             pos( p ),
-            rgb( c.rgb() )
+            rgb( c.rgba() )
         {
             r = qRed( rgb );
             g = qGreen( rgb );
             b = qBlue( rgb );
+            a = qAlpha( rgb );
+
+            /* 
+                when mapping a value to rgb we will have to calcualate: 
+                   - const int v = int( ( s1.v0 + ratio * s1.vStep ) + 0.5 );
+
+                Thus adding 0.5 ( for rounding ) can be done in advance
+             */
+            r0 = r + 0.5;
+            g0 = g + 0.5;
+            b0 = b + 0.5;
+            a0 = a + 0.5;
+
+            rStep = gStep = bStep = aStep = 0.0;
+            posStep = 0.0;
+        }
+
+        void updateSteps( const ColorStop &nextStop )
+        {
+            rStep = nextStop.r - r;
+            gStep = nextStop.g - g;
+            bStep = nextStop.b - b;
+            aStep = nextStop.a - a;
+            posStep = nextStop.pos - pos;
         }
 
         double pos;
         QRgb rgb;
-        int r, g, b;
+        int r, g, b, a;
+
+        // precalculated values
+        double rStep, gStep, bStep, aStep;
+        double r0, g0, b0, a0;
+        double posStep;
     };
 
     inline int findUpper( double pos ) const;
-    QVector<ColorStop> _stops;
+    QVector<ColorStop> d_stops;
+    bool d_doAlpha;
 };
 
 void QwtLinearColorMap::ColorStops::insert( double pos, const QColor &color )
@@ -63,40 +94,48 @@ void QwtLinearColorMap::ColorStops::insert( double pos, const QColor &color )
         return;
 
     int index;
-    if ( _stops.size() == 0 )
+    if ( d_stops.size() == 0 )
     {
         index = 0;
-        _stops.resize( 1 );
+        d_stops.resize( 1 );
     }
     else
     {
         index = findUpper( pos );
-        if ( index == _stops.size() ||
-                qAbs( _stops[index].pos - pos ) >= 0.001 )
+        if ( index == d_stops.size() ||
+                qAbs( d_stops[index].pos - pos ) >= 0.001 )
         {
-            _stops.resize( _stops.size() + 1 );
-            for ( int i = _stops.size() - 1; i > index; i-- )
-                _stops[i] = _stops[i-1];
+            d_stops.resize( d_stops.size() + 1 );
+            for ( int i = d_stops.size() - 1; i > index; i-- )
+                d_stops[i] = d_stops[i-1];
         }
     }
 
-    _stops[index] = ColorStop( pos, color );
+    d_stops[index] = ColorStop( pos, color );
+    if ( color.alpha() != 255 )
+        d_doAlpha = true;
+
+    if ( index > 0 )
+        d_stops[index-1].updateSteps( d_stops[index] );
+
+    if ( index < d_stops.size() - 1 )
+        d_stops[index].updateSteps( d_stops[index+1] );
 }
 
 inline QVector<double> QwtLinearColorMap::ColorStops::stops() const
 {
-    QVector<double> positions( _stops.size() );
-    for ( int i = 0; i < _stops.size(); i++ )
-        positions[i] = _stops[i].pos;
+    QVector<double> positions( d_stops.size() );
+    for ( int i = 0; i < d_stops.size(); i++ )
+        positions[i] = d_stops[i].pos;
     return positions;
 }
 
 inline int QwtLinearColorMap::ColorStops::findUpper( double pos ) const
 {
     int index = 0;
-    int n = _stops.size();
+    int n = d_stops.size();
 
-    const ColorStop *stops = _stops.data();
+    const ColorStop *stops = d_stops.data();
 
     while ( n > 0 )
     {
@@ -119,27 +158,41 @@ inline QRgb QwtLinearColorMap::ColorStops::rgb(
     QwtLinearColorMap::Mode mode, double pos ) const
 {
     if ( pos <= 0.0 )
-        return _stops[0].rgb;
+        return d_stops[0].rgb;
     if ( pos >= 1.0 )
-        return _stops[ _stops.size() - 1 ].rgb;
+        return d_stops[ d_stops.size() - 1 ].rgb;
 
     const int index = findUpper( pos );
     if ( mode == FixedColors )
     {
-        return _stops[index-1].rgb;
+        return d_stops[index-1].rgb;
     }
     else
     {
-        const ColorStop &s1 = _stops[index-1];
-        const ColorStop &s2 = _stops[index];
+        const ColorStop &s1 = d_stops[index-1];
 
-        const double ratio = ( pos - s1.pos ) / ( s2.pos - s1.pos );
+        const double ratio = ( pos - s1.pos ) / ( s1.posStep );
 
-        const int r = s1.r + qRound( ratio * ( s2.r - s1.r ) );
-        const int g = s1.g + qRound( ratio * ( s2.g - s1.g ) );
-        const int b = s1.b + qRound( ratio * ( s2.b - s1.b ) );
+        const int r = int( s1.r0 + ratio * s1.rStep );
+        const int g = int( s1.g0 + ratio * s1.gStep );
+        const int b = int( s1.b0 + ratio * s1.bStep );
 
-        return qRgb( r, g, b );
+        if ( d_doAlpha )
+        {
+            if ( s1.aStep )
+            {
+                const int a = int( s1.a0 + ratio * s1.aStep );
+                return qRgba( r, g, b, a );
+            }
+            else
+            {
+                return qRgba( r, g, b, s1.a );
+            }
+        }
+        else
+        {
+            return qRgb( r, g, b );
+        }
     }
 }
 
@@ -316,14 +369,13 @@ QRgb QwtLinearColorMap::rgb(
     const QwtInterval &interval, double value ) const
 {
     if ( qIsNaN(value) )
-        return qRgba(0, 0, 0, 0);
+        return 0u;
 
     const double width = interval.width();
+    if ( width <= 0.0 )
+        return 0u;
 
-    double ratio = 0.0;
-    if ( width > 0.0 )
-        ratio = ( value - interval.minValue() ) / width;
-
+    const double ratio = ( value - interval.minValue() ) / width;
     return d_data->colorStops.rgb( d_data->mode, ratio );
 }
 
@@ -352,7 +404,7 @@ unsigned char QwtLinearColorMap::colorIndex(
     if ( d_data->mode == FixedColors )
         index = static_cast<unsigned char>( ratio * 255 ); // always floor
     else
-        index = static_cast<unsigned char>( qRound( ratio * 255 ) );
+        index = static_cast<unsigned char>( ratio * 255 + 0.5 );
 
     return index;
 }
@@ -362,6 +414,7 @@ class QwtAlphaColorMap::PrivateData
 public:
     QColor color;
     QRgb rgb;
+    QRgb rgbMax;
 };
 
 
@@ -373,8 +426,7 @@ QwtAlphaColorMap::QwtAlphaColorMap( const QColor &color ):
     QwtColorMap( QwtColorMap::RGB )
 {
     d_data = new PrivateData;
-    d_data->color = color;
-    d_data->rgb = color.rgb() & qRgba( 255, 255, 255, 0 );
+    setColor( color );
 }
 
 //! Destructor
@@ -392,7 +444,8 @@ QwtAlphaColorMap::~QwtAlphaColorMap()
 void QwtAlphaColorMap::setColor( const QColor &color )
 {
     d_data->color = color;
-    d_data->rgb = color.rgb();
+    d_data->rgb = color.rgb() & qRgba( 255, 255, 255, 0 );
+    d_data->rgbMax = d_data->rgb | ( 255 << 24 );
 }
 
 /*!
@@ -415,19 +468,21 @@ QColor QwtAlphaColorMap::color() const
 */
 QRgb QwtAlphaColorMap::rgb( const QwtInterval &interval, double value ) const
 {
-    const double width = interval.width();
-    if ( !qIsNaN(value) && width >= 0.0 )
-    {
-        const double ratio = ( value - interval.minValue() ) / width;
-        int alpha = qRound( 255 * ratio );
-        if ( alpha < 0 )
-            alpha = 0;
-        if ( alpha > 255 )
-            alpha = 255;
+    if ( qIsNaN(value) )
+        return 0u;
 
-        return d_data->rgb | ( alpha << 24 );
-    }
-    return d_data->rgb;
+    const double width = interval.width();
+    if ( width <= 0.0 )
+        return 0u;
+
+    if ( value <= interval.minValue() )
+        return d_data->rgb;
+
+    if ( value >= interval.maxValue() )
+        return d_data->rgbMax;
+
+    const double ratio = ( value - interval.minValue() ) / width;
+    return d_data->rgb | ( qRound( 255 * ratio ) << 24 );
 }
 
 /*!

--- a/ground/gcs/src/libs/qwt/src/qwt_color_map.h
+++ b/ground/gcs/src/libs/qwt/src/qwt_color_map.h
@@ -179,7 +179,7 @@ inline QColor QwtColorMap::color(
 {
     if ( d_format == RGB )
     {
-        return QColor( rgb( interval, value ) );
+        return QColor::fromRgba( rgb( interval, value ) );
     }
     else
     {

--- a/ground/gcs/src/libs/qwt/src/qwt_date.cpp
+++ b/ground/gcs/src/libs/qwt/src/qwt_date.cpp
@@ -1,3 +1,12 @@
+/* -*- mode: C++ ; c-file-style: "stroustrup" -*- *****************************
+ * Qwt Widget Library
+ * Copyright (C) 1997   Josef Wilgen
+ * Copyright (C) 2002   Uwe Rathmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the Qwt License, Version 1.0
+ *****************************************************************************/
+
 #include "qwt_date.h"
 #include <qdebug.h>
 #include <qlocale.h>

--- a/ground/gcs/src/libs/qwt/src/qwt_date_scale_draw.cpp
+++ b/ground/gcs/src/libs/qwt/src/qwt_date_scale_draw.cpp
@@ -1,3 +1,12 @@
+/* -*- mode: C++ ; c-file-style: "stroustrup" -*- *****************************
+ * Qwt Widget Library
+ * Copyright (C) 1997   Josef Wilgen
+ * Copyright (C) 2002   Uwe Rathmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the Qwt License, Version 1.0
+ *****************************************************************************/
+
 #include "qwt_date_scale_draw.h"
 
 class QwtDateScaleDraw::PrivateData

--- a/ground/gcs/src/libs/qwt/src/qwt_date_scale_draw.h
+++ b/ground/gcs/src/libs/qwt/src/qwt_date_scale_draw.h
@@ -1,3 +1,12 @@
+/* -*- mode: C++ ; c-file-style: "stroustrup" -*- *****************************
+ * Qwt Widget Library
+ * Copyright (C) 1997   Josef Wilgen
+ * Copyright (C) 2002   Uwe Rathmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the Qwt License, Version 1.0
+ *****************************************************************************/
+
 #ifndef _QWT_DATE_SCALE_DRAW_H_
 #define _QWT_DATE_SCALE_DRAW_H_ 1
 

--- a/ground/gcs/src/libs/qwt/src/qwt_date_scale_engine.cpp
+++ b/ground/gcs/src/libs/qwt/src/qwt_date_scale_engine.cpp
@@ -1,3 +1,12 @@
+/* -*- mode: C++ ; c-file-style: "stroustrup" -*- *****************************
+ * Qwt Widget Library
+ * Copyright (C) 1997   Josef Wilgen
+ * Copyright (C) 2002   Uwe Rathmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the Qwt License, Version 1.0
+ *****************************************************************************/
+
 #include "qwt_date_scale_engine.h"
 #include "qwt_math.h"
 #include "qwt_transform.h"

--- a/ground/gcs/src/libs/qwt/src/qwt_date_scale_engine.h
+++ b/ground/gcs/src/libs/qwt/src/qwt_date_scale_engine.h
@@ -1,3 +1,12 @@
+/* -*- mode: C++ ; c-file-style: "stroustrup" -*- *****************************
+ * Qwt Widget Library
+ * Copyright (C) 1997   Josef Wilgen
+ * Copyright (C) 2002   Uwe Rathmann
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the Qwt License, Version 1.0
+ *****************************************************************************/
+
 #ifndef _QWT_DATE_SCALE_ENGINE_H_
 #define _QWT_DATE_SCALE_ENGINE_H_ 1
 

--- a/ground/gcs/src/libs/qwt/src/qwt_global.h
+++ b/ground/gcs/src/libs/qwt/src/qwt_global.h
@@ -14,8 +14,8 @@
 
 // QWT_VERSION is (major << 16) + (minor << 8) + patch.
 
-#define QWT_VERSION       0x060101
-#define QWT_VERSION_STR   "6.1.1"
+#define QWT_VERSION       0x060102
+#define QWT_VERSION_STR   "6.1.2"
 
 #if defined(_MSC_VER) /* MSVC Compiler */
 /* template-class specialization 'identifier' is already instantiated */

--- a/ground/gcs/src/libs/qwt/src/qwt_legend.cpp
+++ b/ground/gcs/src/libs/qwt/src/qwt_legend.cpp
@@ -416,6 +416,16 @@ void QwtLegend::updateLegend( const QVariant &itemInfo,
             if ( contentsLayout )
                 contentsLayout->addWidget( widget );
 
+            if ( isVisible() )
+            {
+                // QLayout does a delayed show, with the effect, that
+                // the size hint will be wrong, when applications
+                // call replot() right after changing the list
+                // of plot items. So we better do the show now.
+
+                widget->setVisible( true );
+            }
+
             widgetList += widget;
         }
 

--- a/ground/gcs/src/libs/qwt/src/qwt_math.h
+++ b/ground/gcs/src/libs/qwt/src/qwt_math.h
@@ -134,13 +134,13 @@ inline double qwtFastAtan2( double y, double x )
     return 0.0;
 }
 
-// Translate degrees into radians
+//! Translate degrees into radians
 inline double qwtRadians( double degrees )
 {
     return degrees * M_PI / 180.0;
 }
 
-// Translate radians into degrees
+//! Translate radians into degrees
 inline double qwtDegrees( double degrees )
 {
     return degrees * 180.0 / M_PI;

--- a/ground/gcs/src/libs/qwt/src/qwt_painter.cpp
+++ b/ground/gcs/src/libs/qwt/src/qwt_painter.cpp
@@ -84,7 +84,8 @@ static inline void qwtDrawPolyline( QPainter *painter,
 
     if ( doSplit )
     {
-        const int splitSize = 20;
+        const int splitSize = 6;
+
         for ( int i = 0; i < pointCount; i += splitSize )
         {
             const int n = qMin( splitSize + 1, pointCount - i );
@@ -92,7 +93,9 @@ static inline void qwtDrawPolyline( QPainter *painter,
         }
     }
     else
+    {
         painter->drawPolyline( points, pointCount );
+    }
 }
 
 static inline QSize qwtScreenResolution()
@@ -1096,6 +1099,8 @@ void QwtPainter::drawColorBar( QPainter *painter,
      */
 
     QPixmap pixmap( devRect.size() );
+    pixmap.fill( Qt::transparent );
+
     QPainter pmPainter( &pixmap );
     pmPainter.translate( -devRect.x(), -devRect.y() );
 
@@ -1127,7 +1132,7 @@ void QwtPainter::drawColorBar( QPainter *painter,
             const double value = sMap.invTransform( y );
 
             if ( colorMap.format() == QwtColorMap::RGB )
-                c.setRgb( colorMap.rgb( interval, value ) );
+                c.setRgba( colorMap.rgb( interval, value ) );
             else
                 c = colorTable[colorMap.colorIndex( interval, value )];
 

--- a/ground/gcs/src/libs/qwt/src/qwt_pixel_matrix.cpp
+++ b/ground/gcs/src/libs/qwt/src/qwt_pixel_matrix.cpp
@@ -1,7 +1,7 @@
 /* -*- mode: C++ ; c-file-style: "stroustrup" -*- *****************************
  * Qwt Widget Library
  * Copyright (C) 1997   Josef Wilgen
- * Copyright (C) 2003   Uwe Rathmann
+ * Copyright (C) 2002   Uwe Rathmann
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the Qwt License, Version 1.0

--- a/ground/gcs/src/libs/qwt/src/qwt_pixel_matrix.h
+++ b/ground/gcs/src/libs/qwt/src/qwt_pixel_matrix.h
@@ -1,7 +1,7 @@
 /* -*- mode: C++ ; c-file-style: "stroustrup" -*- *****************************
  * Qwt Widget Library
  * Copyright (C) 1997   Josef Wilgen
- * Copyright (C) 2003   Uwe Rathmann
+ * Copyright (C) 2002   Uwe Rathmann
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the Qwt License, Version 1.0

--- a/ground/gcs/src/libs/qwt/src/qwt_plot_spectrogram.cpp
+++ b/ground/gcs/src/libs/qwt/src/qwt_plot_spectrogram.cpp
@@ -23,6 +23,12 @@
 #include <qtconcurrentrun.h>
 #endif
 
+#define DEBUG_RENDER 0
+
+#if DEBUG_RENDER
+#include <QElapsedTimer>
+#endif
+
 class QwtPlotSpectrogram::PrivateData
 {
 public:
@@ -416,6 +422,11 @@ QImage QwtPlotSpectrogram::renderImage(
 
     d_data->data->initRaster( area, image.size() );
 
+#if DEBUG_RENDER
+    QElapsedTimer time;
+    time.start();
+#endif
+
 #if QT_VERSION >= 0x040400 && !defined(QT_NO_QFUTURE)
     uint numThreads = renderThreadCount();
 
@@ -449,6 +460,11 @@ QImage QwtPlotSpectrogram::renderImage(
 #else // QT_VERSION < 0x040400
     const QRect tile( 0, 0, image.width(), image.height() );
     renderTile( xMap, yMap, tile, &image );
+#endif
+
+#if DEBUG_RENDER
+    const qint64 elapsed = time.elapsed();
+    qDebug() << "renderImage" << imageSize << elapsed;
 #endif
 
     d_data->data->discardRaster();

--- a/ground/gcs/src/libs/qwt/src/qwt_point_mapper.h
+++ b/ground/gcs/src/libs/qwt/src/qwt_point_mapper.h
@@ -1,7 +1,7 @@
 /* -*- mode: C++ ; c-file-style: "stroustrup" -*- *****************************
  * Qwt Widget Library
  * Copyright (C) 1997   Josef Wilgen
- * Copyright (C) 2003   Uwe Rathmann
+ * Copyright (C) 2002   Uwe Rathmann
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the Qwt License, Version 1.0

--- a/ground/gcs/src/libs/qwt/src/qwt_scale_engine.cpp
+++ b/ground/gcs/src/libs/qwt/src/qwt_scale_engine.cpp
@@ -1043,6 +1043,9 @@ void QwtLogScaleEngine::buildMinorTicks(
 
             if ( s >= 1.0 )
             {
+                if ( !qFuzzyCompare( s, 1.0 ) )
+                    minorTicks += v * s;
+
                 for ( int j = 2; j < numSteps; j++ )
                 {
                     minorTicks += v * j * s;

--- a/ground/gcs/src/libs/qwt/src/qwt_text.cpp
+++ b/ground/gcs/src/libs/qwt/src/qwt_text.cpp
@@ -1,7 +1,7 @@
 /* -*- mode: C++ ; c-file-style: "stroustrup" -*- *****************************
  * Qwt Widget Library
  * Copyright (C) 1997   Josef Wilgen
- * Copyright (C) 2003   Uwe Rathmann
+ * Copyright (C) 2002   Uwe Rathmann
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the Qwt License, Version 1.0

--- a/ground/gcs/src/libs/qwt/src/qwt_text.h
+++ b/ground/gcs/src/libs/qwt/src/qwt_text.h
@@ -1,7 +1,7 @@
 /* -*- mode: C++ ; c-file-style: "stroustrup" -*- *****************************
  * Qwt Widget Library
  * Copyright (C) 1997   Josef Wilgen
- * Copyright (C) 2003   Uwe Rathmann
+ * Copyright (C) 2002   Uwe Rathmann
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the Qwt License, Version 1.0

--- a/ground/gcs/src/libs/qwt/src/qwt_text_engine.cpp
+++ b/ground/gcs/src/libs/qwt/src/qwt_text_engine.cpp
@@ -1,7 +1,7 @@
 /* -*- mode: C++ ; c-file-style: "stroustrup" -*- *****************************
  * Qwt Widget Library
  * Copyright (C) 1997   Josef Wilgen
- * Copyright (C) 2003   Uwe Rathmann
+ * Copyright (C) 2002   Uwe Rathmann
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the Qwt License, Version 1.0

--- a/ground/gcs/src/libs/qwt/src/qwt_text_engine.h
+++ b/ground/gcs/src/libs/qwt/src/qwt_text_engine.h
@@ -1,7 +1,7 @@
 /* -*- mode: C++ ; c-file-style: "stroustrup" -*- *****************************
  * Qwt Widget Library
  * Copyright (C) 1997   Josef Wilgen
- * Copyright (C) 2003   Uwe Rathmann
+ * Copyright (C) 2002   Uwe Rathmann
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the Qwt License, Version 1.0

--- a/ground/gcs/src/libs/qwt/src/qwt_thermo.cpp
+++ b/ground/gcs/src/libs/qwt/src/qwt_thermo.cpp
@@ -331,7 +331,7 @@ void QwtThermo::layoutThermo( bool update_geometry )
             scaleDraw()->move( from, tRect.bottom() + bw );
         }
 
-        scaleDraw()->setLength( to - from );
+        scaleDraw()->setLength( qMax( to - from, 0 ) );
     }
     else // Qt::Vertical
     {
@@ -364,7 +364,7 @@ void QwtThermo::layoutThermo( bool update_geometry )
             scaleDraw()->move( tRect.left() - bw, from );
         }
 
-        scaleDraw()->setLength( to - from );
+        scaleDraw()->setLength( qMax( to - from, 0 ) );
     }
 
     if ( update_geometry )

--- a/ground/gcs/src/libs/qwt/src/qwt_transform.cpp
+++ b/ground/gcs/src/libs/qwt/src/qwt_transform.cpp
@@ -14,11 +14,23 @@
 #define qExp(x) ::exp(x)
 #endif
 
+#if QT_VERSION >= 0x050400
+
 //! Smallest allowed value for logarithmic scales: 1.0e-150
 const double QwtLogTransform::LogMin = 1.0e-150;
-
+    
 //! Largest allowed value for logarithmic scales: 1.0e150
 const double QwtLogTransform::LogMax = 1.0e150;
+
+#else
+
+//! Smallest allowed value for logarithmic scales: 1.0e-150
+QT_STATIC_CONST_IMPL double QwtLogTransform::LogMin = 1.0e-150;
+
+//! Largest allowed value for logarithmic scales: 1.0e150
+QT_STATIC_CONST_IMPL double QwtLogTransform::LogMax = 1.0e150;
+
+#endif
 
 //! Constructor
 QwtTransform::QwtTransform()

--- a/ground/gcs/src/libs/qwt/src/qwt_transform.h
+++ b/ground/gcs/src/libs/qwt/src/qwt_transform.h
@@ -107,8 +107,13 @@ public:
 
     virtual QwtTransform *copy() const;
 
+#if QT_VERSION >= 0x050400
     static const double LogMin;
     static const double LogMax;
+#else
+    QT_STATIC_CONST double LogMin;
+    QT_STATIC_CONST double LogMax;
+#endif
 };
 
 /*!

--- a/ground/gcs/src/libs/qwt/textengines/mathml/qwtmathml.prf
+++ b/ground/gcs/src/libs/qwt/textengines/mathml/qwtmathml.prf
@@ -19,20 +19,10 @@ QT       *= xml
 contains(QWT_CONFIG, QwtFramework) {
 
     INCLUDEPATH *= $${QWT_INSTALL_LIBS}/qwtmathml.framework/Headers
-    LIBS        *= -F$${QWT_INSTALL_LIBS}
 }
 else {
 
     INCLUDEPATH *= $${QWT_INSTALL_HEADERS}
-    LIBS        *= -L$${QWT_INSTALL_LIBS}
 }
 
-INCLUDEPATH_QWTMATHML = $${INCLUDEPATH}
-qtAddLibrary(qwtmathml)
-
-# we don't want qtAddLibrary to expand the 
-# include path, with directories, that might
-# conflict with other installations of qwt
-
-INCLUDEPATH      = $${INCLUDEPATH_QWTMATHML}
-
+qwtAddLibrary($${QWT_INSTALL_LIBS}, qwtmathml)

--- a/ground/gcs/src/libs/qwt/textengines/textengines.pri
+++ b/ground/gcs/src/libs/qwt/textengines/textengines.pri
@@ -32,14 +32,9 @@ else {
 contains(QWT_CONFIG, QwtFramework) {
 
     CONFIG += lib_bundle
-    LIBS      += -F$${QWT_OUT_ROOT}/lib
-}
-else {
-
-    LIBS      += -L$${QWT_OUT_ROOT}/lib
 }
 
-qwtAddLibrary(qwt)
+qwtAddLibrary($${QWT_OUT_ROOT}/lib, qwt)
 
 # Install directives
 


### PR DESCRIPTION
```
Qwt 6.1.2
=========

1) Qt 5.4 compatibility

   - QT_STATIC_CONST
     "QT_STATIC_CONST" replaced by "static const"

2) build environment

   - QMAKELIBDIRFLAGS
     using QMAKELIBDIRFLAGS to avoid conflicts with already 
     installed linux distro packages

3) color maps

    - QwtLinearColorMap 
      handling of alpha values added

    - QwtAlphaColorMap
      basic functinality fixed

    - QwtPainter
      QwtPainter::drawColorBar() fixed for semi transparent colors.

4) QwtPlot and friends

   - QwtLegend
     layout issue fixed

   - QwtLogScaleEngine
     tick duplicates fixed     

   - QwtPainter
     internal chunk size for drawing polylines with the raster paint engine 
     reduced from 20 to 6 ( faster ).
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/824)

<!-- Reviewable:end -->
