### PR TITLE
Flight: Add Frsky Sensor Hub + GPS rx configuration.

### DIFF
--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -469,20 +469,47 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 
 	case HWSHARED_PORTTYPES_FRSKYSENSORHUB:
 #if defined(PIOS_INCLUDE_FRSKY_SENSOR_HUB)
-		usart_port_params.init.USART_BaudRate            = 57600;
+		usart_port_params.init.USART_BaudRate            = 9600;
 		usart_port_params.init.USART_WordLength          = USART_WordLength_8b;
 		usart_port_params.init.USART_Parity              = USART_Parity_No;
 		usart_port_params.init.USART_StopBits            = USART_StopBits_1;
 		usart_port_params.init.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
 		usart_port_params.init.USART_Mode                = USART_Mode_Tx;
 
+#if defined(STM32F30X)
+		// F3 has internal inverters and can switch rx/tx pins
 		usart_port_params.rx_invert   = false;
 		usart_port_params.tx_invert   = true;
 		usart_port_params.single_wire = false;
+#endif // STM32F30X
 
 		PIOS_HAL_ConfigureCom(usart_port_cfg, &usart_port_params, 0, PIOS_COM_FRSKYSENSORHUB_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_frsky_sensor_hub_id;
 		PIOS_Modules_Enable(PIOS_MODULE_UAVOFRSKYSENSORHUBBRIDGE);
+#endif /* PIOS_INCLUDE_FRSKY_SENSOR_HUB */
+		break;
+
+	case HWSHARED_PORTTYPES_FRSKYSENSORHUBGPSRX:
+#if defined(PIOS_INCLUDE_FRSKY_SENSOR_HUB)
+		usart_port_params.init.USART_BaudRate            = 9600;
+		usart_port_params.init.USART_WordLength          = USART_WordLength_8b;
+		usart_port_params.init.USART_Parity              = USART_Parity_No;
+		usart_port_params.init.USART_StopBits            = USART_StopBits_1;
+		usart_port_params.init.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+		usart_port_params.init.USART_Mode                = USART_Mode_Rx | USART_Mode_Tx;
+
+#if defined(STM32F30X)
+		// F3 has internal inverters and can switch rx/tx pins
+		usart_port_params.rx_invert   = false;
+		usart_port_params.tx_invert   = true;
+		usart_port_params.single_wire = false;
+#endif // STM32F30X
+
+		PIOS_HAL_ConfigureCom(usart_port_cfg, &usart_port_params, PIOS_COM_GPS_RX_BUF_LEN, PIOS_COM_FRSKYSENSORHUB_TX_BUF_LEN, com_driver, &port_driver_id);
+		target = &pios_com_frsky_sensor_hub_id;
+		target2 = &pios_com_gps_id;
+		PIOS_Modules_Enable(PIOS_MODULE_UAVOFRSKYSENSORHUBBRIDGE);
+		PIOS_Modules_Enable(PIOS_MODULE_GPS);
 #endif /* PIOS_INCLUDE_FRSKY_SENSOR_HUB */
 		break;
 

--- a/shared/uavobjectdefinition/hwshared.xml
+++ b/shared/uavobjectdefinition/hwshared.xml
@@ -19,6 +19,7 @@
 				<option>HoTT SUMH</option>
 				<option>HoTT Telemetry</option>
 				<option>FrSKY Sensor Hub</option>
+				<option>FrSKY Sensor Hub GPS RX</option>
 				<option>FrSKY SPort Telemetry</option>
 				<option>LighttelemetryTx</option>
 				<option>PicoC</option>


### PR DESCRIPTION
Here's something I've been playing with on my Naze32Pro F3 boards.  It's FrSKY Sensor Hub and GPS RX on the same uart port.

GPS config needs to be saved to the GPS flash, and the GPS baud rate needs to be 9600.

On an F3 board, I now have FrSKY Sensor Hub telem, GPS, external mag, and MSP running.  With the gyro rate at 500 Hz, I'm at 50% CPU load with a little over 4K of heap remaining.  That's also with vtol path follower, altitude hold, and autotune modules enabled.  My mini tri is now fully NAV capable.

If this is a worthwhile change for the general population, I'll add the mode to the target  files.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/826)

<!-- Reviewable:end -->
