### PR TITLE
flight: initialize settings objects even if module not running

### DIFF
--- a/flight/Modules/Airspeed/airspeed.c
+++ b/flight/Modules/Airspeed/airspeed.c
@@ -156,6 +156,8 @@ static void doSettingsUpdate()
  */
 int32_t AirspeedInitialize()
 {
+	AirspeedSettingsInitialize();
+
 #ifdef MODULE_Airspeed_BUILTIN
 	module_enabled = true;
 #else
@@ -173,7 +175,6 @@ int32_t AirspeedInitialize()
 
 	BaroAirspeedInitialize();
 	AirspeedActualInitialize();
-	AirspeedSettingsInitialize();
 
 #ifdef BARO_AIRSPEED_PRESENT
 	// Get the analog pin

--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -94,6 +94,10 @@ static void af_init(float X[AF_NUMX], float P[AF_NUMP]);
  */
 int32_t AutotuneInitialize(void)
 {
+#ifndef SMALLF1
+	SystemIdentInitialize();
+#endif
+
 	// Create a queue, connect to manual control command and flightstatus
 #ifdef MODULE_Autotune_BUILTIN
 	module_enabled = true;

--- a/flight/Modules/Battery/battery.c
+++ b/flight/Modules/Battery/battery.c
@@ -73,6 +73,7 @@ static int32_t BatteryStart(void)
  */
 int32_t BatteryInitialize(void)
 {
+	FlightBatterySettingsInitialize();
 #ifdef MODULE_Battery_BUILTIN
 	module_enabled = true;
 #else
@@ -85,7 +86,6 @@ int32_t BatteryInitialize(void)
 		return 0;
 	}
 #endif
-	FlightBatterySettingsInitialize();
 	FlightBatteryStateInitialize();
 
 	return 0;

--- a/flight/Modules/CameraStab/camerastab.c
+++ b/flight/Modules/CameraStab/camerastab.c
@@ -114,6 +114,8 @@ int32_t CameraStabInitialize(void)
 	}
 #endif
 
+	CameraStabSettingsInitialize();
+
 	if (module_enabled) {
 
 		// allocate and initialize the static data storage only if module is enabled
@@ -128,7 +130,6 @@ int32_t CameraStabInitialize(void)
 		csd->lastSysTime = PIOS_Thread_Systime() - SAMPLE_PERIOD_MS;
 
 		AttitudeActualInitialize();
-		CameraStabSettingsInitialize();
 		CameraDesiredInitialize();
 
 		CameraStabSettingsConnectCallback(settings_updated_cb);

--- a/flight/Modules/Geofence/geofence.c
+++ b/flight/Modules/Geofence/geofence.c
@@ -75,10 +75,9 @@ int32_t GeofenceInitialize(void)
 	}
 #endif
 
+	GeoFenceSettingsInitialize();
+
 	if (module_enabled) {
-
-		GeoFenceSettingsInitialize();
-
 		// allocate and initialize the static data storage only if module is enabled
 		geofenceSettings = (GeoFenceSettingsData *) PIOS_malloc(sizeof(GeoFenceSettingsData));
 		if (geofenceSettings == NULL) {

--- a/flight/Modules/PathPlanner/pathplanner.c
+++ b/flight/Modules/PathPlanner/pathplanner.c
@@ -114,8 +114,9 @@ int32_t PathPlannerInitialize()
 	}
 #endif
 
+	PathPlannerSettingsInitialize();
+
 	if(module_enabled) {
-		PathPlannerSettingsInitialize();
 		WaypointInitialize();
 		WaypointActiveInitialize();
 

--- a/flight/Modules/PicoC/picoc_module.c
+++ b/flight/Modules/PicoC/picoc_module.c
@@ -117,8 +117,9 @@ static int32_t picocInitialize(void)
 
 	module_enabled = false;
 
+	PicoCSettingsInitialize();
+
 	if (module_state[MODULESETTINGS_ADMINSTATE_PICOC] == MODULESETTINGS_ADMINSTATE_ENABLED) {
-		PicoCSettingsInitialize();
 		PicoCStatusInitialize();
 
 		// get picoc settings

--- a/flight/Modules/TxPID/txpid.c
+++ b/flight/Modules/TxPID/txpid.c
@@ -112,6 +112,10 @@ int32_t TxPIDInitialize(void)
 	}
 #endif
 
+#ifndef SMALLF1
+	TxPIDSettingsInitialize();
+#endif
+
 	if (module_enabled) {
 		txpid_data = PIOS_malloc(sizeof(*txpid_data));
 

--- a/flight/Modules/VtolPathFollower/vtolpathfollower.c
+++ b/flight/Modules/VtolPathFollower/vtolpathfollower.c
@@ -111,18 +111,18 @@ int32_t VtolPathFollowerInitialize()
 		module_enabled = false;
 	}
 #endif
+	AltitudeHoldSettingsInitialize();
+	VtolPathFollowerSettingsInitialize();
 
 	if (!module_enabled) {
 		return -1;
 	}
 
 	AccelDesiredInitialize();
-	AltitudeHoldSettingsInitialize();
 	AltitudeHoldStateInitialize();
 	PathDesiredInitialize();
 	PathStatusInitialize();
 	VelocityDesiredInitialize();
-	VtolPathFollowerSettingsInitialize();
 	VtolPathFollowerStatusInitialize();
 	
 	return 0;


### PR DESCRIPTION
Exceptions: txpid and autotune on F1

This way you can import or export or access settings even when the module isn't running.

Connects to #821

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/838)

<!-- Reviewable:end -->
