### PR TITLE
build: windows: bash_profile adjustments

### DIFF
--- a/make/winx86/bash_profile
+++ b/make/winx86/bash_profile
@@ -19,11 +19,11 @@ test_and_add_to_path ()
   fi
 
   if [ -f "$1/$2" ] ; then
-    PATH=$PATH\:$1
+    PATH=$1\:$PATH
   fi
 }
 
-test_and_add_to_path "$QT_BASEDIR/$QT_VERSION/$QT_MINGWVER/bin" "qmake.exe"
+test_and_add_to_path "$QT_BASEDIR/$QT_VERSION/$QT_MINGWVER/bin" "QtWebProcess.exe"
 test_and_add_to_path "$QT_BASEDIR/Tools/$QT_MINGWVER/bin" "gcc.exe"
 test_and_add_to_path "/C/Python27" "python.exe"
 test_and_add_to_path "/C/OpenOCD/0.4.0/bin/" "openocd.exe"


### PR DESCRIPTION
1. prepend paths instead of postpending, allowing the dev tools we
   find to take precedence over other tools that may be in the path.
2. search for qtwebprocess instead of qmake, in case qmake is
   already in the path (e.g. the Anaconda python distribution has a
   qmake bin).

This is not a cure-all but makes things better.  Fixes #657

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/d-ronin/dronin/853)

<!-- Reviewable:end -->
