### PR TITLE
flight: althold: always initialize altholdsettings

### DIFF
--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -109,8 +109,9 @@ int32_t AltitudeHoldInitialize()
 	}
 #endif
 
+	AltitudeHoldSettingsInitialize();
+
 	if(module_enabled) {
-		AltitudeHoldSettingsInitialize();
 		AltitudeHoldDesiredInitialize();
 		AltitudeHoldStateInitialize();
 


### PR DESCRIPTION
Was missed in #838 ; noticed by @pug398
