### PR TITLE
gcs: upgrade bootloaders on quanton and revolution

### DIFF
--- a/ground/gcs/src/plugins/boards_brainfpv/brain.cpp
+++ b/ground/gcs/src/plugins/boards_brainfpv/brain.cpp
@@ -62,6 +62,9 @@ Brain::~Brain()
 
 }
 
+int Brain::minBootLoaderVersion() {
+    return 0x82;
+}
 
 QString Brain::shortName()
 {

--- a/ground/gcs/src/plugins/boards_brainfpv/brain.h
+++ b/ground/gcs/src/plugins/boards_brainfpv/brain.h
@@ -40,6 +40,7 @@ public:
 
     virtual QString shortName();
     virtual QString boardDescription();
+    virtual int minBootLoaderVersion();
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();

--- a/ground/gcs/src/plugins/boards_openpilot/revolution.cpp
+++ b/ground/gcs/src/plugins/boards_openpilot/revolution.cpp
@@ -73,6 +73,10 @@ Revolution::~Revolution()
 
 }
 
+int Revolution::minBootLoaderVersion() {
+    return 0x84;
+}
+
 QString Revolution::shortName()
 {
     return QString("Revolution");

--- a/ground/gcs/src/plugins/boards_openpilot/revolution.h
+++ b/ground/gcs/src/plugins/boards_openpilot/revolution.h
@@ -42,6 +42,7 @@ public:
 
     virtual QString shortName();
     virtual QString boardDescription();
+    virtual int minBootLoaderVersion();
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();

--- a/ground/gcs/src/plugins/boards_quantec/quanton.cpp
+++ b/ground/gcs/src/plugins/boards_quantec/quanton.cpp
@@ -73,6 +73,11 @@ QString Quanton::boardDescription()
     return QString("quanton flight control rev. 1 by Quantec Networks GmbH");
 }
 
+int Quanton::minBootLoaderVersion() {
+    return 0x84;
+}
+
+
 //! Return which capabilities this board has
 bool Quanton::queryCapabilities(BoardCapabilities capability)
 {

--- a/ground/gcs/src/plugins/boards_quantec/quanton.h
+++ b/ground/gcs/src/plugins/boards_quantec/quanton.h
@@ -40,6 +40,7 @@ public:
 
     virtual QString shortName();
     virtual QString boardDescription();
+    virtual int minBootLoaderVersion();
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();

--- a/ground/gcs/src/plugins/coreplugin/iboardtype.h
+++ b/ground/gcs/src/plugins/coreplugin/iboardtype.h
@@ -177,6 +177,9 @@ public:
         INPUT_TYPE_ANY
     };
 
+    //! Returns the minimum bootloader version required
+    virtual int minBootLoaderVersion() { return 0; }
+
     //! Determine if this board supports configuring the receiver
     virtual bool isInputConfigurationSupported(enum InputType type = INPUT_TYPE_ANY) { Q_UNUSED(type); return false; }
 

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -810,7 +810,7 @@ void UploaderGadgetWidget::stepChangeAndDelay(QEventLoop &loop, int delayMs,
     delay.stop();
 }
 
-void UploaderGadgetWidget::doUpgradeOperation(bool blankFC)
+void UploaderGadgetWidget::doUpgradeOperation(bool blankFC, tl_dfu::device &dev)
 {
     Core::ModeManager::instance()->activateModeByWorkspaceName("Firmware");
 
@@ -862,6 +862,12 @@ void UploaderGadgetWidget::doUpgradeOperation(bool blankFC)
     if (!isCrippledBoard) {
         /* If no settings part known, new loader needed. */
         upgradingLoader = !haveSettingsPart();
+
+        int requiredLoader = board.board->minBootLoaderVersion();
+
+        if (requiredLoader > dev.BL_Version) {
+            upgradingLoader = true;
+        }
     }
 
     m_dialog.setOperatingMode(upgradingLoader, isCrippledBoard, blankFC);
@@ -1496,7 +1502,7 @@ void UploaderGadgetWidget::onBootloaderDetected()
                 bool canBeUpgraded = currentBoard.board->queryCapabilities(Core::IBoardType::BOARD_CAPABILITIES_UPGRADEABLE);
 
                 if (canBeUpgraded) {
-                    doUpgradeOperation(blankFC);
+                    doUpgradeOperation(blankFC, dev);
                     return;
                 }
             }

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.h
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.h
@@ -111,7 +111,7 @@ private:
     bool downloadSettings();
     void stepChangeAndDelay(QEventLoop &loop, int delayMs,
                     UpgradeAssistantDialog::UpgradeAssistantStep step);
-    void doUpgradeOperation(bool blankFC);
+    void doUpgradeOperation(bool blankFC,  tl_dfu::device &dev);
     void upgradeError(QString why);
     bool flashFirmware(QByteArray &firmwareImage);
     bool haveSettingsPart() const;


### PR DESCRIPTION
In Mar 2015, the bootloaders for Quanton and Revolution were changed to have a larger flash partition size for code to fit ChibiOS and picoc.

This alters the bootloader logic to attempt to upgrade these older loaders.

As a side effect, it will upgrade some Revolution loaders from OP that support the full code size but have their revisions drawn from a different space.

For consideration in Tanto, though this helps a pretty small user population.  I need to test this.
