### PR TITLE
python: simple fixes

### DIFF
--- a/python/dronin/telemetry.py
+++ b/python/dronin/telemetry.py
@@ -594,7 +594,8 @@ def get_telemetry_by_args(desc="Process telemetry", service_in_iter=True,
 
     if args.serial:
         return telemetry.SerialTelemetry(args.source, speed=args.baud,
-                service_in_iter=service_in_iter, iter_blocks=iter_blocks)
+                service_in_iter=service_in_iter, iter_blocks=iter_blocks,
+                githash=githash)
 
     if args.baud != "115200":
         parser.print_help()
@@ -606,7 +607,8 @@ def get_telemetry_by_args(desc="Process telemetry", service_in_iter=True,
         file_obj = file(args.source, 'rb')
 
         t = telemetry.FileTelemetry(file_obj, parse_header=parse_header,
-            gcs_timestamps=args.timestamped, name=args.source)
+            gcs_timestamps=args.timestamped, name=args.source,
+            githash=githash)
 
         return t
 
@@ -618,4 +620,5 @@ def get_telemetry_by_args(desc="Process telemetry", service_in_iter=True,
         raise ValueError("Target doesn't exist and isn't a network address")
 
     return telemetry.NetworkTelemetry(host=host, port=int(port), name=args.source,
-            service_in_iter=service_in_iter, iter_blocks=iter_blocks)
+            service_in_iter=service_in_iter, iter_blocks=iter_blocks,
+            githash=githash)

--- a/python/dronin/uavo_collection.py
+++ b/python/dronin/uavo_collection.py
@@ -48,6 +48,9 @@ class UAVOCollection(dict):
 
         # Build up the UAV objects from the xml definitions
         for f_info in f_members:
+            if f_info.name.count("oplinksettings") > 0:
+                continue
+
             f = t.extractfile(f_info)
 
             u = uavo.make_class(self, f)


### PR DESCRIPTION
1. we lost the plumbing for githashes on the command line at some point
2. don't try to parse an old xml file (oplink_settings) that we don't know how to deal with.

Tested, good.

fixes #878
