### PR TITLE
GCS:SysHealth: Add HTML for Actuator-Warning

### DIFF
--- a/ground/gcs/src/plugins/systemhealth/html/Actuator-Warning.html
+++ b/ground/gcs/src/plugins/systemhealth/html/Actuator-Warning.html
@@ -1,0 +1,16 @@
+<html>
+  <head>
+    <title></title>
+    <meta content="">
+    <style></style>
+  </head>
+  <body style="color: black">
+    <h1>Servo Output: Warning</h1>
+    <p>
+    One of the following conditions may be present:
+    <ul>
+    <li>Actuator output is clipping.</li>
+    </ul>
+    </p>
+  </body>
+</html>

--- a/ground/gcs/src/plugins/systemhealth/systemhealth.qrc
+++ b/ground/gcs/src/plugins/systemhealth/systemhealth.qrc
@@ -20,8 +20,8 @@
         <file>html/Battery-Critical.html</file>
         <file>html/Battery-Error.html</file>
         <file>html/FlightTime-Warning.html</file>
-		<file>html/Gimbal-Critical.html</file>
-		<file>html/Gimbal-Warning.html</file>
+        <file>html/Gimbal-Critical.html</file>
+        <file>html/Gimbal-Warning.html</file>
         <file>html/GPS-Critical.html</file>
         <file>html/GPS-Error.html</file>
         <file>html/GPS-Warning.html</file>
@@ -53,8 +53,9 @@
         <file>html/StateEstimation-PDOP-Too-High.html</file>
         <file>html/StateEstimation-Too-Few-Satellites.html</file>
         <file>html/StateEstimation-Undefined.html</file>
-	<file>html/TempBaro-Warning.html</file>
-	<file>html/TempBaro-Error.html</file>
-	<file>html/TempBaro-Critical.html</file>
+        <file>html/TempBaro-Warning.html</file>
+        <file>html/TempBaro-Error.html</file>
+        <file>html/TempBaro-Critical.html</file>
+        <file>html/Actuator-Warning.html</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Was missing, occurs during clipping. QtCreator cleaned up the tabs in the resource file too. Maybe Tanto, maybe not?
