### PR TITLE
make $(error) when qt sdk is non existant or out of date

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -22,7 +22,19 @@ ifdef OPENOCD_FTDI
 endif
 
 # Set up QT toolchain
-QT_SDK_DIR := $(TOOLS_DIR)/Qt5.5.1
+QT_VERSION := 5.5.1
+QT_SDK_DIR := $(TOOLS_DIR)/Qt$(QT_VERSION)
+
+# On any platform except windows
+ifndef WINDOWS
+# Check for a current QT SDK dir, abort without
+ifeq ($(wildcard $(QT_SDK_DIR)),)
+ifneq ($(MAKECMDGOALS), qt_sdk_install)
+	$(error "QT SDK not found, please run `qt_sdk_install`")
+endif
+endif
+endif
+
 
 ifdef LINUX
   ifdef AMD64


### PR DESCRIPTION
not sure if this is the right solution, but the problem is moving from master -> next, qt was upgraded in the make files, so the paths were wrong. hopefully folks wont need to dig through the makefile to figure this out in the future

the problems w/ this is that this line guards all commands except qt_sdk_install when the qt version is out of date: https://github.com/d-ronin/dRonin/compare/next...nathantsoi:make-err-on-qt-err?expand=1#diff-d848f181cd782d5d32ac4749ce706bf1R31

idk if more commands should be allowed, or this should just be a warning?
