### PR TITLE
telemetry: remove redundant telemetry updateSettings()

### DIFF
--- a/flight/Modules/Telemetry/telemetry.c
+++ b/flight/Modules/Telemetry/telemetry.c
@@ -123,9 +123,6 @@ int32_t TelemetryInitialize(void)
 	// Create object queues
 	queue = PIOS_Queue_Create(MAX_QUEUE_SIZE, sizeof(UAVObjEvent));
 
-	// Update telemetry settings
-	updateSettings();
-    
 	// Initialise UAVTalk
 	uavTalkCon = UAVTalkInitialize(&transmitData);
 


### PR DESCRIPTION
This got introduced by an errant rebase during telemetry refactor.

updateSettings is supposed to happen in the tx task, to avoid blowing watchdog during module initialization when bluetooth is configured.
