### PR TITLE
New vibrationAnalysis module and Spectrogram with FFT

### DIFF
--- a/flight/Modules/VibrationAnalysis/vibrationanalysis.c
+++ b/flight/Modules/VibrationAnalysis/vibrationanalysis.c
@@ -205,7 +205,7 @@ static int32_t VibrationAnalysisStart(void)
         uint16_t existing_instances = VibrationAnalysisOutputGetNumInstances();
         if(existing_instances < instances) {
             //Create missing instances
-            for (int i=existing_instances; i<instances; i++) {
+            for (int i = existing_instances; i < instances; i++) {
                 uint16_t ret = VibrationAnalysisOutputCreateInstance();
                 if (ret == 0) {
                     // This fails when it's a metaobject. Not a very helpful test.
@@ -361,7 +361,7 @@ static void VibrationAnalysisTask(void *parameters)
     {
 
         // Only check settings once every 100ms and not in the middle of a buffer accumulation to reduce artifacts
-        if (PIOS_Thread_Systime() - lastSettingsUpdateTime > SETTINGS_THROTTLING_MS && sample_count == 0 && instance_number==0) {
+        if (PIOS_Thread_Systime() - lastSettingsUpdateTime > SETTINGS_THROTTLING_MS && sample_count == 0 && instance_number == 0) {
             //First check if the analysis is active
             VibrationAnalysisSettingsTestingStatusGet(&runAnalysisFlag);
             
@@ -436,22 +436,22 @@ static void VibrationAnalysisTask(void *parameters)
 
         // Process and dump an instance at a time
 #ifdef USE_SINGLE_INSTANCE_BUFFERS
-        if (sample_count ==  vtd->buffers_size) {
+        if (sample_count == vtd->buffers_size) {
             sample_count = 0;
 
         // Or process and dump the full window using multiple instances
 #else
-        if (sample_count ==  vtd->window_size) {
+        if (sample_count == vtd->window_size) {
             sample_count = 0;
 
-            for (instance_number=0; instance_number<vtd->instances; instance_number++) 
+            for (instance_number = 0; instance_number < vtd->instances; instance_number++)
 #endif
             {
                 // Dump an instance
-                for (uint16_t k=0; k<VIBRATION_ELEMENTS_COUNT; k++) {   
-                    vibrationAnalysisOutputData.x[k] = vtd->accel_buffer_x[k + VIBRATION_ELEMENTS_COUNT*instance_number];
-                    vibrationAnalysisOutputData.y[k] = vtd->accel_buffer_y[k + VIBRATION_ELEMENTS_COUNT*instance_number];
-                    vibrationAnalysisOutputData.z[k] = vtd->accel_buffer_z[k + VIBRATION_ELEMENTS_COUNT*instance_number];
+                for (uint16_t k = 0; k < VIBRATION_ELEMENTS_COUNT; k++) {
+                    vibrationAnalysisOutputData.x[k] = vtd->accel_buffer_x[k + VIBRATION_ELEMENTS_COUNT * instance_number];
+                    vibrationAnalysisOutputData.y[k] = vtd->accel_buffer_y[k + VIBRATION_ELEMENTS_COUNT * instance_number];
+                    vibrationAnalysisOutputData.z[k] = vtd->accel_buffer_z[k + VIBRATION_ELEMENTS_COUNT * instance_number];
                 }
                 VibrationAnalysisOutputInstSet(instance_number, &vibrationAnalysisOutputData);
                 VibrationAnalysisOutputInstUpdated(instance_number);

--- a/flight/Modules/VibrationAnalysis/vibrationanalysis.c
+++ b/flight/Modules/VibrationAnalysis/vibrationanalysis.c
@@ -110,23 +110,23 @@ static void VibrationAnalysisCleanup(void) {
     }
     
     // Cleanup
-    if(vtd != NULL) {
+    if (vtd != NULL) {
         PIOS_free(vtd);
         vtd = NULL;        
     }
 
-    if(vtd->accel_buffer_x != NULL){
+    if (vtd->accel_buffer_x != NULL){
         PIOS_free(vtd->accel_buffer_x);
         vtd->accel_buffer_x = NULL;
     }
     
-    if(vtd->accel_buffer_y != NULL) {
+    if (vtd->accel_buffer_y != NULL) {
         PIOS_free(vtd->accel_buffer_y);
         vtd->accel_buffer_y = NULL;
 
     }
 
-    if(vtd->accel_buffer_z != NULL) {
+    if (vtd->accel_buffer_z != NULL) {
         PIOS_free(vtd->accel_buffer_z);
         vtd->accel_buffer_z = NULL;
     }
@@ -146,7 +146,7 @@ static int32_t VibrationAnalysisStart(void)
     uint16_t instances = 0;
 
     // Allocate and initialize the static data storage only if module is enabled the first time
-    if(vtd == NULL){
+    if (vtd == NULL){
         vtd = (struct VibrationAnalysis_data *) PIOS_malloc(sizeof(struct VibrationAnalysis_data));
         if (vtd == NULL) {
             module_enabled = false;
@@ -183,7 +183,7 @@ static int32_t VibrationAnalysisStart(void)
 
     // Is the new window size different?
     // Will happen upon initialization and when the window size changes
-    if(window_size != vtd->window_size) {
+    if (window_size != vtd->window_size) {
         instances = window_size / VIBRATION_ELEMENTS_COUNT;
 
         // Check number of existing instances
@@ -248,7 +248,7 @@ static int32_t VibrationAnalysisStart(void)
     }
     
     // Start main task
-    if( taskHandle == NULL){
+    if (taskHandle == NULL) {
         taskHandle = PIOS_Thread_Create(VibrationAnalysisTask, "VibrationAnalysis", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
         task = TaskMonitorAdd(TASKINFO_RUNNING_VIBRATIONANALYSIS, taskHandle);
     }
@@ -294,7 +294,6 @@ MODULE_INITCALL(VibrationAnalysisInitialize, VibrationAnalysisStart)
 
 static void VibrationAnalysisTask(void *parameters)
 {
-#define MAX_BLOCKSIZE   2048    
     uint32_t lastSysTime;
     uint32_t lastSettingsUpdateTime;
     uint8_t runAnalysisFlag = VIBRATIONANALYSISSETTINGS_TESTINGSTATUS_OFF; // By default, turn analysis off
@@ -315,11 +314,11 @@ static void VibrationAnalysisTask(void *parameters)
     vibrationAnalysisOutputData.samples = vtd->window_size;
 
     // Main module task, never exit from while loop
-    while(module_enabled)
+    while (module_enabled)
     {
 
         // Only check settings once every 100ms and not in the middle of a buffer accumulation
-        if(PIOS_Thread_Systime() - lastSettingsUpdateTime > SETTINGS_THROTTLING_MS && sample_count == 0) {
+        if (PIOS_Thread_Systime() - lastSettingsUpdateTime > SETTINGS_THROTTLING_MS && sample_count == 0) {
             //First check if the analysis is active
             VibrationAnalysisSettingsTestingStatusGet(&runAnalysisFlag);
             
@@ -361,7 +360,7 @@ static void VibrationAnalysisTask(void *parameters)
         }
         
         // If not enough time has passed, keep accumulating data
-        if(PIOS_Thread_Systime() - lastSysTime < sampleRate_ms) {
+        if (PIOS_Thread_Systime() - lastSysTime < sampleRate_ms) {
             continue;
         }
         
@@ -374,7 +373,7 @@ static void VibrationAnalysisTask(void *parameters)
         float accels_avg_z = vtd->accels_data_sum_z / vtd->accels_sum_count;
         
         //Calculate DC bias
-        float alpha=.005; //Hard-coded to drift very slowly
+        float alpha = .005; //Hard-coded to drift very slowly
         vtd->accels_static_bias_x = alpha*accels_avg_x + (1-alpha)*vtd->accels_static_bias_x;
         vtd->accels_static_bias_y = alpha*accels_avg_y + (1-alpha)*vtd->accels_static_bias_y;
         vtd->accels_static_bias_z = alpha*accels_avg_z + (1-alpha)*vtd->accels_static_bias_z;
@@ -399,10 +398,10 @@ static void VibrationAnalysisTask(void *parameters)
             //Reset sample count
             sample_count = 0;
             //Write output to UAVO
-            for (int j=0; j<vtd->instances; j++) {
+            for (uint16_t j=0; j<vtd->instances; j++) {
                 vibrationAnalysisOutputData.scale = FLOAT_TO_FIXED;
 
-                for (int k=0; k<VIBRATION_ELEMENTS_COUNT; k++) {                    
+                for (uint16_t k=0; k<VIBRATION_ELEMENTS_COUNT; k++) {                    
                     vibrationAnalysisOutputData.x[k] = vtd->accel_buffer_x[k + VIBRATION_ELEMENTS_COUNT*j];
                     vibrationAnalysisOutputData.y[k] = vtd->accel_buffer_y[k + VIBRATION_ELEMENTS_COUNT*j];
                     vibrationAnalysisOutputData.z[k] = vtd->accel_buffer_z[k + VIBRATION_ELEMENTS_COUNT*j];

--- a/flight/Modules/VibrationAnalysis/vibrationanalysis.c
+++ b/flight/Modules/VibrationAnalysis/vibrationanalysis.c
@@ -7,7 +7,7 @@
  *
  * @file       vibrationanalysis.c
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
- * @brief      Performs an FFT on the accels to estimation vibration
+ * @brief      Gathers data on the accels to estimate vibration
  *
  * @see        The GNU Public License (GPL) Version 3
  *
@@ -33,13 +33,12 @@
  * Output object: @ref VibrationAnalysisOutput
  *
  * This module executes on a timer trigger. When the module is
- * triggered it will update the data of VibrationAnalysiOutput, based on
- * the output of an FFT running on the accelerometer samples. 
+ * triggered it will update the data of VibrationAnalysiOutput,
+ * with the accumulated accelerometer samples. 
  */
 
 #include "openpilot.h"
 #include "physical_constants.h"
-#include "arm_math.h"
 #include "pios_thread.h"
 #include "pios_queue.h"
 
@@ -52,7 +51,7 @@
 // Private constants
 
 #define MAX_QUEUE_SIZE 2
-#define STACK_SIZE_BYTES (200 + 484 + (13*fft_window_size)*0) // The fft memory requirement grows linearly 
+#define STACK_SIZE_BYTES (200 + 484 + (6*window_size)*0) // The memory requirement grows linearly 
 																				  // with window size. The constant is multiplied
 																				  // by 0 in order to reflect the fact that the
 																				  // malloc'ed memory is not taken from the module 
@@ -63,17 +62,19 @@
 #define SETTINGS_THROTTLING_MS 100
 
 #define MAX_ACCEL_RANGE 16                          // Maximum accelerometer resolution in [g]
-#define FLOAT_TO_Q15 (32768/(MAX_ACCEL_RANGE*GRAVITY)) // This is the scaling constant that scales all input floats to +-
+#define FLOAT_TO_FIXED (32768/(MAX_ACCEL_RANGE*2)-1) // This is the scaling constant that scales input floats to +/-32736
+#define VIBRATION_ELEMENTS_COUNT 16  // Number of elements per object Instance
 
 // Private variables
 static struct pios_thread *taskHandle;
+static TaskInfoRunningElem task;
 static struct pios_queue *queue;
 static bool module_enabled = false;
 
 static struct VibrationAnalysis_data {
 	uint16_t accels_sum_count;
-	uint16_t fft_window_size;
-	uint8_t num_upscale_bits;
+	uint16_t window_size;
+	uint16_t instances;
 
 	float accels_data_sum_x;
 	float accels_data_sum_y;
@@ -83,16 +84,53 @@ static struct VibrationAnalysis_data {
 	float accels_static_bias_y; // (0,0,-g). In the case where they are not, this will still  
 	float accels_static_bias_z; // converge to the true bias in a few thousand measurements.	
 	
-	int16_t *accel_buffer_complex_x_q15;
-	int16_t *accel_buffer_complex_y_q15;
-	int16_t *accel_buffer_complex_z_q15;
-	
-	int16_t *fft_output;
+	int16_t *accel_buffer_x;
+	int16_t *accel_buffer_y;
+	int16_t *accel_buffer_z;
 } *vtd;
 
 
 // Private functions
 static void VibrationAnalysisTask(void *parameters);
+
+/*
+*   Releases any memory dinamically allocated
+*   Because this module can have a big footprint this will ensure we can
+*   reduce it when something fails.
+*/
+static void VibrationAnalysisCleanup(void) {
+    // Cleanup allocated memory
+    module_enabled = false;
+
+    // Stop main task
+    if (taskHandle != NULL) {
+        TaskMonitorRemove(task);
+        PIOS_Thread_Delete(taskHandle);
+        taskHandle = NULL;
+    }
+    
+    // Cleanup
+    if(vtd != NULL) {
+        PIOS_free(vtd);
+        vtd = NULL;        
+    }
+
+    if(vtd->accel_buffer_x != NULL){
+        PIOS_free(vtd->accel_buffer_x);
+        vtd->accel_buffer_x = NULL;
+    }
+    
+    if(vtd->accel_buffer_y != NULL) {
+        PIOS_free(vtd->accel_buffer_y);
+        vtd->accel_buffer_y = NULL;
+
+    }
+
+    if(vtd->accel_buffer_z != NULL) {
+        PIOS_free(vtd->accel_buffer_z);
+        vtd->accel_buffer_z = NULL;
+    }
+}
 
 /**
  * Start the module, called on startup
@@ -103,100 +141,119 @@ static int32_t VibrationAnalysisStart(void)
 	if (!module_enabled)
 		return -1;
 
-	//Get the FFT window size
-	uint16_t fft_window_size; // Make a local copy in order to check settings before allocating memory
-	uint8_t num_upscale_bits;
-	VibrationAnalysisSettingsFFTWindowSizeOptions fft_window_size_enum;
-	VibrationAnalysisSettingsFFTWindowSizeGet(&fft_window_size_enum);
-	switch (fft_window_size_enum) {
-		case VIBRATIONANALYSISSETTINGS_FFTWINDOWSIZE_16:
-			fft_window_size = 16;
-			num_upscale_bits = 4;
-			break;
-		case VIBRATIONANALYSISSETTINGS_FFTWINDOWSIZE_64:
-			fft_window_size = 64;
-			num_upscale_bits = 6;
-			break;
-		case VIBRATIONANALYSISSETTINGS_FFTWINDOWSIZE_256:
-			fft_window_size = 256;
-			num_upscale_bits = 8;
-			break;
-		case VIBRATIONANALYSISSETTINGS_FFTWINDOWSIZE_1024:
-			fft_window_size = 1024;
-			num_upscale_bits = 10;
-			break;
-		default:
-			//This represents a serious configuration error. Do not start module.
-			module_enabled = false;
-			return -1;
-			break;
-	}
-	
+    //Get the window size
+    uint16_t window_size; // Make a local copy in order to check settings before allocating memory
+    uint16_t instances = 0;
 
-	// Create instances for vibration analysis. Start from i=1 because the first instance is generated
-	// by VibrationAnalysisOutputInitialize(). Generate three times the length because there are three
-	// vectors. Generate half the length because the FFT output is symmetric about the mid-frequency, 
-	// so there's no point in using memory additional memory.
-	for (int i=1; i < (fft_window_size>>1); i++) {
-		uint16_t ret = VibrationAnalysisOutputCreateInstance();
-		if (ret == 0) {
-			// This fails when it's a metaobject. Not a very helpful test.
-			module_enabled = false;
-			return -1;
-		}
-	}
-	
-	if (VibrationAnalysisOutputGetNumInstances() != (fft_window_size>>1)){
-		// This is a more useful test for failure.
-		module_enabled = false;
-		return -1;
-	}
-	
-	
-	// Allocate and initialize the static data storage only if module is enabled
-	vtd = (struct VibrationAnalysis_data *) PIOS_malloc(sizeof(struct VibrationAnalysis_data));
-	if (vtd == NULL) {
-		module_enabled = false;
-		return -1;
-	}
-	
-	// make sure that all struct values are zeroed...
-	memset(vtd, 0, sizeof(struct VibrationAnalysis_data));
-	//... except for Z axis static bias
-	vtd->accels_static_bias_z=-GRAVITY; // [See note in definition of VibrationAnalysis_data structure]
+    // Allocate and initialize the static data storage only if module is enabled the first time
+    if(vtd == NULL){
+        vtd = (struct VibrationAnalysis_data *) PIOS_malloc(sizeof(struct VibrationAnalysis_data));
+        if (vtd == NULL) {
+            module_enabled = false;
+            return -1;
+        }
+        
+        // make sure that all struct values are zeroed...
+        memset(vtd, 0, sizeof(struct VibrationAnalysis_data));
+        //... except for Z axis static bias
+        vtd->accels_static_bias_z -= GRAVITY; // [See note in definition of VibrationAnalysis_data structure]
+    }
 
-	// Now place the fft window size and number of upscale bits variables into the buffer
-	vtd->fft_window_size = fft_window_size;
-	vtd->num_upscale_bits = num_upscale_bits;
-	
-	// Allocate ouput vector
-	vtd->fft_output = (int16_t *) PIOS_malloc(fft_window_size*2*sizeof(typeof(*(vtd->fft_output))));
-	if (vtd->fft_output == NULL) {
-		module_enabled = false; //Check if allocation succeeded
-		return -1;
-	}
-	
-	//Create the buffers. They are in Q15 format.
-	vtd->accel_buffer_complex_x_q15 = (int16_t *) PIOS_malloc(fft_window_size*2*sizeof(typeof(*vtd->accel_buffer_complex_x_q15)));
-	if (vtd->accel_buffer_complex_x_q15 == NULL) {
-		module_enabled = false; //Check if allocation succeeded
-		return -1;
-	}
-	vtd->accel_buffer_complex_y_q15 = (int16_t *) PIOS_malloc(fft_window_size*2*sizeof(typeof(*vtd->accel_buffer_complex_y_q15)));
-	if (vtd->accel_buffer_complex_y_q15 == NULL) {
-		module_enabled = false; //Check if allocation succeeded
-		return -1;
-	}
-	vtd->accel_buffer_complex_z_q15 = (int16_t *) PIOS_malloc(fft_window_size*2*sizeof(typeof(*vtd->accel_buffer_complex_z_q15)));
-	if (vtd->accel_buffer_complex_z_q15 == NULL) {
-		module_enabled = false; //Check if allocation succeeded
-		return -1;
-	}
-	
-	// Start main task
-	taskHandle = PIOS_Thread_Create(VibrationAnalysisTask, "VibrationAnalysis", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
-	TaskMonitorAdd(TASKINFO_RUNNING_VIBRATIONANALYSIS, taskHandle);
-	return 0;
+    VibrationAnalysisSettingsFFTWindowSizeOptions window_size_enum;
+    VibrationAnalysisSettingsFFTWindowSizeGet(&window_size_enum);
+    switch (window_size_enum) {
+        case VIBRATIONANALYSISSETTINGS_FFTWINDOWSIZE_16:
+            window_size = 16;
+            break;
+        case VIBRATIONANALYSISSETTINGS_FFTWINDOWSIZE_64:
+            window_size = 64;
+            break;
+        case VIBRATIONANALYSISSETTINGS_FFTWINDOWSIZE_256:
+            window_size = 256;
+            break;
+        case VIBRATIONANALYSISSETTINGS_FFTWINDOWSIZE_1024:
+            window_size = 1024;
+            break;
+        default:
+            //This represents a serious configuration error. Do not start module.
+            module_enabled = false;
+            return -1;
+            break;
+    }
+
+    // Is the new window size different?
+    // Will happen upon initialization and when the window size changes
+    if(window_size != vtd->window_size) {
+        instances = window_size / VIBRATION_ELEMENTS_COUNT;
+
+        // Check number of existing instances
+        uint16_t existing_instances = VibrationAnalysisOutputGetNumInstances();
+        if(existing_instances < instances) {
+            //Create missing instances
+            for (int i=existing_instances; i<instances; i++) {
+                uint16_t ret = VibrationAnalysisOutputCreateInstance();
+                if (ret == 0) {
+                    // This fails when it's a metaobject. Not a very helpful test.
+                    module_enabled = false;
+                    return -1;
+                }
+            }
+        }
+
+        // We need at least these instances
+        if (VibrationAnalysisOutputGetNumInstances() < instances) {
+            return -1;
+        }
+        
+        // Delete existing buffers
+        if (vtd->accel_buffer_x != NULL)
+            PIOS_free(vtd->accel_buffer_x);
+        if (vtd->accel_buffer_y != NULL)
+            PIOS_free(vtd->accel_buffer_y);
+        if (vtd->accel_buffer_z != NULL)
+            PIOS_free(vtd->accel_buffer_z);
+
+        // Clear buffers
+        memset(vtd, 0, sizeof(struct VibrationAnalysis_data));
+        vtd->accels_static_bias_z -= GRAVITY; // [See note in definition of VibrationAnalysis_data structure]
+
+        // Now place the window size into the buffer
+        vtd->window_size = window_size;
+        vtd->instances = instances;
+
+        //Create new buffers.  
+        vtd->accel_buffer_x = (int16_t *) PIOS_malloc(window_size*sizeof(typeof(*vtd->accel_buffer_x)));
+        if (vtd->accel_buffer_x == NULL) {
+            VibrationAnalysisCleanup();
+
+            module_enabled = false;
+            return -1;
+        }
+
+        vtd->accel_buffer_y = (int16_t *) PIOS_malloc(window_size*sizeof(typeof(*vtd->accel_buffer_y)));
+        if (vtd->accel_buffer_y == NULL) {
+            VibrationAnalysisCleanup();
+
+            module_enabled = false;
+            return -1;
+        }
+
+        vtd->accel_buffer_z = (int16_t *) PIOS_malloc(window_size*sizeof(typeof(*vtd->accel_buffer_z)));
+        if (vtd->accel_buffer_z == NULL) {
+            VibrationAnalysisCleanup();
+
+            module_enabled = false;
+            return -1;
+        }
+    }
+    
+    // Start main task
+    if( taskHandle == NULL){
+        taskHandle = PIOS_Thread_Create(VibrationAnalysisTask, "VibrationAnalysis", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
+        task = TaskMonitorAdd(TASKINFO_RUNNING_VIBRATIONANALYSIS, taskHandle);
+    }
+
+    return 0;
 }
 
 
@@ -237,189 +294,129 @@ MODULE_INITCALL(VibrationAnalysisInitialize, VibrationAnalysisStart)
 
 static void VibrationAnalysisTask(void *parameters)
 {
-#define MAX_BLOCKSIZE   2048
-	
-	uint32_t lastSysTime;
-	uint32_t lastSettingsUpdateTime;
-	uint8_t runAnalysisFlag = VIBRATIONANALYSISSETTINGS_TESTINGSTATUS_OFF; // By default, turn analysis off
-	uint16_t sampleRate_ms = 100; // Default sample rate of 100ms
-	uint8_t sample_count;
-	UAVObjEvent ev;
-	
-	// Listen for updates.
-	AccelsConnectQueue(queue);
-	
-	// Declare FFT structure and status variable
-	arm_cfft_radix4_instance_q15 cfft_instance;
-	arm_status status;
-	
-	// Initialize the CFFT/CIFFT module
-	status = ARM_MATH_SUCCESS;
-	bool ifftFlag = false;
-	bool doBitReverse = 1;
-	status = arm_cfft_radix4_init_q15(&cfft_instance, vtd->fft_window_size, ifftFlag, doBitReverse);
-	
-	
-/** These values are useful for insight into the Fourier transform performed by this module.
-	float freq_sample = 1.0f/sampleRate_ms;
-	float freq_nyquist = f_s/2.0f;
-	uint16_t num_samples = vtd->fft_window_size;
- */
+#define MAX_BLOCKSIZE   2048    
+    uint32_t lastSysTime;
+    uint32_t lastSettingsUpdateTime;
+    uint8_t runAnalysisFlag = VIBRATIONANALYSISSETTINGS_TESTINGSTATUS_OFF; // By default, turn analysis off
+    uint16_t sampleRate_ms = 100; // Default sample rate of 100ms
+    uint16_t sample_count;
+    
+    UAVObjEvent ev;
+    
+    // Listen for updates.
+    AccelsConnectQueue(queue);
 
-	// Main task loop
-	VibrationAnalysisOutputData vibrationAnalysisOutputData;
-	sample_count = 0;
-	lastSysTime = PIOS_Thread_Systime();
-	lastSettingsUpdateTime = PIOS_Thread_Systime() - SETTINGS_THROTTLING_MS;
+    // Main task loop
+    VibrationAnalysisOutputData vibrationAnalysisOutputData;
+    sample_count = 0;
+    lastSysTime = PIOS_Thread_Systime();
+    lastSettingsUpdateTime = PIOS_Thread_Systime() - SETTINGS_THROTTLING_MS;
+    
+    vibrationAnalysisOutputData.samples = vtd->window_size;
 
-	
-	// Main module task, never exit from while loop
-	while(1)
-	{
-		// Only check settings once every 100ms
-		if(PIOS_Thread_Systime() - lastSettingsUpdateTime > SETTINGS_THROTTLING_MS) {
-			//First check if the analysis is active
-			VibrationAnalysisSettingsTestingStatusGet(&runAnalysisFlag);
-			
-			// Get sample rate
-			VibrationAnalysisSettingsSampleRateGet(&sampleRate_ms);
-			sampleRate_ms = sampleRate_ms > 0 ? sampleRate_ms : 1; //Ensure sampleRate never is 0.
-			
-			lastSettingsUpdateTime = PIOS_Thread_Systime();
-		}
-		
-		// If analysis is turned off, delay and then loop.
-		if (runAnalysisFlag == VIBRATIONANALYSISSETTINGS_TESTINGSTATUS_OFF) {
-			PIOS_Thread_Sleep(200);
-			continue;
-		}
-		
-		// Wait until the Accels object is updated, and never time out
-		if (PIOS_Queue_Receive(queue, &ev, PIOS_QUEUE_TIMEOUT_MAX) == true)
-		{
-			/**
-			 * Accumulate accelerometer data. This would be a great place to add a 
-			 * high-pass filter, in order to eliminate the DC bias from gravity.
-			 * Until then, a DC bias subtraction has been added in the main loop.
-			 */
-			
-			AccelsData accels_data;
-			AccelsGet(&accels_data);
-			
-			vtd->accels_data_sum_x += accels_data.x;
-			vtd->accels_data_sum_y += accels_data.y;
-			vtd->accels_data_sum_z += accels_data.z;
-			
-			vtd->accels_sum_count++;
-		}
-		
-		// If not enough time has passed, keep accumulating data
-		if(PIOS_Thread_Systime() - lastSysTime < sampleRate_ms) {
-			continue;
-		}
-		
-		lastSysTime += sampleRate_ms;
-		
-		
-		//Calculate averaged values
-		float accels_avg_x = vtd->accels_data_sum_x / vtd->accels_sum_count;
-		float accels_avg_y = vtd->accels_data_sum_y / vtd->accels_sum_count;
-		float accels_avg_z = vtd->accels_data_sum_z / vtd->accels_sum_count;
-		
-		//Calculate DC bias
-		float alpha=.005; //Hard-coded to drift very slowly
-		vtd->accels_static_bias_x = alpha*accels_avg_x + (1-alpha)*vtd->accels_static_bias_x;
-		vtd->accels_static_bias_y = alpha*accels_avg_y + (1-alpha)*vtd->accels_static_bias_y;
-		vtd->accels_static_bias_z = alpha*accels_avg_z + (1-alpha)*vtd->accels_static_bias_z;
-		
-		// Add averaged values to the buffer, and remove DC bias. Only add real component, the
-		// complex component was already set to zero by a memset operation
-		vtd->accel_buffer_complex_x_q15[sample_count*2] = (accels_avg_x - vtd->accels_static_bias_x)*FLOAT_TO_Q15 + 0.5f; // Extra +0.5 rounds value when casting to int
-		vtd->accel_buffer_complex_y_q15[sample_count*2] = (accels_avg_y - vtd->accels_static_bias_y)*FLOAT_TO_Q15 + 0.5f; // Extra +0.5 rounds value when casting to int
-		vtd->accel_buffer_complex_z_q15[sample_count*2] = (accels_avg_z - vtd->accels_static_bias_z)*FLOAT_TO_Q15 + 0.5f; // Extra +0.5 rounds value when casting to int
-		
-		//Reset the accumulators
-		vtd->accels_data_sum_x = 0;
-		vtd->accels_data_sum_y = 0;
-		vtd->accels_data_sum_z = 0;
-		vtd->accels_sum_count = 0;
+    // Main module task, never exit from while loop
+    while(module_enabled)
+    {
 
-		// Advance sample and reset when at buffer end
-		sample_count++;
-		
-		// Only process once the buffers are filled. This could be done continuously, 
-		// but this way is probably easier on the processor
-		if (sample_count >= vtd->fft_window_size) {
-			//Reset sample count
-			sample_count = 0;
-			
-			// Perform the DFT on each of the three axes
-			for (int i=0; i < 3; i++) {
-				if (status == ARM_MATH_SUCCESS) {
-					
-					//Create pointer and assign buffer vectors to it
-					int16_t *ptr_cmplx_vec;
-					
-					switch (i) {
-						case 0:
-							ptr_cmplx_vec = vtd->accel_buffer_complex_x_q15;
-							break;
-						case 1:
-							ptr_cmplx_vec = vtd->accel_buffer_complex_y_q15;
-							break;
-						case 2:
-							ptr_cmplx_vec = vtd->accel_buffer_complex_z_q15;
-							break;
-						default:
-							//Whoops, this is a major error, leave before we overwrite memory
-							continue;
-					}
-					
-					// Process the data through the CFFT/CIFFT module. This is an in-place
-					// operation, so the FFT output is saved onto the accelerometer input buffer. 
-					// Moving forward from this point, ptr_cmplx_vec contains the DFT of the
-					// acceleration signal. 
-					// While the input is Q15, the output is not (see next comment)
-					arm_cfft_radix4_q15(&cfft_instance, ptr_cmplx_vec);
-					
-					// Upscale ptr_cmplx_vec back into Q15 format. The number of bits necessary is defined in 
-					// ARM's arm_cfft_radix4_q15 documentation, figure CFFTQ15.gif
-					arm_shift_q15(ptr_cmplx_vec, vtd->num_upscale_bits, ptr_cmplx_vec, vtd->fft_window_size);
-					
-					// Process the data through the Complex Magnitude Module. This calculates
-					// the magnitude of each complex number, so that the output is a scalar
-					// magnitude without complex phase. Only the first half of the values are
-					// calculated because in a Fourier transform the second half is symmetric.
-					arm_cmplx_mag_q15(ptr_cmplx_vec, vtd->fft_output, vtd->fft_window_size>>1);
-					
-					// Upscale fft_output back into Q15 format
-					arm_shift_q15(vtd->fft_output, 1, vtd->fft_output, vtd->fft_window_size>>1);
-					
-					// Save RAM by copying back onto original input vector.
-					memcpy(ptr_cmplx_vec, vtd->fft_output, (vtd->fft_window_size>>1) * sizeof(typeof(*vtd->accel_buffer_complex_x_q15)));
-				}
-			}
-			
-			//Write output to UAVO
-			for (int j=0; j < (vtd->fft_window_size>>1); j++) 
-			{
-				//Assertion check that we are not trying to write to instances that don't exist
-				if (j >= VibrationAnalysisOutputGetNumInstances())
-					continue;
-				
-				vibrationAnalysisOutputData.x = vtd->accel_buffer_complex_x_q15[j]/FLOAT_TO_Q15;
-				vibrationAnalysisOutputData.y = vtd->accel_buffer_complex_y_q15[j]/FLOAT_TO_Q15;
-				vibrationAnalysisOutputData.z = vtd->accel_buffer_complex_z_q15[j]/FLOAT_TO_Q15;
-				VibrationAnalysisOutputInstSet(j, &vibrationAnalysisOutputData);
-			}
-			
-			
-			// Erase buffer, which has the effect of setting the complex part to 0.
-			memset(vtd->accel_buffer_complex_x_q15, 0, vtd->fft_window_size*2*sizeof(typeof(*(vtd->accel_buffer_complex_x_q15))));
-			memset(vtd->accel_buffer_complex_y_q15, 0, vtd->fft_window_size*2*sizeof(typeof(*(vtd->accel_buffer_complex_y_q15))));
-			memset(vtd->accel_buffer_complex_z_q15, 0, vtd->fft_window_size*2*sizeof(typeof(*(vtd->accel_buffer_complex_z_q15))));
-		}
-	}
+        // Only check settings once every 100ms and not in the middle of a buffer accumulation
+        if(PIOS_Thread_Systime() - lastSettingsUpdateTime > SETTINGS_THROTTLING_MS && sample_count == 0) {
+            //First check if the analysis is active
+            VibrationAnalysisSettingsTestingStatusGet(&runAnalysisFlag);
+            
+            // If analysis is turned off, delay and then loop.
+            if (runAnalysisFlag == VIBRATIONANALYSISSETTINGS_TESTINGSTATUS_OFF) {
+                PIOS_Thread_Sleep(200);
+                continue;
+            }
+            // Get sample rate
+            VibrationAnalysisSettingsSampleRateGet(&sampleRate_ms);
+            sampleRate_ms = sampleRate_ms > 0 ? sampleRate_ms : 1; //Ensure sampleRate never is 0.
+            
+            //Reconfigure any parameter
+            VibrationAnalysisStart();
+            
+            vibrationAnalysisOutputData.samples = vtd->window_size;
+
+            lastSettingsUpdateTime = PIOS_Thread_Systime();
+        }
+        
+
+        // Wait until the Accels object is updated, and never time out
+        if (PIOS_Queue_Receive(queue, &ev, PIOS_QUEUE_TIMEOUT_MAX) == true)
+        {
+            /**
+             * Accumulate accelerometer data. This would be a great place to add a 
+             * high-pass filter, in order to eliminate the DC bias from gravity.
+             * Until then, a DC bias subtraction has been added in the main loop.
+             */
+            
+            AccelsData accels_data;
+            AccelsGet(&accels_data);
+            
+            vtd->accels_data_sum_x += accels_data.x;
+            vtd->accels_data_sum_y += accels_data.y;
+            vtd->accels_data_sum_z += accels_data.z;
+            
+            vtd->accels_sum_count++;
+        }
+        
+        // If not enough time has passed, keep accumulating data
+        if(PIOS_Thread_Systime() - lastSysTime < sampleRate_ms) {
+            continue;
+        }
+        
+        
+        lastSysTime = PIOS_Thread_Systime();
+        
+        //Calculate averaged values
+        float accels_avg_x = vtd->accels_data_sum_x / vtd->accels_sum_count;
+        float accels_avg_y = vtd->accels_data_sum_y / vtd->accels_sum_count;
+        float accels_avg_z = vtd->accels_data_sum_z / vtd->accels_sum_count;
+        
+        //Calculate DC bias
+        float alpha=.005; //Hard-coded to drift very slowly
+        vtd->accels_static_bias_x = alpha*accels_avg_x + (1-alpha)*vtd->accels_static_bias_x;
+        vtd->accels_static_bias_y = alpha*accels_avg_y + (1-alpha)*vtd->accels_static_bias_y;
+        vtd->accels_static_bias_z = alpha*accels_avg_z + (1-alpha)*vtd->accels_static_bias_z;
+        
+        // Add averaged values to the buffer, and remove DC bias.
+        vtd->accel_buffer_x[sample_count] = (accels_avg_x - vtd->accels_static_bias_x)*FLOAT_TO_FIXED;
+        vtd->accel_buffer_y[sample_count] = (accels_avg_y - vtd->accels_static_bias_y)*FLOAT_TO_FIXED;
+        vtd->accel_buffer_z[sample_count] = (accels_avg_z - vtd->accels_static_bias_z)*FLOAT_TO_FIXED;
+        
+        //Reset the accumulators
+        vtd->accels_data_sum_x = 0;
+        vtd->accels_data_sum_y = 0;
+        vtd->accels_data_sum_z = 0;
+        vtd->accels_sum_count = 0;
+
+        // Advance sample and reset when at buffer end
+        sample_count++;
+
+        // Only process once the buffers are filled. This could be done continuously, 
+        // but this way is probably easier on the processor
+        if (sample_count >= vtd->window_size) {
+            //Reset sample count
+            sample_count = 0;
+            //Write output to UAVO
+            for (int j=0; j<vtd->instances; j++) {
+                vibrationAnalysisOutputData.scale = FLOAT_TO_FIXED;
+
+                for (int k=0; k<VIBRATION_ELEMENTS_COUNT; k++) {                    
+                    vibrationAnalysisOutputData.x[k] = vtd->accel_buffer_x[k + VIBRATION_ELEMENTS_COUNT*j];
+                    vibrationAnalysisOutputData.y[k] = vtd->accel_buffer_y[k + VIBRATION_ELEMENTS_COUNT*j];
+                    vibrationAnalysisOutputData.z[k] = vtd->accel_buffer_z[k + VIBRATION_ELEMENTS_COUNT*j];
+                }
+                VibrationAnalysisOutputInstSet(j, &vibrationAnalysisOutputData);
+            }
+
+
+            // Erase buffer, which has the effect of setting the complex part to 0.
+            memset(vtd->accel_buffer_x, 0, vtd->window_size*sizeof(typeof(*(vtd->accel_buffer_x))));
+            memset(vtd->accel_buffer_y, 0, vtd->window_size*sizeof(typeof(*(vtd->accel_buffer_y))));
+            memset(vtd->accel_buffer_z, 0, vtd->window_size*sizeof(typeof(*(vtd->accel_buffer_z))));
+        }
+    }
 }
 
 /**

--- a/flight/Modules/VibrationAnalysis/vibrationanalysis.c
+++ b/flight/Modules/VibrationAnalysis/vibrationanalysis.c
@@ -51,7 +51,15 @@
 // Private constants
 
 #define MAX_QUEUE_SIZE 2
-#define STACK_SIZE_BYTES (200 + 484 + (6*window_size)*0) // The memory requirement grows linearly 
+
+/*
+    Stack usage reported by gcc:
+    VibrationAnalysisCleanup     16
+    VibrationAnalysisInitialize  24
+    VibrationAnalysisStart       48
+    VibrationAnalysisTask        192
+*/
+#define STACK_SIZE_BYTES (192 + 48 + 16 + (2*3*window_size)*0) // The memory requirement grows linearly 
 																				  // with window size. The constant is multiplied
 																				  // by 0 in order to reflect the fact that the
 																				  // malloc'ed memory is not taken from the module 
@@ -341,8 +349,7 @@ static void VibrationAnalysisTask(void *parameters)
         
 
         // Wait until the Accels object is updated, and never time out
-        if (PIOS_Queue_Receive(queue, &ev, PIOS_QUEUE_TIMEOUT_MAX) == true)
-        {
+        if (PIOS_Queue_Receive(queue, &ev, PIOS_QUEUE_TIMEOUT_MAX) == true) {
             /**
              * Accumulate accelerometer data. This would be a great place to add a 
              * high-pass filter, in order to eliminate the DC bias from gravity.

--- a/ground/gcs/src/plugins/scope/scopegadgetoptionspage.cpp
+++ b/ground/gcs/src/plugins/scope/scopegadgetoptionspage.cpp
@@ -122,7 +122,7 @@ QWidget* ScopeGadgetOptionsPage::createPage(QWidget *parent)
     }
 
     QStringList mathFunctions;
-    mathFunctions << "None" << "Boxcar average" << "Standard deviation";
+    mathFunctions << "None" << "Boxcar average" << "Standard deviation" << "FFT";
 
     options_page->mathFunctionComboBox->addItems(mathFunctions);
     options_page->cmbMathFunctionSpectrogram->addItems(mathFunctions);
@@ -283,6 +283,21 @@ void ScopeGadgetOptionsPage::on_cmbSpectrogramSource_currentIndexChanged(QString
         options_page->sbSpectrogramFrequency->setEnabled(false);
         options_page->sbSpectrogramWidth->setEnabled(false);
 
+        options_page->cmbUavoFieldSpectrogram->clear();
+
+        UAVObject* inst = objManager->getObject(vibrationAnalysisOutput->getObjID());
+
+        QList<UAVObjectField*> fieldList = inst->getFields();
+
+        foreach (UAVObjectField* field, fieldList) {
+            if(field->getType() == UAVObjectField::STRING || field->getType() == UAVObjectField::ENUM)
+              continue;
+            
+            if(field->getElementNames().count() > 1) {
+                options_page->cmbUavoFieldSpectrogram->addItem(field->getName());
+            }
+        }
+    
     }
     else{
         options_page->cmbUAVObjectsSpectrogram->setEnabled(true);

--- a/ground/gcs/src/plugins/scope/scopes3d/ffft/DynArray.h
+++ b/ground/gcs/src/plugins/scope/scopes3d/ffft/DynArray.h
@@ -1,0 +1,101 @@
+/*****************************************************************************
+
+        DynArray.h
+        By Laurent de Soras
+
+--- Legal stuff ---
+
+This program is free software. It comes without any warranty, to
+the extent permitted by applicable law. You can redistribute it
+and/or modify it under the terms of the Do What The Fuck You Want
+To Public License, Version 2, as published by Sam Hocevar. See
+http://sam.zoy.org/wtfpl/COPYING for more details.
+
+*Tab=3***********************************************************************/
+
+
+
+#if ! defined (ffft_DynArray_HEADER_INCLUDED)
+#define	ffft_DynArray_HEADER_INCLUDED
+
+#if defined (_MSC_VER)
+	#pragma once
+	#pragma warning (4 : 4250) // "Inherits via dominance."
+#endif
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+
+
+namespace ffft
+{
+
+
+
+template <class T>
+class DynArray
+{
+
+/*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+public:
+
+	typedef	T	DataType;
+
+						DynArray ();
+	explicit			DynArray (long size);
+						~DynArray ();
+
+	inline long		size () const;
+	inline void		resize (long size);
+
+	inline const DataType &
+						operator [] (long pos) const;
+	inline DataType &
+						operator [] (long pos);
+
+
+
+/*\\\ PROTECTED \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+protected:
+
+
+
+/*\\\ PRIVATE \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+private:
+
+	DataType *		_data_ptr;
+	long				_len;
+
+
+
+/*\\\ FORBIDDEN MEMBER FUNCTIONS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+private:
+
+						DynArray (const DynArray &other);
+	DynArray &		operator = (const DynArray &other);
+	bool				operator == (const DynArray &other);
+	bool				operator != (const DynArray &other);
+
+};	// class DynArray
+
+
+
+}	// namespace ffft
+
+
+
+#include	"DynArray.hpp"
+
+
+
+#endif	// ffft_DynArray_HEADER_INCLUDED
+
+
+
+/*\\\ EOF \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/ground/gcs/src/plugins/scope/scopes3d/ffft/DynArray.hpp
+++ b/ground/gcs/src/plugins/scope/scopes3d/ffft/DynArray.hpp
@@ -1,0 +1,144 @@
+/*****************************************************************************
+
+        DynArray.hpp
+        By Laurent de Soras
+
+--- Legal stuff ---
+
+This program is free software. It comes without any warranty, to
+the extent permitted by applicable law. You can redistribute it
+and/or modify it under the terms of the Do What The Fuck You Want
+To Public License, Version 2, as published by Sam Hocevar. See
+http://sam.zoy.org/wtfpl/COPYING for more details.
+
+*Tab=3***********************************************************************/
+
+
+
+#if defined (ffft_DynArray_CURRENT_CODEHEADER)
+	#error Recursive inclusion of DynArray code header.
+#endif
+#define	ffft_DynArray_CURRENT_CODEHEADER
+
+#if ! defined (ffft_DynArray_CODEHEADER_INCLUDED)
+#define	ffft_DynArray_CODEHEADER_INCLUDED
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#include	<cassert>
+
+
+
+namespace ffft
+{
+
+
+
+/*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+
+
+template <class T>
+DynArray <T>::DynArray ()
+:	_data_ptr (0)
+,	_len (0)
+{
+	// Nothing
+}
+
+
+
+template <class T>
+DynArray <T>::DynArray (long size)
+:	_data_ptr (0)
+,	_len (0)
+{
+	assert (size >= 0);
+	if (size > 0)
+	{
+		_data_ptr = new DataType [size];
+		_len = size;
+	}
+}
+
+
+
+template <class T>
+DynArray <T>::~DynArray ()
+{
+	delete [] _data_ptr;
+	_data_ptr = 0;
+	_len = 0;
+}
+
+
+
+template <class T>
+long	DynArray <T>::size () const
+{
+	return (_len);
+}
+
+
+
+template <class T>
+void	DynArray <T>::resize (long size)
+{
+	assert (size >= 0);
+	if (size > 0)
+	{
+		DataType *		old_data_ptr = _data_ptr;
+		DataType *		tmp_data_ptr = new DataType [size];
+
+		_data_ptr = tmp_data_ptr;
+		_len = size;
+
+		delete [] old_data_ptr;
+	}
+}
+
+
+
+template <class T>
+const typename DynArray <T>::DataType &	DynArray <T>::operator [] (long pos) const
+{
+	assert (pos >= 0);
+	assert (pos < _len);
+
+	return (_data_ptr [pos]);
+}
+
+
+
+template <class T>
+typename DynArray <T>::DataType &	DynArray <T>::operator [] (long pos)
+{
+	assert (pos >= 0);
+	assert (pos < _len);
+
+	return (_data_ptr [pos]);
+}
+
+
+
+/*\\\ PROTECTED \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+
+
+/*\\\ PRIVATE \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+
+
+}	// namespace ffft
+
+
+
+#endif	// ffft_DynArray_CODEHEADER_INCLUDED
+
+#undef ffft_DynArray_CURRENT_CODEHEADER
+
+
+
+/*\\\ EOF \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/ground/gcs/src/plugins/scope/scopes3d/ffft/FFTReal.h
+++ b/ground/gcs/src/plugins/scope/scopes3d/ffft/FFTReal.h
@@ -1,0 +1,143 @@
+/*****************************************************************************
+
+        FFTReal.h
+        By Laurent de Soras
+
+--- Legal stuff ---
+
+This program is free software. It comes without any warranty, to
+the extent permitted by applicable law. You can redistribute it
+and/or modify it under the terms of the Do What The Fuck You Want
+To Public License, Version 2, as published by Sam Hocevar. See
+http://sam.zoy.org/wtfpl/COPYING for more details.
+
+*Tab=3***********************************************************************/
+
+
+
+#if ! defined (ffft_FFTReal_HEADER_INCLUDED)
+#define	ffft_FFTReal_HEADER_INCLUDED
+
+#if defined (_MSC_VER)
+	#pragma once
+	#pragma warning (4 : 4250) // "Inherits via dominance."
+#endif
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#include	"def.h"
+#include	"DynArray.h"
+#include	"OscSinCos.h"
+
+
+
+namespace ffft
+{
+
+
+
+template <class DT>
+class FFTReal
+{
+
+/*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+public:
+
+	enum {			MAX_BIT_DEPTH	= 30	};	// So length can be represented as long int
+
+	typedef	DT	DataType;
+
+	explicit			FFTReal (long length);
+	virtual			~FFTReal () {}
+
+	long				get_length () const;
+	void				do_fft (DataType f [], const DataType x []) const;
+	void				do_ifft (const DataType f [], DataType x []) const;
+	void				rescale (DataType x []) const;
+	DataType *		use_buffer () const;
+
+
+
+/*\\\ PROTECTED \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+protected:
+
+
+
+/*\\\ PRIVATE \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+private:
+
+   // Over this bit depth, we use direct calculation for sin/cos
+   enum {	      TRIGO_BD_LIMIT	= 12  };
+
+	typedef	OscSinCos <DataType>	OscType;
+
+	void				init_br_lut ();
+	void				init_trigo_lut ();
+	void				init_trigo_osc ();
+
+	ffft_FORCEINLINE const long *
+						get_br_ptr () const;
+	ffft_FORCEINLINE const DataType	*
+						get_trigo_ptr (int level) const;
+	ffft_FORCEINLINE long
+						get_trigo_level_index (int level) const;
+
+	inline void		compute_fft_general (DataType f [], const DataType x []) const;
+	inline void		compute_direct_pass_1_2 (DataType df [], const DataType x []) const;
+	inline void		compute_direct_pass_3 (DataType df [], const DataType sf []) const;
+	inline void		compute_direct_pass_n (DataType df [], const DataType sf [], int pass) const;
+	inline void		compute_direct_pass_n_lut (DataType df [], const DataType sf [], int pass) const;
+	inline void		compute_direct_pass_n_osc (DataType df [], const DataType sf [], int pass) const;
+
+	inline void		compute_ifft_general (const DataType f [], DataType x []) const;
+	inline void		compute_inverse_pass_n (DataType df [], const DataType sf [], int pass) const;
+	inline void		compute_inverse_pass_n_osc (DataType df [], const DataType sf [], int pass) const;
+	inline void		compute_inverse_pass_n_lut (DataType df [], const DataType sf [], int pass) const;
+	inline void		compute_inverse_pass_3 (DataType df [], const DataType sf []) const;
+	inline void		compute_inverse_pass_1_2 (DataType x [], const DataType sf []) const;
+
+	const long		_length;
+	const int		_nbr_bits;
+	DynArray <long>
+						_br_lut;
+	DynArray <DataType>
+						_trigo_lut;
+	mutable DynArray <DataType>
+						_buffer;
+   mutable DynArray <OscType>
+						_trigo_osc;
+
+
+
+/*\\\ FORBIDDEN MEMBER FUNCTIONS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+private:
+
+						FFTReal ();
+						FFTReal (const FFTReal &other);
+	FFTReal &		operator = (const FFTReal &other);
+	bool				operator == (const FFTReal &other);
+	bool				operator != (const FFTReal &other);
+
+};	// class FFTReal
+
+
+
+}	// namespace ffft
+
+
+
+#include	"FFTReal.hpp"
+
+
+
+#endif	// ffft_FFTReal_HEADER_INCLUDED
+
+
+
+/*\\\ EOF \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/ground/gcs/src/plugins/scope/scopes3d/ffft/FFTReal.hpp
+++ b/ground/gcs/src/plugins/scope/scopes3d/ffft/FFTReal.hpp
@@ -1,0 +1,917 @@
+/*****************************************************************************
+
+        FFTReal.hpp
+        By Laurent de Soras
+
+--- Legal stuff ---
+
+This program is free software. It comes without any warranty, to
+the extent permitted by applicable law. You can redistribute it
+and/or modify it under the terms of the Do What The Fuck You Want
+To Public License, Version 2, as published by Sam Hocevar. See
+http://sam.zoy.org/wtfpl/COPYING for more details.
+
+*Tab=3***********************************************************************/
+
+
+
+#if defined (ffft_FFTReal_CURRENT_CODEHEADER)
+	#error Recursive inclusion of FFTReal code header.
+#endif
+#define	ffft_FFTReal_CURRENT_CODEHEADER
+
+#if ! defined (ffft_FFTReal_CODEHEADER_INCLUDED)
+#define	ffft_FFTReal_CODEHEADER_INCLUDED
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#include	<cassert>
+#include	<cmath>
+
+
+
+namespace ffft
+{
+
+
+
+static inline bool	FFTReal_is_pow2 (long x)
+{
+	assert (x > 0);
+
+	return  ((x & -x) == x);
+}
+
+
+
+static inline int	FFTReal_get_next_pow2 (long x)
+{
+	--x;
+
+	int				p = 0;
+	while ((x & ~0xFFFFL) != 0)
+	{
+		p += 16;
+		x >>= 16;
+	}
+	while ((x & ~0xFL) != 0)
+	{
+		p += 4;
+		x >>= 4;
+	}
+	while (x > 0)
+	{
+		++p;
+		x >>= 1;
+	}
+
+	return (p);
+}
+
+
+
+/*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+
+
+/*
+==============================================================================
+Name: ctor
+Input parameters:
+	- length: length of the array on which we want to do a FFT. Range: power of
+		2 only, > 0.
+Throws: std::bad_alloc
+==============================================================================
+*/
+
+template <class DT>
+FFTReal <DT>::FFTReal (long length)
+:	_length (length)
+,	_nbr_bits (FFTReal_get_next_pow2 (length))
+,	_br_lut ()
+,	_trigo_lut ()
+,	_buffer (length)
+,	_trigo_osc ()
+{
+	assert (FFTReal_is_pow2 (length));
+	assert (_nbr_bits <= MAX_BIT_DEPTH);
+
+	init_br_lut ();
+	init_trigo_lut ();
+	init_trigo_osc ();
+}
+
+
+
+/*
+==============================================================================
+Name: get_length
+Description:
+	Returns the number of points processed by this FFT object.
+Returns: The number of points, power of 2, > 0.
+Throws: Nothing
+==============================================================================
+*/
+
+template <class DT>
+long	FFTReal <DT>::get_length () const
+{
+	return (_length);
+}
+
+
+
+/*
+==============================================================================
+Name: do_fft
+Description:
+	Compute the FFT of the array.
+Input parameters:
+	- x: pointer on the source array (time).
+Output parameters:
+	- f: pointer on the destination array (frequencies).
+		f [0...length(x)/2] = real values,
+		f [length(x)/2+1...length(x)-1] = negative imaginary values of
+		coefficents 1...length(x)/2-1.
+Throws: Nothing
+==============================================================================
+*/
+
+template <class DT>
+void	FFTReal <DT>::do_fft (DataType f [], const DataType x []) const
+{
+	assert (f != 0);
+	assert (f != use_buffer ());
+	assert (x != 0);
+	assert (x != use_buffer ());
+	assert (x != f);
+
+	// General case
+	if (_nbr_bits > 2)
+	{
+		compute_fft_general (f, x);
+	}
+
+	// 4-point FFT
+	else if (_nbr_bits == 2)
+	{
+		f [1] = x [0] - x [2];
+		f [3] = x [1] - x [3];
+
+		const DataType	b_0 = x [0] + x [2];
+		const DataType	b_2 = x [1] + x [3];
+		
+		f [0] = b_0 + b_2;
+		f [2] = b_0 - b_2;
+	}
+
+	// 2-point FFT
+	else if (_nbr_bits == 1)
+	{
+		f [0] = x [0] + x [1];
+		f [1] = x [0] - x [1];
+	}
+
+	// 1-point FFT
+	else
+	{
+		f [0] = x [0];
+	}
+}
+
+
+
+/*
+==============================================================================
+Name: do_ifft
+Description:
+	Compute the inverse FFT of the array. Note that data must be post-scaled:
+	IFFT (FFT (x)) = x * length (x).
+Input parameters:
+	- f: pointer on the source array (frequencies).
+		f [0...length(x)/2] = real values
+		f [length(x)/2+1...length(x)-1] = negative imaginary values of
+		coefficents 1...length(x)/2-1.
+Output parameters:
+	- x: pointer on the destination array (time).
+Throws: Nothing
+==============================================================================
+*/
+
+template <class DT>
+void	FFTReal <DT>::do_ifft (const DataType f [], DataType x []) const
+{
+	assert (f != 0);
+	assert (f != use_buffer ());
+	assert (x != 0);
+	assert (x != use_buffer ());
+	assert (x != f);
+
+	// General case
+	if (_nbr_bits > 2)
+	{
+		compute_ifft_general (f, x);
+	}
+
+	// 4-point IFFT
+	else if (_nbr_bits == 2)
+	{
+		const DataType	b_0 = f [0] + f [2];
+		const DataType	b_2 = f [0] - f [2];
+
+		x [0] = b_0 + f [1] * 2;
+		x [2] = b_0 - f [1] * 2;
+		x [1] = b_2 + f [3] * 2;
+		x [3] = b_2 - f [3] * 2;
+	}
+
+	// 2-point IFFT
+	else if (_nbr_bits == 1)
+	{
+		x [0] = f [0] + f [1];
+		x [1] = f [0] - f [1];
+	}
+
+	// 1-point IFFT
+	else
+	{
+		x [0] = f [0];
+	}
+}
+
+
+
+/*
+==============================================================================
+Name: rescale
+Description:
+	Scale an array by divide each element by its length. This function should
+	be called after FFT + IFFT.
+Input parameters:
+	- x: pointer on array to rescale (time or frequency).
+Throws: Nothing
+==============================================================================
+*/
+
+template <class DT>
+void	FFTReal <DT>::rescale (DataType x []) const
+{
+	const DataType	mul = DataType (1.0 / _length);
+
+	if (_length < 4)
+	{
+		long				i = _length - 1;
+		do
+		{
+			x [i] *= mul;
+			--i;
+		}
+		while (i >= 0);
+	}
+
+	else
+	{
+		assert ((_length & 3) == 0);
+
+		// Could be optimized with SIMD instruction sets (needs alignment check)
+		long				i = _length - 4;
+		do
+		{
+			x [i + 0] *= mul;
+			x [i + 1] *= mul;
+			x [i + 2] *= mul;
+			x [i + 3] *= mul;
+			i -= 4;
+		}
+		while (i >= 0);
+	}
+}
+
+
+
+/*
+==============================================================================
+Name: use_buffer
+Description:
+	Access the internal buffer, whose length is the FFT one.
+	Buffer content will be erased at each do_fft() / do_ifft() call!
+	This buffer cannot be used as:
+		- source for FFT or IFFT done with this object
+		- destination for FFT or IFFT done with this object
+Returns:
+	Buffer start address
+Throws: Nothing
+==============================================================================
+*/
+
+template <class DT>
+typename FFTReal <DT>::DataType *	FFTReal <DT>::use_buffer () const
+{
+	return (&_buffer [0]);
+}
+
+
+
+/*\\\ PROTECTED \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+
+
+/*\\\ PRIVATE \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+
+
+template <class DT>
+void	FFTReal <DT>::init_br_lut ()
+{
+	const long		length = 1L << _nbr_bits;
+	_br_lut.resize (length);
+
+	_br_lut [0] = 0;
+	long				br_index = 0;
+	for (long cnt = 1; cnt < length; ++cnt)
+	{
+		// ++br_index (bit reversed)
+		long				bit = length >> 1;
+		while (((br_index ^= bit) & bit) == 0)
+		{
+			bit >>= 1;
+		}
+
+		_br_lut [cnt] = br_index;
+	}
+}
+
+
+
+template <class DT>
+void	FFTReal <DT>::init_trigo_lut ()
+{
+	using namespace std;
+
+	if (_nbr_bits > 3)
+	{
+		const long		total_len = (1L << (_nbr_bits - 1)) - 4;
+		_trigo_lut.resize (total_len);
+
+		for (int level = 3; level < _nbr_bits; ++level)
+		{
+			const long		level_len = 1L << (level - 1);
+			DataType	* const	level_ptr =
+				&_trigo_lut [get_trigo_level_index (level)];
+			const double	mul = PI / (level_len << 1);
+
+			for (long i = 0; i < level_len; ++ i)
+			{
+				level_ptr [i] = static_cast <DataType> (cos (i * mul));
+			}
+		}
+	}
+}
+
+
+
+template <class DT>
+void	FFTReal <DT>::init_trigo_osc ()
+{
+	const int		nbr_osc = _nbr_bits - TRIGO_BD_LIMIT;
+	if (nbr_osc > 0)
+	{
+		_trigo_osc.resize (nbr_osc);
+
+		for (int osc_cnt = 0; osc_cnt < nbr_osc; ++osc_cnt)
+		{
+			OscType &		osc = _trigo_osc [osc_cnt];
+
+			const long		len = 1L << (TRIGO_BD_LIMIT + osc_cnt);
+			const double	mul = (0.5 * PI) / len;
+			osc.set_step (mul);
+		}
+	}
+}
+
+
+
+template <class DT>
+const long *	FFTReal <DT>::get_br_ptr () const
+{
+	return (&_br_lut [0]);
+}
+
+
+
+template <class DT>
+const typename FFTReal <DT>::DataType *	FFTReal <DT>::get_trigo_ptr (int level) const
+{
+	assert (level >= 3);
+
+	return (&_trigo_lut [get_trigo_level_index (level)]);
+}
+
+
+
+template <class DT>
+long	FFTReal <DT>::get_trigo_level_index (int level) const
+{
+	assert (level >= 3);
+
+	return ((1L << (level - 1)) - 4);
+}
+
+
+
+// Transform in several passes
+template <class DT>
+void	FFTReal <DT>::compute_fft_general (DataType f [], const DataType x []) const
+{
+	assert (f != 0);
+	assert (f != use_buffer ());
+	assert (x != 0);
+	assert (x != use_buffer ());
+	assert (x != f);
+
+	DataType *		sf;
+	DataType *		df;
+
+	if ((_nbr_bits & 1) != 0)
+	{
+		df = use_buffer ();
+		sf = f;
+	}
+	else
+	{
+		df = f;
+		sf = use_buffer ();
+	}
+
+	compute_direct_pass_1_2 (df, x);
+	compute_direct_pass_3 (sf, df);
+
+	for (int pass = 3; pass < _nbr_bits; ++ pass)
+	{
+		compute_direct_pass_n (df, sf, pass);
+
+		DataType * const	temp_ptr = df;
+		df = sf;
+		sf = temp_ptr;
+	}
+}
+
+
+
+template <class DT>
+void	FFTReal <DT>::compute_direct_pass_1_2 (DataType df [], const DataType x []) const
+{
+	assert (df != 0);
+	assert (x != 0);
+	assert (df != x);
+
+	const long * const	bit_rev_lut_ptr = get_br_ptr ();
+	long				coef_index = 0;
+	do
+	{
+		const long		rev_index_0 = bit_rev_lut_ptr [coef_index];
+		const long		rev_index_1 = bit_rev_lut_ptr [coef_index + 1];
+		const long		rev_index_2 = bit_rev_lut_ptr [coef_index + 2];
+		const long		rev_index_3 = bit_rev_lut_ptr [coef_index + 3];
+
+		DataType	* const	df2 = df + coef_index;
+		df2 [1] = x [rev_index_0] - x [rev_index_1];
+		df2 [3] = x [rev_index_2] - x [rev_index_3];
+
+		const DataType	sf_0 = x [rev_index_0] + x [rev_index_1];
+		const DataType	sf_2 = x [rev_index_2] + x [rev_index_3];
+
+		df2 [0] = sf_0 + sf_2;
+		df2 [2] = sf_0 - sf_2;
+		
+		coef_index += 4;
+	}
+	while (coef_index < _length);
+}
+
+
+
+template <class DT>
+void	FFTReal <DT>::compute_direct_pass_3 (DataType df [], const DataType sf []) const
+{
+	assert (df != 0);
+	assert (sf != 0);
+	assert (df != sf);
+
+	const DataType	sqrt2_2 = DataType (SQRT2 * 0.5);
+	long				coef_index = 0;
+	do
+	{
+		DataType			v;
+
+		df [coef_index] = sf [coef_index] + sf [coef_index + 4];
+		df [coef_index + 4] = sf [coef_index] - sf [coef_index + 4];
+		df [coef_index + 2] = sf [coef_index + 2];
+		df [coef_index + 6] = sf [coef_index + 6];
+
+		v = (sf [coef_index + 5] - sf [coef_index + 7]) * sqrt2_2;
+		df [coef_index + 1] = sf [coef_index + 1] + v;
+		df [coef_index + 3] = sf [coef_index + 1] - v;
+
+		v = (sf [coef_index + 5] + sf [coef_index + 7]) * sqrt2_2;
+		df [coef_index + 5] = v + sf [coef_index + 3];
+		df [coef_index + 7] = v - sf [coef_index + 3];
+
+		coef_index += 8;
+	}
+	while (coef_index < _length);
+}
+
+
+
+template <class DT>
+void	FFTReal <DT>::compute_direct_pass_n (DataType df [], const DataType sf [], int pass) const
+{
+	assert (df != 0);
+	assert (sf != 0);
+	assert (df != sf);
+	assert (pass >= 3);
+	assert (pass < _nbr_bits);
+
+	if (pass <= TRIGO_BD_LIMIT)
+	{
+		compute_direct_pass_n_lut (df, sf, pass);
+	}
+	else
+	{
+		compute_direct_pass_n_osc (df, sf, pass);
+	}
+}
+
+
+
+template <class DT>
+void	FFTReal <DT>::compute_direct_pass_n_lut (DataType df [], const DataType sf [], int pass) const
+{
+	assert (df != 0);
+	assert (sf != 0);
+	assert (df != sf);
+	assert (pass >= 3);
+	assert (pass < _nbr_bits);
+
+	const long		nbr_coef = 1 << pass;
+	const long		h_nbr_coef = nbr_coef >> 1;
+	const long		d_nbr_coef = nbr_coef << 1;
+	long				coef_index = 0;
+	const DataType	* const	cos_ptr = get_trigo_ptr (pass);
+	do
+	{
+		const DataType	* const	sf1r = sf + coef_index;
+		const DataType	* const	sf2r = sf1r + nbr_coef;
+		DataType			* const	dfr = df + coef_index;
+		DataType			* const	dfi = dfr + nbr_coef;
+
+		// Extreme coefficients are always real
+		dfr [0] = sf1r [0] + sf2r [0];
+		dfi [0] = sf1r [0] - sf2r [0];	// dfr [nbr_coef] =
+		dfr [h_nbr_coef] = sf1r [h_nbr_coef];
+		dfi [h_nbr_coef] = sf2r [h_nbr_coef];
+
+		// Others are conjugate complex numbers
+		const DataType * const	sf1i = sf1r + h_nbr_coef;
+		const DataType * const	sf2i = sf1i + nbr_coef;
+		for (long i = 1; i < h_nbr_coef; ++ i)
+		{
+			const DataType	c = cos_ptr [i];					// cos (i*PI/nbr_coef);
+			const DataType	s = cos_ptr [h_nbr_coef - i];	// sin (i*PI/nbr_coef);
+			DataType	 		v;
+
+			v = sf2r [i] * c - sf2i [i] * s;
+			dfr [i] = sf1r [i] + v;
+			dfi [-i] = sf1r [i] - v;	// dfr [nbr_coef - i] =
+
+			v = sf2r [i] * s + sf2i [i] * c;
+			dfi [i] = v + sf1i [i];
+			dfi [nbr_coef - i] = v - sf1i [i];
+		}
+
+		coef_index += d_nbr_coef;
+	}
+	while (coef_index < _length);
+}
+
+
+
+template <class DT>
+void	FFTReal <DT>::compute_direct_pass_n_osc (DataType df [], const DataType sf [], int pass) const
+{
+	assert (df != 0);
+	assert (sf != 0);
+	assert (df != sf);
+	assert (pass > TRIGO_BD_LIMIT);
+	assert (pass < _nbr_bits);
+
+	const long		nbr_coef = 1 << pass;
+	const long		h_nbr_coef = nbr_coef >> 1;
+	const long		d_nbr_coef = nbr_coef << 1;
+	long				coef_index = 0;
+	OscType &		osc = _trigo_osc [pass - (TRIGO_BD_LIMIT + 1)];
+	do
+	{
+		const DataType	* const	sf1r = sf + coef_index;
+		const DataType	* const	sf2r = sf1r + nbr_coef;
+		DataType			* const	dfr = df + coef_index;
+		DataType			* const	dfi = dfr + nbr_coef;
+
+		osc.clear_buffers ();
+
+		// Extreme coefficients are always real
+		dfr [0] = sf1r [0] + sf2r [0];
+		dfi [0] = sf1r [0] - sf2r [0];	// dfr [nbr_coef] =
+		dfr [h_nbr_coef] = sf1r [h_nbr_coef];
+		dfi [h_nbr_coef] = sf2r [h_nbr_coef];
+
+		// Others are conjugate complex numbers
+		const DataType * const	sf1i = sf1r + h_nbr_coef;
+		const DataType * const	sf2i = sf1i + nbr_coef;
+		for (long i = 1; i < h_nbr_coef; ++ i)
+		{
+			osc.step ();
+			const DataType	c = osc.get_cos ();
+			const DataType	s = osc.get_sin ();
+			DataType	 		v;
+
+			v = sf2r [i] * c - sf2i [i] * s;
+			dfr [i] = sf1r [i] + v;
+			dfi [-i] = sf1r [i] - v;	// dfr [nbr_coef - i] =
+
+			v = sf2r [i] * s + sf2i [i] * c;
+			dfi [i] = v + sf1i [i];
+			dfi [nbr_coef - i] = v - sf1i [i];
+		}
+
+		coef_index += d_nbr_coef;
+	}
+	while (coef_index < _length);
+}
+
+
+
+// Transform in several pass
+template <class DT>
+void	FFTReal <DT>::compute_ifft_general (const DataType f [], DataType x []) const
+{
+	assert (f != 0);
+	assert (f != use_buffer ());
+	assert (x != 0);
+	assert (x != use_buffer ());
+	assert (x != f);
+
+	DataType *		sf = const_cast <DataType *> (f);
+	DataType *		df;
+	DataType *		df_temp;
+
+	if (_nbr_bits & 1)
+	{
+		df = use_buffer ();
+		df_temp = x;
+	}
+	else
+	{
+		df = x;
+		df_temp = use_buffer ();
+	}
+
+	for (int pass = _nbr_bits - 1; pass >= 3; -- pass)
+	{
+		compute_inverse_pass_n (df, sf, pass);
+
+		if (pass < _nbr_bits - 1)
+		{
+			DataType	* const	temp_ptr = df;
+			df = sf;
+			sf = temp_ptr;
+		}
+		else
+		{
+			sf = df;
+			df = df_temp;
+		}
+	}
+
+	compute_inverse_pass_3 (df, sf);
+	compute_inverse_pass_1_2 (x, df);
+}
+
+
+
+template <class DT>
+void	FFTReal <DT>::compute_inverse_pass_n (DataType df [], const DataType sf [], int pass) const
+{
+	assert (df != 0);
+	assert (sf != 0);
+	assert (df != sf);
+	assert (pass >= 3);
+	assert (pass < _nbr_bits);
+
+	if (pass <= TRIGO_BD_LIMIT)
+	{
+		compute_inverse_pass_n_lut (df, sf, pass);
+	}
+	else
+	{
+		compute_inverse_pass_n_osc (df, sf, pass);
+	}
+}
+
+
+
+template <class DT>
+void	FFTReal <DT>::compute_inverse_pass_n_lut (DataType df [], const DataType sf [], int pass) const
+{
+	assert (df != 0);
+	assert (sf != 0);
+	assert (df != sf);
+	assert (pass >= 3);
+	assert (pass < _nbr_bits);
+
+	const long		nbr_coef = 1 << pass;
+	const long		h_nbr_coef = nbr_coef >> 1;
+	const long		d_nbr_coef = nbr_coef << 1;
+	long				coef_index = 0;
+	const DataType * const	cos_ptr = get_trigo_ptr (pass);
+	do
+	{
+		const DataType	* const	sfr = sf + coef_index;
+		const DataType	* const	sfi = sfr + nbr_coef;
+		DataType			* const	df1r = df + coef_index;
+		DataType			* const	df2r = df1r + nbr_coef;
+
+		// Extreme coefficients are always real
+		df1r [0] = sfr [0] + sfi [0];		// + sfr [nbr_coef]
+		df2r [0] = sfr [0] - sfi [0];		// - sfr [nbr_coef]
+		df1r [h_nbr_coef] = sfr [h_nbr_coef] * 2;
+		df2r [h_nbr_coef] = sfi [h_nbr_coef] * 2;
+
+		// Others are conjugate complex numbers
+		DataType * const	df1i = df1r + h_nbr_coef;
+		DataType * const	df2i = df1i + nbr_coef;
+		for (long i = 1; i < h_nbr_coef; ++ i)
+		{
+			df1r [i] = sfr [i] + sfi [-i];		// + sfr [nbr_coef - i]
+			df1i [i] = sfi [i] - sfi [nbr_coef - i];
+
+			const DataType	c = cos_ptr [i];					// cos (i*PI/nbr_coef);
+			const DataType	s = cos_ptr [h_nbr_coef - i];	// sin (i*PI/nbr_coef);
+			const DataType	vr = sfr [i] - sfi [-i];		// - sfr [nbr_coef - i]
+			const DataType	vi = sfi [i] + sfi [nbr_coef - i];
+
+			df2r [i] = vr * c + vi * s;
+			df2i [i] = vi * c - vr * s;
+		}
+
+		coef_index += d_nbr_coef;
+	}
+	while (coef_index < _length);
+}
+
+
+
+template <class DT>
+void	FFTReal <DT>::compute_inverse_pass_n_osc (DataType df [], const DataType sf [], int pass) const
+{
+	assert (df != 0);
+	assert (sf != 0);
+	assert (df != sf);
+	assert (pass > TRIGO_BD_LIMIT);
+	assert (pass < _nbr_bits);
+
+	const long		nbr_coef = 1 << pass;
+	const long		h_nbr_coef = nbr_coef >> 1;
+	const long		d_nbr_coef = nbr_coef << 1;
+	long				coef_index = 0;
+	OscType &		osc = _trigo_osc [pass - (TRIGO_BD_LIMIT + 1)];
+	do
+	{
+		const DataType	* const	sfr = sf + coef_index;
+		const DataType	* const	sfi = sfr + nbr_coef;
+		DataType			* const	df1r = df + coef_index;
+		DataType			* const	df2r = df1r + nbr_coef;
+
+		osc.clear_buffers ();
+
+		// Extreme coefficients are always real
+		df1r [0] = sfr [0] + sfi [0];		// + sfr [nbr_coef]
+		df2r [0] = sfr [0] - sfi [0];		// - sfr [nbr_coef]
+		df1r [h_nbr_coef] = sfr [h_nbr_coef] * 2;
+		df2r [h_nbr_coef] = sfi [h_nbr_coef] * 2;
+
+		// Others are conjugate complex numbers
+		DataType * const	df1i = df1r + h_nbr_coef;
+		DataType * const	df2i = df1i + nbr_coef;
+		for (long i = 1; i < h_nbr_coef; ++ i)
+		{
+			df1r [i] = sfr [i] + sfi [-i];		// + sfr [nbr_coef - i]
+			df1i [i] = sfi [i] - sfi [nbr_coef - i];
+
+			osc.step ();
+			const DataType	c = osc.get_cos ();
+			const DataType	s = osc.get_sin ();
+			const DataType	vr = sfr [i] - sfi [-i];		// - sfr [nbr_coef - i]
+			const DataType	vi = sfi [i] + sfi [nbr_coef - i];
+
+			df2r [i] = vr * c + vi * s;
+			df2i [i] = vi * c - vr * s;
+		}
+
+		coef_index += d_nbr_coef;
+	}
+	while (coef_index < _length);
+}
+
+
+
+template <class DT>
+void	FFTReal <DT>::compute_inverse_pass_3 (DataType df [], const DataType sf []) const
+{
+	assert (df != 0);
+	assert (sf != 0);
+	assert (df != sf);
+
+	const DataType	sqrt2_2 = DataType (SQRT2 * 0.5);
+	long				coef_index = 0;
+	do
+	{
+		df [coef_index] = sf [coef_index] + sf [coef_index + 4];
+		df [coef_index + 4] = sf [coef_index] - sf [coef_index + 4];
+		df [coef_index + 2] = sf [coef_index + 2] * 2;
+		df [coef_index + 6] = sf [coef_index + 6] * 2;
+
+		df [coef_index + 1] = sf [coef_index + 1] + sf [coef_index + 3];
+		df [coef_index + 3] = sf [coef_index + 5] - sf [coef_index + 7];
+
+		const DataType	vr = sf [coef_index + 1] - sf [coef_index + 3];
+		const DataType	vi = sf [coef_index + 5] + sf [coef_index + 7];
+
+		df [coef_index + 5] = (vr + vi) * sqrt2_2;
+		df [coef_index + 7] = (vi - vr) * sqrt2_2;
+
+		coef_index += 8;
+	}
+	while (coef_index < _length);
+}
+
+
+
+template <class DT>
+void	FFTReal <DT>::compute_inverse_pass_1_2 (DataType x [], const DataType sf []) const
+{
+	assert (x != 0);
+	assert (sf != 0);
+	assert (x != sf);
+
+	const long *	bit_rev_lut_ptr = get_br_ptr ();
+	const DataType *	sf2 = sf;
+	long				coef_index = 0;
+	do
+	{
+		{
+			const DataType	b_0 = sf2 [0] + sf2 [2];
+			const DataType	b_2 = sf2 [0] - sf2 [2];
+			const DataType	b_1 = sf2 [1] * 2;
+			const DataType	b_3 = sf2 [3] * 2;
+
+			x [bit_rev_lut_ptr [0]] = b_0 + b_1;
+			x [bit_rev_lut_ptr [1]] = b_0 - b_1;
+			x [bit_rev_lut_ptr [2]] = b_2 + b_3;
+			x [bit_rev_lut_ptr [3]] = b_2 - b_3;
+		}
+		{
+			const DataType	b_0 = sf2 [4] + sf2 [6];
+			const DataType	b_2 = sf2 [4] - sf2 [6];
+			const DataType	b_1 = sf2 [5] * 2;
+			const DataType	b_3 = sf2 [7] * 2;
+
+			x [bit_rev_lut_ptr [4]] = b_0 + b_1;
+			x [bit_rev_lut_ptr [5]] = b_0 - b_1;
+			x [bit_rev_lut_ptr [6]] = b_2 + b_3;
+			x [bit_rev_lut_ptr [7]] = b_2 - b_3;
+		}
+
+		sf2 += 8;
+		coef_index += 8;
+		bit_rev_lut_ptr += 8;
+	}
+	while (coef_index < _length);
+}
+
+
+
+}	// namespace ffft
+
+
+
+#endif	// ffft_FFTReal_CODEHEADER_INCLUDED
+
+#undef ffft_FFTReal_CURRENT_CODEHEADER
+
+
+
+/*\\\ EOF \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/ground/gcs/src/plugins/scope/scopes3d/ffft/OscSinCos.h
+++ b/ground/gcs/src/plugins/scope/scopes3d/ffft/OscSinCos.h
@@ -1,0 +1,107 @@
+/*****************************************************************************
+
+        OscSinCos.h
+        By Laurent de Soras
+
+--- Legal stuff ---
+
+This program is free software. It comes without any warranty, to
+the extent permitted by applicable law. You can redistribute it
+and/or modify it under the terms of the Do What The Fuck You Want
+To Public License, Version 2, as published by Sam Hocevar. See
+http://sam.zoy.org/wtfpl/COPYING for more details.
+
+*Tab=3***********************************************************************/
+
+
+
+#if ! defined (ffft_OscSinCos_HEADER_INCLUDED)
+#define	ffft_OscSinCos_HEADER_INCLUDED
+
+#if defined (_MSC_VER)
+	#pragma once
+	#pragma warning (4 : 4250) // "Inherits via dominance."
+#endif
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#include	"def.h"
+
+
+
+namespace ffft
+{
+
+
+
+template <class T>
+class OscSinCos
+{
+
+/*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+public:
+
+	typedef	T	DataType;
+
+						OscSinCos ();
+
+	ffft_FORCEINLINE void
+						set_step (double angle_rad);
+
+	ffft_FORCEINLINE DataType
+						get_cos () const;
+	ffft_FORCEINLINE DataType
+						get_sin () const;
+	ffft_FORCEINLINE void
+						step ();
+	ffft_FORCEINLINE void
+						clear_buffers ();
+
+
+
+/*\\\ PROTECTED \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+protected:
+
+
+
+/*\\\ PRIVATE \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+private:
+
+	DataType			_pos_cos;		// Current phase expressed with sin and cos. [-1 ; 1]
+	DataType			_pos_sin;		// -
+	DataType			_step_cos;		// Phase increment per step, [-1 ; 1]
+	DataType			_step_sin;		// -
+
+
+
+/*\\\ FORBIDDEN MEMBER FUNCTIONS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+private:
+
+						OscSinCos (const OscSinCos &other);
+	OscSinCos &		operator = (const OscSinCos &other);
+	bool				operator == (const OscSinCos &other);
+	bool				operator != (const OscSinCos &other);
+
+};	// class OscSinCos
+
+
+
+}	// namespace ffft
+
+
+
+#include	"OscSinCos.hpp"
+
+
+
+#endif	// ffft_OscSinCos_HEADER_INCLUDED
+
+
+
+/*\\\ EOF \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/ground/gcs/src/plugins/scope/scopes3d/ffft/OscSinCos.hpp
+++ b/ground/gcs/src/plugins/scope/scopes3d/ffft/OscSinCos.hpp
@@ -1,0 +1,123 @@
+/*****************************************************************************
+
+        OscSinCos.hpp
+        By Laurent de Soras
+
+--- Legal stuff ---
+
+This program is free software. It comes without any warranty, to
+the extent permitted by applicable law. You can redistribute it
+and/or modify it under the terms of the Do What The Fuck You Want
+To Public License, Version 2, as published by Sam Hocevar. See
+http://sam.zoy.org/wtfpl/COPYING for more details.
+
+*Tab=3***********************************************************************/
+
+
+
+#if defined (ffft_OscSinCos_CURRENT_CODEHEADER)
+	#error Recursive inclusion of OscSinCos code header.
+#endif
+#define	ffft_OscSinCos_CURRENT_CODEHEADER
+
+#if ! defined (ffft_OscSinCos_CODEHEADER_INCLUDED)
+#define	ffft_OscSinCos_CODEHEADER_INCLUDED
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#include	<cmath>
+
+namespace std { }
+
+
+
+namespace ffft
+{
+
+
+
+/*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+
+
+template <class T>
+OscSinCos <T>::OscSinCos ()
+:	_pos_cos (1)
+,	_pos_sin (0)
+,	_step_cos (1)
+,	_step_sin (0)
+{
+	// Nothing
+}
+
+
+
+template <class T>
+void	OscSinCos <T>::set_step (double angle_rad)
+{
+	using namespace std;
+
+	_step_cos = static_cast <DataType> (cos (angle_rad));
+	_step_sin = static_cast <DataType> (sin (angle_rad));
+}
+
+
+
+template <class T>
+typename OscSinCos <T>::DataType	OscSinCos <T>::get_cos () const
+{
+	return (_pos_cos);
+}
+
+
+
+template <class T>
+typename OscSinCos <T>::DataType	OscSinCos <T>::get_sin () const
+{
+	return (_pos_sin);
+}
+
+
+
+template <class T>
+void	OscSinCos <T>::step ()
+{
+	const DataType	old_cos = _pos_cos;
+	const DataType	old_sin = _pos_sin;
+
+	_pos_cos = old_cos * _step_cos - old_sin * _step_sin;
+	_pos_sin = old_cos * _step_sin + old_sin * _step_cos;
+}
+
+
+
+template <class T>
+void	OscSinCos <T>::clear_buffers ()
+{
+	_pos_cos = static_cast <DataType> (1);
+	_pos_sin = static_cast <DataType> (0);
+}
+
+
+
+/*\\\ PROTECTED \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+
+
+/*\\\ PRIVATE \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+
+
+}	// namespace ffft
+
+
+
+#endif	// ffft_OscSinCos_CODEHEADER_INCLUDED
+
+#undef ffft_OscSinCos_CURRENT_CODEHEADER
+
+
+
+/*\\\ EOF \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/ground/gcs/src/plugins/scope/scopes3d/ffft/def.h
+++ b/ground/gcs/src/plugins/scope/scopes3d/ffft/def.h
@@ -1,0 +1,60 @@
+/*****************************************************************************
+
+        def.h
+        By Laurent de Soras
+
+--- Legal stuff ---
+
+This program is free software. It comes without any warranty, to
+the extent permitted by applicable law. You can redistribute it
+and/or modify it under the terms of the Do What The Fuck You Want
+To Public License, Version 2, as published by Sam Hocevar. See
+http://sam.zoy.org/wtfpl/COPYING for more details.
+
+*Tab=3***********************************************************************/
+
+
+
+#if ! defined (ffft_def_HEADER_INCLUDED)
+#define	ffft_def_HEADER_INCLUDED
+
+#if defined (_MSC_VER)
+	#pragma once
+	#pragma warning (4 : 4250) // "Inherits via dominance."
+#endif
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+
+
+namespace ffft
+{
+
+
+
+const double	PI		= 3.1415926535897932384626433832795;
+const double	SQRT2	= 1.41421356237309514547462185873883;
+
+#if defined (_MSC_VER)
+
+	#define	ffft_FORCEINLINE	__forceinline
+
+#else
+
+	#define	ffft_FORCEINLINE	inline
+
+#endif
+
+
+
+}	// namespace ffft
+
+
+
+#endif	// ffft_def_HEADER_INCLUDED
+
+
+
+/*\\\ EOF \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.cpp
+++ b/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.cpp
@@ -200,7 +200,7 @@ bool SpectrogramData::append(UAVObject* multiObj)
             qDebug() << "Spectrogram width adjusted to " << windowWidth;
         }
 
-        UAVObjectField* multiField =  multiObj->getField(uavFieldName);
+        UAVObjectField* multiField = multiObj->getField(uavFieldName);
         Q_ASSERT(multiField);
         if (multiField ) {
 
@@ -218,7 +218,7 @@ bool SpectrogramData::append(UAVObject* multiObj)
                     }
                 }
 
-                for (int i=0; i<numElements; i++) {
+                for (int i = 0; i < numElements; i++) {
                     double currentValue = field->getValue(i).toDouble() / scale;  // Get the value and scale it
 
                     //Normally some math would go here, modifying currentValue before appending it to values
@@ -262,7 +262,7 @@ bool SpectrogramData::append(UAVObject* multiObj)
                 }
 
                 // Hanning Window
-                for (int i=0;i<valuesToProcess; i++) {
+                for (int i = 0; i < valuesToProcess; i++) {
                     plotData[i] *= pow(sin(PI*i/(valuesToProcess - 1) ), 2);
                 }
 
@@ -275,14 +275,14 @@ bool SpectrogramData::append(UAVObject* multiObj)
                 // mag = X * sqrt(re^2 + im^2)/n
                 // X (4.2) is chosen so that the magnitude presented is similar to the acceleration registered
                 // although this is not 100% correct, it helps users understanding the spectrogram.
-                for (unsigned int i=0;i<valuesToProcess/2; i++) {
+                for (unsigned int i = 0; i < valuesToProcess/2; i++) {
                     plotData << 4.2*sqrt(pow(fftout[i], 2) + pow(fftout[valuesToProcess/2 + i], 2)) / valuesToProcess;
                 }
             }
             
             // Apply autoscale if enabled
             if (zMaximum == 0) {
-				for (unsigned int i=0; i<windowWidth; i++) {
+				for (unsigned int i = 0; i < windowWidth; i++) {
 	                 // See if autoscale is turned on and if the value exceeds the maximum for the scope.
 	                if (plotData[i] > rasterData->interval(Qt::ZAxis).maxValue()){
 	                    // Change scope maximum and color depth

--- a/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.h
+++ b/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.h
@@ -37,6 +37,7 @@
 #include <QTime>
 #include <QVector>
 
+#include "ffft/FFTReal.h"
 
 /**
  * @brief The SpectrogramData class The spectrogram plot has a fixed size
@@ -86,6 +87,7 @@ private:
     double timeHorizon;
     unsigned int windowWidth;
     double autoscaleValueUpdated;
+    ffft::FFTReal <double> *fft_object;
 
 };
 

--- a/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.h
+++ b/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.h
@@ -89,7 +89,7 @@ private:
     double autoscaleValueUpdated;
     ffft::FFTReal <double> *fft_object;
     QVector<double> plotData;
-
+    int lastInstanceIndex;
 };
 
 #endif // SPECTROGRAMDATA_H

--- a/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.h
+++ b/ground/gcs/src/plugins/scope/scopes3d/spectrogramplotdata.h
@@ -88,6 +88,7 @@ private:
     unsigned int windowWidth;
     double autoscaleValueUpdated;
     ffft::FFTReal <double> *fft_object;
+    QVector<double> plotData;
 
 };
 

--- a/shared/uavobjectdefinition/vibrationanalysisoutput.xml
+++ b/shared/uavobjectdefinition/vibrationanalysisoutput.xml
@@ -6,6 +6,7 @@
         <field name="z" units="m/s^2" type="int16" elements="16"/>
         <field name="scale" units="" type="float" elements="1" />
         <field name="samples" units="" type="int16" elements="1" />
+        <field name="index" units="" type="int16" elements="1" />
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="false" updatemode="onchange" period="0"/>
         <telemetryflight acked="false" updatemode="onchange" period="0"/>

--- a/shared/uavobjectdefinition/vibrationanalysisoutput.xml
+++ b/shared/uavobjectdefinition/vibrationanalysisoutput.xml
@@ -1,14 +1,14 @@
 <xml>
     <object name="VibrationAnalysisOutput" singleinstance="false" settings="false">
-        <description>FFT output from @VibrationTest module.</description>
-        <!-- Discrete Fourier Transform units are the same as the original units. To 
-        get signal per Hz, each sample must be multiplied by the period step.-->
-        <field name="x" units="m/s^2" type="float" elements="1"/>
-        <field name="y" units="m/s^2" type="float" elements="1"/>
-        <field name="z" units="m/s^2" type="float" elements="1"/>
+        <description>Output from @VibrationTest module.</description>
+        <field name="x" units="m/s^2" type="int16" elements="16"/>
+        <field name="y" units="m/s^2" type="int16" elements="16"/>
+        <field name="z" units="m/s^2" type="int16" elements="16"/>
+        <field name="scale" units="" type="float" elements="1" />
+        <field name="samples" units="" type="int16" elements="1" />
         <access gcs="readwrite" flight="readwrite"/>
-        <telemetrygcs acked="false" updatemode="manual" period="0"/>
-        <telemetryflight acked="false" updatemode="throttled" period="1000"/>
+        <telemetrygcs acked="false" updatemode="onchange" period="0"/>
+        <telemetryflight acked="false" updatemode="onchange" period="0"/>
         <logging updatemode="manual" period="0"/>
     </object>
 </xml>

--- a/shared/uavobjectdefinition/vibrationanalysissettings.xml
+++ b/shared/uavobjectdefinition/vibrationanalysissettings.xml
@@ -6,7 +6,7 @@
         <field name="TestingStatus" units="" type="enum" elements="1" options="Off,On" defaultvalue="Off"/>
         <access gcs="readwrite" flight="readwrite"/>
         <telemetrygcs acked="true" updatemode="onchange" period="0"/>
-        <telemetryflight acked="true" updatemode="onchange" period="0"/>
+        <telemetryflight acked="true" updatemode="onchange" period="1000"/>
         <logging updatemode="manual" period="0"/>
 	</object>
 </xml>


### PR DESCRIPTION
New take at #610 

VibrationAnalysis Module
- module will only acquire and send data (no FFT)
- using 16 bits to reduce memory footprint. Floats scaled without clipping (considering +/-16g accel)
- module will reallocate buffers according to the number of samples required or allocates a single buffer (using an ifdef)
- reconfiguration will only take place at the start of an acquisition period so that jitter is minimised
- supports up to 1024 bins and can potentially support much more. Be careful of the bandwidth required.

GCS Spectrogram
- calculates FFT from data (optional according to settings)
- updates window_width dynamically
- scales FFT magnitude so that the values presented are similar to the real G. This is an aesthetical feature.
- applies a Hann window to the data captured

VibrationAnalysisOutpudData object
- is multi instance and will grow as needed (but will not shrink), or can be single instance reducing memory footprint.
- each instance carries 16 values for each axis

edit by mpl: fixes #610
