### PR TITLE
GCS: Solves Logging crash when existing. Fixes #746

### DIFF
--- a/ground/gcs/src/plugins/logging/loggingplugin.cpp
+++ b/ground/gcs/src/plugins/logging/loggingplugin.cpp
@@ -484,7 +484,7 @@ void LoggingPlugin::extensionsInitialized()
 
 void LoggingPlugin::shutdown()
 {
-    if(state == LOGGING) {
+    if (state == LOGGING) {
         stopLogging();
 
         loggingThread->wait();

--- a/ground/gcs/src/plugins/logging/loggingplugin.cpp
+++ b/ground/gcs/src/plugins/logging/loggingplugin.cpp
@@ -490,7 +490,7 @@ void LoggingPlugin::shutdown()
         loggingThread->wait();
     }
 
-    if (loggingThread == NULL) {
+    if (loggingThread != NULL) {
         delete loggingThread;
         loggingThread = NULL;
     }

--- a/ground/gcs/src/plugins/logging/loggingplugin.cpp
+++ b/ground/gcs/src/plugins/logging/loggingplugin.cpp
@@ -127,7 +127,6 @@ QString LoggingConnection::shortName()
  */
 LoggingThread::~LoggingThread()
 {
-    stopLogging();
 }
 
 /**
@@ -485,7 +484,16 @@ void LoggingPlugin::extensionsInitialized()
 
 void LoggingPlugin::shutdown()
 {
-    // Do nothing
+    if(state == LOGGING) {
+        stopLogging();
+
+        loggingThread->wait();
+    }
+
+    if (loggingThread == NULL) {
+        delete loggingThread;
+        loggingThread = NULL;
+    }
 }
 
 /**


### PR DESCRIPTION
Let the thread exit and wait for it during shutdown.

edit by mpl: fixes #746 -- github is picky that this has to be in this top comment block
