### PR TITLE
gcs: boardmanager: don't consider vendorid 0

### DIFF
--- a/ground/gcs/src/plugins/coreplugin/boardmanager.cpp
+++ b/ground/gcs/src/plugins/coreplugin/boardmanager.cpp
@@ -80,8 +80,8 @@ QList<int> BoardManager::getKnownVendorIDs()
 
     foreach (IBoardType* board, m_boardTypesList) {
         int vid = board->getUSBInfo().vendorID;
-        if (!list.contains(vid))
-        list.append(vid);
+        if ((vid > 0) && (!list.contains(vid)))
+            list.append(vid);
     }
 
     return list;


### PR DESCRIPTION
possibly fixes #910 ; only found through inspection.  Naze has no
vendor information--- on windows ACPI HID buttons show up with vendorid
0.
