### PR TITLE
flight: don't busfight on DSM binding

### DIFF
--- a/flight/targets/brain/fw/pios_board.c
+++ b/flight/targets/brain/fw/pios_board.c
@@ -385,7 +385,7 @@ void PIOS_Board_Init(void) {
 			NULL,                                // pwm_cfg
 			PIOS_LED_ALARM,                      // led_id
 			&pios_mainport_dsm_aux_cfg,          // dsm_cfg
-			hw_DSMxMode,                         // dsm_mode
+			0,                                   // dsm_mode
 			&pios_mainport_sbus_aux_cfg);        // sbus_cfg
 
 	/* Flx Port */

--- a/flight/targets/cc3d/fw/pios_board.c
+++ b/flight/targets/cc3d/fw/pios_board.c
@@ -260,7 +260,7 @@ void PIOS_Board_Init(void) {
 			NULL,                                // pwm_cfg
 			0,                                   // led_id
 			&pios_dsm_main_cfg,                  // dsm_cfg
-			hw_DSMxMode,                         // dsm_mode
+			0,                                   // dsm_mode
 			&pios_sbus_cfg);                     // sbus_cfg
 
 	/* Configure the flexi port */

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -375,7 +375,7 @@ void PIOS_Board_Init(void) {
 			NULL,                                // pwm_cfg
 			PIOS_LED_ALARM,                      // led_id
 			&pios_usart2_dsm_aux_cfg,            // dsm_cfg
-			hw_DSMxMode,                         // dsm_mode
+			0,                                   // dsm_mode
 			&pios_usart2_sbus_aux_cfg);          // sbus_cfg
 
 	/* UART3 Port */


### PR DESCRIPTION
When there's an inverter/xor present, it's essential that we not drive
its output.  Fixes #716, makes Quanton, Brain, CC3D consistent with S2
and revo.
