### PR TITLE
Naze32: Add S.BUS inverter support + fix DSM bind->inverter conflict

### DIFF
--- a/flight/targets/naze32/board-info/board_hw_defs.c
+++ b/flight/targets/naze32/board-info/board_hw_defs.c
@@ -1135,3 +1135,42 @@ static struct pios_mpu_cfg pios_mpu_cfg = {
 	.orientation = PIOS_MPU_TOP_90DEG,
 };
 #endif /* PIOS_INCLUDE_MPU */
+
+
+#if defined(PIOS_INCLUDE_SBUS)
+
+#include <pios_sbus_priv.h>
+
+static const struct pios_sbus_cfg pios_sbus_cfg = {
+    /* Inverter configuration */
+    .inv = {
+        .gpio = GPIOB,
+        .init = {
+            .GPIO_Pin   = GPIO_Pin_2,
+            .GPIO_Speed = GPIO_Speed_2MHz,
+            .GPIO_Mode  = GPIO_Mode_Out_PP
+        },
+    },
+    .gpio_inv_enable = Bit_SET,
+    .gpio_inv_disable = Bit_RESET,
+};
+
+const struct pios_sbus_cfg *get_sbus_cfg(enum board_revision board_rev)
+{
+    switch(board_rev) {
+    case BOARD_REVISION_6:
+        return &pios_sbus_cfg;
+    default:
+        return NULL;
+    }
+}
+
+#else
+
+const struct pios_sbus_cfg *get_sbus_cfg(enum board_revision board_rev)
+{
+    (void)board_rev;
+    return NULL;
+}
+
+#endif  /* PIOS_INCLUDE_SBUS */

--- a/shared/uavobjectdefinition/hwnaze.xml
+++ b/shared/uavobjectdefinition/hwnaze.xml
@@ -35,6 +35,7 @@
 				<option>LighttelemetryTx</option>
 				<option>MavLinkTX</option>
 				<option>MSP</option>
+				<option>S.Bus</option>
 				<option>S.Bus Non Inverted</option>
 				<option>Telemetry</option>
 			</options>


### PR DESCRIPTION
Completely untested because I don't have any inverter/inverted hardware at all.

Fixes #577
