### PR TITLE
Flight: Lux target RX port definition

### DIFF
--- a/flight/targets/lux/board-info/board_hw_defs.c
+++ b/flight/targets/lux/board-info/board_hw_defs.c
@@ -360,6 +360,31 @@ static const struct pios_usart_cfg pios_main_usart_cfg = {
 		.pin_source = GPIO_PinSource10,
 	},
 };
+
+static const struct pios_usart_cfg pios_rcvr_usart_cfg = {
+	.regs = USART1,
+	.remap = GPIO_AF_7,
+	.irq = {
+		.init = {
+			.NVIC_IRQChannel                   = USART1_IRQn,
+			.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_HIGHEST,
+			.NVIC_IRQChannelSubPriority        = 0,
+			.NVIC_IRQChannelCmd                = ENABLE,
+		  },
+	},
+	.rx = {
+		.gpio = GPIOC,
+		.init = {
+			.GPIO_Pin   = GPIO_Pin_5,
+			.GPIO_Speed = GPIO_Speed_2MHz,
+			.GPIO_Mode  = GPIO_Mode_AF,
+			.GPIO_OType = GPIO_OType_PP,
+			.GPIO_PuPd  = GPIO_PuPd_UP
+		},
+		.pin_source = GPIO_PinSource5,
+	},
+};
+
 #endif  /* PIOS_INCLUDE_USART */
 
 #if defined(PIOS_INCLUDE_COM)

--- a/flight/targets/lux/fw/pios_board.c
+++ b/flight/targets/lux/fw/pios_board.c
@@ -296,7 +296,7 @@ void PIOS_Board_Init(void)
 	uint8_t hw_rcvrport;
 	HwLuxRcvrPortGet(&hw_rcvrport);
 	PIOS_HAL_ConfigurePort(hw_rcvrport,           // port_type
-                         NULL,                    // usart_port_cfg
+                         &pios_rcvr_usart_cfg,    // usart_port_cfg
                          &pios_usart_com_driver,  // com_driver
                          NULL,                    // i2c_id
                          NULL,                    // i2c_cfg


### PR DESCRIPTION
Adds uart definition to RX port.  Compiles, but needs testing by a user with a Lux board.

Fixes #914.
