### PR TITLE
Flight: Add Usart6 to Quanton

### DIFF
--- a/flight/targets/quanton/board-info/board_hw_defs.c
+++ b/flight/targets/quanton/board-info/board_hw_defs.c
@@ -799,6 +799,19 @@ static const struct pios_dsm_cfg pios_usart5_dsm_aux_cfg = {
 	},
 };
 
+static const struct pios_dsm_cfg pios_rcvrserial_dsm_aux_cfg = {
+	.bind = {
+		.gpio = GPIOC,
+		.init = {
+			.GPIO_Pin   = GPIO_Pin_7,
+			.GPIO_Speed = GPIO_Speed_2MHz,
+			.GPIO_Mode  = GPIO_Mode_OUT,
+			.GPIO_OType = GPIO_OType_PP,
+			.GPIO_PuPd  = GPIO_PuPd_NOPULL
+		},
+	},
+};
+
 #endif	/* PIOS_INCLUDE_DSM */
 
 #if defined(PIOS_INCLUDE_SBUS)
@@ -994,6 +1007,41 @@ static const struct pios_usart_cfg pios_usart5_cfg = {
 			.GPIO_PuPd  = GPIO_PuPd_UP
 		},
 		.pin_source = GPIO_PinSource12,
+	},
+};
+
+static const struct pios_usart_cfg pios_usart_rcvrserial_cfg = {
+	.regs  = USART6,
+	.remap = GPIO_AF_USART6,
+	.irq = {
+		.init = {
+			.NVIC_IRQChannel                   = USART6_IRQn,
+			.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_MID,
+			.NVIC_IRQChannelSubPriority        = 0,
+			.NVIC_IRQChannelCmd                = ENABLE,
+		},
+	},
+	.rx   = {
+		.gpio = GPIOC,
+		.init = {
+			.GPIO_Pin   = GPIO_Pin_7,
+			.GPIO_Speed = GPIO_Speed_2MHz,
+			.GPIO_Mode  = GPIO_Mode_AF,
+			.GPIO_OType = GPIO_OType_PP,
+			.GPIO_PuPd  = GPIO_PuPd_UP
+		},
+		.pin_source = GPIO_PinSource7,
+	},
+	.tx   = {
+		.gpio = GPIOC,
+		.init = {
+			.GPIO_Pin   = GPIO_Pin_6,
+			.GPIO_Speed = GPIO_Speed_2MHz,
+			.GPIO_Mode  = GPIO_Mode_AF,
+			.GPIO_OType = GPIO_OType_PP,
+			.GPIO_PuPd  = GPIO_PuPd_UP
+		},
+		.pin_source = GPIO_PinSource6,
 	},
 };
 

--- a/flight/targets/quanton/board-info/board_hw_defs.c
+++ b/flight/targets/quanton/board-info/board_hw_defs.c
@@ -799,7 +799,7 @@ static const struct pios_dsm_cfg pios_usart5_dsm_aux_cfg = {
 	},
 };
 
-static const struct pios_dsm_cfg pios_rcvrserial_dsm_aux_cfg = {
+static const struct pios_dsm_cfg pios_inportserial_dsm_aux_cfg = {
 	.bind = {
 		.gpio = GPIOC,
 		.init = {
@@ -1010,7 +1010,7 @@ static const struct pios_usart_cfg pios_usart5_cfg = {
 	},
 };
 
-static const struct pios_usart_cfg pios_usart_rcvrserial_cfg = {
+static const struct pios_usart_cfg pios_usart_inportserial_cfg = {
 	.regs  = USART6,
 	.remap = GPIO_AF_USART6,
 	.irq = {

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -426,15 +426,15 @@ void PIOS_Board_Init(void) {
 			hw_DSMxMode,                         // dsm_mode
 			NULL);                               // sbus_cfg
 
-	/* Configure the rcvr port */
-	uint8_t hw_rcvrport;
-	HwQuantonRcvrPortGet(&hw_rcvrport);
+	/* Configure the inport */
+	uint8_t hw_inport;
+	HwQuantonInPortGet(&hw_inport);
 
-	switch (hw_rcvrport) {
-	case HWQUANTON_RCVRPORT_DISABLED:
+	switch (hw_inport) {
+	case HWQUANTON_INPORT_DISABLED:
 		break;
 	
-	case HWQUANTON_RCVRPORT_PWM:
+	case HWQUANTON_INPORT_PWM:
 		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PWM,  // port type protocol
 				NULL,                                   // usart_port_cfg
 				NULL,                                   // com_driver
@@ -448,7 +448,7 @@ void PIOS_Board_Init(void) {
 				NULL);                                  // sbus_cfg
 		break;
 
-	case HWQUANTON_RCVRPORT_PWMADC:
+	case HWQUANTON_INPORT_PWMADC:
 		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PWM,  // port type protocol
 				NULL,                                   // usart_port_cfg
 				NULL,                                   // com_driver
@@ -462,35 +462,35 @@ void PIOS_Board_Init(void) {
 				NULL);                                  // sbus_cfg
 		break;
 
-	case HWQUANTON_RCVRPORT_PPMSERIAL:
-	case HWQUANTON_RCVRPORT_PPMSERIALADC:
-	case HWQUANTON_RCVRPORT_SERIAL:
+	case HWQUANTON_INPORT_PPMSERIAL:
+	case HWQUANTON_INPORT_PPMSERIALADC:
+	case HWQUANTON_INPORT_SERIAL:
 		{
-			uint8_t hw_rcvrserial;
-			HwQuantonRcvrSerialGet(&hw_rcvrserial);
+			uint8_t hw_inportserial;
+			HwQuantonInPortSerialGet(&hw_inportserial);
 
-			PIOS_HAL_ConfigurePort(hw_rcvrserial,        // port type protocol
-					&pios_usart_rcvrserial_cfg,          // usart_port_cfg
+			PIOS_HAL_ConfigurePort(hw_inportserial,      // port type protocol
+					&pios_usart_inportserial_cfg,        // usart_port_cfg
 					&pios_usart_com_driver,              // com_driver
 					NULL,                                // i2c_id
 					NULL,                                // i2c_cfg
 					NULL,                                // ppm_cfg
 					NULL,                                // pwm_cfg
 					PIOS_LED_ALARM,                      // led_id
-					&pios_rcvrserial_dsm_aux_cfg,        // dsm_cfg
+					&pios_inportserial_dsm_aux_cfg,      // dsm_cfg
 					hw_DSMxMode,                         // dsm_mode
 					NULL);                               // sbus_cfg
 		}
 
-		if (hw_rcvrport == HWQUANTON_RCVRPORT_SERIAL)
+		if (hw_inport == HWQUANTON_INPORT_SERIAL)
 			break;
 
 		// Else fall through to set up PPM.
 
-	case HWQUANTON_RCVRPORT_PPM:
-	case HWQUANTON_RCVRPORT_PPMADC:
-	case HWQUANTON_RCVRPORT_PPMOUTPUTS:
-	case HWQUANTON_RCVRPORT_PPMOUTPUTSADC:
+	case HWQUANTON_INPORT_PPM:
+	case HWQUANTON_INPORT_PPMADC:
+	case HWQUANTON_INPORT_PPMOUTPUTS:
+	case HWQUANTON_INPORT_PPMOUTPUTSADC:
 		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PPM,  // port type protocol
 				NULL,                                   // usart_port_cfg
 				NULL,                                   // com_driver
@@ -504,7 +504,7 @@ void PIOS_Board_Init(void) {
 				NULL);                                  // sbus_cfg
 		break;
 
-	case HWQUANTON_RCVRPORT_PPMPWM:
+	case HWQUANTON_INPORT_PPMPWM:
 		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PPM,  // port type protocol
 				NULL,                                   // usart_port_cfg
 				NULL,                                   // com_driver
@@ -530,7 +530,7 @@ void PIOS_Board_Init(void) {
 				NULL);                                  // sbus_cfg
 		break;
 
-	case HWQUANTON_RCVRPORT_PPMPWMADC:
+	case HWQUANTON_INPORT_PPMPWMADC:
 		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PPM,  // port type protocol
 				NULL,                                   // usart_port_cfg
 				NULL,                                   // com_driver
@@ -569,27 +569,27 @@ void PIOS_Board_Init(void) {
 #endif	/* PIOS_INCLUDE_GCSRCVR */
 
 #ifndef PIOS_DEBUG_ENABLE_DEBUG_PINS
-	switch (hw_rcvrport) {
-		case HWQUANTON_RCVRPORT_DISABLED:
-		case HWQUANTON_RCVRPORT_PWM:
-		case HWQUANTON_RCVRPORT_PWMADC:
-		case HWQUANTON_RCVRPORT_PPM:
-		case HWQUANTON_RCVRPORT_PPMADC:
-		case HWQUANTON_RCVRPORT_PPMPWM:
-		case HWQUANTON_RCVRPORT_PPMPWMADC:
+	switch (hw_inport) {
+		case HWQUANTON_INPORT_DISABLED:
+		case HWQUANTON_INPORT_PWM:
+		case HWQUANTON_INPORT_PWMADC:
+		case HWQUANTON_INPORT_PPM:
+		case HWQUANTON_INPORT_PPMADC:
+		case HWQUANTON_INPORT_PPMPWM:
+		case HWQUANTON_INPORT_PPMPWMADC:
 			/* Set up the servo outputs */
 #ifdef PIOS_INCLUDE_SERVO
 			PIOS_Servo_Init(&pios_servo_cfg);
 #endif
 			break;
-		case HWQUANTON_RCVRPORT_PPMOUTPUTS:
-		case HWQUANTON_RCVRPORT_OUTPUTS:
+		case HWQUANTON_INPORT_PPMOUTPUTS:
+		case HWQUANTON_INPORT_OUTPUTS:
 #ifdef PIOS_INCLUDE_SERVO
 			PIOS_Servo_Init(&pios_servo_with_rcvr_cfg);
 #endif
 			break;
-		case HWQUANTON_RCVRPORT_PPMOUTPUTSADC:
-		case HWQUANTON_RCVRPORT_OUTPUTSADC:
+		case HWQUANTON_INPORT_PPMOUTPUTSADC:
+		case HWQUANTON_INPORT_OUTPUTSADC:
 #ifdef PIOS_INCLUDE_SERVO
 			PIOS_Servo_Init(&pios_servo_with_rcvr_with_adc_cfg);
 #endif
@@ -751,12 +751,12 @@ void PIOS_Board_Init(void) {
 #endif
 
 #if defined(PIOS_INCLUDE_ADC)
-	if (hw_rcvrport == HWQUANTON_RCVRPORT_OUTPUTSADC ||
-		hw_rcvrport == HWQUANTON_RCVRPORT_PPMADC ||
-		hw_rcvrport == HWQUANTON_RCVRPORT_PPMOUTPUTSADC ||
-		hw_rcvrport == HWQUANTON_RCVRPORT_PPMPWMADC ||
-		hw_rcvrport == HWQUANTON_RCVRPORT_PPMSERIALADC ||
-		hw_rcvrport == HWQUANTON_RCVRPORT_PWMADC)
+	if (hw_inport == HWQUANTON_INPORT_OUTPUTSADC ||
+		hw_inport == HWQUANTON_INPORT_PPMADC ||
+		hw_inport == HWQUANTON_INPORT_PPMOUTPUTSADC ||
+		hw_inport == HWQUANTON_INPORT_PPMPWMADC ||
+		hw_inport == HWQUANTON_INPORT_PPMSERIALADC ||
+		hw_inport == HWQUANTON_INPORT_PWMADC)
 	{
 		uint32_t internal_adc_id;
 		PIOS_INTERNAL_ADC_Init(&internal_adc_id, &pios_adc_cfg);

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -462,6 +462,31 @@ void PIOS_Board_Init(void) {
 				NULL);                                  // sbus_cfg
 		break;
 
+	case HWQUANTON_RCVRPORT_PPMSERIAL:
+	case HWQUANTON_RCVRPORT_PPMSERIALADC:
+	case HWQUANTON_RCVRPORT_SERIAL:
+		{
+			uint8_t hw_rcvrserial;
+			HwQuantonRcvrSerialGet(&hw_rcvrserial);
+
+			PIOS_HAL_ConfigurePort(hw_rcvrserial,        // port type protocol
+					&pios_usart_rcvrserial_cfg,          // usart_port_cfg
+					&pios_usart_com_driver,              // com_driver
+					NULL,                                // i2c_id
+					NULL,                                // i2c_cfg
+					NULL,                                // ppm_cfg
+					NULL,                                // pwm_cfg
+					PIOS_LED_ALARM,                      // led_id
+					&pios_rcvrserial_dsm_aux_cfg,        // dsm_cfg
+					hw_DSMxMode,                         // dsm_mode
+					NULL);                               // sbus_cfg
+		}
+
+		if (hw_rcvrport == HWQUANTON_RCVRPORT_SERIAL)
+			break;
+
+		// Else fall through to set up PPM.
+
 	case HWQUANTON_RCVRPORT_PPM:
 	case HWQUANTON_RCVRPORT_PPMADC:
 	case HWQUANTON_RCVRPORT_PPMOUTPUTS:
@@ -726,11 +751,13 @@ void PIOS_Board_Init(void) {
 #endif
 
 #if defined(PIOS_INCLUDE_ADC)
-	if (hw_rcvrport == HWQUANTON_RCVRPORT_PWMADC ||
-			hw_rcvrport == HWQUANTON_RCVRPORT_PPMADC ||
-			hw_rcvrport == HWQUANTON_RCVRPORT_PPMPWMADC ||
-			hw_rcvrport == HWQUANTON_RCVRPORT_OUTPUTSADC ||
-			hw_rcvrport == HWQUANTON_RCVRPORT_PPMOUTPUTSADC) {
+	if (hw_rcvrport == HWQUANTON_RCVRPORT_OUTPUTSADC ||
+		hw_rcvrport == HWQUANTON_RCVRPORT_PPMADC ||
+		hw_rcvrport == HWQUANTON_RCVRPORT_PPMOUTPUTSADC ||
+		hw_rcvrport == HWQUANTON_RCVRPORT_PPMPWMADC ||
+		hw_rcvrport == HWQUANTON_RCVRPORT_PPMSERIALADC ||
+		hw_rcvrport == HWQUANTON_RCVRPORT_PWMADC)
+	{
 		uint32_t internal_adc_id;
 		PIOS_INTERNAL_ADC_Init(&internal_adc_id, &pios_adc_cfg);
 		PIOS_ADC_Init(&pios_internal_adc_id, &pios_internal_adc_driver, internal_adc_id);

--- a/ground/gcs/src/plugins/boards_quantec/quanton.cpp
+++ b/ground/gcs/src/plugins/boards_quantec/quanton.cpp
@@ -151,11 +151,12 @@ QStringList Quanton::getAdcNames()
         return QStringList();
 
     HwQuanton::DataFields settings = hwQuanton->getData();
-    if (settings.RcvrPort == HwQuanton::RCVRPORT_OUTPUTSADC ||
-            settings.RcvrPort == HwQuanton::RCVRPORT_PPMADC ||
-            settings.RcvrPort == HwQuanton::RCVRPORT_PPMOUTPUTSADC ||
-            settings.RcvrPort == HwQuanton::RCVRPORT_PPMPWMADC ||
-            settings.RcvrPort == HwQuanton::RCVRPORT_PWMADC) {
+    if (settings.InPort == HwQuanton::INPORT_OUTPUTSADC ||
+            settings.InPort == HwQuanton::INPORT_PPMADC ||
+            settings.InPort == HwQuanton::INPORT_PPMOUTPUTSADC ||
+            settings.InPort == HwQuanton::INPORT_PPMPWMADC ||
+            settings.InPort == HwQuanton::INPORT_PWMADC ||
+            settings.InPort == HwQuanton::INPORT_PPMSERIALADC) {
         return QStringList() << "IN 7" << "IN 8";
     }
 

--- a/shared/uavobjectdefinition/hwquanton.xml
+++ b/shared/uavobjectdefinition/hwquanton.xml
@@ -11,10 +11,37 @@
 				<option>PPM+ADC</option>
 				<option>PPM+Outputs</option>
 				<option>PPM+Outputs+ADC</option>
+				<option>PPM+Serial</option>
+				<option>PPM+Serial+ADC</option>
 				<option>PPM+PWM</option>
 				<option>PPM+PWM+ADC</option>
 				<option>PWM</option>
 				<option>PWM+ADC</option>
+				<option>Serial</option>
+			</options>
+		</field>
+
+		<field name="RcvrSerial" units="function" type="enum" elements="1" parent="HwShared.PortTypes" defaultvalue="Disabled">
+			<options>
+				<option>Disabled</option>
+				<option>ComBridge</option>
+				<option>DebugConsole</option>
+				<option>DSM</option>
+				<option>FrSKY Sensor Hub</option>
+				<option>FrSKY SPort Telemetry</option>
+				<option>GPS</option>
+				<option>HoTT SUMD</option>
+				<option>HoTT SUMH</option>
+				<option>HoTT Telemetry</option>
+				<option>LighttelemetryTx</option>
+				<option>MavLinkTX</option>
+				<option>MavLinkTX_GPS_RX</option>
+				<option>MSP</option>
+				<option>OpenLog</option>
+				<option>PicoC</option>
+				<option>S.Bus Non Inverted</option>
+				<option>Storm32Bgc</option>
+				<option>Telemetry</option>
 			</options>
 		</field>
 

--- a/shared/uavobjectdefinition/hwquanton.xml
+++ b/shared/uavobjectdefinition/hwquanton.xml
@@ -2,7 +2,7 @@
 	<object name="HwQuanton" singleinstance="true" settings="true" category="HardwareSettings">
 		<description>Selection of optional hardware configurations.</description>
 
-		<field name="RcvrPort" units="function" type="enum" elements="1" defaultvalue="PWM">
+		<field name="InPort" units="function" type="enum" elements="1" defaultvalue="PWM">
 			<options>
 				<option>Disabled</option>
 				<option>Outputs</option>
@@ -21,7 +21,7 @@
 			</options>
 		</field>
 
-		<field name="RcvrSerial" units="function" type="enum" elements="1" parent="HwShared.PortTypes" defaultvalue="Disabled">
+		<field name="InPortSerial" units="function" type="enum" elements="1" parent="HwShared.PortTypes" defaultvalue="Disabled">
 			<options>
 				<option>Disabled</option>
 				<option>ComBridge</option>


### PR DESCRIPTION
Addition of Usart6 to Quanton.  New rcvrport modes:

PPM+Serial
PPM+Serial+ADC
Serial

Usart6 TX is PWM In2, Usart6 RX is PWM In3.

Setup DSM satellite on Usart6 RX, PPM+Serial selected.  Was able to successfully complete the input wizard.  Satellite functioned as expected.  Changed to PPM+Serial+ADC, and satellite still worked as expected.  Same with Serial selected.  Selecting PPM caused satellite to become unresponsive.

This is the extent of the testing I can do with the hardware I have readily available.  If someone could test PPM and ADC function, that would be a more complete test.

Addresses #924.
