### PR TITLE
Naze32: Attempt retry with alternate EXTI config on failed MPU init

### DIFF
--- a/flight/PiOS/Common/pios_mpu.c
+++ b/flight/PiOS/Common/pios_mpu.c
@@ -423,7 +423,8 @@ static int32_t PIOS_MPU_Common_Init(void)
 
 	/* Wait 20 ms for data ready interrupt and make sure it happens twice */
 	if ((PIOS_Semaphore_Take(mpu_dev->data_ready_sema, 20) != true) ||
-		(PIOS_Semaphore_Take(mpu_dev->data_ready_sema, 20) != true)) {
+			(PIOS_Semaphore_Take(mpu_dev->data_ready_sema, 20) != true)) {
+		PIOS_EXTI_DeInit(mpu_dev->cfg->exti_cfg);
 		return -PIOS_MPU_ERROR_NOIRQ;
 	}
 

--- a/flight/PiOS/STM32F30x/pios_exti.c
+++ b/flight/PiOS/STM32F30x/pios_exti.c
@@ -150,6 +150,32 @@ out_fail:
 	return -1;
 }
 
+void PIOS_EXTI_DeInit(const struct pios_exti_cfg *cfg)
+{
+	PIOS_Assert(cfg);
+	PIOS_Assert(&__start__exti);
+	PIOS_Assert(cfg >= &__start__exti);
+	PIOS_Assert(cfg < &__stop__exti);
+
+	/* Disconnect this config from the requested vector */
+	uint8_t line_index = PIOS_EXTI_line_to_index(cfg->line);
+	pios_exti_line_to_cfg_map[line_index] = PIOS_EXTI_INVALID;
+
+	/* Disconnect EXTI */
+	uint8_t exti_source_pin = PIOS_EXTI_gpio_pin_to_exti_source_pin(cfg->pin.init.GPIO_Pin);
+	// sadly std-periph doesn't provide a way to disable the exti line
+	uint32_t tmp = ((uint32_t)0x0F) << (0x04 * (exti_source_pin & (uint8_t)0x03));
+	SYSCFG->EXTICR[exti_source_pin >> 0x02] &= ~tmp;
+
+	/* Disable EXTI */
+	EXTI_InitTypeDef init = {
+		.EXTI_LineCmd = DISABLE,
+		.EXTI_Mode = cfg->exti.init.EXTI_Mode,
+		.EXTI_Line = cfg->exti.init.EXTI_Line,
+	};
+	EXTI_Init(&init);
+}
+
 static bool PIOS_EXTI_generic_irq_handler(uint8_t line_index)
 {
 	uint8_t cfg_index = pios_exti_line_to_cfg_map[line_index];

--- a/flight/PiOS/STM32F4xx/pios_exti.c
+++ b/flight/PiOS/STM32F4xx/pios_exti.c
@@ -150,6 +150,32 @@ out_fail:
 	return -1;
 }
 
+void PIOS_EXTI_DeInit(const struct pios_exti_cfg *cfg)
+{
+	PIOS_Assert(cfg);
+	PIOS_Assert(&__start__exti);
+	PIOS_Assert(cfg >= &__start__exti);
+	PIOS_Assert(cfg < &__stop__exti);
+
+	/* Disconnect this config from the requested vector */
+	uint8_t line_index = PIOS_EXTI_line_to_index(cfg->line);
+	pios_exti_line_to_cfg_map[line_index] = PIOS_EXTI_INVALID;
+
+	/* Disconnect EXTI */
+	uint8_t exti_source_pin = PIOS_EXTI_gpio_pin_to_exti_source_pin(cfg->pin.init.GPIO_Pin);
+	// sadly std-periph doesn't provide a way to disable the exti line
+	uint32_t tmp = ((uint32_t)0x0F) << (0x04 * (exti_source_pin & (uint8_t)0x03));
+	SYSCFG->EXTICR[exti_source_pin >> 0x02] &= ~tmp;
+
+	/* Disable EXTI */
+	EXTI_InitTypeDef init = {
+		.EXTI_LineCmd = DISABLE,
+		.EXTI_Mode = cfg->exti.init.EXTI_Mode,
+		.EXTI_Line = cfg->exti.init.EXTI_Line,
+	};
+	EXTI_Init(&init);
+}
+
 static bool PIOS_EXTI_generic_irq_handler(uint8_t line_index)
 {
 	uint8_t cfg_index = pios_exti_line_to_cfg_map[line_index];

--- a/flight/PiOS/inc/pios_exti.h
+++ b/flight/PiOS/inc/pios_exti.h
@@ -46,7 +46,8 @@ struct pios_exti_cfg {
 /* must be added to any pios_exti_cfg definition for it to be valid */
 #define __exti_config	__attribute__((section("_exti")))
 
-extern int32_t PIOS_EXTI_Init(const struct pios_exti_cfg * cfg);
+extern int32_t PIOS_EXTI_Init(const struct pios_exti_cfg *cfg);
+extern void PIOS_EXTI_DeInit(const struct pios_exti_cfg *cfg);
 
 #endif /* PIOS_EXTI_H */
 

--- a/flight/targets/naze32/fw/pios_board.c
+++ b/flight/targets/naze32/fw/pios_board.c
@@ -243,6 +243,11 @@ void PIOS_Board_Init(void) {
 
 	pios_mpu_dev_t mpu_dev = NULL;
 	int retval = PIOS_MPU_I2C_Init(&mpu_dev, pios_i2c_internal_id, &pios_mpu_cfg);
+	if (retval == -PIOS_MPU_ERROR_NOIRQ && mpu_pin == HWNAZE_MPU6050INTPIN_AUTO) {
+		// retry with alternate exti config, needed on afromini
+		pios_mpu_cfg.exti_cfg = (pios_mpu_cfg.exti_cfg == &pios_exti_mpu_cfg_v5) ? &pios_exti_mpu_cfg : &pios_exti_mpu_cfg_v5;
+		retval = PIOS_MPU_I2C_Init(&mpu_dev, pios_i2c_internal_id, &pios_mpu_cfg);
+	}
 	if (retval != 0)
 		PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_IMU);
 


### PR DESCRIPTION
Should make Afromini Amaze work. Completely untested, but compiles. Please test @dustin.

Fixes #938 
