### PR TITLE
Finish the removal of MWRate flight mode.

### DIFF
--- a/ground/gcs/src/plugins/config/input.ui
+++ b/ground/gcs/src/plugins/config/input.ui
@@ -128,8 +128,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>852</width>
-            <height>584</height>
+            <width>850</width>
+            <height>572</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout">
@@ -578,8 +578,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>852</width>
-            <height>584</height>
+            <width>850</width>
+            <height>572</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_7" rowstretch="1,0,0">
@@ -1228,16 +1228,6 @@ channel value for each flight mode.</string>
                   </property>
                  </widget>
                 </item>
-                <item row="2" column="0">
-                 <widget class="QLabel" name="lblMultiwii">
-                  <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:12pt; font-weight:600; color:#ff0000;&quot;&gt;Note:&lt;/span&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt; Multiwii flight mode is deprecated, it will be &lt;/span&gt;&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;&gt;removed&lt;/span&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt; in a future release! Consider Acro+ instead.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                  </property>
-                  <property name="wordWrap">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
                </layout>
               </item>
               <item row="2" column="1">
@@ -1404,8 +1394,8 @@ channel value for each flight mode.</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>838</width>
-            <height>817</height>
+            <width>588</width>
+            <height>818</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/shared/uavobjectdefinition/flightstatus.xml
+++ b/shared/uavobjectdefinition/flightstatus.xml
@@ -9,7 +9,6 @@
 				<option>Manual</option>
 				<option>Acro</option>
 				<option>Leveling</option>
-				<option>MWRate</option>
 				<option>Horizon</option>
 				<option>AxisLock</option>
 				<option>VirtualBar</option>

--- a/shared/uavobjectdefinition/manualcontrolsettings.xml
+++ b/shared/uavobjectdefinition/manualcontrolsettings.xml
@@ -124,13 +124,13 @@
 		<field name="DisarmTime" units="ms" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="1000"/>
  
 		<!-- Note these options should be identical to those in StabilizationDesired.StabilizationMode -->
-		<field name="Stabilization1Settings" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,MWRate,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled,Failsafe" defaultvalue="Attitude,Attitude,Rate"/>
-		<field name="Stabilization2Settings" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,MWRate,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled,Failsafe" defaultvalue="Attitude,Attitude,Rate"/>
-		<field name="Stabilization3Settings" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,MWRate,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled,Failsafe" defaultvalue="Attitude,Attitude,Rate"/>
+		<field name="Stabilization1Settings" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled,Failsafe" defaultvalue="Attitude,Attitude,Rate"/>
+		<field name="Stabilization2Settings" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled,Failsafe" defaultvalue="Attitude,Attitude,Rate"/>
+		<field name="Stabilization3Settings" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled,Failsafe" defaultvalue="Attitude,Attitude,Rate"/>
 
 		<!-- Note these options values should be identical to those defined in FlightMode -->
 		<field name="FlightModeNumber" units="" type="uint8" elements="1" defaultvalue="3"/>
-		<field name="FlightModePosition" units="" type="enum" elements="6" options="Manual,Acro,Leveling,MWRate,Horizon,AxisLock,VirtualBar,Stabilized1,Stabilized2,Stabilized3,Autotune,AltitudeHold,PositionHold,ReturnToHome,PathPlanner,TabletControl,AcroPlus,Failsafe" defaultvalue="Leveling,Leveling,Leveling,Horizon,ReturnToHome,PositionHold"/>
+		<field name="FlightModePosition" units="" type="enum" elements="6" options="Manual,Acro,Leveling,Horizon,AxisLock,VirtualBar,Stabilized1,Stabilized2,Stabilized3,Autotune,AltitudeHold,PositionHold,ReturnToHome,PathPlanner,TabletControl,AcroPlus,Failsafe" defaultvalue="Leveling,Leveling,Leveling,Horizon,ReturnToHome,PositionHold"/>
 
 		<!-- This option prevents timing out arming when disabled and in autonomous modes.
                      It is enabled by default for additional safety to prevent flyaways -->

--- a/shared/uavobjectdefinition/stabilizationdesired.xml
+++ b/shared/uavobjectdefinition/stabilizationdesired.xml
@@ -6,7 +6,7 @@
 		<field name="Yaw" units="degrees" type="float" elements="1"/>
 		<field name="Thrust" units="%" type="float" elements="1"/>
 		<!-- These values should match those in ManualControlCommand.Stabilization{1,2,3}Settings -->
-		<field name="StabilizationMode" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,MWRate,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled,Failsafe"/>
+		<field name="StabilizationMode" units="" type="enum" elementnames="Roll,Pitch,Yaw" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled,Failsafe"/>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="false" updatemode="manual" period="0"/>
 		<telemetryflight acked="false" updatemode="throttled" period="1000"/>


### PR DESCRIPTION
UAVOs were skipped in the initial pass, as was a warning on the flight
mode selection screen.

Fixes #934
