### PR TITLE
flight: avoid getting uavos unnecessarily

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -286,9 +286,6 @@ static void actuator_task(void* parameters)
 			manualControlCommandUpdated = false;
 		}
 
-#if defined(MIXERSTATUS_DIAGNOSTICS)
-		MixerStatusGet(&mixerStatus);
-#endif
 		int nMixers = 0;
 
 		for (int ct = 0; ct < MAX_MIX_ACTUATORS; ct++) {
@@ -445,9 +442,13 @@ static void actuator_task(void* parameters)
 			command.MaxUpdateTime = 1000.0f*dT;
 
 		// Update output object
-		ActuatorCommandSet(&command);
-		// Update in case read only (eg. during servo configuration)
-		ActuatorCommandGet(&command);
+		if (!ActuatorCommandReadOnly()) {
+			ActuatorCommandSet(&command);
+		} else {
+			// it's read only during servo configuration--
+			// so GCS takes precedence.
+			ActuatorCommandGet(&command);
+		}
 
 #if defined(MIXERSTATUS_DIAGNOSTICS)
 		MixerStatusSet(&mixerStatus);

--- a/flight/Modules/Airspeed/airspeed.c
+++ b/flight/Modules/Airspeed/airspeed.c
@@ -195,8 +195,6 @@ static void airspeedTask(void *parameters)
 {
 	BaroAirspeedData airspeedData;
 	AirspeedActualData airspeedActualData;
-
-	airspeedData.BaroConnected = BAROAIRSPEED_BAROCONNECTED_FALSE;
 	
 #ifdef BARO_AIRSPEED_PRESENT		
 	uint32_t lastGPSTime = PIOS_Thread_Systime(); //Time since last GPS-derived airspeed calculation
@@ -215,6 +213,12 @@ static void airspeedTask(void *parameters)
 	
 	// Main task loop
 	uint32_t lastSysTime = PIOS_Thread_Systime();
+
+	// Get initial values of airspeed object
+	BaroAirspeedGet(&airspeedData);
+
+	airspeedData.BaroConnected = BAROAIRSPEED_BAROCONNECTED_FALSE;
+
 	while (1)
 	{
 		if (settingsUpdated) {
@@ -222,9 +226,6 @@ static void airspeedTask(void *parameters)
 
 			doSettingsUpdate();
 		}
-
-		// Update the airspeed object
-		BaroAirspeedGet(&airspeedData);
 
 #ifdef BARO_AIRSPEED_PRESENT
 		float airspeed_tas_baro=0;
@@ -348,7 +349,6 @@ static void airspeedTask(void *parameters)
 		airspeedActualData.CalibratedAirspeed = airspeedData.CalibratedAirspeed;
 		BaroAirspeedSet(&airspeedData);
 		AirspeedActualSet(&airspeedActualData);
-			
 	}
 }
 

--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -246,7 +246,6 @@ static void altitudeHoldTask(void *parameters)
 			altitudeHoldState.Thrust = throttle_desired;
 			AltitudeHoldStateSet(&altitudeHoldState);
 
-			StabilizationDesiredGet(&stabilizationDesired);
 			stabilizationDesired.Thrust = bound_min_max(throttle_desired, min_throttle, 1.0f);
 
 			if (landing) {

--- a/flight/Modules/Attitude/acro/attitude.c
+++ b/flight/Modules/Attitude/acro/attitude.c
@@ -135,7 +135,6 @@ int32_t AttitudeInitialize(void)
 	
 	// Initialize quaternion
 	AttitudeActualData attitude;
-	AttitudeActualGet(&attitude);
 	attitude.q1 = 1;
 	attitude.q2 = 0;
 	attitude.q3 = 0;
@@ -546,10 +545,12 @@ static void updateAttitude(AccelsData * accelsData, GyrosData * gyrosData)
 		q[3] = 0;
 	}
 	
-	AttitudeActualData attitudeActual;
-	AttitudeActualGet(&attitudeActual);
-	
-	quat_copy(q, &attitudeActual.q1);
+	AttitudeActualData attitudeActual = {
+		.q1 = q[0],
+		.q2 = q[1],
+		.q3 = q[2],
+		.q4 = q[3],
+	};
 	
 	// Convert into eueler degrees (makes assumptions about RPY order)
 	Quaternion2RPY(&attitudeActual.q1,&attitudeActual.Roll);

--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -831,14 +831,12 @@ static int32_t setNavigationRaw()
 		getNED(&gpsPosition, NED);
 
 		NEDPositionData nedPosition;
-		NEDPositionGet(&nedPosition);
 		nedPosition.North = NED[0];
 		nedPosition.East = NED[1];
 		nedPosition.Down = NED[2];
 		NEDPositionSet(&nedPosition);
 
 		PositionActualData positionActual;
-		PositionActualGet(&positionActual);
 		positionActual.North = NED[0];
 		positionActual.East = NED[1];
 		positionActual.Down = cfvert.position_z;
@@ -853,7 +851,6 @@ static int32_t setNavigationRaw()
 		GPSVelocityGet(&gpsVelocity);
 
 		VelocityActualData velocityActual;
-		VelocityActualGet(&velocityActual);
 		velocityActual.North = gpsVelocity.North;
 		velocityActual.East = gpsVelocity.East;
 		velocityActual.Down = cfvert.velocity_z;
@@ -905,7 +902,6 @@ static void accumulate_gyro_compute()
 
 		// Accumulate integral of error.  Scale here so that units are (deg/s) but Ki has units of s
 		GyrosBiasData gyrosBias;
-		GyrosBiasGet(&gyrosBias);
 		gyrosBias.x = complementary_filter_state.accumulated_gyro[0] / complementary_filter_state.accumulated_gyro_samples;
 		gyrosBias.y = complementary_filter_state.accumulated_gyro[1] / complementary_filter_state.accumulated_gyro_samples;
 		gyrosBias.z = complementary_filter_state.accumulated_gyro[2] / complementary_filter_state.accumulated_gyro_samples;
@@ -1410,7 +1406,6 @@ static void updateNedAccel()
 	accel_ned[2] += GRAVITY;
 	
 	NedAccelData accelData;
-	NedAccelGet(&accelData);
 	accelData.North = accelData.North * TAU + accel_ned[0] * (1 - TAU);
 	accelData.East = accelData.East * TAU + accel_ned[1] * (1 - TAU);
 	accelData.Down = accelData.Down * TAU + accel_ned[2] * (1 - TAU);
@@ -1475,7 +1470,6 @@ static void settingsUpdatedCb(UAVObjEvent * ev, void *ctx, void *obj, int len)
 		
 		/* When the calibration is updated, update the GyroBias object */
 		GyrosBiasData gyrosBias;
-		GyrosBiasGet(&gyrosBias);
 		gyrosBias.x = 0;
 		gyrosBias.y = 0;
 		gyrosBias.z = 0;

--- a/flight/Modules/Battery/battery.c
+++ b/flight/Modules/Battery/battery.c
@@ -107,17 +107,17 @@ static void batteryTask(void * parameters)
 	bool cells_calculated = false;
 	unsigned cells = 1;
 
+	FlightBatteryStateData flightBatteryData;
+	FlightBatterySettingsData batterySettings;
+
+	FlightBatteryStateGet(&flightBatteryData);
+
 	// Main task loop
 	uint32_t lastSysTime;
 	lastSysTime = PIOS_Thread_Systime();
 	while (true) {
 		PIOS_Thread_Sleep_Until(&lastSysTime, SAMPLE_PERIOD_MS);
-
-		FlightBatteryStateData flightBatteryData;
-		FlightBatterySettingsData batterySettings;
 		float energyRemaining;
-
-		FlightBatteryStateGet(&flightBatteryData);
 
 		if (battery_settings_updated) {
 			battery_settings_updated = false;

--- a/flight/Modules/ManualControl/failsafe_control.c
+++ b/flight/Modules/ManualControl/failsafe_control.c
@@ -78,7 +78,6 @@ int32_t failsafe_control_select(bool reset_controller)
 	SystemSettingsAirframeTypeGet(&airframe_type);
 
 	StabilizationDesiredData stabilization_desired;
-	StabilizationDesiredGet(&stabilization_desired);
 	stabilization_desired.Thrust = (airframe_type == SYSTEMSETTINGS_AIRFRAMETYPE_HELICP) ? 0 : -1;
 	stabilization_desired.Roll = 0;
 	stabilization_desired.Pitch = 0;

--- a/flight/Modules/Sensors/simulated/sensors.c
+++ b/flight/Modules/Sensors/simulated/sensors.c
@@ -136,18 +136,6 @@ int sensors_count;
 static void SensorsTask(void *parameters)
 {
 	AlarmsClear(SYSTEMALARMS_ALARM_SENSORS);
-	
-//	HomeLocationData homeLocation;
-//	HomeLocationGet(&homeLocation);
-//	homeLocation.Latitude = 0;
-//	homeLocation.Longitude = 0;
-//	homeLocation.Altitude = 0;
-//	homeLocation.Be[0] = 26000;
-//	homeLocation.Be[1] = 400;
-//	homeLocation.Be[2] = 40000;
-//	homeLocation.Set = HOMELOCATION_SET_TRUE;
-//	HomeLocationSet(&homeLocation);
-
 
 	PIOS_SENSORS_SetMaxGyro(500);
 	// Main task loop


### PR DESCRIPTION
Largely fixes #471.

Avoids copying lots of data and removes some pressure on UAVO lock.
