### PR TITLE
Flight: Fix F3 version of pios_internal_adc.c

### DIFF
--- a/flight/PiOS/STM32F30x/pios_internal_adc.c
+++ b/flight/PiOS/STM32F30x/pios_internal_adc.c
@@ -232,11 +232,6 @@ static void PIOS_INTERNAL_ADC_Converter_Config(uint32_t internal_adc_id)
 			;
 	}
 
-	if (adc_dev->cfg->adc_dev_master == ADC1 || adc_dev->cfg->adc_dev_master == ADC2)
-		RCC_ADCCLKConfig(RCC_ADC12PLLCLK_Div256);
-	else
-		RCC_ADCCLKConfig(RCC_ADC34PLLCLK_Div256);
-
 	/* Do common ADC init */
 	ADC_CommonInitTypeDef ADC_CommonInitStructure;
 	ADC_CommonStructInit(&ADC_CommonInitStructure);

--- a/flight/PiOS/STM32F30x/pios_internal_adc.c
+++ b/flight/PiOS/STM32F30x/pios_internal_adc.c
@@ -212,9 +212,9 @@ static void PIOS_INTERNAL_ADC_Converter_Config(uint32_t internal_adc_id)
 		ADC_DeInit(adc_dev->cfg->adc_dev_slave);
 
 	if (adc_dev->cfg->adc_dev_master == ADC1 || adc_dev->cfg->adc_dev_master == ADC2 )
-		RCC_ADCCLKConfig(RCC_ADC12PLLCLK_Div16);
+		RCC_ADCCLKConfig(RCC_ADC12PLLCLK_Div32);
 	else
-		RCC_ADCCLKConfig(RCC_ADC34PLLCLK_Div16);
+		RCC_ADCCLKConfig(RCC_ADC34PLLCLK_Div32);
 
 	ADC_VoltageRegulatorCmd(adc_dev->cfg->adc_dev_master, ENABLE);
 	PIOS_DELAY_WaituS(10);


### PR DESCRIPTION
I've been working on implementing a servo position feedback using an ADC channel.  I'm reading on ADC channel from the actuator task.  I discovered that I could get stable readings from F4 targets, but F3 targets would not read reliably.

After studying pios_internal_adc.c for F3 targets, I noticed that the ADC clock is set (clock divisor set to 16), then both the master and slave (if applicable) ADCs are calibrated.  So far so good.  Then the clock divisor is changed to 256.  I don't think the ADC clock should be changed after calibration is done.  

After removing the code code that changes the divisor after calibration, the F3 targets now return stable readings.

I'm not sure what the reasoning behind the change from divide by 16 to divide by 256, but that seems to be the cause of the issue I was seeing.

Tested on Sparky 1, on both ADC0 and ADC1.
