### PR TITLE
GCS:Stabilization: Move hangtime to checkable groupbox

### DIFF
--- a/ground/gcs/src/plugins/config/configstabilizationwidget.cpp
+++ b/ground/gcs/src/plugins/config/configstabilizationwidget.cpp
@@ -62,10 +62,11 @@ ConfigStabilizationWidget::ConfigStabilizationWidget(QWidget *parent) : ConfigTa
         m_stabilization->saveStabilizationToRAM_6->setVisible(false);
 
     // display switch arming not selected warning when hangtime enabled
-    connect(m_stabilization->sbHangtime, SIGNAL(valueChanged(double)), this, SLOT(hangtimeChanged()));
+    connect(m_stabilization->sbHangtimeDuration, SIGNAL(valueChanged(double)), this, SLOT(hangtimeDurationChanged()));
     manualControlSettings = getObjectManager()->getObject(ManualControlSettings::NAME);
     if (manualControlSettings)
-        connect(manualControlSettings, SIGNAL(objectUpdated(UAVObject*)), this, SLOT(hangtimeChanged()));
+        connect(manualControlSettings, SIGNAL(objectUpdated(UAVObject*)), this, SLOT(hangtimeDurationChanged()));
+    connect(m_stabilization->gbHangtime, SIGNAL(toggled(bool)), this, SLOT(hangtimeToggle(bool)));
 
 
     autoLoadWidgets();
@@ -353,9 +354,15 @@ void ConfigStabilizationWidget::showExpoPlot()
     }
 }
 
-void ConfigStabilizationWidget::hangtimeChanged()
+void ConfigStabilizationWidget::hangtimeDurationChanged()
 {
-    bool warn = m_stabilization->sbHangtime->value() > 0.0;
+    bool warn = m_stabilization->sbHangtimeDuration->value() > 0.0;
+
+    if (warn && !m_stabilization->gbHangtime->isChecked())
+        m_stabilization->gbHangtime->setChecked(true);
+    else if (!warn && m_stabilization->gbHangtime->isChecked())
+        m_stabilization->gbHangtime->setChecked(false);
+
     if (manualControlSettings) {
         UAVObjectField *field = manualControlSettings->getField("Arming");
         if (field) {
@@ -364,4 +371,12 @@ void ConfigStabilizationWidget::hangtimeChanged()
         }
     }
     m_stabilization->lblSwitchArmingWarning->setVisible(warn);
+}
+
+void ConfigStabilizationWidget::hangtimeToggle(bool enabled)
+{
+    if (!enabled)
+        m_stabilization->sbHangtimeDuration->setValue(0.0); // 0.0 is disabled
+    else if(m_stabilization->sbHangtimeDuration->value() == 0.0)
+        m_stabilization->sbHangtimeDuration->setValue(2.5); // default duration in s
 }

--- a/ground/gcs/src/plugins/config/configstabilizationwidget.h
+++ b/ground/gcs/src/plugins/config/configstabilizationwidget.h
@@ -72,7 +72,8 @@ private slots:
     void applyRateLimits();
 
     void showExpoPlot();
-    void hangtimeChanged();
+    void hangtimeDurationChanged();
+    void hangtimeToggle(bool enabled);
 };
 
 #endif // ConfigStabilizationWidget_H

--- a/ground/gcs/src/plugins/config/stabilization.ui
+++ b/ground/gcs/src/plugins/config/stabilization.ui
@@ -10498,7 +10498,7 @@ border-radius: 5;</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>951</width>
+            <width>1006</width>
             <height>967</height>
            </rect>
           </property>
@@ -28702,9 +28702,6 @@ border-radius: 5;</string>
                   <property name="decimals">
                    <number>1</number>
                   </property>
-                  <property name="maximum">
-                   <double>15.000000000000000</double>
-                  </property>
                   <property name="singleStep">
                    <double>0.500000000000000</double>
                   </property>
@@ -28717,6 +28714,7 @@ border-radius: 5;</string>
                     <string>fieldname:LowPowerStabilizationMaxPowerAdd</string>
                     <string>scale:.01</string>
                     <string>buttongroup:10</string>
+                    <string>haslimits:yes</string>
                    </stringlist>
                   </property>
                  </widget>
@@ -28758,9 +28756,6 @@ border-radius: 5;</string>
                   <property name="suffix">
                    <string> s</string>
                   </property>
-                  <property name="maximum">
-                   <double>4.500000000000000</double>
-                  </property>
                   <property name="singleStep">
                    <double>0.250000000000000</double>
                   </property>
@@ -28769,6 +28764,7 @@ border-radius: 5;</string>
                     <string>objname:ActuatorSettings</string>
                     <string>fieldname:LowPowerStabilizationMaxTime</string>
                     <string>buttongroup:10</string>
+                    <string>haslimits:yes</string>
                    </stringlist>
                   </property>
                  </widget>

--- a/ground/gcs/src/plugins/config/stabilization.ui
+++ b/ground/gcs/src/plugins/config/stabilization.ui
@@ -498,7 +498,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <property name="documentMode">
       <bool>false</bool>
@@ -10498,7 +10498,7 @@ border-radius: 5;</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>1006</width>
+            <width>951</width>
             <height>967</height>
            </rect>
           </property>
@@ -25838,7 +25838,7 @@ border-radius: 5;</string>
             <x>0</x>
             <y>0</y>
             <width>1006</width>
-            <height>1266</height>
+            <height>1346</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -28578,93 +28578,6 @@ border-radius: 5;</string>
                 <string>Advanced Acro Settings</string>
                </property>
                <layout class="QGridLayout" name="gridLayout_31">
-                <item row="0" column="5">
-                 <spacer name="horizontalSpacer_23">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Fixed</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>10</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item row="0" column="10">
-                 <widget class="QDoubleSpinBox" name="sbHungPower">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="toolTip">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This specifies the maximum amount of power to add when stabilization needs more total power than specified by the throttle input.  This is used during HangTime and other maneuvers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                  </property>
-                  <property name="suffix">
-                   <string>%</string>
-                  </property>
-                  <property name="decimals">
-                   <number>1</number>
-                  </property>
-                  <property name="maximum">
-                   <double>15.000000000000000</double>
-                  </property>
-                  <property name="singleStep">
-                   <double>0.500000000000000</double>
-                  </property>
-                  <property name="value">
-                   <double>0.000000000000000</double>
-                  </property>
-                  <property name="objrelation" stdset="0">
-                   <stringlist>
-                    <string>objname:ActuatorSettings</string>
-                    <string>fieldname:LowPowerStabilizationMaxPowerAdd</string>
-                    <string>scale:.01</string>
-                    <string>buttongroup:10</string>
-                   </stringlist>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="9">
-                 <spacer name="horizontalSpacer_25">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Fixed</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>10</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item row="0" column="0">
-                 <widget class="QLabel" name="lblInsanityFactor">
-                  <property name="minimumSize">
-                   <size>
-                    <width>150</width>
-                    <height>16</height>
-                   </size>
-                  </property>
-                  <property name="text">
-                   <string>Acro+ Insanity Factor</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                  </property>
-                 </widget>
-                </item>
                 <item row="0" column="1">
                  <spacer name="horizontalSpacer_21">
                   <property name="orientation">
@@ -28680,26 +28593,6 @@ border-radius: 5;</string>
                    </size>
                   </property>
                  </spacer>
-                </item>
-                <item row="0" column="4">
-                 <widget class="QLabel" name="label_4">
-                  <property name="text">
-                   <string>HangTime Maximum Duration</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="8">
-                 <widget class="QLabel" name="label_5">
-                  <property name="text">
-                   <string>Maximum Power Add</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                  </property>
-                 </widget>
                 </item>
                 <item row="0" column="2">
                  <widget class="QDoubleSpinBox" name="sbInsanityFactor">
@@ -28738,8 +28631,118 @@ border-radius: 5;</string>
                   </property>
                  </widget>
                 </item>
-                <item row="0" column="6">
-                 <widget class="QDoubleSpinBox" name="sbHangtime">
+                <item row="1" column="0" colspan="5">
+                 <widget class="QLabel" name="lblSwitchArmingWarning">
+                  <property name="text">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;Warning:&lt;/span&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; It is strongly recommended to use switch arming when HangTime is enabled.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="lblInsanityFactor">
+                  <property name="minimumSize">
+                   <size>
+                    <width>150</width>
+                    <height>16</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Acro+ Insanity Factor</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="3">
+                 <spacer name="horizontalSpacer_35">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="gbHangtime">
+               <property name="title">
+                <string>HangTime</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+               <property name="checked">
+                <bool>false</bool>
+               </property>
+               <layout class="QGridLayout" name="gridLayout_7">
+                <item row="0" column="4">
+                 <widget class="QDoubleSpinBox" name="sbHangtimePower">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="toolTip">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This specifies the maximum amount of power to add when stabilization needs more total power than specified by the throttle input.  This is used during HangTime and other maneuvers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                  <property name="suffix">
+                   <string>%</string>
+                  </property>
+                  <property name="decimals">
+                   <number>1</number>
+                  </property>
+                  <property name="maximum">
+                   <double>15.000000000000000</double>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.500000000000000</double>
+                  </property>
+                  <property name="value">
+                   <double>0.000000000000000</double>
+                  </property>
+                  <property name="objrelation" stdset="0">
+                   <stringlist>
+                    <string>objname:ActuatorSettings</string>
+                    <string>fieldname:LowPowerStabilizationMaxPowerAdd</string>
+                    <string>scale:.01</string>
+                    <string>buttongroup:10</string>
+                   </stringlist>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="lblHangtimeDuration">
+                  <property name="text">
+                   <string>HangTime Maximum Duration</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="3">
+                 <widget class="QLabel" name="lblHangtimePower">
+                  <property name="text">
+                   <string>Maximum Power Add</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QDoubleSpinBox" name="sbHangtimeDuration">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                     <horstretch>0</horstretch>
@@ -28770,8 +28773,8 @@ border-radius: 5;</string>
                   </property>
                  </widget>
                 </item>
-                <item row="0" column="3">
-                 <spacer name="horizontalSpacer_35">
+                <item row="0" column="2">
+                 <spacer name="horizontalSpacer_23">
                   <property name="orientation">
                    <enum>Qt::Horizontal</enum>
                   </property>
@@ -28783,25 +28786,18 @@ border-radius: 5;</string>
                   </property>
                  </spacer>
                 </item>
-                <item row="0" column="7">
-                 <spacer name="horizontalSpacer_40">
+                <item row="0" column="5">
+                 <spacer name="horizontalSpacer_25">
                   <property name="orientation">
                    <enum>Qt::Horizontal</enum>
                   </property>
                   <property name="sizeHint" stdset="0">
                    <size>
-                    <width>0</width>
+                    <width>40</width>
                     <height>20</height>
                    </size>
                   </property>
                  </spacer>
-                </item>
-                <item row="1" column="0" colspan="11">
-                 <widget class="QLabel" name="lblSwitchArmingWarning">
-                  <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;Warning:&lt;/span&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; It is strongly recommended to use switch arming when HangTime is enabled.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                  </property>
-                 </widget>
                 </item>
                </layout>
               </widget>

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -22,10 +22,10 @@
         <field name="MotorsSpinWhileArmed" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE">
             <description>When enabled, the motors will spin at the ChannelNeutral command when armed with zero throttle.</description>
         </field>
-        <field name="LowPowerStabilizationMaxPowerAdd" units="" type="float" elements="1" defaultvalue="0.07">
+        <field name="LowPowerStabilizationMaxPowerAdd" units="" type="float" elements="1" defaultvalue="0.07" limits="%BE:0.0:0.15">
             <description>Maximum power to add to ensure stabilization at low power.  Always select a value well under hover power.</description>
         </field>
-        <field name="LowPowerStabilizationMaxTime" units="s" type="float" elements="1" defaultvalue="0">
+        <field name="LowPowerStabilizationMaxTime" units="s" type="float" elements="1" defaultvalue="0" limits="%BE:0.0:4.5">
             <description>Maximum time in seconds to add power when at zero throttle to ensure stabilization.  Choosing 0 prevents adding power at zero throttle.</description>
         </field>
 


### PR DESCRIPTION
Unchecked sets duration to 0/disables, checked sets it to default value of 2.5s.

<img width="794" alt="hangtime" src="https://cloud.githubusercontent.com/assets/9995998/14944720/1ba15492-1050-11e6-84d1-b461f27ae5b3.png">
