### PR TITLE
Startup high priority modules first

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -160,7 +160,7 @@ int32_t ActuatorInitialize()
 
 	return 0;
 }
-MODULE_INITCALL(ActuatorInitialize, ActuatorStart);
+MODULE_HIPRI_INITCALL(ActuatorInitialize, ActuatorStart);
 
 static float get_curve2_source(ActuatorDesiredData *desired, SystemSettingsAirframeTypeOptions airframe_type, MixerSettingsCurve2SourceOptions source)
 {

--- a/flight/Modules/Attitude/acro/attitude.c
+++ b/flight/Modules/Attitude/acro/attitude.c
@@ -163,7 +163,7 @@ int32_t AttitudeInitialize(void)
 	return 0;
 }
 
-MODULE_INITCALL(AttitudeInitialize, AttitudeStart)
+MODULE_HIPRI_INITCALL(AttitudeInitialize, AttitudeStart)
 
 /**
  * Module thread, should not return.

--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -297,7 +297,7 @@ int32_t AttitudeStart(void)
 	return 0;
 }
 
-MODULE_INITCALL(AttitudeInitialize, AttitudeStart)
+MODULE_HIPRI_INITCALL(AttitudeInitialize, AttitudeStart)
 
 /**
  * Module thread, should not return.

--- a/flight/Modules/FirmwareIAP/firmwareiap.c
+++ b/flight/Modules/FirmwareIAP/firmwareiap.c
@@ -89,7 +89,7 @@ static void resetTask(UAVObjEvent * ev, void *ctx, void *obj, int len);
  * \note
  *
  */
-MODULE_INITCALL(FirmwareIAPInitialize, 0)
+MODULE_HIPRI_INITCALL(FirmwareIAPInitialize, 0)
 int32_t FirmwareIAPInitialize()
 {
 	

--- a/flight/Modules/ManualControl/manualcontrol.c
+++ b/flight/Modules/ManualControl/manualcontrol.c
@@ -108,7 +108,7 @@ int32_t ManualControlInitialize()
 	return 0;
 }
 
-MODULE_INITCALL(ManualControlInitialize, ManualControlStart);
+MODULE_HIPRI_INITCALL(ManualControlInitialize, ManualControlStart);
 
 /**
  * Module task

--- a/flight/Modules/Sensors/sensors.c
+++ b/flight/Modules/Sensors/sensors.c
@@ -213,7 +213,7 @@ static int32_t SensorsStart(void)
 	return 0;
 }
 
-MODULE_INITCALL(SensorsInitialize, SensorsStart);
+MODULE_HIPRI_INITCALL(SensorsInitialize, SensorsStart);
 
 
 /**

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -194,7 +194,7 @@ int32_t StabilizationInitialize()
 }
 
 
-MODULE_INITCALL(StabilizationInitialize, StabilizationStart);
+MODULE_HIPRI_INITCALL(StabilizationInitialize, StabilizationStart);
 
 /**
  * Module task

--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -189,7 +189,7 @@ int32_t SystemModInitialize(void)
 	return 0;
 }
 
-MODULE_INITCALL(SystemModInitialize, 0)
+MODULE_HIPRI_INITCALL(SystemModInitialize, 0)
 static void systemTask(void *parameters)
 {
 	/* create all modules thread */

--- a/flight/Modules/Telemetry/telemetry.c
+++ b/flight/Modules/Telemetry/telemetry.c
@@ -145,7 +145,7 @@ int32_t TelemetryInitialize(void)
 	return 0;
 }
 
-MODULE_INITCALL(TelemetryInitialize, TelemetryStart)
+MODULE_HIPRI_INITCALL(TelemetryInitialize, TelemetryStart)
 
 /**
  * Register a new object, adds object to local list and connects the queue depending on the object's

--- a/flight/PiOS.posix/inc/pios_initcall.h
+++ b/flight/PiOS.posix/inc/pios_initcall.h
@@ -50,6 +50,9 @@ static void _add_init_fn(void) { \
 	__module_initcall_end++; \
 }
 
+#define MODULE_HIPRI_INITCALL(ifn, sfn) \
+	MODULE_INITCALL(ifn, sfn)
+
 #define MODULE_INITSYSTEM_DECLS \
 static initmodule_t __module_initcalls[256]; \
 initmodule_t *__module_initcall_start = __module_initcalls; \

--- a/flight/PiOS.posix/posix/sections_chibios.ld
+++ b/flight/PiOS.posix/posix/sections_chibios.ld
@@ -133,16 +133,16 @@ SECTIONS
   }
 
   /* 
-  * Module init section section
-  */
+   * Module init section section
+   */
   .initcallmodule.init :
   {
     . = ALIGN(4);
     __module_initcall_start = .;
-    KEEP(*(.initcallmodule.init))
+    KEEP(*(SORT_BY_NAME(.initcall.*)))
     . = ALIGN(4);
     __module_initcall_end   = .;
-  }
+  } > flash
 
   .jcr            : { KEEP (*(.jcr)) }
   .data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro* .gnu.linkonce.d.rel.ro.*) }

--- a/flight/PiOS.posix/posix/sections_chibios.ld
+++ b/flight/PiOS.posix/posix/sections_chibios.ld
@@ -133,18 +133,6 @@ SECTIONS
   }
 
   /* 
-   * Init section for UAVObjects.
-   */
-  .initcalluavobj.init :
-  {
-    . = ALIGN(4);
-    __uavobj_initcall_start = .;
-    KEEP(*(.initcalluavobj.init))
-    . = ALIGN(4);
-    __uavobj_initcall_end   = .;
-  }
-
-  /* 
   * Module init section section
   */
   .initcallmodule.init :

--- a/flight/PiOS/STM32F10x/link_STM32103CB_CC_Rev1_sections.ld
+++ b/flight/PiOS/STM32F10x/link_STM32103CB_CC_Rev1_sections.ld
@@ -24,15 +24,17 @@ SECTIONS
         *(.rodata .rodata* .gnu.linkonce.r.*)
     } > FLASH
 
-    /* module sections */
+    /* 
+     * Module init section section
+     */
     .initcallmodule.init :
     {
         . = ALIGN(4);
         __module_initcall_start = .;
-        KEEP(*(.initcallmodule.init))
+        KEEP(*(SORT_BY_NAME(.initcall.*)))
         . = ALIGN(4);
         __module_initcall_end   = .;
-    } >FLASH
+    } > FLASH
 
     .ARM.extab :
     {

--- a/flight/PiOS/STM32F10x/link_STM32103CB_PIPXTREME_sections.ld
+++ b/flight/PiOS/STM32F10x/link_STM32103CB_PIPXTREME_sections.ld
@@ -24,15 +24,17 @@ SECTIONS
         *(.rodata .rodata* .gnu.linkonce.r.*)
     } > FLASH
 
-    /* module sections */
+    /* 
+     * Module init section section
+     */
     .initcallmodule.init :
     {
         . = ALIGN(4);
         __module_initcall_start = .;
-        KEEP(*(.initcallmodule.init))
+        KEEP(*(SORT_BY_NAME(.initcall.*)))
         . = ALIGN(4);
         __module_initcall_end   = .;
-    } >FLASH
+    } > FLASH
 
     .ARM.extab :
     {

--- a/flight/PiOS/STM32F30x/link_STM32F30x_sections.ld
+++ b/flight/PiOS/STM32F30x/link_STM32F30x_sections.ld
@@ -16,18 +16,6 @@ SECTIONS
     } > FLASH
 
     /* 
-     * Init section for UAVObjects. 
-     */
-    .initcalluavobj.init :
-    {
-        . = ALIGN(4);
-        __uavobj_initcall_start = .;
-        KEEP(*(.initcalluavobj.init))
-        . = ALIGN(4);
-        __uavobj_initcall_end   = .;
-    } >FLASH
-
-    /* 
      * Module init section section
      */
     .initcallmodule.init :

--- a/flight/PiOS/STM32F30x/link_STM32F30x_sections.ld
+++ b/flight/PiOS/STM32F30x/link_STM32F30x_sections.ld
@@ -15,18 +15,6 @@ SECTIONS
         *(.rodata .rodata* .gnu.linkonce.r.*)
     } > FLASH
 
-    /* 
-     * Module init section section
-     */
-    .initcallmodule.init :
-    {
-        . = ALIGN(4);
-        __module_initcall_start = .;
-        KEEP(*(.initcallmodule.init))
-        . = ALIGN(4);
-        __module_initcall_end   = .;
-    } >FLASH
-
     /*
      * C++ exception handling.
      */

--- a/flight/PiOS/STM32F30x/sections_chibios.ld
+++ b/flight/PiOS/STM32F30x/sections_chibios.ld
@@ -77,7 +77,7 @@ SECTIONS
     {
         . = ALIGN(4);
         __module_initcall_start = .;
-        KEEP(*(.initcallmodule.init))
+        KEEP(*(SORT_BY_NAME(.initcall.*)))
         . = ALIGN(4);
         __module_initcall_end   = .;
     } > flash

--- a/flight/PiOS/STM32F30x/sections_chibios.ld
+++ b/flight/PiOS/STM32F30x/sections_chibios.ld
@@ -71,18 +71,6 @@ SECTIONS
     } > flash
 
     /* 
-     * Init section for UAVObjects.
-     */
-    .initcalluavobj.init :
-    {
-        . = ALIGN(4);
-        __uavobj_initcall_start = .;
-        KEEP(*(.initcalluavobj.init))
-        . = ALIGN(4);
-        __uavobj_initcall_end   = .;
-    } > flash
-
-    /* 
      * Module init section section
      */
     .initcallmodule.init :

--- a/flight/PiOS/STM32F4xx/link_STM32F4xx_sections.ld
+++ b/flight/PiOS/STM32F4xx/link_STM32F4xx_sections.ld
@@ -16,18 +16,6 @@ SECTIONS
     } > FLASH
 
     /* 
-     * Init section for UAVObjects. 
-     */
-    .initcalluavobj.init :
-    {
-        . = ALIGN(4);
-        __uavobj_initcall_start = .;
-        KEEP(*(.initcalluavobj.init))
-        . = ALIGN(4);
-        __uavobj_initcall_end   = .;
-    } >FLASH
-
-    /* 
      * Module init section section
      */
     .initcallmodule.init :

--- a/flight/PiOS/STM32F4xx/link_STM32F4xx_sections.ld
+++ b/flight/PiOS/STM32F4xx/link_STM32F4xx_sections.ld
@@ -15,18 +15,6 @@ SECTIONS
         *(.rodata .rodata* .gnu.linkonce.r.*)
     } > FLASH
 
-    /* 
-     * Module init section section
-     */
-    .initcallmodule.init :
-    {
-        . = ALIGN(4);
-        __module_initcall_start = .;
-        KEEP(*(.initcallmodule.init))
-        . = ALIGN(4);
-        __module_initcall_end   = .;
-    } >FLASH
-
     /*
      * C++ exception handling.
      */

--- a/flight/PiOS/STM32F4xx/sections_chibios.ld
+++ b/flight/PiOS/STM32F4xx/sections_chibios.ld
@@ -77,7 +77,7 @@ SECTIONS
     {
         . = ALIGN(4);
         __module_initcall_start = .;
-        KEEP(*(.initcallmodule.init))
+        KEEP(*(SORT_BY_NAME(.initcall.*)))
         . = ALIGN(4);
         __module_initcall_end   = .;
     } > flash

--- a/flight/PiOS/STM32F4xx/sections_chibios.ld
+++ b/flight/PiOS/STM32F4xx/sections_chibios.ld
@@ -71,18 +71,6 @@ SECTIONS
     } > flash
 
     /* 
-     * Init section for UAVObjects.
-     */
-    .initcalluavobj.init :
-    {
-        . = ALIGN(4);
-        __uavobj_initcall_start = .;
-        KEEP(*(.initcalluavobj.init))
-        . = ALIGN(4);
-        __uavobj_initcall_end   = .;
-    } > flash
-
-    /* 
      * Module init section section
      */
     .initcallmodule.init :

--- a/flight/PiOS/inc/pios_initcall.h
+++ b/flight/PiOS/inc/pios_initcall.h
@@ -60,10 +60,6 @@ extern initmodule_t __module_initcall_start[], __module_initcall_end[];
  * can point at the same handler without causing duplicate-symbol build errors.
  */
 
-#define __define_initcall(level,fn,id) \
-	static initcall_t __initcall_##fn##id __attribute__((__used__)) \
-	__attribute__((__section__(".initcall" level ".init"))) = fn
-
 #define __define_module_initcall(level, ifn, sfn) \
 	static initmodule_t __initcall_##fn __attribute__((__used__)) \
 	__attribute__((__section__(".initcall" level ".init"))) = { .fn_minit = ifn, .fn_tinit = sfn };

--- a/flight/PiOS/inc/pios_initcall.h
+++ b/flight/PiOS/inc/pios_initcall.h
@@ -62,8 +62,9 @@ extern initmodule_t __module_initcall_start[], __module_initcall_end[];
 
 #define __define_module_initcall(level, ifn, sfn) \
 	static initmodule_t __initcall_##fn __attribute__((__used__)) \
-	__attribute__((__section__(".initcall" level ".init"))) = { .fn_minit = ifn, .fn_tinit = sfn };
+	__attribute__((__section__(".initcall." level))) = { .fn_minit = ifn, .fn_tinit = sfn };
 
+#define MODULE_HIPRI_INITCALL(ifn, sfn)		__define_module_initcall("a_module", ifn, sfn)
 #define MODULE_INITCALL(ifn, sfn)		__define_module_initcall("module", ifn, sfn)
 
 #define MODULE_INITIALISE_ALL(wdgfn)  { \


### PR DESCRIPTION
Fixes #966 
Continuation of #932 

Have verified that it puts high priority modules first in the modules list.  Need to confirm startup on flight targets still.
