### PR TITLE
flight: improvements to object persistence

### DIFF
--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -367,55 +367,25 @@ static void objectUpdatedCb(UAVObjEvent * ev, void *ctx, void *obj_data, int len
 		}
 
 		if (objper.Operation == OBJECTPERSISTENCE_OPERATION_LOAD) {
-			if (objper.Selection == OBJECTPERSISTENCE_SELECTION_SINGLEOBJECT) {
-				// Get selected object
-				obj = UAVObjGetByID(objper.ObjectID);
-				if (obj == 0) {
-					return;
-				}
-				// Load selected instance
-				retval = UAVObjLoad(obj, objper.InstanceID);
-			} else if (objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLSETTINGS
-				   || objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLOBJECTS) {
-				retval = UAVObjLoadSettings();
-			} else if (objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLMETAOBJECTS
-				   || objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLOBJECTS) {
-				retval = UAVObjLoadMetaobjects();
+			// Get selected object
+			obj = UAVObjGetByID(objper.ObjectID);
+			if (obj == 0) {
+				return;
 			}
+			// Load selected instance
+			retval = UAVObjLoad(obj, objper.InstanceID);
 		} else if (objper.Operation == OBJECTPERSISTENCE_OPERATION_SAVE) {
-			if (objper.Selection == OBJECTPERSISTENCE_SELECTION_SINGLEOBJECT) {
-				// Get selected object
-				obj = UAVObjGetByID(objper.ObjectID);
-				if (obj == 0) {
-					return;
-				}
-				// Save selected instance
-				retval = UAVObjSave(obj, objper.InstanceID);
-
-				// Not sure why this is needed
-				PIOS_Thread_Sleep(10);
-
-				// Verify saving worked
-				if (retval == 0)
-					retval = UAVObjLoad(obj, objper.InstanceID);
-			} else if (objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLSETTINGS
-				   || objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLOBJECTS) {
-				retval = UAVObjSaveSettings();
-			} else if (objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLMETAOBJECTS
-				   || objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLOBJECTS) {
-				retval = UAVObjSaveMetaobjects();
+			// Get selected object
+			obj = UAVObjGetByID(objper.ObjectID);
+			if (obj == 0) {
+				return;
 			}
+
+			// Save selected instance
+			retval = UAVObjSave(obj, objper.InstanceID);
 		} else if (objper.Operation == OBJECTPERSISTENCE_OPERATION_DELETE) {
-			if (objper.Selection == OBJECTPERSISTENCE_SELECTION_SINGLEOBJECT) {
-				// Delete selected instance
-				retval = UAVObjDeleteById(objper.ObjectID, objper.InstanceID);
-			} else if (objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLSETTINGS
-				   || objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLOBJECTS) {
-				retval = UAVObjDeleteSettings();
-			} else if (objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLMETAOBJECTS
-				   || objper.Selection == OBJECTPERSISTENCE_SELECTION_ALLOBJECTS) {
-				retval = UAVObjDeleteMetaobjects();
-			}
+			// Delete selected instance
+			retval = UAVObjDeleteById(objper.ObjectID, objper.InstanceID);
 		} else if (objper.Operation == OBJECTPERSISTENCE_OPERATION_FULLERASE) {
 			retval = -1;
 #if defined(PIOS_INCLUDE_LOGFS_SETTINGS)
@@ -423,6 +393,10 @@ static void objectUpdatedCb(UAVObjEvent * ev, void *ctx, void *obj_data, int len
 			retval = PIOS_FLASHFS_Format(pios_uavo_settings_fs_id);
 #endif
 		}
+
+		// Yield when saving, so if there's a ton of updates we don't
+		// prevent other threads from updatin'.
+		PIOS_Thread_Sleep(25);
 
 		switch(retval) {
 			case 0:

--- a/ground/gcs/src/plugins/config/configplugin.cpp
+++ b/ground/gcs/src/plugins/config/configplugin.cpp
@@ -170,23 +170,13 @@ void ConfigPlugin::eraseFailed()
 
     ObjectPersistence* objper = ObjectPersistence::GetInstance(getObjectManager());
 
-    ObjectPersistence::DataFields data = objper->getData();
-    if(data.Operation == ObjectPersistence::OPERATION_FULLERASE) {
-        // First attempt via flash erase failed.  Fall back on erase all settings
-        data.Operation = ObjectPersistence::OPERATION_DELETE;
-        data.Selection = ObjectPersistence::SELECTION_ALLSETTINGS;
-        objper->setData(data);
-        objper->updated();
-        QTimer::singleShot(FLASH_ERASE_TIMEOUT_MS,this,SLOT(eraseFailed()));
-    } else {
-        disconnect(objper, SIGNAL(objectUpdated(UAVObject*)), this, SLOT(eraseDone(UAVObject *)));
-        QMessageBox msgBox;
-        msgBox.setText(tr("Error trying to erase settings."));
-        msgBox.setInformativeText(tr("Power-cycle your board after removing all blades. Settings might be inconsistent."));
-        msgBox.setStandardButtons(QMessageBox::Ok);
-        msgBox.setDefaultButton(QMessageBox::Ok);
-        msgBox.exec();
-    }
+    disconnect(objper, SIGNAL(objectUpdated(UAVObject*)), this, SLOT(eraseDone(UAVObject *)));
+    QMessageBox msgBox;
+    msgBox.setText(tr("Error trying to erase settings."));
+    msgBox.setInformativeText(tr("Power-cycle your board after removing all blades. Settings might be inconsistent."));
+    msgBox.setStandardButtons(QMessageBox::Ok);
+    msgBox.setDefaultButton(QMessageBox::Ok);
+    msgBox.exec();
 }
 
 void ConfigPlugin::eraseDone(UAVObject * obj)

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjectbrowserwidget.cpp
@@ -512,7 +512,6 @@ void UAVObjectBrowserWidget::updateObjectPersistance(ObjectPersistence::Operatio
     {
         ObjectPersistence::DataFields data;
         data.Operation = op;
-        data.Selection = ObjectPersistence::SELECTION_SINGLEOBJECT;
         data.ObjectID = obj->getObjID();
         data.InstanceID = obj->getInstID();
         objper->setData(data);

--- a/ground/gcs/src/plugins/uavobjectutil/uavobjectutilmanager.cpp
+++ b/ground/gcs/src/plugins/uavobjectutil/uavobjectutilmanager.cpp
@@ -158,7 +158,6 @@ void UAVObjectUtilManager::saveNextObject()
 
     ObjectPersistence::DataFields data;
     data.Operation = ObjectPersistence::OPERATION_SAVE;
-    data.Selection = ObjectPersistence::SELECTION_SINGLEOBJECT;
     data.ObjectID = obj->getObjID();
     data.InstanceID = obj->getInstID();
     objectPersistence->setData(data);

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
@@ -1045,7 +1045,6 @@ void ConfigTaskWidget::reloadButtonClicked()
                 temp.append(value);
             ObjectPersistence::DataFields data;
             data.Operation = ObjectPersistence::OPERATION_LOAD;
-            data.Selection = ObjectPersistence::SELECTION_SINGLEOBJECT;
             data.ObjectID = oTw->object->getObjID();
             data.InstanceID = oTw->object->getInstID();
             objper->setData(data);

--- a/shared/uavobjectdefinition/objectpersistence.xml
+++ b/shared/uavobjectdefinition/objectpersistence.xml
@@ -2,7 +2,6 @@
     <object name="ObjectPersistence" singleinstance="true" settings="false">
         <description>Someone who knows please enter this</description>
         <field name="Operation" units="" type="enum" elements="1" options="NOP,Load,Save,Delete,FullErase,Completed,Error"/>
-        <field name="Selection" units="" type="enum" elements="1" options="SingleObject,AllSettings,AllMetaObjects,AllObjects"/>
         <field name="ObjectID" units="" type="uint32" elements="1"/>
         <field name="InstanceID" units="" type="uint32" elements="1"/>
         <access gcs="readwrite" flight="readwrite"/>


### PR DESCRIPTION
- Don't support an object persistence "selection" anymore.  Just save
  the specified object.
- Don't load back objects immediately after saving them to "double
  check".
- Yield for 25ms after any persistence op so other threads can run.

Hoped that this fixes #810
