### PR TITLE
GCS: Module tab cleanup

### DIFF
--- a/ground/gcs/src/plugins/config/config.pro
+++ b/ground/gcs/src/plugins/config/config.pro
@@ -47,7 +47,8 @@ HEADERS += calibration.h \
     configmodulewidget.h \
     configosdwidget.h \
     expocurve.h \
-    autotuneshareform.h
+    autotuneshareform.h \
+    qreadonlycheckbox.h
 
 SOURCES += calibration.cpp \
     configplugin.cpp \

--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -41,6 +41,7 @@
 #include "vibrationanalysissettings.h"
 #include "picocsettings.h"
 #include "taskinfo.h"
+#include "loggingsettings.h"
 
 ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(parent)
 {
@@ -92,6 +93,7 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     enableGeofenceTab(false);
     enablePicoCTab(false);
     enableGpsTab(false);
+    enableLoggingTab(false);
 
     // Load UAVObjects to widget relations from UI file
     // using objrelation dynamic property
@@ -109,6 +111,7 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     setNotMandatory(HoTTSettings::NAME);
     setNotMandatory(PicoCSettings::NAME);
     setNotMandatory(GeoFenceSettings::NAME);
+    setNotMandatory(LoggingSettings::NAME);
 }
 
 ConfigModuleWidget::~ConfigModuleWidget()
@@ -171,6 +174,10 @@ void ConfigModuleWidget::recheckTabs()
     connect(obj, SIGNAL(transactionCompleted(UAVObject*,bool)), this, SLOT(objectUpdated(UAVObject*,bool)), Qt::UniqueConnection);
     obj->requestUpdate();
 
+    obj = getObjectManager()->getObject(LoggingSettings::NAME);
+    connect(obj, SIGNAL(transactionCompleted(UAVObject*,bool)), this, SLOT(objectUpdated(UAVObject*,bool)), Qt::UniqueConnection);
+    obj->requestUpdate();
+
     // This requires re-evaluation so that board connection doesn't re-enable
     // the fields.
     ui->cbAutotune->setDisabled(true);
@@ -196,22 +203,19 @@ void ConfigModuleWidget::objectUpdated(UAVObject * obj, bool success)
     QString objName = obj->getName();
     if (objName.compare(AirspeedSettings::NAME) == 0) {
         enableAirspeedTab(success && moduleSettings->getAdminState_Airspeed() == ModuleSettings::ADMINSTATE_ENABLED);
-    }
-    else if (objName.compare(FlightBatterySettings::NAME) == 0) {
+    } else if (objName.compare(FlightBatterySettings::NAME) == 0) {
         enableBatteryTab(success && moduleSettings->getAdminState_Battery() == ModuleSettings::ADMINSTATE_ENABLED);
         refreshAdcNames();
-    }
-    else if (objName.compare(VibrationAnalysisSettings::NAME) == 0) {
+    } else if (objName.compare(VibrationAnalysisSettings::NAME) == 0) {
         enableVibrationTab(success && moduleSettings->getAdminState_VibrationAnalysis() == ModuleSettings::ADMINSTATE_ENABLED);
-    }
-    else if (objName.compare(HoTTSettings::NAME) == 0) {
+    } else if (objName.compare(HoTTSettings::NAME) == 0) {
         enableHoTTTelemetryTab(success && enableHott);
-    }
-    else if (objName.compare(GeoFenceSettings::NAME) == 0) {
+    } else if (objName.compare(GeoFenceSettings::NAME) == 0) {
         enableGeofenceTab(success && moduleSettings->getAdminState_Geofence() == ModuleSettings::ADMINSTATE_ENABLED);
-    }
-    else if (objName.compare(PicoCSettings::NAME) == 0) {
+    } else if (objName.compare(PicoCSettings::NAME) == 0) {
         enablePicoCTab(success && moduleSettings->getAdminState_PicoC() == ModuleSettings::ADMINSTATE_ENABLED);
+    } else if (objName.compare(LoggingSettings::NAME) == 0) {
+        enableLoggingTab(success && moduleSettings->getAdminState_Logging() == ModuleSettings::ADMINSTATE_ENABLED);
     }
 
     // indicate that we can't tell which modules are running when taskinfo isn't available
@@ -371,6 +375,13 @@ void ConfigModuleWidget::enablePicoCTab(bool enabled)
 void ConfigModuleWidget::enableGpsTab(bool enabled)
 {
     int idx = ui->moduleTab->indexOf(ui->tabGPS);
+    ui->moduleTab->setTabEnabled(idx, enabled);
+}
+
+//! Enable or disable the Logging tab
+void ConfigModuleWidget::enableLoggingTab(bool enabled)
+{
+    int idx = ui->moduleTab->indexOf(ui->tabLogging);
     ui->moduleTab->setTabEnabled(idx, enabled);
 }
 

--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -42,11 +42,6 @@
 #include "picocsettings.h"
 #include "taskinfo.h"
 
-// Define static variables
-QString ConfigModuleWidget::trueString("TrueString");
-QString ConfigModuleWidget::falseString("FalseString");
-
-
 ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(parent)
 {
     ui = new Ui::Modules();
@@ -57,67 +52,15 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     // Populate UAVO strings
     AirspeedSettings *airspeedSettings;
     airspeedSettings = AirspeedSettings::GetInstance(getObjectManager());
-    QString airspeedSettingsName = airspeedSettings->getName();
-
-    FlightBatterySettings batterySettings;
-    QString batterySettingsName = batterySettings.getName();
-
-    FlightBatteryState batteryState;
-    QString batteryStateName = batteryState.getName();
-
-    ModuleSettings moduleSettings;
-    QString moduleSettingsName = moduleSettings.getName();
-
-    VibrationAnalysisSettings vibrationAnalysisSettings;
-    QString vibrationAnalysisSettingsName = vibrationAnalysisSettings.getName();
-
-    HoTTSettings hoTTSettings;
-    QString hoTTSettingsName = hoTTSettings.getName();
-
-    PicoCSettings picoCSettings;
-    QString picoCSettingsName = picoCSettings.getName();
 
     ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
     Core::Internal::GeneralSettings *settings = pm->getObject<Core::Internal::GeneralSettings>();
-    if (!settings->useExpertMode())
-       ui->saveRAM->setVisible(false);
-
-    // Link the checkboxes for manual module enable
-    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbAirspeed, ModuleSettings::ADMINSTATE_AIRSPEED);
-    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbAltitudeHold, ModuleSettings::ADMINSTATE_ALTITUDEHOLD);
-    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbBattery, ModuleSettings::ADMINSTATE_BATTERY);
-    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbVibrationAnalysis, ModuleSettings::ADMINSTATE_VIBRATIONANALYSIS);
-    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbVtolFollower, ModuleSettings::ADMINSTATE_VTOLPATHFOLLOWER);
-    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbPathPlanner, ModuleSettings::ADMINSTATE_PATHPLANNER);
-    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbPicoC, ModuleSettings::ADMINSTATE_PICOC);
-    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbGeofence, ModuleSettings::ADMINSTATE_GEOFENCE);
-    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbAutotune, ModuleSettings::ADMINSTATE_AUTOTUNE);
-    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbTxPid, ModuleSettings::ADMINSTATE_TXPID);
-    addUAVObjectToWidgetRelation(moduleSettingsName, "AdminState", ui->cbLogging, ModuleSettings::ADMINSTATE_LOGGING);
-
-    // Link the checkboxes for auto module enable, for information only
-    addUAVObjectToWidgetRelation(TaskInfo::NAME, "Running", ui->cbComBridge, TaskInfo::RUNNING_COM2USBBRIDGE); // only looking at com2usb (not usb2com) task should be good enough
-    addUAVObjectToWidgetRelation(TaskInfo::NAME, "Running", ui->cbGPS, TaskInfo::RUNNING_GPS);
-    addUAVObjectToWidgetRelation(TaskInfo::NAME, "Running", ui->cbUavoMavlink, TaskInfo::RUNNING_UAVOMAVLINKBRIDGE);
-    addUAVObjectToWidgetRelation(TaskInfo::NAME, "Running", ui->cbUAVOHottBridge, TaskInfo::RUNNING_UAVOHOTTBRIDGE);
-    addUAVObjectToWidgetRelation(TaskInfo::NAME, "Running", ui->cbUAVOLighttelemetryBridge, TaskInfo::RUNNING_UAVOLIGHTTELEMETRYBRIDGE);
-    addUAVObjectToWidgetRelation(TaskInfo::NAME, "Running", ui->cbUAVOFrskyBridge, TaskInfo::RUNNING_UAVOFRSKYSBRIDGE);
-    addUAVObjectToWidgetRelation(TaskInfo::NAME, "Running", ui->cbUAVOMSPBridge, TaskInfo::RUNNING_UAVOMSPBRIDGE);
-    addUAVObjectToWidgetRelation(TaskInfo::NAME, "Running", ui->cbUAVOFrSkySPortBridge, TaskInfo::RUNNING_UAVOFRSKYSPORTBRIDGE);
-
-    // Don't allow auto-modules to be changed
-    ui->cbComBridge->setDisabled(true);
-    ui->cbGPS->setDisabled(true);
-    ui->cbUavoMavlink->setDisabled(true);
-    ui->cbUAVOHottBridge->setDisabled(true);
-    ui->cbUAVOLighttelemetryBridge->setDisabled(true);
-    ui->cbUAVOFrskyBridge->setDisabled(true);
-    ui->cbUAVOMSPBridge->setDisabled(true);
-    ui->cbUAVOFrSkySPortBridge->setDisabled(true);
+    ui->saveRAM->setVisible(settings->useExpertMode());
 
     // Don't allow these to be changed here, only in the respective tabs.
     ui->cbAutotune->setDisabled(true);
     ui->cbTxPid->setDisabled(true);
+    ui->cbCameraStab->setDisabled(true);
 
     // Connect auto-cell detection logic
     connect(ui->gbAutoCellDetection, SIGNAL(toggled(bool)), this, SLOT(autoCellDetectionToggled(bool)));
@@ -129,301 +72,18 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     connect(ui->cbVoltagePin, SIGNAL(currentIndexChanged(int)), this, SLOT(toggleBatteryMonitoringGb()));
     connect(ui->cbCurrentPin, SIGNAL(currentIndexChanged(int)), this, SLOT(toggleBatteryMonitoringGb()));
 
-    addUAVObjectToWidgetRelation(batterySettingsName, "MaxCellVoltage", ui->sbMaxCellVoltage);
-    addUAVObjectToWidgetRelation(batterySettingsName, "NbCells", ui->sb_numBatteryCells);
-    addUAVObjectToWidgetRelation(batterySettingsName, "Capacity", ui->sb_batteryCapacity);
-    addUAVObjectToWidgetRelation(batterySettingsName, "VoltagePin", ui->cbVoltagePin);
-    addUAVObjectToWidgetRelation(batterySettingsName, "CurrentPin", ui->cbCurrentPin);
-    addUAVObjectToWidgetRelation(batterySettingsName, "CellVoltageThresholds", ui->sb_lowVoltageAlarm, FlightBatterySettings::CELLVOLTAGETHRESHOLDS_ALARM);
-    addUAVObjectToWidgetRelation(batterySettingsName, "CellVoltageThresholds", ui->sb_lowVoltageWarning, FlightBatterySettings::CELLVOLTAGETHRESHOLDS_WARNING);
-    addUAVObjectToWidgetRelation(batterySettingsName, "SensorCalibrationFactor", ui->sb_voltageFactor, FlightBatterySettings::SENSORCALIBRATIONFACTOR_VOLTAGE);
-    addUAVObjectToWidgetRelation(batterySettingsName, "SensorCalibrationFactor", ui->sb_currentFactor, FlightBatterySettings::SENSORCALIBRATIONFACTOR_CURRENT);
-    addUAVObjectToWidgetRelation(batterySettingsName, "SensorCalibrationOffset", ui->sb_voltageOffSet, FlightBatterySettings::SENSORCALIBRATIONOFFSET_VOLTAGE);
-    addUAVObjectToWidgetRelation(batterySettingsName, "SensorCalibrationOffset", ui->sb_currentOffSet, FlightBatterySettings::SENSORCALIBRATIONOFFSET_CURRENT);
-    addUAVObjectToWidgetRelation(batterySettingsName, "FlightTimeThresholds", ui->sb_flightTimeAlarm, FlightBatterySettings::FLIGHTTIMETHRESHOLDS_ALARM);
-    addUAVObjectToWidgetRelation(batterySettingsName, "FlightTimeThresholds", ui->sb_flightTimeWarning, FlightBatterySettings::FLIGHTTIMETHRESHOLDS_WARNING);
-
-    addUAVObjectToWidgetRelation(batteryStateName, "DetectedCellCount", ui->leLiveCellCount);
-    addUAVObjectToWidgetRelation(batteryStateName, "Voltage", ui->le_liveVoltageReading);
-    addUAVObjectToWidgetRelation(batteryStateName, "Current", ui->le_liveCurrentReading);
-
-    addUAVObjectToWidgetRelation(batteryStateName, "ConsumedEnergy", ui->le_liveConsumedEnergy);
-    addUAVObjectToWidgetRelation(batteryStateName, "EstimatedFlightTime", ui->le_liveEstimatedFlightTime);
-
     // connect the voltage ratio and factor boxes so they update each other when edited
     connect(ui->sb_voltageRatio, SIGNAL(editingFinished()), this, SLOT(updateVoltageRatio()));
     connect(ui->sb_voltageFactor, SIGNAL(editingFinished()), this, SLOT(updateVoltageFactor()));
     connect(FlightBatterySettings::GetInstance(getObjectManager()), SIGNAL(SensorCalibrationFactor_VoltageChanged(float)), this, SLOT(updateVoltageFactorFromUavo(float)));
 
-    addUAVObjectToWidgetRelation(vibrationAnalysisSettingsName, "SampleRate", ui->sb_sampleRate);
-    addUAVObjectToWidgetRelation(vibrationAnalysisSettingsName, "FFTWindowSize", ui->cb_windowSize);
-
-    //HoTT Sensor
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Sensor", ui->cb_GAM, HoTTSettings::SENSOR_GAM);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Sensor", ui->cb_EAM, HoTTSettings::SENSOR_EAM);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Sensor", ui->cb_Vario, HoTTSettings::SENSOR_VARIO);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Sensor", ui->cb_GPS, HoTTSettings::SENSOR_GPS);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Sensor", ui->cb_ESC, HoTTSettings::SENSOR_ESC);
-
-    ui->cb_GAM->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_GAM->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cb_EAM->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_EAM->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cb_Vario->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_Vario->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cb_GPS->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_GPS->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cb_ESC->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_ESC->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings POWERVOLTAGE
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MINPOWERVOLTAGE, HoTTSettings::LIMIT_MINPOWERVOLTAGE);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MAXPOWERVOLTAGE, HoTTSettings::LIMIT_MAXPOWERVOLTAGE);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MINPOWERVOLTAGE, HoTTSettings::WARNING_MINPOWERVOLTAGE);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MAXPOWERVOLTAGE, HoTTSettings::WARNING_MAXPOWERVOLTAGE);
-    ui->cb_MINPOWERVOLTAGE->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MINPOWERVOLTAGE->setProperty(falseString.toLatin1(), "Disabled");
-    ui->cb_MAXPOWERVOLTAGE->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MAXPOWERVOLTAGE->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings CURRENT
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MAXCURRENT, HoTTSettings::LIMIT_MAXCURRENT);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MAXCURRENT, HoTTSettings::WARNING_MAXCURRENT);
-    ui->cb_MAXCURRENT->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MAXCURRENT->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings USEDCAPACITY
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MAXUSEDCAPACITY, HoTTSettings::LIMIT_MAXUSEDCAPACITY);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MAXUSEDCAPACITY, HoTTSettings::WARNING_MAXUSEDCAPACITY);
-    ui->cb_MAXUSEDCAPACITY->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MAXUSEDCAPACITY->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings CELLVOLTAGE
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MINCELLVOLTAGE, HoTTSettings::LIMIT_MINCELLVOLTAGE);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MINCELLVOLTAGE, HoTTSettings::WARNING_MINCELLVOLTAGE);
-    ui->cb_MINCELLVOLTAGE->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MINCELLVOLTAGE->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings SENSOR1VOLTAGE
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MINSENSOR1VOLTAGE, HoTTSettings::LIMIT_MINSENSOR1VOLTAGE);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MAXSENSOR1VOLTAGE, HoTTSettings::LIMIT_MAXSENSOR1VOLTAGE);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MINSENSOR1VOLTAGE, HoTTSettings::WARNING_MINSENSOR1VOLTAGE);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MAXSENSOR1VOLTAGE, HoTTSettings::WARNING_MAXSENSOR1VOLTAGE);
-    ui->cb_MINSENSOR1VOLTAGE->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MINSENSOR1VOLTAGE->setProperty(falseString.toLatin1(), "Disabled");
-    ui->cb_MAXSENSOR1VOLTAGE->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MAXSENSOR1VOLTAGE->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings SENSOR2VOLTAGE
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MINSENSOR2VOLTAGE, HoTTSettings::LIMIT_MINSENSOR2VOLTAGE);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MAXSENSOR2VOLTAGE, HoTTSettings::LIMIT_MAXSENSOR2VOLTAGE);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MINSENSOR2VOLTAGE, HoTTSettings::WARNING_MINSENSOR2VOLTAGE);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MAXSENSOR2VOLTAGE, HoTTSettings::WARNING_MAXSENSOR2VOLTAGE);
-    ui->cb_MINSENSOR2VOLTAGE->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MINSENSOR2VOLTAGE->setProperty(falseString.toLatin1(), "Disabled");
-    ui->cb_MAXSENSOR2VOLTAGE->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MAXSENSOR2VOLTAGE->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings SENSOR1TEMP
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MINSENSOR1TEMP, HoTTSettings::LIMIT_MINSENSOR1TEMP);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MAXSENSOR1TEMP, HoTTSettings::LIMIT_MAXSENSOR1TEMP);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MINSENSOR1TEMP, HoTTSettings::WARNING_MINSENSOR1TEMP);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MAXSENSOR1TEMP, HoTTSettings::WARNING_MAXSENSOR1TEMP);
-    ui->cb_MINSENSOR1TEMP->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MINSENSOR1TEMP->setProperty(falseString.toLatin1(), "Disabled");
-    ui->cb_MAXSENSOR1TEMP->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MAXSENSOR1TEMP->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings SENSOR2TEMP
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MINSENSOR2TEMP, HoTTSettings::LIMIT_MINSENSOR2TEMP);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MAXSENSOR2TEMP, HoTTSettings::LIMIT_MAXSENSOR2TEMP);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MINSENSOR2TEMP, HoTTSettings::WARNING_MINSENSOR2TEMP);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MAXSENSOR2TEMP, HoTTSettings::WARNING_MAXSENSOR2TEMP);
-    ui->cb_MINSENSOR2TEMP->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MINSENSOR2TEMP->setProperty(falseString.toLatin1(), "Disabled");
-    ui->cb_MAXSENSOR2TEMP->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MAXSENSOR2TEMP->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings FUEL
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MINFUEL, HoTTSettings::LIMIT_MINFUEL);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MINFUEL, HoTTSettings::WARNING_MINFUEL);
-    ui->cb_MINFUEL->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MINFUEL->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings SENSOR1TEMP
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MINRPM, HoTTSettings::LIMIT_MINRPM);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MAXRPM, HoTTSettings::LIMIT_MAXRPM);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MINRPM, HoTTSettings::WARNING_MINRPM);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MAXRPM, HoTTSettings::WARNING_MAXRPM);
-    ui->cb_MINRPM->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MINRPM->setProperty(falseString.toLatin1(), "Disabled");
-    ui->cb_MAXRPM->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MAXRPM->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings SERVOTEMP
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MAXSERVOTEMP, HoTTSettings::LIMIT_MAXSERVOTEMP);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MAXSERVOTEMP, HoTTSettings::WARNING_MAXSERVOTEMP);
-    ui->cb_MAXSERVOTEMP->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MAXSERVOTEMP->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings SERVODIFFERENCE
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MAXSERVODIFFERENCE, HoTTSettings::LIMIT_MAXSERVODIFFERENCE);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MAXSERVODIFFERENCE, HoTTSettings::WARNING_MAXSERVODIFFERENCE);
-    ui->cb_MAXSERVODIFFERENCE->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MAXSERVODIFFERENCE->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings SPEED
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MINSPEED, HoTTSettings::LIMIT_MINSPEED);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MAXSPEED, HoTTSettings::LIMIT_MAXSPEED);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MINSPEED, HoTTSettings::WARNING_MINSPEED);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MAXSPEED, HoTTSettings::WARNING_MAXSPEED);
-    ui->cb_MINSPEED->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MINSPEED->setProperty(falseString.toLatin1(), "Disabled");
-    ui->cb_MAXSPEED->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MAXSPEED->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings SPEED
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MINHEIGHT, HoTTSettings::LIMIT_MINHEIGHT);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MAXHEIGHT, HoTTSettings::LIMIT_MAXHEIGHT);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MINHEIGHT, HoTTSettings::WARNING_MINHEIGHT);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MAXHEIGHT, HoTTSettings::WARNING_MAXHEIGHT);
-    ui->cb_MINHEIGHT->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MINHEIGHT->setProperty(falseString.toLatin1(), "Disabled");
-    ui->cb_MAXHEIGHT->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MAXHEIGHT->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings SERVOTEMP
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_MAXDISTANCE, HoTTSettings::LIMIT_MAXDISTANCE);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_MAXDISTANCE, HoTTSettings::WARNING_MAXDISTANCE);
-    ui->cb_MAXDISTANCE->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_MAXDISTANCE->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings NEGDIFFERENCE1
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_NEGDIFFERENCE1, HoTTSettings::LIMIT_NEGDIFFERENCE1);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_NEGDIFFERENCE1, HoTTSettings::WARNING_NEGDIFFERENCE1);
-    ui->cb_NEGDIFFERENCE1->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_NEGDIFFERENCE1->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings NEGDIFFERENCE2
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_NEGDIFFERENCE2, HoTTSettings::LIMIT_NEGDIFFERENCE2);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_NEGDIFFERENCE2, HoTTSettings::WARNING_NEGDIFFERENCE2);
-    ui->cb_NEGDIFFERENCE2->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_NEGDIFFERENCE2->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings POSDIFFERENCE1
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_POSDIFFERENCE1, HoTTSettings::LIMIT_POSDIFFERENCE1);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_POSDIFFERENCE1, HoTTSettings::WARNING_POSDIFFERENCE1);
-    ui->cb_POSDIFFERENCE1->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_POSDIFFERENCE1->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings POSDIFFERENCE2
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Limit", ui->sb_POSDIFFERENCE2, HoTTSettings::LIMIT_POSDIFFERENCE2);
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_POSDIFFERENCE2, HoTTSettings::WARNING_POSDIFFERENCE2);
-    ui->cb_POSDIFFERENCE2->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_POSDIFFERENCE2->setProperty(falseString.toLatin1(), "Disabled");
-
-    //HoTT Settings ALTITUDEBEEP
-    addUAVObjectToWidgetRelation(hoTTSettingsName, "Warning", ui->cb_ALTITUDEBEEP, HoTTSettings::WARNING_ALTITUDEBEEP);
-    ui->cb_ALTITUDEBEEP->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cb_ALTITUDEBEEP->setProperty(falseString.toLatin1(), "Disabled");
-
-    // Connect PicoC settings
-    addUAVObjectToWidgetRelation(picoCSettingsName, "MaxFileSize", ui->sb_picocMaxFileSize);
-    addUAVObjectToWidgetRelation(picoCSettingsName, "TaskStackSize", ui->sb_picocTaskStackSize);
-    addUAVObjectToWidgetRelation(picoCSettingsName, "PicoCStackSize", ui->sb_picocPicoCStackSize);
-    addUAVObjectToWidgetRelation(picoCSettingsName, "BootFileID", ui->sb_picocBootFileID);
-    addUAVObjectToWidgetRelation(picoCSettingsName, "Startup", ui->cb_picocStartup);
-    addUAVObjectToWidgetRelation(picoCSettingsName, "Source", ui->cb_picocSource);
-    addUAVObjectToWidgetRelation(picoCSettingsName, "ComSpeed", ui->cb_picocComSpeed);
-
     // Connect Airspeed Settings
-    addUAVObjectToWidgetRelation(airspeedSettingsName, "AirspeedSensorType", ui->cb_airspeedSensorType);
-    addUAVObjectToWidgetRelation(airspeedSettingsName, "GPSSamplePeriod_ms", ui->sb_gpsUpdateRate);
-    addUAVObjectToWidgetRelation(airspeedSettingsName, "Scale", ui->sb_pitotScale);
-    addUAVObjectToWidgetRelation(airspeedSettingsName, "ZeroPoint", ui->sb_pitotZeroPoint);
-    addUAVObjectToWidgetRelation(airspeedSettingsName, "AnalogPin", ui->cbAirspeedAnalog);
     connect(airspeedSettings, SIGNAL(objectUpdated(UAVObject*)), this, SLOT(updateAirspeedGroupbox(UAVObject *)));
     connect(ui->gb_airspeedGPS, SIGNAL(clicked(bool)), this, SLOT(enableAirspeedTypeGPS(bool)));
     connect(ui->gb_airspeedPitot, SIGNAL(clicked(bool)), this, SLOT(enableAirspeedTypePitot(bool)));
 
-    //Help button
-    addHelpButton(ui->inputHelp,"https://github.com/d-ronin/dRonin/wiki/OnlineHelp:-Modules");
-
     // Link the fields
     connect(ui->pb_startVibrationTest, SIGNAL(clicked()), this, SLOT(toggleVibrationTest()));
-
-    // Set text properties for checkboxes. The second argument is the UAVO field that corresponds
-    // to the checkbox's true (respectively, false) state.
-    ui->cbAirspeed->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cbAirspeed->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cbAltitudeHold->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cbAltitudeHold->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cbBattery->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cbBattery->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cbVibrationAnalysis->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cbVibrationAnalysis->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cbVtolFollower->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cbVtolFollower->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cbPathPlanner->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cbPathPlanner->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cbPicoC->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cbPicoC->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cbGeofence->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cbGeofence->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cbAutotune->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cbAutotune->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cbLogging->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cbLogging->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->gb_measureVoltage->setProperty(trueString.toLatin1(), "Enabled");
-    ui->gb_measureVoltage->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->gb_measureCurrent->setProperty(trueString.toLatin1(), "Enabled");
-    ui->gb_measureCurrent->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cbTxPid->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cbTxPid->setProperty(falseString.toLatin1(), "Disabled");
-
-    ui->cbLogging->setProperty(trueString.toLatin1(), "Enabled");
-    ui->cbLogging->setProperty(falseString.toLatin1(), "Disabled");
-
-    // read-only/auto-enabled modules
-    ui->cbComBridge->setProperty(trueString.toLatin1(), "True");
-    ui->cbComBridge->setProperty(falseString.toLatin1(), "False");
-
-    ui->cbGPS->setProperty(trueString.toLatin1(), "True");
-    ui->cbGPS->setProperty(falseString.toLatin1(), "False");
-
-    ui->cbUavoMavlink->setProperty(trueString.toLatin1(), "True");
-    ui->cbUavoMavlink->setProperty(falseString.toLatin1(), "False");
-
-    ui->cbUAVOHottBridge->setProperty(trueString.toLatin1(), "True");
-    ui->cbUAVOHottBridge->setProperty(falseString.toLatin1(), "False");
-
-    ui->cbUAVOFrskyBridge->setProperty(trueString.toLatin1(), "True");
-    ui->cbUAVOFrskyBridge->setProperty(falseString.toLatin1(), "False");
-
-    ui->cbUAVOLighttelemetryBridge->setProperty(trueString.toLatin1(), "True");
-    ui->cbUAVOLighttelemetryBridge->setProperty(falseString.toLatin1(), "False");
-
-    ui->cbUAVOMSPBridge->setProperty(trueString.toLatin1(), "True");
-    ui->cbUAVOMSPBridge->setProperty(falseString.toLatin1(), "False");
-
-    ui->cbUAVOFrSkySPortBridge->setProperty(trueString.toLatin1(), "True");
-    ui->cbUAVOFrSkySPortBridge->setProperty(falseString.toLatin1(), "False");
 
     enableBatteryTab(false);
     enableAirspeedTab(false);
@@ -431,6 +91,7 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     enableHoTTTelemetryTab(false);
     enableGeofenceTab(false);
     enablePicoCTab(false);
+    enableGpsTab(false);
 
     // Load UAVObjects to widget relations from UI file
     // using objrelation dynamic property
@@ -442,11 +103,11 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     // Prevent mouse wheel from changing values
     disableMouseWheelEvents();
 
-    setNotMandatory(batterySettingsName);
-    setNotMandatory(airspeedSettingsName);
-    setNotMandatory(vibrationAnalysisSettingsName);
-    setNotMandatory(hoTTSettingsName);
-    setNotMandatory(picoCSettingsName);
+    setNotMandatory(FlightBatterySettings::NAME);
+    setNotMandatory(AirspeedSettings::NAME);
+    setNotMandatory(VibrationAnalysisSettings::NAME);
+    setNotMandatory(HoTTSettings::NAME);
+    setNotMandatory(PicoCSettings::NAME);
     setNotMandatory(GeoFenceSettings::NAME);
 }
 
@@ -468,6 +129,16 @@ void ConfigModuleWidget::enableControls(bool enable)
 //! Query optional objects to determine which tabs can be configured
 void ConfigModuleWidget::recheckTabs()
 {
+    // clear checkboxes in-case taskinfo object doesn't exist (it will look like the last connected board's modules are still enabled)
+    ui->cbComBridge->setChecked(false);
+    ui->cbGPS->setChecked(false);
+    ui->cbUavoMavlink->setChecked(false);
+    ui->cbUAVOHottBridge->setChecked(false);
+    ui->cbUAVOLighttelemetryBridge->setChecked(false);
+    ui->cbUAVOFrskyBridge->setChecked(false);
+    ui->cbUAVOMSPBridge->setChecked(false);
+    ui->cbUAVOFrSkySPortBridge->setChecked(false);
+
     UAVObject * obj;
 
     obj = getObjectManager()->getObject(AirspeedSettings::NAME);
@@ -504,24 +175,7 @@ void ConfigModuleWidget::recheckTabs()
     // the fields.
     ui->cbAutotune->setDisabled(true);
     ui->cbTxPid->setDisabled(true);
-    // Don't allow auto-modules to be changed
-    ui->cbComBridge->setDisabled(true);
-    ui->cbGPS->setDisabled(true);
-    ui->cbUavoMavlink->setDisabled(true);
-    ui->cbUAVOHottBridge->setDisabled(true);
-    ui->cbUAVOLighttelemetryBridge->setDisabled(true);
-    ui->cbUAVOFrskyBridge->setDisabled(true);
-    ui->cbUAVOMSPBridge->setDisabled(true);
-    ui->cbUAVOFrSkySPortBridge->setDisabled(true);
-    // clear checkboxes in-case taskinfo object doesn't exist (it will look like the last connected board's modules are still enabled)
-    ui->cbComBridge->setChecked(false);
-    ui->cbGPS->setChecked(false);
-    ui->cbUavoMavlink->setChecked(false);
-    ui->cbUAVOHottBridge->setChecked(false);
-    ui->cbUAVOLighttelemetryBridge->setChecked(false);
-    ui->cbUAVOFrskyBridge->setChecked(false);
-    ui->cbUAVOMSPBridge->setChecked(false);
-    ui->cbUAVOFrSkySPortBridge->setChecked(false);
+    ui->cbCameraStab->setDisabled(true);
 }
 
 //! Enable appropriate tab when objects are updated
@@ -534,6 +188,10 @@ void ConfigModuleWidget::objectUpdated(UAVObject * obj, bool success)
     Q_ASSERT(moduleSettings);
     TaskInfo *taskInfo = qobject_cast<TaskInfo *>(getObjectManager()->getObject(TaskInfo::NAME));
     bool enableHott = (taskInfo && taskInfo->getIsPresentOnHardware()) ? (taskInfo->getRunning_UAVOHoTTBridge() == TaskInfo::RUNNING_TRUE) : true;
+    bool enableGps = (taskInfo && taskInfo->getIsPresentOnHardware()) ? (taskInfo->getRunning_GPS() == TaskInfo::RUNNING_TRUE) : true;
+    enableGps &= moduleSettings->getIsPresentOnHardware();
+
+    enableGpsTab(enableGps);
 
     QString objName = obj->getName();
     if (objName.compare(AirspeedSettings::NAME) == 0) {
@@ -555,87 +213,13 @@ void ConfigModuleWidget::objectUpdated(UAVObject * obj, bool success)
     else if (objName.compare(PicoCSettings::NAME) == 0) {
         enablePicoCTab(success && moduleSettings->getAdminState_PicoC() == ModuleSettings::ADMINSTATE_ENABLED);
     }
+
+    // indicate that we can't tell which modules are running when taskinfo isn't available
+    const bool haveTaskInfo = taskInfo->getIsPresentOnHardware();
+    ui->lblAutoHaveTaskInfo->setVisible(haveTaskInfo);
+    ui->lblAutoNoTaskInfo->setVisible(!haveTaskInfo);
+    ui->gbAutoModules->setEnabled(haveTaskInfo);
 }
-
-/**
- * @brief ModuleSettingsForm::getWidgetFromVariant Reimplements getWidgetFromVariant. This version supports "FalseString".
- * @param widget pointer to the widget from where to get the value
- * @param scale scale to be used on the assignement
- * @return returns the value of the widget times the scale
- */
-QVariant ConfigModuleWidget::getVariantFromWidget(QWidget * widget, double scale)
-{
-    if(QGroupBox * groupBox=qobject_cast<QGroupBox *>(widget)) {
-        QString ret;
-        if (groupBox->property("TrueString").isValid() && groupBox->property("FalseString").isValid()) {
-            if(groupBox->isChecked())
-                ret = groupBox->property("TrueString").toString();
-            else
-                ret = groupBox->property("FalseString").toString();
-        } else {
-            if(groupBox->isChecked())
-                ret = "TRUE";
-            else
-                ret = "FALSE";
-        }
-
-        return ret;
-    } else if(QCheckBox * checkBox=qobject_cast<QCheckBox *>(widget)) {
-        QString ret;
-        if (checkBox->property("TrueString").isValid() && checkBox->property("FalseString").isValid()) {
-            if (checkBox->isChecked())
-                ret = checkBox->property("TrueString").toString();
-            else
-                ret = checkBox->property("FalseString").toString();
-        }
-        else {
-            if(checkBox->isChecked())
-                ret = "TRUE";
-            else
-                ret = "FALSE";
-        }
-
-        return ret;
-    } else {
-        return ConfigTaskWidget::getVariantFromWidget(widget, scale);
-    }
-}
-
-
-/**
- * @brief ModuleSettingsForm::setWidgetFromVariant Reimplements setWidgetFromVariant. This version supports "FalseString".
- * @param widget pointer for the widget to set
- * @param scale scale to be used on the assignement
- * @param value value to be used on the assignement
- * @return returns true if the assignement was successfull
- */
-bool ConfigModuleWidget::setWidgetFromVariant(QWidget *widget, QVariant value, double scale)
-{
-    if(QGroupBox * groupBox=qobject_cast<QGroupBox *>(widget)) {
-        bool bvalue;
-        if (groupBox->property("TrueString").isValid() && groupBox->property("FalseString").isValid()) {
-            bvalue = value.toString()==groupBox->property("TrueString").toString();
-        }
-        else{
-            bvalue = value.toString()=="TRUE";
-        }
-        groupBox->setChecked(bvalue);
-        return true;
-    } else if(QCheckBox * checkBox=qobject_cast<QCheckBox *>(widget)) {
-        bool bvalue;
-        if (checkBox->property("TrueString").isValid() && checkBox->property("FalseString").isValid()) {
-            bvalue = value.toString()==checkBox->property("TrueString").toString();
-        }
-        else {
-            bvalue = value.toString()=="TRUE";
-        }
-        checkBox->setChecked(bvalue);
-        return true;
-    } else {
-        return ConfigTaskWidget::setWidgetFromVariant(widget, value, scale);
-    }
-}
-
 
 void ConfigModuleWidget::toggleVibrationTest()
 {
@@ -781,6 +365,13 @@ void ConfigModuleWidget::enablePicoCTab(bool enabled)
 {
     int idx = ui->moduleTab->indexOf(ui->tabPicoC);
     ui->moduleTab->setTabEnabled(idx,enabled);
+}
+
+//! Enable or disable the GPS tab
+void ConfigModuleWidget::enableGpsTab(bool enabled)
+{
+    int idx = ui->moduleTab->indexOf(ui->tabGPS);
+    ui->moduleTab->setTabEnabled(idx, enabled);
 }
 
 //! Replace ADC combobox names on battery tab with board specific ones

--- a/ground/gcs/src/plugins/config/configmodulewidget.h
+++ b/ground/gcs/src/plugins/config/configmodulewidget.h
@@ -62,9 +62,6 @@ private slots:
     void maxCellVoltageChanged(double value);
 
 private:
-    QVariant getVariantFromWidget(QWidget * widget, double scale);
-    bool setWidgetFromVariant(QWidget *widget, QVariant value, double scale);
-
     /* To activate the appropriate tabs */
     void enableBatteryTab(bool enabled);
     void enableAirspeedTab(bool enabled);
@@ -72,11 +69,9 @@ private:
     void enableHoTTTelemetryTab(bool enabled);
     void enableGeofenceTab(bool enabled);
     void enablePicoCTab(bool enabled);
+    void enableGpsTab(bool enabled);
 
     void refreshAdcNames(void);
-
-    static QString trueString;
-    static QString falseString;
 
     Ui::Modules *ui;
 

--- a/ground/gcs/src/plugins/config/configmodulewidget.h
+++ b/ground/gcs/src/plugins/config/configmodulewidget.h
@@ -70,6 +70,7 @@ private:
     void enableGeofenceTab(bool enabled);
     void enablePicoCTab(bool enabled);
     void enableGpsTab(bool enabled);
+    void enableLoggingTab(bool enabled);
 
     void refreshAdcNames(void);
 

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>448</width>
-    <height>828</height>
+    <width>1101</width>
+    <height>1037</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -31,201 +31,452 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;After enabling a module, a power cycle is required before you can save those settings.&lt;/p&gt;&lt;p&gt;Some modules are shown greyed out. These modules are either enabled from their own configuration tabs, or are automatically enabled by configuring appropriate ports on the &amp;quot;Hardware&amp;quot; configuration tab. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <widget class="QGroupBox" name="gbManualModules">
+         <property name="title">
+          <string>Manually Enabled Modules</string>
          </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_8">
+          <item>
+           <widget class="QLabel" name="lblManual">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Some modules are shown greyed out, these modules are enabled from their own configuration tabs. After enabling a module, a &lt;span style=&quot; font-weight:600;&quot;&gt;reboot&lt;/span&gt; is required before the module will start.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbAirspeed">
+            <property name="text">
+             <string>Airspeed</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:Airspeed</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbAltitudeHold">
+            <property name="text">
+             <string>Altitude Hold</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:AltitudeHold</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbAutotune">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The autotune module enables automated tuning of PIDs from observed flight characteristics.  See the Autotune configuration tab for more information and to enable this module.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Autotune</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:Autotune</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbBattery">
+            <property name="text">
+             <string>Battery Monitoring</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:Battery</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbCameraStab">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;See &amp;quot;Camera Stab&amp;quot; tab to enable/disable this module.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Camera Stabilisation</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:CameraStab</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbFixedWingPathFollower">
+            <property name="text">
+             <string>Fixed Wing Path Follower</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:FixedWingPathFollower</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbFlightStats">
+            <property name="text">
+             <string>Flight Statistics</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:FlightStats</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbGeofence">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This enables the geofence module, which will cause the UAV to crash at the geofence boundary. Please see the submodule tab or help for more information.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Geofence</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:Geofence</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbGroundPathFollower">
+            <property name="text">
+             <string>Ground Path Follower</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:GroundPathFollower</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbLogging">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select to enable logging to on-board flash memory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Logging</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:Logging</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbPathPlanner">
+            <property name="toolTip">
+             <string>This enables the path planner module which is required for waypoint navigation.</string>
+            </property>
+            <property name="text">
+             <string>Path Planner</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:PathPlanner</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbPicoC">
+            <property name="toolTip">
+             <string>This enables the picoC module which can run user scripts.</string>
+            </property>
+            <property name="text">
+             <string>PicoC Interpreter</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:PicoC</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbTxPid">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The TxPID module allows settings to be tuned in-flight using the transmitter.  See the TxPID configuration tab for more information and to enable this module.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>TxPID</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:TxPID</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbVibrationAnalysis">
+            <property name="text">
+             <string>Vibration Analysis</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:VibrationAnalysis</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbVtolFollower">
+            <property name="toolTip">
+             <string>Enable the VTOL path follower module which is required for RTH, PH and navigation</string>
+            </property>
+            <property name="text">
+             <string>VTOL Path Follower</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:AdminState</string>
+              <string>element:VtolPathFollower</string>
+              <string>checkedoption:Enabled</string>
+              <string>uncheckedoption:Disabled</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+        <widget class="QGroupBox" name="gbAutoModules">
+         <property name="title">
+          <string>Automatically Enabled Modules</string>
          </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>5</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbGPS">
-         <property name="toolTip">
-          <string>Select to enable the GPS module</string>
-         </property>
-         <property name="text">
-          <string>GPS</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbBattery">
-         <property name="text">
-          <string>Battery Monitoring</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbUavoMavlink">
-         <property name="text">
-          <string>UAVO Mavlink stream (for use with minimOSD)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbComBridge">
-         <property name="toolTip">
-          <string>Select to enable USB serial relay to a serial port (select the board on the board options)</string>
-         </property>
-         <property name="text">
-          <string>Com Bridge</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbAirspeed">
-         <property name="text">
-          <string>Airspeed</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbAltitudeHold">
-         <property name="text">
-          <string>Altitude Hold</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbVibrationAnalysis">
-         <property name="text">
-          <string>Vibration Analysis</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbVtolFollower">
-         <property name="toolTip">
-          <string>Enable the VTOL path follower module which is required for RTH, PH and navigation</string>
-         </property>
-         <property name="text">
-          <string>Vtol Path Follower</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbPathPlanner">
-         <property name="toolTip">
-          <string>This enables the path planner module which is required for waypoint navigation.</string>
-         </property>
-         <property name="text">
-          <string>Path Planner</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbPicoC">
-         <property name="toolTip">
-          <string>This enables the picoC module which can run user scripts.</string>
-         </property>
-         <property name="text">
-          <string>PicoC Interpreter</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbUAVOHottBridge">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This enables the Graupner HoTT Telemetry&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>HoTT Telemetry</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbUAVOFrskyBridge">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This enables Frsky Telemetry&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>FrSky Hub Telemetry</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbUAVOLighttelemetryBridge">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable UAVOLighttelemetryBridge module which is required for LightTelemetry protocol&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Light Telemetry</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbGeofence">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This enables the geofence module, which will cause the UAV to crash at the geofence boundary. Please see the submodule tab or help for more information.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Geofence</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbAutotune">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The autotune module enables automated tuning of PIDs from observed flight characteristics.  See the Autotune configuration tab for more information and to enable this module.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Autotune</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbUAVOFrSkySPortBridge">
-         <property name="text">
-          <string>FrSky S.PORT Telemetry</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbLogging">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select to enable logging to on-board flash memory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Logging</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbUAVOMSPBridge">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This enables the UAVOMSPBridge module, which allows the Multiwii Serial Protocol to be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>MSP Telemetry</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbTxPid">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The TxPID module allows settings to be tuned in-flight using the transmitter.  See the TxPID configuration tab for more information and to enable this module.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>TxPID</string>
-         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_9">
+          <item>
+           <widget class="QLabel" name="lblAuto">
+            <property name="text">
+             <string>These modules are  are automatically enabled by configuring appropriate ports on the &quot;Hardware&quot; configuration tab. Note that &quot;Hardware&quot; tab settings won't take effect until after a reboot.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="lblAutoHaveTaskInfo">
+            <property name="text">
+             <string>The checkboxes here indicate which modules are currently running on your board.</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="lblAutoNoTaskInfo">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Unfortunately it is not possible to determine which modules are running on your board (likely due to resource constraints). These checkboxes are &lt;span style=&quot; font-weight:600;&quot;&gt;non-functional&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QReadOnlyCheckBox" name="cbComBridge">
+            <property name="toolTip">
+             <string>Select to enable USB serial relay to a serial port (select the board on the board options)</string>
+            </property>
+            <property name="text">
+             <string>Com Bridge (USB VCP to Serial Port)</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:TaskInfo</string>
+              <string>fieldname:Running</string>
+              <string>element:Com2UsbBridge</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QReadOnlyCheckBox" name="cbUAVOFrskyBridge">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This enables Frsky Telemetry&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>FrSky Sensor Hub Telemetry</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:TaskInfo</string>
+              <string>fieldname:Running</string>
+              <string>element:UAVOFrSKYSBridge</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QReadOnlyCheckBox" name="cbUAVOFrSkySPortBridge">
+            <property name="text">
+             <string>FrSky S.PORT Telemetry</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:TaskInfo</string>
+              <string>fieldname:Running</string>
+              <string>element:UAVOFrSKYSPortBridge</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QReadOnlyCheckBox" name="cbGPS">
+            <property name="toolTip">
+             <string>Select to enable the GPS module</string>
+            </property>
+            <property name="text">
+             <string>GPS</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:TaskInfo</string>
+              <string>fieldname:Running</string>
+              <string>element:GPS</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QReadOnlyCheckBox" name="cbUAVOHottBridge">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This enables the Graupner HoTT Telemetry&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>HoTT Telemetry</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:TaskInfo</string>
+              <string>fieldname:Running</string>
+              <string>element:UAVOHoTTBridge</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QReadOnlyCheckBox" name="cbUAVOLighttelemetryBridge">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable UAVOLighttelemetryBridge module which is required for LightTelemetry protocol&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Light Telemetry (LTM)</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:TaskInfo</string>
+              <string>fieldname:Running</string>
+              <string>element:UAVOLighttelemetryBridge</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QReadOnlyCheckBox" name="cbUavoMavlink">
+            <property name="text">
+             <string>Mavlink Telemetry</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:TaskInfo</string>
+              <string>fieldname:Running</string>
+              <string>element:UAVOMavlinkBridge</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QReadOnlyCheckBox" name="cbUAVOMSPBridge">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This enables the UAVOMSPBridge module, which allows the Multiwii Serial Protocol to be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>MSP Telemetry</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:TaskInfo</string>
+              <string>fieldname:Running</string>
+              <string>element:UAVOMSPBridge</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
@@ -243,20 +494,17 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="misc">
+     <widget class="QWidget" name="tabBaud">
       <attribute name="title">
-       <string>Misc</string>
+       <string>Baudrates</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QGroupBox" name="groupBox">
+        <widget class="QGroupBox" name="gbModuleSpeeds">
          <property name="title">
           <string>Module Baudrates</string>
          </property>
          <layout class="QFormLayout" name="formLayout_4">
-          <property name="fieldGrowthPolicy">
-           <enum>QFormLayout::FieldsStayAtSizeHint</enum>
-          </property>
           <item row="0" column="0">
            <widget class="QLabel" name="lbTelemetry">
             <property name="text">
@@ -325,6 +573,13 @@
             </property>
            </widget>
           </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="lbMavLink">
+            <property name="text">
+             <string>MavLink:</string>
+            </property>
+           </widget>
+          </item>
           <item row="4" column="1">
            <widget class="QComboBox" name="cb_MavlinkSpeed">
             <property name="objrelation" stdset="0">
@@ -335,36 +590,25 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="lbMavLink">
+          <item row="5" column="0">
+           <widget class="QLabel" name="lbMsp">
             <property name="text">
-             <string>MavLink:</string>
+             <string>MSP:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QComboBox" name="cb_MspSpeed">
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:MSPSpeed</string>
+             </stringlist>
             </property>
            </widget>
           </item>
          </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QFormLayout" name="formLayout_5">
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_20">
-           <property name="text">
-            <string>GPS Protocol:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="cb_TelemetryBaudRate_2">
-           <property name="objrelation" stdset="0">
-            <stringlist>
-             <string>objname:ModuleSettings</string>
-             <string>fieldname:GPSDataProtocol</string>
-            </stringlist>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item>
         <spacer name="verticalSpacer_3">
@@ -428,12 +672,18 @@
                <property name="value">
                 <double>0.000000000000000</double>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:FlightBatterySettings</string>
+                 <string>fieldname:MaxCellVoltage</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
              <item row="1" column="0">
               <widget class="QLabel" name="lblLiveCellCount">
                <property name="text">
-                <string>Live detected cell count:</string>
+                <string>Live detected cell count*:</string>
                </property>
               </widget>
              </item>
@@ -441,6 +691,12 @@
               <widget class="QLineEdit" name="leLiveCellCount">
                <property name="readOnly">
                 <bool>true</bool>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:FlightBatteryState</string>
+                 <string>fieldname:DetectedCellCount</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -482,6 +738,12 @@
                <property name="value">
                 <number>2000</number>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:FlightBatterySettings</string>
+                 <string>fieldname:Capacity</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
              <item row="1" column="0">
@@ -518,6 +780,12 @@
                <property name="minimum">
                 <number>1</number>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:FlightBatterySettings</string>
+                 <string>fieldname:NbCells</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
             </layout>
@@ -544,7 +812,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="label_14">
             <property name="text">
-             <string>Live reading (V):</string>
+             <string>Live reading (V)*:</string>
             </property>
            </widget>
           </item>
@@ -552,6 +820,32 @@
            <widget class="QLineEdit" name="le_liveVoltageReading">
             <property name="readOnly">
              <bool>true</bool>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatteryState</string>
+              <string>fieldname:Voltage</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_23">
+            <property name="text">
+             <string>Voltage Pin:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="cbVoltagePin">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select an ADC pin to measure the voltage. Pins not available with the current board configuration are labeled &amp;quot;Disabled&amp;quot;. These pins may be enabled by settings on the &amp;quot;Hardware&amp;quot; tab. Pins labeled &amp;quot;N/A&amp;quot; are not available due to the board hardware design.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatterySettings</string>
+              <string>fieldname:VoltagePin</string>
+             </stringlist>
             </property>
            </widget>
           </item>
@@ -576,45 +870,26 @@
             <property name="singleStep">
              <double>0.010000000000000</double>
             </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatterySettings</string>
+              <string>fieldname:SensorCalibrationFactor</string>
+              <string>element:Voltage</string>
+             </stringlist>
+            </property>
            </widget>
           </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="label_11">
+          <item row="3" column="1">
+           <widget class="QLabel" name="label_5">
             <property name="text">
-             <string>Low cell voltage alarm:</string>
+             <string>or</string>
             </property>
            </widget>
           </item>
-          <item row="8" column="1">
-           <widget class="QDoubleSpinBox" name="sb_lowVoltageAlarm">
+          <item row="4" column="1">
+           <widget class="QDoubleSpinBox" name="sb_voltageRatio">
             <property name="suffix">
-             <string> V</string>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>3.300000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="0">
-           <widget class="QLabel" name="label_12">
-            <property name="text">
-             <string>Low cell voltage warning:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="1">
-           <widget class="QDoubleSpinBox" name="sb_lowVoltageWarning">
-            <property name="suffix">
-             <string> V</string>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>3.500000000000000</double>
+             <string>:1 ratio</string>
             </property>
            </widget>
           </item>
@@ -642,33 +917,66 @@
             <property name="singleStep">
              <double>0.100000000000000</double>
             </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatterySettings</string>
+              <string>fieldname:SensorCalibrationOffset</string>
+              <string>element:Voltage</string>
+             </stringlist>
+            </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_23">
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_11">
             <property name="text">
-             <string>Voltage Pin:</string>
+             <string>Low cell voltage alarm:</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QComboBox" name="cbVoltagePin">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select an ADC pin to measure the voltage. Pins not available with the current board configuration are labeled &amp;quot;Disabled&amp;quot;. These pins may be enabled by settings on the &amp;quot;Hardware&amp;quot; tab. Pins labeled &amp;quot;N/A&amp;quot; are not available due to the board hardware design.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>or</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="sb_voltageRatio">
+          <item row="8" column="1">
+           <widget class="QDoubleSpinBox" name="sb_lowVoltageAlarm">
             <property name="suffix">
-             <string>:1 ratio</string>
+             <string> V</string>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>3.300000000000000</double>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatterySettings</string>
+              <string>fieldname:CellVoltageThresholds</string>
+              <string>element:Alarm</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="label_12">
+            <property name="text">
+             <string>Low cell voltage warning:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1">
+           <widget class="QDoubleSpinBox" name="sb_lowVoltageWarning">
+            <property name="suffix">
+             <string> V</string>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>3.500000000000000</double>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatterySettings</string>
+              <string>fieldname:CellVoltageThresholds</string>
+              <string>element:Warning</string>
+             </stringlist>
             </property>
            </widget>
           </item>
@@ -693,7 +1001,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="label_9">
             <property name="text">
-             <string>Live reading (A):</string>
+             <string>Live reading (A)*:</string>
             </property>
            </widget>
           </item>
@@ -718,12 +1026,25 @@
             <property name="singleStep">
              <double>0.000010000000000</double>
             </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatterySettings</string>
+              <string>fieldname:SensorCalibrationFactor</string>
+              <string>element:Current</string>
+             </stringlist>
+            </property>
            </widget>
           </item>
           <item row="0" column="1">
            <widget class="QLineEdit" name="le_liveCurrentReading">
             <property name="readOnly">
              <bool>true</bool>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatteryState</string>
+              <string>fieldname:Current</string>
+             </stringlist>
             </property>
            </widget>
           </item>
@@ -751,6 +1072,13 @@
             <property name="singleStep">
              <double>0.100000000000000</double>
             </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatterySettings</string>
+              <string>fieldname:SensorCalibrationOffset</string>
+              <string>element:Current</string>
+             </stringlist>
+            </property>
            </widget>
           </item>
           <item row="4" column="0">
@@ -764,6 +1092,12 @@
            <widget class="QComboBox" name="cbCurrentPin">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select an ADC pin to measure the current. Pins not available with the current board configuration are labeled &amp;quot;Disabled&amp;quot;. These pins may be enabled by settings on the &amp;quot;Hardware&amp;quot; tab. Pins labeled &amp;quot;N/A&amp;quot; are not available due to the board hardware design.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatterySettings</string>
+              <string>fieldname:CurrentPin</string>
+             </stringlist>
             </property>
            </widget>
           </item>
@@ -792,6 +1126,13 @@
             <property name="maximum">
              <number>255</number>
             </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatterySettings</string>
+              <string>fieldname:FlightTimeThresholds</string>
+              <string>element:Alarm</string>
+             </stringlist>
+            </property>
            </widget>
           </item>
           <item row="8" column="1">
@@ -804,6 +1145,13 @@
             </property>
             <property name="maximum">
              <number>255</number>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatterySettings</string>
+              <string>fieldname:FlightTimeThresholds</string>
+              <string>element:Warning</string>
+             </stringlist>
             </property>
            </widget>
           </item>
@@ -826,6 +1174,12 @@
             <property name="readOnly">
              <bool>true</bool>
             </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatteryState</string>
+              <string>fieldname:ConsumedEnergy</string>
+             </stringlist>
+            </property>
            </widget>
           </item>
           <item row="2" column="1">
@@ -833,9 +1187,22 @@
             <property name="readOnly">
              <bool>true</bool>
             </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:FlightBatteryState</string>
+              <string>fieldname:EstimatedFlightTime</string>
+             </stringlist>
+            </property>
            </widget>
           </item>
          </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblForNoobs">
+         <property name="text">
+          <string>* Settings need to be applied before their effect will be seen here.</string>
+         </property>
         </widget>
        </item>
        <item>
@@ -850,6 +1217,86 @@
           </size>
          </property>
         </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabGPS">
+      <attribute name="title">
+       <string>GPS</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_11">
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>GPS Settings</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_12">
+          <item row="0" column="0">
+           <widget class="QLabel" name="lblGPSProtocol">
+            <property name="text">
+             <string>Protocol:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="cbGPSProtocol">
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:GPSDataProtocol</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="lblGPSConstellation">
+            <property name="text">
+             <string>Constellation:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="cbGPSConstellation">
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:GPSConstellation</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QCheckBox" name="cbxGPSAutoConfig">
+            <property name="text">
+             <string>Auto Configure u-blox</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:GPSAutoConfigure</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>SBAS Constellation:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="cbGPSSBASConstellation">
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:ModuleSettings</string>
+              <string>fieldname:GPSSBASConstellation</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -894,6 +1341,12 @@
             <property name="value">
              <number>100</number>
             </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:AirspeedSettings</string>
+              <string>field:GPSSamplePeriod_ms</string>
+             </stringlist>
+            </property>
            </widget>
           </item>
          </layout>
@@ -919,7 +1372,14 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QComboBox" name="cb_airspeedSensorType"/>
+           <widget class="QComboBox" name="cb_airspeedSensorType">
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:AirspeedSettings</string>
+              <string>fieldname:AirspeedSensorType</string>
+             </stringlist>
+            </property>
+           </widget>
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="label_7">
@@ -932,6 +1392,12 @@
            <widget class="QDoubleSpinBox" name="sb_pitotScale">
             <property name="singleStep">
              <double>0.100000000000000</double>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:AirspeedSettings</string>
+              <string>fieldname:Scale</string>
+             </stringlist>
             </property>
            </widget>
           </item>
@@ -947,6 +1413,12 @@
             <property name="singleStep">
              <double>0.100000000000000</double>
             </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:AirspeedSettings</string>
+              <string>fieldname:ZeroPoint</string>
+             </stringlist>
+            </property>
            </widget>
           </item>
           <item row="3" column="0">
@@ -957,7 +1429,14 @@
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QComboBox" name="cbAirspeedAnalog"/>
+           <widget class="QComboBox" name="cbAirspeedAnalog">
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:AirspeedSettings</string>
+              <string>fieldname:AnalogPin</string>
+             </stringlist>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -1009,6 +1488,12 @@
          <property name="value">
           <number>100</number>
          </property>
+         <property name="objrelation" stdset="0">
+          <stringlist>
+           <string>objname:VibrationAnalysisSettings</string>
+           <string>fieldname:SampleRate</string>
+          </stringlist>
+         </property>
         </widget>
        </item>
        <item row="1" column="0">
@@ -1019,7 +1504,14 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QComboBox" name="cb_windowSize"/>
+        <widget class="QComboBox" name="cb_windowSize">
+         <property name="objrelation" stdset="0">
+          <stringlist>
+           <string>objname:VibrationAnalysisSettings</string>
+           <string>fieldname:FFTWindowSize</string>
+          </stringlist>
+         </property>
+        </widget>
        </item>
        <item row="2" column="1">
         <widget class="QPushButton" name="pb_startVibrationTest">
@@ -1128,12 +1620,30 @@
            <property name="text">
             <string>GAM</string>
            </property>
+           <property name="objrelation" stdset="0">
+            <stringlist>
+             <string>objname:HoTTSettings</string>
+             <string>fieldname:Sensor</string>
+             <string>element:GAM</string>
+             <string>checkedoption:Enabled</string>
+             <string>uncheckedoption:Disabled</string>
+            </stringlist>
+           </property>
           </widget>
          </item>
          <item>
           <widget class="QCheckBox" name="cb_EAM">
            <property name="text">
             <string>EAM</string>
+           </property>
+           <property name="objrelation" stdset="0">
+            <stringlist>
+             <string>objname:HoTTSettings</string>
+             <string>fieldname:Sensor</string>
+             <string>element:EAM</string>
+             <string>checkedoption:Enabled</string>
+             <string>uncheckedoption:Disabled</string>
+            </stringlist>
            </property>
           </widget>
          </item>
@@ -1142,6 +1652,15 @@
            <property name="text">
             <string>Vario</string>
            </property>
+           <property name="objrelation" stdset="0">
+            <stringlist>
+             <string>objname:HoTTSettings</string>
+             <string>fieldname:Sensor</string>
+             <string>element:VARIO</string>
+             <string>checkedoption:Enabled</string>
+             <string>uncheckedoption:Disabled</string>
+            </stringlist>
+           </property>
           </widget>
          </item>
          <item>
@@ -1149,12 +1668,30 @@
            <property name="text">
             <string>GPS</string>
            </property>
+           <property name="objrelation" stdset="0">
+            <stringlist>
+             <string>objname:HoTTSettings</string>
+             <string>fieldname:Sensor</string>
+             <string>element:GPS</string>
+             <string>checkedoption:Enabled</string>
+             <string>uncheckedoption:Disabled</string>
+            </stringlist>
+           </property>
           </widget>
          </item>
          <item>
           <widget class="QCheckBox" name="cb_ESC">
            <property name="text">
             <string>ESC</string>
+           </property>
+           <property name="objrelation" stdset="0">
+            <stringlist>
+             <string>objname:HoTTSettings</string>
+             <string>fieldname:Sensor</string>
+             <string>element:ESC</string>
+             <string>checkedoption:Enabled</string>
+             <string>uncheckedoption:Disabled</string>
+            </stringlist>
            </property>
           </widget>
          </item>
@@ -1170,8 +1707,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>392</width>
-            <height>714</height>
+            <width>1059</width>
+            <height>901</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout">
@@ -1236,6 +1773,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MinPowerVoltage</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
              <item>
@@ -1273,6 +1819,15 @@
                </property>
                <property name="text">
                 <string/>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MaxPowerVoltage</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -1339,6 +1894,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MaxUsedCapacity</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
             </layout>
@@ -1404,6 +1968,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MinSensor2Voltage</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
              <item>
@@ -1441,6 +2014,15 @@
                </property>
                <property name="text">
                 <string/>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MaxSensor2Voltage</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -1506,6 +2088,15 @@
                </property>
                <property name="text">
                 <string/>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:PosDifference2</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -1575,6 +2166,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MinHeight</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
              <item>
@@ -1615,6 +2215,15 @@
                </property>
                <property name="text">
                 <string/>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MaxHeight</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -1684,6 +2293,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MinSensor2Temp</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
              <item>
@@ -1724,6 +2342,15 @@
                </property>
                <property name="text">
                 <string/>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MaxSensor2Temp</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -1790,6 +2417,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MinRPM</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
              <item>
@@ -1827,6 +2463,15 @@
                </property>
                <property name="text">
                 <string/>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MaxRPM</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -1893,6 +2538,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MaxServoDifference</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
             </layout>
@@ -1957,6 +2611,15 @@
                </property>
                <property name="text">
                 <string/>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MaxDistance</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -2026,6 +2689,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:NegDifference1</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
             </layout>
@@ -2094,6 +2766,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:NegDifference2</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
             </layout>
@@ -2158,6 +2839,15 @@
                </property>
                <property name="text">
                 <string/>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MinFuel</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -2239,6 +2929,15 @@
                </property>
                <property name="text">
                 <string/>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MaxServoTemp</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -2380,6 +3079,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MinCellVoltage</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
              <item>
@@ -2461,6 +3169,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MinSensor1Voltage</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
              <item>
@@ -2498,6 +3215,15 @@
                </property>
                <property name="text">
                 <string/>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MaxSensor1Voltage</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -2567,6 +3293,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MinSensor1Temp</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
              <item>
@@ -2607,6 +3342,15 @@
                </property>
                <property name="text">
                 <string/>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MaxSensor1Temp</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -2673,6 +3417,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MinSpeed</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
              <item>
@@ -2710,6 +3463,15 @@
                </property>
                <property name="text">
                 <string/>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MaxSpeed</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -2776,6 +3538,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:PosDifference1</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
             </layout>
@@ -2815,6 +3586,15 @@
                </property>
                <property name="text">
                 <string/>
+               </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:AltitudeBeep</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
                </property>
               </widget>
              </item>
@@ -2881,6 +3661,15 @@
                <property name="text">
                 <string/>
                </property>
+               <property name="objrelation" stdset="0">
+                <stringlist>
+                 <string>objname:HoTTSettings</string>
+                 <string>fieldname:Warning</string>
+                 <string>element:MaxCurrent</string>
+                 <string>checkedoption:Enabled</string>
+                 <string>uncheckedoption:Disabled</string>
+                </stringlist>
+               </property>
               </widget>
              </item>
             </layout>
@@ -2930,6 +3719,12 @@
             <property name="maximum">
              <number>255</number>
             </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:PicoCSettings</string>
+              <string>fieldname:BootFileID</string>
+             </stringlist>
+            </property>
            </widget>
           </item>
           <item row="1" column="0">
@@ -2940,7 +3735,14 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QComboBox" name="cb_picocStartup"/>
+           <widget class="QComboBox" name="cb_picocStartup">
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:PicoCSettings</string>
+              <string>fieldname:Startup</string>
+             </stringlist>
+            </property>
+           </widget>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="label_29">
@@ -2950,7 +3752,14 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QComboBox" name="cb_picocSource"/>
+           <widget class="QComboBox" name="cb_picocSource">
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:PicoCSettings</string>
+              <string>fieldname:Source</string>
+             </stringlist>
+            </property>
+           </widget>
           </item>
           <item row="3" column="0">
            <widget class="QLabel" name="label_30">
@@ -2960,7 +3769,14 @@
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QComboBox" name="cb_picocComSpeed"/>
+           <widget class="QComboBox" name="cb_picocComSpeed">
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:PicoCSettings</string>
+              <string>fieldname:ComSpeed</string>
+             </stringlist>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -2981,13 +3797,19 @@
           <item row="0" column="1">
            <widget class="QSpinBox" name="sb_picocMaxFileSize">
             <property name="suffix">
-             <string>Bytes</string>
+             <string> bytes</string>
             </property>
             <property name="minimum">
              <number>2048</number>
             </property>
             <property name="maximum">
              <number>131072</number>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:PicoCSettings</string>
+              <string>fieldname:MaxFileSize</string>
+             </stringlist>
             </property>
            </widget>
           </item>
@@ -3001,13 +3823,19 @@
           <item row="1" column="1">
            <widget class="QSpinBox" name="sb_picocTaskStackSize">
             <property name="suffix">
-             <string>Bytes</string>
+             <string> bytes</string>
             </property>
             <property name="minimum">
              <number>5120</number>
             </property>
             <property name="maximum">
              <number>131072</number>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:PicoCSettings</string>
+              <string>fieldname:TaskStackSize</string>
+             </stringlist>
             </property>
            </widget>
           </item>
@@ -3021,13 +3849,19 @@
           <item row="2" column="1">
            <widget class="QSpinBox" name="sb_picocPicoCStackSize">
             <property name="suffix">
-             <string>Bytes</string>
+             <string> bytes</string>
             </property>
             <property name="minimum">
              <number>10240</number>
             </property>
             <property name="maximum">
              <number>131072</number>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:PicoCSettings</string>
+              <string>fieldname:PicoCStackSize</string>
+             </stringlist>
             </property>
            </widget>
           </item>
@@ -3101,6 +3935,12 @@
        </property>
        <property name="flat">
         <bool>true</bool>
+       </property>
+       <property name="objrelation" stdset="0">
+        <stringlist>
+         <string>button:help</string>
+         <string>url:https://github.com/d-ronin/dRonin/wiki/OnlineHelp:-Modules</string>
+        </stringlist>
        </property>
       </widget>
      </item>
@@ -3198,6 +4038,13 @@ Apply or Save button afterwards.</string>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QReadOnlyCheckBox</class>
+   <extends>QCheckBox</extends>
+   <header>qreadonlycheckbox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../coreplugin/core.qrc"/>
   <include location="../coreplugin/core.qrc"/>

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -1300,6 +1300,88 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tabLogging">
+      <attribute name="title">
+       <string>Logging</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_12">
+       <item>
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="title">
+          <string>Logging Settings</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_5">
+          <item row="0" column="0">
+           <widget class="QLabel" name="lblLogBehavior">
+            <property name="text">
+             <string>Behavior:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="cbLogBehavior">
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:LoggingSettings</string>
+              <string>fieldname:LogBehavior</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="lblMaxLogRate">
+            <property name="text">
+             <string>Maximum Rate:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="cbMaxLogRate">
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:LoggingSettings</string>
+              <string>fieldname:MaxLogRate</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="lblLogProfile">
+            <property name="text">
+             <string>Profile:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="cbLogProfile">
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:LoggingSettings</string>
+              <string>fieldname:Profile</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QCheckBox" name="cbxLogSettings">
+            <property name="text">
+             <string>Log Settings on Start</string>
+            </property>
+            <property name="objrelation" stdset="0">
+             <stringlist>
+              <string>objname:LoggingSettings</string>
+              <string>fieldname:LogSettingsOnStart</string>
+              <string>checkedoption:True</string>
+              <string>uncheckedoption:False</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="tabAirspeed">
       <attribute name="title">
        <string>Airspeed</string>

--- a/ground/gcs/src/plugins/config/qreadonlycheckbox.h
+++ b/ground/gcs/src/plugins/config/qreadonlycheckbox.h
@@ -1,0 +1,61 @@
+/**
+ ******************************************************************************
+ * @file       qreadonlycheckbox.h
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
+ * @addtogroup GCSPlugins GCS Plugins
+ * @{
+ * @addtogroup ConfigPlugin Config Plugin
+ * @{
+ * @brief Provides a read-only checkbox
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
+ */
+
+
+#ifndef QREADONLYCHECKBOX_H
+#define QREADONLYCHECKBOX_H
+
+#include <QCheckBox>
+
+class QReadOnlyCheckBox : public QCheckBox
+{
+    Q_OBJECT
+public:
+    QReadOnlyCheckBox(QWidget *parent = 0) : QCheckBox(parent)
+    {
+    }
+
+protected:
+    void mousePressEvent(QMouseEvent *event)
+    {
+        Q_UNUSED(event);
+    }
+    void mouseReleaseEvent(QMouseEvent *event)
+    {
+        Q_UNUSED(event);
+    }
+};
+
+#endif // QREADONLYCHECKBOX_H
+
+/**
+ * @}
+ * @}
+ */

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
@@ -754,84 +754,71 @@ bool ConfigTaskWidget::addShadowWidget(QString object, QString field, QWidget *w
  */
 void ConfigTaskWidget::autoLoadWidgets()
 {
-    QPushButton * saveButtonWidget=NULL;
-    QPushButton * applyButtonWidget=NULL;
-    foreach(QWidget * widget,this->findChildren<QWidget*>())
-    {
-        QVariant info=widget->property("objrelation");
-        if(info.isValid())
-        {
+    QPushButton *saveButtonWidget = NULL;
+    QPushButton *applyButtonWidget = NULL;
+    foreach (QWidget *widget, this->findChildren<QWidget *>()) {
+        QVariant info = widget->property("objrelation");
+        if (info.isValid()) {
             uiRelationAutomation uiRelation;
-            uiRelation.buttonType=none;
-            uiRelation.scale=1;
-            uiRelation.element=QString();
-            uiRelation.haslimits=false;
-            foreach(QString str, info.toStringList())
-            {
-                QString prop=str.split(":").at(0);
-                QString value=str.split(":").at(1);
-                if(prop== "objname")
-                    uiRelation.objname=value;
-                else if(prop== "fieldname")
-                    uiRelation.fieldname=value;
-                else if(prop=="element")
-                    uiRelation.element=value;
-                else if(prop== "scale")
-                {
-                    if(value=="null")
-                        uiRelation.scale=1;
+            uiRelation.buttonType = none;
+            uiRelation.scale = 1;
+            uiRelation.element = QString();
+            uiRelation.haslimits = false;
+            foreach (QString str, info.toStringList()) {
+                QString prop = str.split(":").at(0);
+                QString value = str.split(":").at(1);
+                if (prop == "objname") {
+                    uiRelation.objname = value;
+                } else if (prop == "fieldname") {
+                    uiRelation.fieldname = value;
+                } else if (prop=="element") {
+                    uiRelation.element = value;
+                } else if (prop == "scale") {
+                    if (value == "null")
+                        uiRelation.scale = 1;
                     else
-                        uiRelation.scale=value.toDouble();
-                }
-                else if(prop== "haslimits")
-                {
-                    if(value=="yes")
-                        uiRelation.haslimits=true;
+                        uiRelation.scale = value.toDouble();
+                } else if (prop == "haslimits") {
+                    if (value == "yes")
+                        uiRelation.haslimits = true;
                     else
-                        uiRelation.haslimits=false;
-                }
-                else if(prop== "button")
-                {
-                    if(value=="save")
-                        uiRelation.buttonType=save_button;
-                    else if(value=="apply")
-                        uiRelation.buttonType=apply_button;
-                    else if(value=="reload")
-                        uiRelation.buttonType=reload_button;
-                    else if(value=="default")
-                        uiRelation.buttonType=default_button;
-                    else if(value=="help")
-                        uiRelation.buttonType=help_button;
-                    else if(value=="reboot")
-                        uiRelation.buttonType=reboot_button;
-                }
-                else if(prop== "buttongroup")
-                {
-                    foreach(QString s,value.split(","))
-                    {
+                        uiRelation.haslimits = false;
+                } else if (prop == "button") {
+                    if (value == "save")
+                        uiRelation.buttonType = save_button;
+                    else if (value == "apply")
+                        uiRelation.buttonType = apply_button;
+                    else if (value == "reload")
+                        uiRelation.buttonType = reload_button;
+                    else if (value == "default")
+                        uiRelation.buttonType = default_button;
+                    else if (value == "help")
+                        uiRelation.buttonType = help_button;
+                    else if (value == "reboot")
+                        uiRelation.buttonType = reboot_button;
+                } else if (prop == "buttongroup") {
+                    foreach (QString s, value.split(","))
                         uiRelation.buttonGroup.append(s.toInt());
-                    }
+                } else if (prop == "url") {
+                    uiRelation.url = str.mid(str.indexOf(":") + 1);
                 }
-                else if(prop=="url")
-                    uiRelation.url=str.mid(str.indexOf(":")+1);
             }
-            if(uiRelation.buttonType!=none)
-            {
-                QPushButton * button=NULL;
-                switch(uiRelation.buttonType)
-                {
+
+            if (uiRelation.buttonType != none) {
+                QPushButton *button = NULL;
+                switch (uiRelation.buttonType) {
                 case save_button:
-                    saveButtonWidget=qobject_cast<QPushButton *>(widget);
-                    if(saveButtonWidget)
-                        addApplySaveButtons(NULL,saveButtonWidget);
+                    saveButtonWidget = qobject_cast<QPushButton *>(widget);
+                    if (saveButtonWidget)
+                        addApplySaveButtons(NULL, saveButtonWidget);
                     break;
                 case apply_button:
-                    applyButtonWidget=qobject_cast<QPushButton *>(widget);
-                    if(applyButtonWidget)
-                        addApplySaveButtons(applyButtonWidget,NULL);
+                    applyButtonWidget = qobject_cast<QPushButton *>(widget);
+                    if (applyButtonWidget)
+                        addApplySaveButtons(applyButtonWidget, NULL);
                     break;
                 case default_button:
-                    button=qobject_cast<QPushButton *>(widget);
+                    button = qobject_cast<QPushButton *>(widget);
                     if (button) {
                         if (!uiRelation.buttonGroup.length()) {
                             qWarning() << "[autoLoadWidgets] No button group specified for default button!";
@@ -841,7 +828,7 @@ void ConfigTaskWidget::autoLoadWidgets()
                     }
                     break;
                 case reload_button:
-                    button=qobject_cast<QPushButton *>(widget);
+                    button = qobject_cast<QPushButton *>(widget);
                     if (button) {
                         if (!uiRelation.buttonGroup.length()) {
                             qWarning() << "[autoLoadWidgets] No button group specified for reload button!";
@@ -851,25 +838,24 @@ void ConfigTaskWidget::autoLoadWidgets()
                     }
                     break;
                 case help_button:
-                    button=qobject_cast<QPushButton *>(widget);
-                    if(button)
-                        addHelpButton(button,uiRelation.url);
+                    button = qobject_cast<QPushButton *>(widget);
+                    if (button)
+                        addHelpButton(button, uiRelation.url);
                     break;
                 case reboot_button:
-                    button=qobject_cast<QPushButton *>(widget);
-                    if(button)
+                    button = qobject_cast<QPushButton *>(widget);
+                    if (button)
                         addRebootButton(button);
                     break;
-
                 default:
                     break;
                 }
-            }
-            else
-            {
-                QWidget * wid=qobject_cast<QWidget *>(widget);
-                if(wid)
-                    addUAVObjectToWidgetRelation(uiRelation.objname,uiRelation.fieldname,wid,uiRelation.element,uiRelation.scale,uiRelation.haslimits,&uiRelation.buttonGroup);
+            } else {
+                QWidget *wid = qobject_cast<QWidget *>(widget);
+                if (wid) {
+                    addUAVObjectToWidgetRelation(uiRelation.objname, uiRelation.fieldname, wid, uiRelation.element,
+                                                 uiRelation.scale, uiRelation.haslimits, &uiRelation.buttonGroup);
+                }
             }
         }
     }
@@ -1198,6 +1184,7 @@ void ConfigTaskWidget::disconnectWidgetUpdatesToSlot(QWidget * widget,const char
         qDebug() << __FUNCTION__ << "widget to uavobject relation not implemented for widget: " << widget->objectName()  << "of class:" << widget->metaObject()->className();
 
 }
+
 /**
  * Sets a widget value from an UAVObject field
  * @param widget pointer for the widget to set
@@ -1226,6 +1213,7 @@ bool ConfigTaskWidget::setFieldFromWidget(QWidget * widget,UAVObjectField * fiel
         return false;
     }
 }
+
 /**
  * Gets a variant from a widget
  * @param widget pointer to the widget from where to get the value
@@ -1234,37 +1222,24 @@ bool ConfigTaskWidget::setFieldFromWidget(QWidget * widget,UAVObjectField * fiel
  */
 QVariant ConfigTaskWidget::getVariantFromWidget(QWidget * widget,double scale)
 {
-    if(QComboBox * comboBox=qobject_cast<QComboBox *>(widget))
-    {
+    if (QComboBox *comboBox = qobject_cast<QComboBox *>(widget))
         return comboBox->currentData();
-    }
-    else if(QDoubleSpinBox * dblSpinBox=qobject_cast<QDoubleSpinBox *>(widget))
-    {
-        return (double)(dblSpinBox->value()* scale);
-    }
-    else if(QSpinBox * spinBox=qobject_cast<QSpinBox *>(widget))
-    {
-        return (double)(spinBox->value()* scale);
-    }
-    else if(QSlider * slider=qobject_cast<QSlider *>(widget))
-    {
-        return(double)(slider->value()* scale);
-    }
-    else if(QGroupBox * groupBox=qobject_cast<QGroupBox *>(widget))
-    {
-        return (QString)(groupBox->isChecked() ? "TRUE":"FALSE");
-    }
-    else if(QCheckBox * checkBox=qobject_cast<QCheckBox *>(widget))
-    {
-        return (QString)(checkBox->isChecked() ? "TRUE":"FALSE");
-    }
-    else if(QLineEdit * lineEdit=qobject_cast<QLineEdit *>(widget))
-    {
-        return (QString)lineEdit->displayText();
-    }
+    else if (QDoubleSpinBox *dblSpinBox = qobject_cast<QDoubleSpinBox *>(widget))
+        return (double)(dblSpinBox->value() * scale);
+    else if (QSpinBox *spinBox = qobject_cast<QSpinBox *>(widget))
+        return (double)(spinBox->value() * scale);
+    else if (QSlider *slider = qobject_cast<QSlider *>(widget))
+        return (double)(slider->value() * scale);
+    else if (QGroupBox *groupBox = qobject_cast<QGroupBox *>(widget))
+        return QString(groupBox->isChecked() ? "TRUE" : "FALSE");
+    else if (QCheckBox *checkBox = qobject_cast<QCheckBox *>(widget))
+        return QString(checkBox->isChecked() ? "TRUE" : "FALSE");
+    else if (QLineEdit *lineEdit = qobject_cast<QLineEdit *>(widget))
+        return lineEdit->displayText();
     else
         return QVariant();
 }
+
 /**
  * Sets a widget from a variant
  * @param widget pointer for the widget to set
@@ -1274,57 +1249,43 @@ QVariant ConfigTaskWidget::getVariantFromWidget(QWidget * widget,double scale)
  */
 bool ConfigTaskWidget::setWidgetFromVariant(QWidget *widget, QVariant value, double scale)
 {
-    if(QComboBox * comboBox=qobject_cast<QComboBox *>(widget))
-    {
+    if (QComboBox *comboBox = qobject_cast<QComboBox *>(widget)) {
         comboBox->setCurrentIndex(comboBox->findData(value.toString()));
         return true;
-    }
-    else if(QLabel * label=qobject_cast<QLabel *>(widget))
-    {
-        if(scale==0)
+    } else if (QLabel *label = qobject_cast<QLabel *>(widget)) {
+        if (scale == 0)
             label->setText(value.toString());
         else
-            label->setText(QString::number((value.toDouble()/scale)));
+            label->setText(QString::number((value.toDouble() / scale)));
         return true;
-    }
-    else if(QDoubleSpinBox * dblSpinBox=qobject_cast<QDoubleSpinBox *>(widget))
-    {
-        dblSpinBox->setValue((double)(value.toDouble()/scale));
+    } else if (QDoubleSpinBox *dblSpinBox = qobject_cast<QDoubleSpinBox *>(widget)) {
+        dblSpinBox->setValue(value.toDouble() / scale);
         return true;
-    }
-    else if(QSpinBox * spinBox=qobject_cast<QSpinBox *>(widget))
-    {
-        spinBox->setValue((int)qRound(value.toDouble()/scale));
+    } else if (QSpinBox *spinBox = qobject_cast<QSpinBox *>(widget)) {
+        spinBox->setValue(qRound(value.toDouble() / scale));
         return true;
-    }
-    else if(QSlider * slider=qobject_cast<QSlider *>(widget))
-    {
-        slider->setValue((int)qRound(value.toDouble()/scale));
+    } else if (QSlider *slider = qobject_cast<QSlider *>(widget)) {
+        slider->setValue(qRound(value.toDouble() / scale));
         return true;
-    }
-    else if(QGroupBox * groupBox=qobject_cast<QGroupBox *>(widget))
-    {
-        bool bvalue=value.toString()=="TRUE";
+    } else if (QGroupBox *groupBox = qobject_cast<QGroupBox *>(widget)) {
+        bool bvalue = value.toString() == "TRUE";
         groupBox->setChecked(bvalue);
         return true;
-    }
-    else if(QCheckBox * checkBox=qobject_cast<QCheckBox *>(widget))
-    {
-        bool bvalue=value.toString()=="TRUE";
+    } else if (QCheckBox *checkBox=qobject_cast<QCheckBox *>(widget)) {
+        bool bvalue = value.toString() == "TRUE";
         checkBox->setChecked(bvalue);
         return true;
-    }
-    else if(QLineEdit * lineEdit=qobject_cast<QLineEdit *>(widget))
-    {
-        if(scale==0)
+    } else if (QLineEdit *lineEdit=qobject_cast<QLineEdit *>(widget)) {
+        if (scale == 0)
             lineEdit->setText(value.toString());
         else
-            lineEdit->setText(QString::number((value.toDouble()/scale)));
+            lineEdit->setText(QString::number((value.toDouble() / scale)));
         return true;
     }
-    else
-        return false;
+
+    return false;
 }
+
 /**
  * Sets a widget from a UAVObject field
  * @param widget pointer to the widget to set
@@ -1367,6 +1328,7 @@ bool ConfigTaskWidget::setWidgetFromField(QWidget * widget,UAVObjectField * fiel
         return false;
     }
 }
+
 void ConfigTaskWidget::checkWidgetsLimits(QWidget * widget,UAVObjectField * field,int index,bool hasLimits, QVariant value, double scale)
 {
     if(!hasLimits)

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.cpp
@@ -801,6 +801,10 @@ void ConfigTaskWidget::autoLoadWidgets()
                         uiRelation.buttonGroup.append(s.toInt());
                 } else if (prop == "url") {
                     uiRelation.url = str.mid(str.indexOf(":") + 1);
+                } else if (prop == "checkedoption") {
+                    widget->setProperty("checkedOption", value);
+                } else if (prop == "uncheckedoption") {
+                    widget->setProperty("unCheckedOption", value);
                 }
             }
 
@@ -1220,7 +1224,7 @@ bool ConfigTaskWidget::setFieldFromWidget(QWidget * widget,UAVObjectField * fiel
  * @param scale scale to be used on the assignement
  * @return returns the value of the widget times the scale
  */
-QVariant ConfigTaskWidget::getVariantFromWidget(QWidget * widget,double scale)
+QVariant ConfigTaskWidget::getVariantFromWidget(QWidget *widget, double scale)
 {
     if (QComboBox *comboBox = qobject_cast<QComboBox *>(widget))
         return comboBox->currentData();
@@ -1231,9 +1235,9 @@ QVariant ConfigTaskWidget::getVariantFromWidget(QWidget * widget,double scale)
     else if (QSlider *slider = qobject_cast<QSlider *>(widget))
         return (double)(slider->value() * scale);
     else if (QGroupBox *groupBox = qobject_cast<QGroupBox *>(widget))
-        return QString(groupBox->isChecked() ? "TRUE" : "FALSE");
+        return getOptionFromChecked(widget, groupBox->isChecked());
     else if (QCheckBox *checkBox = qobject_cast<QCheckBox *>(widget))
-        return QString(checkBox->isChecked() ? "TRUE" : "FALSE");
+        return getOptionFromChecked(widget, checkBox->isChecked());
     else if (QLineEdit *lineEdit = qobject_cast<QLineEdit *>(widget))
         return lineEdit->displayText();
     else
@@ -1268,12 +1272,10 @@ bool ConfigTaskWidget::setWidgetFromVariant(QWidget *widget, QVariant value, dou
         slider->setValue(qRound(value.toDouble() / scale));
         return true;
     } else if (QGroupBox *groupBox = qobject_cast<QGroupBox *>(widget)) {
-        bool bvalue = value.toString() == "TRUE";
-        groupBox->setChecked(bvalue);
+        groupBox->setChecked(getCheckedFromOption(widget, value.toString()));
         return true;
     } else if (QCheckBox *checkBox=qobject_cast<QCheckBox *>(widget)) {
-        bool bvalue = value.toString() == "TRUE";
-        checkBox->setChecked(bvalue);
+        checkBox->setChecked(getCheckedFromOption(widget, value.toString()));
         return true;
     } else if (QLineEdit *lineEdit=qobject_cast<QLineEdit *>(widget)) {
         if (scale == 0)
@@ -1489,6 +1491,36 @@ bool ConfigTaskWidget::eventFilter( QObject * obj, QEvent * evt ) {
     }
     return QWidget::eventFilter( obj, evt );
 }
+
+/**
+ * @brief Determine which enum option based on checkbox
+ * @param widget Target widget
+ * @param checked Checked status of widget
+ * @return Enum option as string
+ */
+QString ConfigTaskWidget::getOptionFromChecked(QWidget *widget, bool checked)
+{
+    if (checked)
+        return widget->property("checkedOption").isValid() ? widget->property("checkedOption").toString() : "TRUE";
+    else
+        return widget->property("unCheckedOption").isValid() ? widget->property("unCheckedOption").toString() : "FALSE";
+}
+
+/**
+ * @brief Determine whether checkbox should be checked
+ * @param widget Target widget
+ * @param option Enum option as string
+ * @return
+ */
+bool ConfigTaskWidget::getCheckedFromOption(QWidget *widget, QString option)
+{
+    if (widget->property("checkedOption").isValid())
+        return option == widget->property("checkedOption").toString();
+    if (widget->property("unCheckedOption").isValid())
+        return option != widget->property("unCheckedOption").toString();
+    return option == "TRUE";
+}
+
 /**
   @}
   @}

--- a/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.h
+++ b/ground/gcs/src/plugins/uavobjectwidgetutils/configtaskwidget.h
@@ -217,6 +217,8 @@ protected:
     void checkWidgetsLimits(QWidget *widget, UAVObjectField *field, int index, bool hasLimits, QVariant value, double scale);
     virtual QVariant getVariantFromWidget(QWidget *widget, double scale);
     virtual bool setWidgetFromVariant(QWidget *widget,QVariant value,double scale);
+    virtual QString getOptionFromChecked(QWidget* widget, bool checked);
+    virtual bool getCheckedFromOption(QWidget* widget, QString option);
     UAVObjectUtilManager* utilMngr;
 };
 

--- a/shared/uavobjectdefinition/taskinfo.xml
+++ b/shared/uavobjectdefinition/taskinfo.xml
@@ -88,8 +88,8 @@
 			<elementname>IMU</elementname>
 		</elementnames>
 		<options>
-			<option>False</option>
-			<option>True</option>
+			<option>FALSE</option>
+			<option>TRUE</option>
 		</options>
 		<description>The run state of each task.</description>
 	</field>


### PR DESCRIPTION
- Clarify auto/manual modules much more
- Move UAVO->Widget relations to UI file
- ConfigTaskWidget (UAVO->widget relations) now supports arbitrary mapping of checkbox state to enum options
- Move GPS to own tab and add constellations + auto-setup
- General improvements

![screenshot from 2016-05-15 18-18-58](https://cloud.githubusercontent.com/assets/9995998/15272394/072036b2-1aca-11e6-9085-524f2dabcd15.png)
