### PR TITLE
gcs: hidapi: from upstream: hid open mode shared

### DIFF
--- a/ground/gcs/src/plugins/rawhid/hidapi/hidapi_windows.c
+++ b/ground/gcs/src/plugins/rawhid/hidapi/hidapi_windows.c
@@ -224,9 +224,7 @@ static HANDLE open_device(const char *path, BOOL enumerate)
 {
 	HANDLE handle;
 	DWORD desired_access = (enumerate)? 0: (GENERIC_WRITE | GENERIC_READ);
-	DWORD share_mode = (enumerate)?
-	                      FILE_SHARE_READ|FILE_SHARE_WRITE:
-	                      FILE_SHARE_READ;
+	DWORD share_mode = FILE_SHARE_READ|FILE_SHARE_WRITE;
 
 	handle = CreateFileA(path,
 		desired_access,


### PR DESCRIPTION
From https://github.com/signal11/hidapi/commit/b5b2e1779b6cd2edda3066bbbf0921a2d6b1c3c

This may explain some anomalies experienced during upgrade on Windows;
we saw various open failures because of Windows holding hid stuff open.
It may also fix the cc3d "wrong driver for composite device" problem
that users sporadically experience.

It does make running multiple GCS at once potentially more dangerous.
