### PR TITLE
Brain: Add UART+Outputs option on RxPort

### DIFF
--- a/flight/targets/brain/fw/pios_board.c
+++ b/flight/targets/brain/fw/pios_board.c
@@ -455,6 +455,7 @@ void PIOS_Board_Init(void) {
 		break;
 
 	case HWBRAIN_RXPORT_UART:
+	case HWBRAIN_RXPORT_UARTOUTPUTS:
 		use_rxport_usart = true;
 		break;
 
@@ -523,6 +524,7 @@ void PIOS_Board_Init(void) {
 #endif
 		break;
 	case HWBRAIN_RXPORT_PPMUARTOUTPUTS:
+	case HWBRAIN_RXPORT_UARTOUTPUTS:
 #ifdef PIOS_INCLUDE_SERVO
 		PIOS_Servo_Init(&pios_servo_rcvr_ppm_uart_out_cfg);
 #endif

--- a/shared/uavobjectdefinition/hwbrain.xml
+++ b/shared/uavobjectdefinition/hwbrain.xml
@@ -14,6 +14,7 @@
 				<option>PPM+UART+Outputs</option>
 				<option>PWM</option>
 				<option>UART</option>
+				<option>UART+Outputs</option>
 			</options>
 		</field>
 


### PR DESCRIPTION
Allows having 6 outputs and 3 UARTS. The other options that have PPM in them always make PPM the primary receiver.
