### PR TITLE
actuator: don't stabilize when disarmed

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -323,7 +323,7 @@ static void actuator_task(void* parameters)
 			throttle_source = desired.Thrust;
 		}
 
-		bool stabilize_now = throttle_source > 0.0f;
+		bool stabilize_now = armed && (throttle_source > 0.0f);
 
 		static uint32_t last_pos_throttle_time = 0;
 


### PR DESCRIPTION
Not that we really did anyways, but this prevents actuator alarms when
disarmed which were screwing some people up for setup wizard stuff.

Fixes #1008.
