### PR TITLE
Change Outer Loop sliders to 200 maximum

### DIFF
--- a/ground/gcs/src/plugins/config/stabilization.ui
+++ b/ground/gcs/src/plugins/config/stabilization.ui
@@ -9831,7 +9831,7 @@ border-radius: 5;</string>
                     <string notr="true"/>
                    </property>
                    <property name="maximum">
-                    <number>100</number>
+                    <number>200</number>
                    </property>
                    <property name="sliderPosition">
                     <number>50</number>
@@ -9913,7 +9913,7 @@ border-radius: 5;</string>
                     <string notr="true"/>
                    </property>
                    <property name="maximum">
-                    <number>100</number>
+                    <number>200</number>
                    </property>
                    <property name="sliderPosition">
                     <number>50</number>
@@ -9995,7 +9995,7 @@ border-radius: 5;</string>
                     <string notr="true"/>
                    </property>
                    <property name="maximum">
-                    <number>100</number>
+                    <number>200</number>
                    </property>
                    <property name="sliderPosition">
                     <number>50</number>
@@ -10096,7 +10096,7 @@ border-radius: 5;</string>
                     <string notr="true"/>
                    </property>
                    <property name="maximum">
-                    <number>100</number>
+                    <number>200</number>
                    </property>
                    <property name="sliderPosition">
                     <number>50</number>
@@ -10178,7 +10178,7 @@ border-radius: 5;</string>
                     <string notr="true"/>
                    </property>
                    <property name="maximum">
-                    <number>100</number>
+                    <number>200</number>
                    </property>
                    <property name="sliderPosition">
                     <number>50</number>
@@ -10260,7 +10260,7 @@ border-radius: 5;</string>
                     <string notr="true"/>
                    </property>
                    <property name="maximum">
-                    <number>100</number>
+                    <number>200</number>
                    </property>
                    <property name="sliderPosition">
                     <number>50</number>

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -14,9 +14,9 @@
 	<field name="RollRatePID" units="" type="float" elementnames="Kp,Ki,Kd,ILimit" defaultvalue="0.002,0.0015,0,0.3" limits="%BE:0:0.01,%BE:0:0.05,, "/>
 	<field name="PitchRatePID" units="" type="float" elementnames="Kp,Ki,Kd,ILimit" defaultvalue="0.002,0.0015,0,0.3" limits="%BE:0:0.01,%BE:0:0.05,, "/>
 	<field name="YawRatePID" units="" type="float" elementnames="Kp,Ki,Kd,ILimit" defaultvalue="0.0035,0.0035,0,0.3" limits="%BE:0:0.01,%BE:0:0.05,, "/>
-	<field name="RollPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:10,%BE:0:10,"/>
-	<field name="PitchPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:10,%BE:0:10,"/>
-	<field name="YawPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:10,%BE:0:10,"/>
+	<field name="RollPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
+	<field name="PitchPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
+	<field name="YawPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
 
 	<field name="VbarSensitivity" units="frac" type="float" elementnames="Roll,Pitch,Yaw" defaultvalue="0.5,0.5,0.5"/>
 	<field name="VbarRollPID" units="1/(deg/s)" type="float" elementnames="Kp,Ki,Kd" defaultvalue="0.005,0.002,0"/>


### PR DESCRIPTION
Outer Loop text boxes were set to a maximum of 200, but the sliders were set to only 100 causing the sider to sometimes max out. Values of 100+ aren't uncommon. Changed sliders to 200 as well.
