### PR TITLE
Fixes Quanton pin mapping when IN port is mapped as outputs

### DIFF
--- a/flight/targets/quanton/board-info/board_hw_defs.c
+++ b/flight/targets/quanton/board-info/board_hw_defs.c
@@ -1648,281 +1648,281 @@ static const struct pios_tim_channel pios_tim_servoport_rcvrport_PPM_pins[] = {
 
 /*
  * 	OUTPUTS with extra outputs on receiverport
-    1:  TIM3_CH1  (PB4)
-    2:  TIM3_CH2  (PB5)
-    3:  TIM3_CH3  (PB0)
-    4:  TIM3_CH4  (PB1)
-    5:  TIM12_CH1 (PB14)
-    6:  TIM12_CH2 (PB15)
-    7:  TIM10_CH1 (PB8)
-    8:  TIM11_CH1 (PB9)
-    9:  TIM1_CH3  (PA10)    (IN1)
-    10: TIM8_CH1  (PC6)		(IN2)
-    11: TIM8_CH2  (PC7)		(IN3)
-    12: TIM8_CH3  (PC8)		(IN4)
-    13: TIM2_CH1  (PA15)	(IN5)
-    14: TIM2_CH2  (PB3)		(IN6)
-    15: TIM5_CH1  (PA0)		(IN7)
-    16: TIM5_CH2  (PA1)		(IN8)
+	1:  TIM3_CH1  (PB4)
+	2:  TIM3_CH2  (PB5)
+	3:  TIM3_CH3  (PB0)
+	4:  TIM3_CH4  (PB1)
+	5:  TIM12_CH1 (PB14)
+	6:  TIM12_CH2 (PB15)
+	7:  TIM10_CH1 (PB8)
+	8:  TIM11_CH1 (PB9)
+	9:  TIM1_CH3  (PA10)	(IN1)
+	10: TIM8_CH1  (PC6)		(IN2)
+	11: TIM8_CH2  (PC7)		(IN3)
+	12: TIM8_CH3  (PC8)		(IN4)
+	13: TIM2_CH1  (PA15)	(IN5)
+	14: TIM2_CH2  (PB3)		(IN6)
+	15: TIM5_CH1  (PA0)		(IN7)
+	16: TIM5_CH2  (PA1)		(IN8)
  */
 
 static const struct pios_tim_channel pios_tim_servoport_rcvrport_pins[] = {
-    {
-        .timer = TIM3,
-        .timer_chan = TIM_Channel_1,
-        .remap = GPIO_AF_TIM3,
-        .pin = {
-            .gpio = GPIOB,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_4,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource4,
-        },
-    },
-    {
-        .timer = TIM3,
-        .timer_chan = TIM_Channel_2,
-        .remap = GPIO_AF_TIM3,
-        .pin = {
-            .gpio = GPIOB,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_5,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource5,
-        },
-    },
-    {
-        .timer = TIM3,
-        .timer_chan = TIM_Channel_3,
-        .remap = GPIO_AF_TIM3,
-        .pin = {
-            .gpio = GPIOB,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_0,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource0,
-        },
-    },
-    {
-        .timer = TIM3,
-        .timer_chan = TIM_Channel_4,
-        .remap = GPIO_AF_TIM3,
-        .pin = {
-            .gpio = GPIOB,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_1,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource1,
-        },
-    },
-    {
-        .timer = TIM12,
-        .timer_chan = TIM_Channel_1,
-        .remap = GPIO_AF_TIM12,
-        .pin = {
-            .gpio = GPIOB,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_14,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource14,
-        },
-    },
-    {
-        .timer = TIM12,
-        .timer_chan = TIM_Channel_2,
-        .remap = GPIO_AF_TIM12,
-        .pin = {
-            .gpio = GPIOB,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_15,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource15,
-        },
-    },
-    {
-        .timer = TIM10,
-        .timer_chan = TIM_Channel_1,
-        .remap = GPIO_AF_TIM10,
-        .pin = {
-            .gpio = GPIOB,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_8,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource8,
-        },
-    },
-    {
-        .timer = TIM11,
-        .timer_chan = TIM_Channel_1,
-        .remap = GPIO_AF_TIM11,
-        .pin = {
-            .gpio = GPIOB,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_9,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource9,
-        },
-    },
-    {
-        .timer = TIM1,
-        .timer_chan = TIM_Channel_3,
-        .remap = GPIO_AF_TIM1,
-        .pin = {
-            .gpio = GPIOA,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_10,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource10,
-        },
-    },
-    {
-        .timer = TIM8,
-        .timer_chan = TIM_Channel_1,
-        .remap = GPIO_AF_TIM8,
-        .pin = {
-            .gpio = GPIOC,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_6,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource6,
-        },
-    },
-    {
-        .timer = TIM8,
-        .timer_chan = TIM_Channel_2,
-        .remap = GPIO_AF_TIM8,
-        .pin = {
-            .gpio = GPIOC,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_7,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource7,
-        },
-    },
-    {
-        .timer = TIM8,
-        .timer_chan = TIM_Channel_3,
-        .remap = GPIO_AF_TIM8,
-        .pin = {
-            .gpio = GPIOC,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_8,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource8,
-        },
-    },
-    {
-        .timer = TIM2,
-        .timer_chan = TIM_Channel_1,
-        .remap = GPIO_AF_TIM2,
-        .pin = {
-            .gpio = GPIOA,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_15,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource15,
-        },
-    },
-    {
-        .timer = TIM2,
-        .timer_chan = TIM_Channel_2,
-        .remap = GPIO_AF_TIM2,
-        .pin = {
-            .gpio = GPIOB,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_3,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource3,
-        },
-    },
-    {
-        .timer = TIM5,
-        .timer_chan = TIM_Channel_1,
-        .remap = GPIO_AF_TIM5,
-        .pin = {
-            .gpio = GPIOA,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_0,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource0,
-        },
-    },
-    {
-        .timer = TIM5,
-        .timer_chan = TIM_Channel_2,
-        .remap = GPIO_AF_TIM5,
-        .pin = {
-            .gpio = GPIOA,
-            .init = {
-                .GPIO_Pin = GPIO_Pin_1,
-                .GPIO_Speed = GPIO_Speed_2MHz,
-                .GPIO_Mode  = GPIO_Mode_AF,
-                .GPIO_OType = GPIO_OType_PP,
-                .GPIO_PuPd  = GPIO_PuPd_UP
-            },
-            .pin_source = GPIO_PinSource1,
-        },
-    },
+	{
+		.timer = TIM3,
+		.timer_chan = TIM_Channel_1,
+		.remap = GPIO_AF_TIM3,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_4,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource4,
+		},
+	},
+	{
+		.timer = TIM3,
+		.timer_chan = TIM_Channel_2,
+		.remap = GPIO_AF_TIM3,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_5,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource5,
+		},
+	},
+	{
+		.timer = TIM3,
+		.timer_chan = TIM_Channel_3,
+		.remap = GPIO_AF_TIM3,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_0,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource0,
+		},
+	},
+	{
+		.timer = TIM3,
+		.timer_chan = TIM_Channel_4,
+		.remap = GPIO_AF_TIM3,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_1,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource1,
+		},
+	},
+	{
+		.timer = TIM12,
+		.timer_chan = TIM_Channel_1,
+		.remap = GPIO_AF_TIM12,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_14,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource14,
+		},
+	},
+	{
+		.timer = TIM12,
+		.timer_chan = TIM_Channel_2,
+		.remap = GPIO_AF_TIM12,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_15,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource15,
+		},
+	},
+	{
+		.timer = TIM10,
+		.timer_chan = TIM_Channel_1,
+		.remap = GPIO_AF_TIM10,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_8,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource8,
+		},
+	},
+	{
+		.timer = TIM11,
+		.timer_chan = TIM_Channel_1,
+		.remap = GPIO_AF_TIM11,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_9,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource9,
+		},
+	},
+	{
+		.timer = TIM1,
+		.timer_chan = TIM_Channel_3,
+		.remap = GPIO_AF_TIM1,
+		.pin = {
+			.gpio = GPIOA,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_10,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource10,
+		},
+	},
+	{
+		.timer = TIM8,
+		.timer_chan = TIM_Channel_1,
+		.remap = GPIO_AF_TIM8,
+		.pin = {
+			.gpio = GPIOC,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_6,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource6,
+		},
+	},
+	{
+		.timer = TIM8,
+		.timer_chan = TIM_Channel_2,
+		.remap = GPIO_AF_TIM8,
+		.pin = {
+			.gpio = GPIOC,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_7,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource7,
+		},
+	},
+	{
+		.timer = TIM8,
+		.timer_chan = TIM_Channel_3,
+		.remap = GPIO_AF_TIM8,
+		.pin = {
+			.gpio = GPIOC,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_8,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource8,
+		},
+	},
+	{
+		.timer = TIM2,
+		.timer_chan = TIM_Channel_1,
+		.remap = GPIO_AF_TIM2,
+		.pin = {
+			.gpio = GPIOA,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_15,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource15,
+		},
+	},
+	{
+		.timer = TIM2,
+		.timer_chan = TIM_Channel_2,
+		.remap = GPIO_AF_TIM2,
+		.pin = {
+			.gpio = GPIOB,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_3,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource3,
+		},
+	},
+	{
+		.timer = TIM5,
+		.timer_chan = TIM_Channel_1,
+		.remap = GPIO_AF_TIM5,
+		.pin = {
+			.gpio = GPIOA,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_0,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource0,
+		},
+	},
+	{
+		.timer = TIM5,
+		.timer_chan = TIM_Channel_2,
+		.remap = GPIO_AF_TIM5,
+		.pin = {
+			.gpio = GPIOA,
+			.init = {
+				.GPIO_Pin = GPIO_Pin_1,
+				.GPIO_Speed = GPIO_Speed_2MHz,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd  = GPIO_PuPd_UP
+			},
+			.pin_source = GPIO_PinSource1,
+		},
+	},
 };
 
 #if defined(PIOS_INCLUDE_SERVO) && defined(PIOS_INCLUDE_TIM)
@@ -1978,18 +1978,18 @@ const struct pios_servo_cfg pios_servo_with_rcvr_cfg = {
 };
 
 const struct pios_servo_cfg pios_servo_with_rcvr_ppm_cfg = {
-    .tim_oc_init = {
-        .TIM_OCMode = TIM_OCMode_PWM1,
-        .TIM_OutputState = TIM_OutputState_Enable,
-        .TIM_OutputNState = TIM_OutputNState_Disable,
-        .TIM_Pulse = PIOS_SERVOS_INITIAL_POSITION,
-        .TIM_OCPolarity = TIM_OCPolarity_High,
-        .TIM_OCNPolarity = TIM_OCPolarity_High,
-        .TIM_OCIdleState = TIM_OCIdleState_Reset,
-        .TIM_OCNIdleState = TIM_OCNIdleState_Reset,
-    },
-    .channels = pios_tim_servoport_rcvrport_PPM_pins,
-    .num_channels = NELEMENTS(pios_tim_servoport_rcvrport_PPM_pins),
+	.tim_oc_init = {
+		.TIM_OCMode = TIM_OCMode_PWM1,
+		.TIM_OutputState = TIM_OutputState_Enable,
+		.TIM_OutputNState = TIM_OutputNState_Disable,
+		.TIM_Pulse = PIOS_SERVOS_INITIAL_POSITION,
+		.TIM_OCPolarity = TIM_OCPolarity_High,
+		.TIM_OCNPolarity = TIM_OCPolarity_High,
+		.TIM_OCIdleState = TIM_OCIdleState_Reset,
+		.TIM_OCNIdleState = TIM_OCNIdleState_Reset,
+	},
+	.channels = pios_tim_servoport_rcvrport_PPM_pins,
+	.num_channels = NELEMENTS(pios_tim_servoport_rcvrport_PPM_pins),
 };
 
 const struct pios_servo_cfg pios_servo_with_rcvr_with_adc_cfg = {

--- a/flight/targets/quanton/board-info/board_hw_defs.c
+++ b/flight/targets/quanton/board-info/board_hw_defs.c
@@ -1403,7 +1403,7 @@ static const struct pios_tim_channel pios_tim_servoport_all_pins[] = {
 	15: TIM5_CH2  (PA1)		(IN8)
  */
 
-static const struct pios_tim_channel pios_tim_servoport_rcvrport_pins[] = {
+static const struct pios_tim_channel pios_tim_servoport_rcvrport_PPM_pins[] = {
 	{
 		.timer = TIM3,
 		.timer_chan = TIM_Channel_1,
@@ -1646,7 +1646,284 @@ static const struct pios_tim_channel pios_tim_servoport_rcvrport_pins[] = {
 	},
 };
 
+/*
+ * 	OUTPUTS with extra outputs on receiverport
+    1:  TIM3_CH1  (PB4)
+    2:  TIM3_CH2  (PB5)
+    3:  TIM3_CH3  (PB0)
+    4:  TIM3_CH4  (PB1)
+    5:  TIM12_CH1 (PB14)
+    6:  TIM12_CH2 (PB15)
+    7:  TIM10_CH1 (PB8)
+    8:  TIM11_CH1 (PB9)
+    9:  TIM1_CH3  (PA10)    (IN1)
+    10: TIM8_CH1  (PC6)		(IN2)
+    11: TIM8_CH2  (PC7)		(IN3)
+    12: TIM8_CH3  (PC8)		(IN4)
+    13: TIM2_CH1  (PA15)	(IN5)
+    14: TIM2_CH2  (PB3)		(IN6)
+    15: TIM5_CH1  (PA0)		(IN7)
+    16: TIM5_CH2  (PA1)		(IN8)
+ */
 
+static const struct pios_tim_channel pios_tim_servoport_rcvrport_pins[] = {
+    {
+        .timer = TIM3,
+        .timer_chan = TIM_Channel_1,
+        .remap = GPIO_AF_TIM3,
+        .pin = {
+            .gpio = GPIOB,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_4,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource4,
+        },
+    },
+    {
+        .timer = TIM3,
+        .timer_chan = TIM_Channel_2,
+        .remap = GPIO_AF_TIM3,
+        .pin = {
+            .gpio = GPIOB,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_5,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource5,
+        },
+    },
+    {
+        .timer = TIM3,
+        .timer_chan = TIM_Channel_3,
+        .remap = GPIO_AF_TIM3,
+        .pin = {
+            .gpio = GPIOB,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_0,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource0,
+        },
+    },
+    {
+        .timer = TIM3,
+        .timer_chan = TIM_Channel_4,
+        .remap = GPIO_AF_TIM3,
+        .pin = {
+            .gpio = GPIOB,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_1,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource1,
+        },
+    },
+    {
+        .timer = TIM12,
+        .timer_chan = TIM_Channel_1,
+        .remap = GPIO_AF_TIM12,
+        .pin = {
+            .gpio = GPIOB,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_14,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource14,
+        },
+    },
+    {
+        .timer = TIM12,
+        .timer_chan = TIM_Channel_2,
+        .remap = GPIO_AF_TIM12,
+        .pin = {
+            .gpio = GPIOB,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_15,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource15,
+        },
+    },
+    {
+        .timer = TIM10,
+        .timer_chan = TIM_Channel_1,
+        .remap = GPIO_AF_TIM10,
+        .pin = {
+            .gpio = GPIOB,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_8,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource8,
+        },
+    },
+    {
+        .timer = TIM11,
+        .timer_chan = TIM_Channel_1,
+        .remap = GPIO_AF_TIM11,
+        .pin = {
+            .gpio = GPIOB,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_9,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource9,
+        },
+    },
+    {
+        .timer = TIM1,
+        .timer_chan = TIM_Channel_3,
+        .remap = GPIO_AF_TIM1,
+        .pin = {
+            .gpio = GPIOA,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_10,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource10,
+        },
+    },
+    {
+        .timer = TIM8,
+        .timer_chan = TIM_Channel_1,
+        .remap = GPIO_AF_TIM8,
+        .pin = {
+            .gpio = GPIOC,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_6,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource6,
+        },
+    },
+    {
+        .timer = TIM8,
+        .timer_chan = TIM_Channel_2,
+        .remap = GPIO_AF_TIM8,
+        .pin = {
+            .gpio = GPIOC,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_7,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource7,
+        },
+    },
+    {
+        .timer = TIM8,
+        .timer_chan = TIM_Channel_3,
+        .remap = GPIO_AF_TIM8,
+        .pin = {
+            .gpio = GPIOC,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_8,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource8,
+        },
+    },
+    {
+        .timer = TIM2,
+        .timer_chan = TIM_Channel_1,
+        .remap = GPIO_AF_TIM2,
+        .pin = {
+            .gpio = GPIOA,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_15,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource15,
+        },
+    },
+    {
+        .timer = TIM2,
+        .timer_chan = TIM_Channel_2,
+        .remap = GPIO_AF_TIM2,
+        .pin = {
+            .gpio = GPIOB,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_3,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource3,
+        },
+    },
+    {
+        .timer = TIM5,
+        .timer_chan = TIM_Channel_1,
+        .remap = GPIO_AF_TIM5,
+        .pin = {
+            .gpio = GPIOA,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_0,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource0,
+        },
+    },
+    {
+        .timer = TIM5,
+        .timer_chan = TIM_Channel_2,
+        .remap = GPIO_AF_TIM5,
+        .pin = {
+            .gpio = GPIOA,
+            .init = {
+                .GPIO_Pin = GPIO_Pin_1,
+                .GPIO_Speed = GPIO_Speed_2MHz,
+                .GPIO_Mode  = GPIO_Mode_AF,
+                .GPIO_OType = GPIO_OType_PP,
+                .GPIO_PuPd  = GPIO_PuPd_UP
+            },
+            .pin_source = GPIO_PinSource1,
+        },
+    },
+};
 
 #if defined(PIOS_INCLUDE_SERVO) && defined(PIOS_INCLUDE_TIM)
 /*
@@ -1698,6 +1975,21 @@ const struct pios_servo_cfg pios_servo_with_rcvr_cfg = {
 	},
 	.channels = pios_tim_servoport_rcvrport_pins,
 	.num_channels = NELEMENTS(pios_tim_servoport_rcvrport_pins),
+};
+
+const struct pios_servo_cfg pios_servo_with_rcvr_ppm_cfg = {
+    .tim_oc_init = {
+        .TIM_OCMode = TIM_OCMode_PWM1,
+        .TIM_OutputState = TIM_OutputState_Enable,
+        .TIM_OutputNState = TIM_OutputNState_Disable,
+        .TIM_Pulse = PIOS_SERVOS_INITIAL_POSITION,
+        .TIM_OCPolarity = TIM_OCPolarity_High,
+        .TIM_OCNPolarity = TIM_OCPolarity_High,
+        .TIM_OCIdleState = TIM_OCIdleState_Reset,
+        .TIM_OCNIdleState = TIM_OCNIdleState_Reset,
+    },
+    .channels = pios_tim_servoport_rcvrport_PPM_pins,
+    .num_channels = NELEMENTS(pios_tim_servoport_rcvrport_PPM_pins),
 };
 
 const struct pios_servo_cfg pios_servo_with_rcvr_with_adc_cfg = {

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -581,6 +581,10 @@ void PIOS_Board_Init(void) {
 #endif
 			break;
 		case HWQUANTON_INPORT_PPMOUTPUTS:
+#ifdef PIOS_INCLUDE_SERVO
+            PIOS_Servo_Init(&pios_servo_with_rcvr_ppm_cfg);
+#endif
+            break;
 		case HWQUANTON_INPORT_OUTPUTS:
 #ifdef PIOS_INCLUDE_SERVO
 			PIOS_Servo_Init(&pios_servo_with_rcvr_cfg);

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -582,9 +582,9 @@ void PIOS_Board_Init(void) {
 			break;
 		case HWQUANTON_INPORT_PPMOUTPUTS:
 #ifdef PIOS_INCLUDE_SERVO
-            PIOS_Servo_Init(&pios_servo_with_rcvr_ppm_cfg);
+			PIOS_Servo_Init(&pios_servo_with_rcvr_ppm_cfg);
 #endif
-            break;
+			break;
 		case HWQUANTON_INPORT_OUTPUTS:
 #ifdef PIOS_INCLUDE_SERVO
 			PIOS_Servo_Init(&pios_servo_with_rcvr_cfg);


### PR DESCRIPTION
When quanton IN pins are configured as outputs, the 9th and 10th outputs are now mapped onto IN1 and IN2 instead of IN2 and IN3.

Before, the code handled "PPM+Outputs" same as "Outputs" when configuring the IN port.
