### PR TITLE
setupwizard: oneshot range

### DIFF
--- a/ground/gcs/src/plugins/setupwizard/pages/outputcalibrationpage.cpp
+++ b/ground/gcs/src/plugins/setupwizard/pages/outputcalibrationpage.cpp
@@ -155,12 +155,12 @@ void OutputCalibrationPage::startWizard()
 
     if (getWizard()->getESCType() == SetupWizard::ESC_ONESHOT125) {
         ui->motorNeutralSlider->setMinimum(125);
-        ui->motorNeutralSlider->setMaximum(140);
+        ui->motorNeutralSlider->setMaximum(152);
         ui->motorNeutralSlider->setPageStep(1);
         ui->motorNeutralSlider->setSingleStep(1);
     } else if (getWizard()->getESCType() == SetupWizard::ESC_ONESHOT42) {
         ui->motorNeutralSlider->setMinimum(125/3);
-        ui->motorNeutralSlider->setMaximum(140/3);
+        ui->motorNeutralSlider->setMaximum(152/3);
         ui->motorNeutralSlider->setPageStep(1);
         ui->motorNeutralSlider->setSingleStep(1);
     }

--- a/ground/gcs/src/plugins/setupwizard/pages/outputcalibrationpage.ui
+++ b/ground/gcs/src/plugins/setupwizard/pages/outputcalibrationpage.ui
@@ -85,7 +85,7 @@ p, li { white-space: pre-wrap; }
           <number>1000</number>
          </property>
          <property name="maximum">
-          <number>1300</number>
+          <number>1216</number>
          </property>
          <property name="singleStep">
           <number>10</number>


### PR DESCRIPTION
set to a value experimentally required by some users and consistent
between modes.  Before we were limited to 140, but some people need
145 to spin (bad minimum value IMO).

Similarly, turn the non-oneshot max neutral value from 1300 to 1216,
which corresponds to the new oneshot value (152); it used to
correspond to 1216.
