### PR TITLE
GCS:Input: Add warnings for bad reprojection settings

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.h
+++ b/ground/gcs/src/plugins/config/configinputwidget.h
@@ -196,12 +196,14 @@ private slots:
         void simpleCalibration(bool state);
         void updateCalibration();
         void checkArmingConfig(QString option);
-        void checkFlightMode(QString option);
         void checkHangtimeConfig();
+        void checkReprojection();
 
 protected:
         void resizeEvent(QResizeEvent *event);
         virtual void enableControls(bool enable);
+        void addMessage(QWidget *widget, const QString type, const QString msg);
+        void clearMessages(QWidget *widget, const QString type);
 };
 
 #endif

--- a/ground/gcs/src/plugins/config/input.ui
+++ b/ground/gcs/src/plugins/config/input.ui
@@ -1366,6 +1366,26 @@ margin:1px;</string>
             </widget>
            </item>
            <item>
+            <widget class="QGroupBox" name="gbxFMMessages">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="title">
+              <string>Messages</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_15"/>
+            </widget>
+           </item>
+           <item>
             <spacer name="verticalSpacer_5">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -1481,8 +1501,8 @@ margin:1px;</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>865</width>
-            <height>769</height>
+            <width>579</width>
+            <height>818</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">


### PR DESCRIPTION
<img width="1083" alt="untitled" src="https://cloud.githubusercontent.com/assets/9995998/16030993/9eb0b4b0-324a-11e6-985b-facd4b93bbb2.png">

Fixes #961 
Although it doesn't enforce, just warns.
