### PR TITLE
OSD: hide fields / scales for which no sensor is present

### DIFF
--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -449,7 +449,7 @@ static int32_t updateAttitudeComplementary(bool first_run, bool secondary, bool 
 		magData.z = 0;
 
 		// Wait for a mag reading if a magnetometer was registered
-		if ((PIOS_SENSORS_GetQueue(PIOS_SENSOR_MAG) != NULL) && (MagnetometerHandle() != NULL)) {
+		if (MagnetometerHandle() != NULL) {
 			if (!secondary && PIOS_Queue_Receive(magQueue, &ev, 20) != true) {
 				return -1;
 			}

--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -449,7 +449,7 @@ static int32_t updateAttitudeComplementary(bool first_run, bool secondary, bool 
 		magData.z = 0;
 
 		// Wait for a mag reading if a magnetometer was registered
-		if (PIOS_SENSORS_GetQueue(PIOS_SENSOR_MAG) != NULL) {
+		if ((PIOS_SENSORS_GetQueue(PIOS_SENSOR_MAG) != NULL) && (MagnetometerHandle() != NULL)) {
 			if (!secondary && PIOS_Queue_Receive(magQueue, &ev, 20) != true) {
 				return -1;
 			}
@@ -631,7 +631,7 @@ static int32_t updateAttitudeComplementary(bool first_run, bool secondary, bool 
 	}
 
 	float mag_err[3];
-	if (secondary || PIOS_Queue_Receive(magQueue, &ev, 0) == true)
+	if (MagnetometerHandle() && (secondary || PIOS_Queue_Receive(magQueue, &ev, 0) == true))
 	{
 		MagnetometerData mag;
 		MagnetometerGet(&mag);

--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -1438,6 +1438,11 @@ static void check_home_location()
 	if (homeLocation.Set == HOMELOCATION_SET_TRUE)
 		return;
 
+	// We need GPS
+	if (!GPSPositionHandle()) {
+		return;
+	}
+
 	GPSPositionData gps;
 	GPSPositionGet(&gps);
 	GPSTimeData gpsTime;

--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -495,9 +495,11 @@ static int32_t updateAttitudeComplementary(bool first_run, bool secondary, bool 
 
 		complementary_filter_state.arming_count = 0;
 
-		float baro;
-		BaroAltitudeAltitudeGet(&baro);
-		cfvert_reset(&cfvert, baro, attitudeSettings.VertPositionTau);
+		if (BaroAltitudeHandle()) {
+			float baro;
+			BaroAltitudeAltitudeGet(&baro);
+			cfvert_reset(&cfvert, baro, attitudeSettings.VertPositionTau);
+		}
 
 		return 0;
 	}
@@ -549,9 +551,11 @@ static int32_t updateAttitudeComplementary(bool first_run, bool secondary, bool 
 		}
 
 		// Reset the filter for barometric data
-		float baro;
-		BaroAltitudeAltitudeGet(&baro);
-		cfvert_reset(&cfvert, baro, attitudeSettings.VertPositionTau);
+		if (BaroAltitudeHandle()) {
+			float baro;
+			BaroAltitudeAltitudeGet(&baro);
+			cfvert_reset(&cfvert, baro, attitudeSettings.VertPositionTau);
+		}
 
 	} else if (complementary_filter_state.initialization == CF_ARMING ||
 	           complementary_filter_state.initialization == CF_INITIALIZING) {
@@ -572,10 +576,11 @@ static int32_t updateAttitudeComplementary(bool first_run, bool secondary, bool 
 		complementary_filter_state.initialization = CF_NORMAL;
 
 		// Reset the filter for barometric data
-		float baro;
-		BaroAltitudeAltitudeGet(&baro);
-		cfvert_reset(&cfvert, baro, attitudeSettings.VertPositionTau);
-
+		if (BaroAltitudeHandle()) {
+			float baro;
+			BaroAltitudeAltitudeGet(&baro);
+			cfvert_reset(&cfvert, baro, attitudeSettings.VertPositionTau);
+		}
 	}
 
 	GyrosGet(&gyrosData);
@@ -730,7 +735,7 @@ static int32_t updateAttitudeComplementary(bool first_run, bool secondary, bool 
 		// When this is the only filter compute th vertical state from baro data
 		// Reset the filter for barometric data
 		cfvert_predict_pos(&cfvert, z_accel, dT);
-		if (PIOS_Queue_Receive(baroQueue, &ev, 0) == true) {
+		if ((PIOS_Queue_Receive(baroQueue, &ev, 0) == true) && BaroAltitudeHandle()) {
 			float baro;
 			BaroAltitudeAltitudeGet(&baro);
 			cfvert_update_baro(&cfvert, baro, dT);

--- a/flight/Modules/GPS/GPS.c
+++ b/flight/Modules/GPS/GPS.c
@@ -130,11 +130,7 @@ int32_t GPSInitialize(void)
 	module_enabled = PIOS_Modules_IsEnabled(PIOS_MODULE_GPS);
 #endif
 
-	// These things are only conditional on small F1 targets.
-	// Expected to be always present otherwise.
-#ifdef SMALLF1
 	if (gpsPort && module_enabled) {
-#endif
 		if (GPSPositionInitialize() == -1 \
 			|| GPSVelocityInitialize() == -1) {
 			
@@ -157,9 +153,7 @@ int32_t GPSInitialize(void)
 		}
 #endif
 		updateSettings();
-#ifdef SMALLF1
 	}
-#endif
 
 	if (gpsPort && module_enabled) {
 		ModuleSettingsGPSDataProtocolGet(&gpsProtocol);

--- a/flight/Modules/OnScreenDisplay/onscreendisplay.c
+++ b/flight/Modules/OnScreenDisplay/onscreendisplay.c
@@ -1491,15 +1491,17 @@ int render_stats()
 		y_pos += STATS_LINE_SPACING;
 	}
 
-	tmp = convert_distance * stats.MaxClimbRate;
-	sprintf(tmp_str, "Maximum climb rate:       %0.2f %s/s", (double)tmp, dist_unit_short);
-	write_string(tmp_str, STATS_LINE_X, y_pos, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, STATS_FONT);
-	y_pos += STATS_LINE_SPACING;
+	if (BaroAltitudeHandle()) {
+		tmp = convert_distance * stats.MaxClimbRate;
+		sprintf(tmp_str, "Maximum climb rate:       %0.2f %s/s", (double)tmp, dist_unit_short);
+		write_string(tmp_str, STATS_LINE_X, y_pos, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, STATS_FONT);
+		y_pos += STATS_LINE_SPACING;
 
-	tmp = convert_distance * stats.MaxDescentRate;
-	sprintf(tmp_str, "Maximum descent rate:     %0.2f %s/s", (double)tmp, dist_unit_short);
-	write_string(tmp_str, STATS_LINE_X, y_pos, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, STATS_FONT);
-	y_pos += 2 * STATS_LINE_SPACING;
+		tmp = convert_distance * stats.MaxDescentRate;
+		sprintf(tmp_str, "Maximum descent rate:     %0.2f %s/s", (double)tmp, dist_unit_short);
+		write_string(tmp_str, STATS_LINE_X, y_pos, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, STATS_FONT);
+		y_pos += 2 * STATS_LINE_SPACING;
+	}
 
 	sprintf(tmp_str, "Maximum roll rate:        %d deg/s", stats.MaxRollRate);
 	write_string(tmp_str, STATS_LINE_X, y_pos, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, STATS_FONT);

--- a/flight/Modules/OnScreenDisplay/onscreendisplay.c
+++ b/flight/Modules/OnScreenDisplay/onscreendisplay.c
@@ -1103,47 +1103,47 @@ void render_user_page(OnScreenDisplayPageSettingsData * page)
 
 	// Altitude Scale
 	if (page->AltitudeScale) {
+		bool valid_altitude = false;
 		if (page->AltitudeScaleSource == ONSCREENDISPLAYPAGESETTINGS_ALTITUDESCALESOURCE_BARO) {
 			if (BaroAltitudeHandle()){
 				BaroAltitudeAltitudeGet(&tmp);
 				tmp -= home_baro_altitude;
-			}
-			else {
-				tmp =0;
+				valid_altitude = true;
 			}
 		} else if (PositionActualHandle()) {
 			PositionActualDownGet(&tmp);
 			tmp *= -1.0f;
-		} else {
-			tmp = 0.f;
+			valid_altitude = true;
 		}
-		if (page->AltitudeScaleAlign == ONSCREENDISPLAYPAGESETTINGS_ALTITUDESCALEALIGN_LEFT)
-			hud_draw_vertical_scale(tmp * convert_distance, 100, -1, page->AltitudeScalePos, GRAPHICS_Y_MIDDLE, 120, 10, 20, 5, 8,
-					11, 10000, 0);
-		else
-			hud_draw_vertical_scale(tmp * convert_distance, 100, 1, page->AltitudeScalePos, GRAPHICS_Y_MIDDLE, 120, 10, 20, 5, 8,
-					11, 10000, 0);
+		if (valid_altitude) {
+			if (page->AltitudeScaleAlign == ONSCREENDISPLAYPAGESETTINGS_ALTITUDESCALEALIGN_LEFT)
+				hud_draw_vertical_scale(tmp * convert_distance, 100, -1, page->AltitudeScalePos, GRAPHICS_Y_MIDDLE, 120, 10, 20, 5, 8,
+						11, 10000, 0);
+			else
+				hud_draw_vertical_scale(tmp * convert_distance, 100, 1, page->AltitudeScalePos, GRAPHICS_Y_MIDDLE, 120, 10, 20, 5, 8,
+						11, 10000, 0);
+		}
 	}
 
 	// Altitude Numeric
 	if (page->AltitudeNumeric) {
+		bool valid_altitude = false;
 		if (page->AltitudeNumericSource == ONSCREENDISPLAYPAGESETTINGS_ALTITUDENUMERICSOURCE_BARO) {
 			if (BaroAltitudeHandle()) {
 				BaroAltitudeAltitudeGet(&tmp);
 				tmp -= home_baro_altitude;
-			}
-			else {
-				tmp = 0;
+				valid_altitude = true;
 			}
 		} else if (PositionActualHandle()) {
 			PositionActualDownGet(&tmp);
 			tmp *= -1.0f;
-		} else {
-			tmp = 0.f;
+			valid_altitude = true;
 		}
-		sprintf(tmp_str, "%d", (int)(tmp * convert_distance));
-		write_string(tmp_str, page->AltitudeNumericPosX, page->AltitudeNumericPosY, 0, 0, TEXT_VA_TOP, (int)page->AltitudeNumericAlign,
-				0, page->AltitudeNumericFont);
+		if (valid_altitude) {
+			sprintf(tmp_str, "%d", (int)(tmp * convert_distance));
+			write_string(tmp_str, page->AltitudeNumericPosX, page->AltitudeNumericPosY, 0, 0, TEXT_VA_TOP, (int)page->AltitudeNumericAlign,
+					0, page->AltitudeNumericFont);
+		}
 	}
 
 	// Arming Status
@@ -1191,7 +1191,7 @@ void render_user_page(OnScreenDisplayPageSettingsData * page)
 	}
 
 	// Climb rate
-	if (page->ClimbRate && VelocityActualHandle()) {
+	if (page->ClimbRate && VelocityActualHandle() && BaroAltitudeHandle()) {
 		VelocityActualDownGet(&tmp);
 		sprintf(tmp_str, "%0.1f", (double)(-1.f * convert_distance * tmp));
 		write_string(tmp_str, page->ClimbRatePosX, page->ClimbRatePosY, 0, 0, TEXT_VA_TOP, (int)page->ClimbRateAlign, 0,

--- a/flight/Modules/OnScreenDisplay/onscreendisplay.c
+++ b/flight/Modules/OnScreenDisplay/onscreendisplay.c
@@ -1348,70 +1348,80 @@ void render_user_page(OnScreenDisplayPageSettingsData * page)
 	// Speed Scale
 	if (page->SpeedScale) {
 		tmp = 0.f;
+		bool speed_valid = false;
 		switch (page->SpeedScaleSource)
 		{
-			tmp = 0.f;
-		case ONSCREENDISPLAYPAGESETTINGS_SPEEDSCALESOURCE_NAV:
-			if (VelocityActualHandle()) {
-				VelocityActualNorthGet(&tmp);
-				VelocityActualEastGet(&tmp1);
-				tmp = sqrt(tmp * tmp + tmp1 * tmp1);
-			}
-			sprintf(tmp_str, "%s", "GND");
-			break;
-		case ONSCREENDISPLAYPAGESETTINGS_SPEEDSCALESOURCE_GPS:
-			if (GPSVelocityHandle()) {
-				GPSVelocityNorthGet(&tmp);
-				GPSVelocityEastGet(&tmp1);
-				tmp = sqrt(tmp * tmp + tmp1 * tmp1);
-			}
-			sprintf(tmp_str, "%s", "GND");
-			break;
-		case ONSCREENDISPLAYPAGESETTINGS_SPEEDSCALESOURCE_AIRSPEED:
-			if (AirspeedActualHandle()) {
-				AirspeedActualTrueAirspeedGet(&tmp);
-			}
-			sprintf(tmp_str, "%s", "AIR");
+			case ONSCREENDISPLAYPAGESETTINGS_SPEEDSCALESOURCE_NAV:
+				if (VelocityActualHandle()) {
+					VelocityActualNorthGet(&tmp);
+					VelocityActualEastGet(&tmp1);
+					tmp = sqrt(tmp * tmp + tmp1 * tmp1);
+					speed_valid = true;
+				}
+				sprintf(tmp_str, "%s", "GND");
+				break;
+			case ONSCREENDISPLAYPAGESETTINGS_SPEEDSCALESOURCE_GPS:
+				if (GPSVelocityHandle()) {
+					GPSVelocityNorthGet(&tmp);
+					GPSVelocityEastGet(&tmp1);
+					tmp = sqrt(tmp * tmp + tmp1 * tmp1);
+					speed_valid = true;
+				}
+				sprintf(tmp_str, "%s", "GND");
+				break;
+			case ONSCREENDISPLAYPAGESETTINGS_SPEEDSCALESOURCE_AIRSPEED:
+				if (AirspeedActualHandle()) {
+					AirspeedActualTrueAirspeedGet(&tmp);
+					speed_valid = true;
+				}
+				sprintf(tmp_str, "%s", "AIR");
 		}
-		if (page->SpeedScaleAlign == ONSCREENDISPLAYPAGESETTINGS_SPEEDSCALEALIGN_LEFT) {
-			hud_draw_vertical_scale(tmp * convert_speed, 30, -1,  page->SpeedScalePos, GRAPHICS_Y_MIDDLE, 120, 10, 20, 5, 8, 11,
-					100, 0);
-			write_string(tmp_str, page->SpeedScalePos + 10, 200, 0, 0, TEXT_VA_MIDDLE, TEXT_HA_LEFT, 0, FONT_OUTLINED8X8);
-		} else {
-			hud_draw_vertical_scale(tmp * convert_speed, 30, 1,  page->SpeedScalePos, GRAPHICS_Y_MIDDLE, 120, 10, 20, 5, 8, 11, 100,
-					0);
-			write_string(tmp_str, page->SpeedScalePos - 30, 200, 0, 0, TEXT_VA_MIDDLE, TEXT_HA_LEFT, 0, FONT_OUTLINED8X8);
+		if (speed_valid){
+			if (page->SpeedScaleAlign == ONSCREENDISPLAYPAGESETTINGS_SPEEDSCALEALIGN_LEFT) {
+				hud_draw_vertical_scale(tmp * convert_speed, 30, -1,  page->SpeedScalePos, GRAPHICS_Y_MIDDLE, 120, 10, 20, 5, 8, 11,
+						100, 0);
+				write_string(tmp_str, page->SpeedScalePos + 10, 200, 0, 0, TEXT_VA_MIDDLE, TEXT_HA_LEFT, 0, FONT_OUTLINED8X8);
+			} else {
+				hud_draw_vertical_scale(tmp * convert_speed, 30, 1,  page->SpeedScalePos, GRAPHICS_Y_MIDDLE, 120, 10, 20, 5, 8, 11, 100,
+						0);
+				write_string(tmp_str, page->SpeedScalePos - 30, 200, 0, 0, TEXT_VA_MIDDLE, TEXT_HA_LEFT, 0, FONT_OUTLINED8X8);
+			}
 		}
 	}
 
 	// Speed Numeric
 	if (page->SpeedNumeric) {
 		tmp = 0.f;
+		bool speed_valid = false;
 		switch (page->SpeedNumericSource)
 		{
-			tmp = 0.f;
-		case ONSCREENDISPLAYPAGESETTINGS_SPEEDNUMERICSOURCE_NAV:
-			if (VelocityActualHandle()) {
-				VelocityActualNorthGet(&tmp);
-				VelocityActualEastGet(&tmp1);
-			}
-			tmp = sqrt(tmp * tmp + tmp1 * tmp1);
-			break;
-		case ONSCREENDISPLAYPAGESETTINGS_SPEEDNUMERICSOURCE_GPS:
-			if (GPSVelocityHandle()) {
-				GPSVelocityNorthGet(&tmp);
-				GPSVelocityEastGet(&tmp1);
+			case ONSCREENDISPLAYPAGESETTINGS_SPEEDNUMERICSOURCE_NAV:
+				if (VelocityActualHandle()) {
+					VelocityActualNorthGet(&tmp);
+					VelocityActualEastGet(&tmp1);
+					speed_valid = true;
+				}
 				tmp = sqrt(tmp * tmp + tmp1 * tmp1);
-			}
-			break;
-		case ONSCREENDISPLAYPAGESETTINGS_SPEEDNUMERICSOURCE_AIRSPEED:
-			if (AirspeedActualHandle()) {
-				AirspeedActualTrueAirspeedGet(&tmp);
-			}
+				break;
+			case ONSCREENDISPLAYPAGESETTINGS_SPEEDNUMERICSOURCE_GPS:
+				if (GPSVelocityHandle()) {
+					GPSVelocityNorthGet(&tmp);
+					GPSVelocityEastGet(&tmp1);
+					tmp = sqrt(tmp * tmp + tmp1 * tmp1);
+					speed_valid = true;
+				}
+				break;
+			case ONSCREENDISPLAYPAGESETTINGS_SPEEDNUMERICSOURCE_AIRSPEED:
+				if (AirspeedActualHandle()) {
+					AirspeedActualTrueAirspeedGet(&tmp);
+					speed_valid = true;
+				}
 		}
-		sprintf(tmp_str, "%d", (int)(tmp * convert_speed));
-		write_string(tmp_str, page->SpeedNumericPosX, page->SpeedNumericPosY, 0, 0, (int)page->SpeedNumericAlign, TEXT_HA_LEFT, 0,
-				page->SpeedNumericFont);
+		if (speed_valid) {
+			sprintf(tmp_str, "%d", (int)(tmp * convert_speed));
+			write_string(tmp_str, page->SpeedNumericPosX, page->SpeedNumericPosY, 0, 0, (int)page->SpeedNumericAlign, TEXT_HA_LEFT, 0,
+					page->SpeedNumericFont);
+		}
 	}
 
 	// Time

--- a/flight/Modules/OnScreenDisplay/onscreendisplay.c
+++ b/flight/Modules/OnScreenDisplay/onscreendisplay.c
@@ -89,6 +89,7 @@
 #include "gpssatellites.h"
 #include "gpsvelocity.h"
 #include "homelocation.h"
+#include "magnetometer.h"
 #include "manualcontrolcommand.h"
 #include "modulesettings.h"
 #include "stabilizationsettings.h"
@@ -1199,7 +1200,7 @@ void render_user_page(OnScreenDisplayPageSettingsData * page)
 	}
 
 	// Compass
-	if (page->Compass) {
+	if (page->Compass && MagnetometerHandle()) {
 		AttitudeActualYawGet(&tmp);
 		if (tmp < 0)
 			tmp += 360;

--- a/flight/Modules/Sensors/sensors.c
+++ b/flight/Modules/Sensors/sensors.c
@@ -141,8 +141,6 @@ static int32_t SensorsInitialize(void)
 	if (GyrosInitialize() == -1 \
 		|| GyrosBiasInitialize() == -1 \
 		|| AccelsInitialize() == -1 \
-		|| MagnetometerInitialize() == -1 \
-		|| MagBiasInitialize() == -1 \
 		|| AttitudeSettingsInitialize() == -1 \
 		|| SensorSettingsInitialize() == -1 \
 		|| INSSettingsInitialize() == -1) {
@@ -271,6 +269,8 @@ static void SensorsTask(void *parameters)
 
 		queue = PIOS_SENSORS_GetQueue(PIOS_SENSOR_MAG);
 		if (queue != NULL && PIOS_Queue_Receive(queue, &mags, 0) != false) {
+			MagnetometerInitialize();
+			MagBiasInitialize();
 			update_mags(&mags);
 		}
 
@@ -710,12 +710,14 @@ static void settingsUpdatedCb(UAVObjEvent * objEv, void *ctx, void *obj, int len
 	z_accel_offset  =  sensorSettings.ZAccelOffset;
 
 	// Zero out any adaptive tracking
-	MagBiasData magBias;
-	MagBiasGet(&magBias);
-	magBias.x = 0;
-	magBias.y = 0;
-	magBias.z = 0;
-	MagBiasSet(&magBias);
+	if (MagBiasHandle()){
+		MagBiasData magBias;
+		MagBiasGet(&magBias);
+		magBias.x = 0;
+		magBias.y = 0;
+		magBias.z = 0;
+		MagBiasSet(&magBias);
+	}
 
 	uint8_t bias_correct;
 	AttitudeSettingsBiasCorrectGyroGet(&bias_correct);

--- a/flight/Modules/Sensors/sensors.c
+++ b/flight/Modules/Sensors/sensors.c
@@ -141,7 +141,6 @@ static int32_t SensorsInitialize(void)
 	if (GyrosInitialize() == -1 \
 		|| GyrosBiasInitialize() == -1 \
 		|| AccelsInitialize() == -1 \
-		|| BaroAltitudeInitialize() == -1 \
 		|| MagnetometerInitialize() == -1 \
 		|| MagBiasInitialize() == -1 \
 		|| AttitudeSettingsInitialize() == -1 \
@@ -277,6 +276,9 @@ static void SensorsTask(void *parameters)
 
 		queue = PIOS_SENSORS_GetQueue(PIOS_SENSOR_BARO);
 		if (queue != NULL) {
+			if (!BaroAltitudeHandle()) {
+				BaroAltitudeInitialize();
+			}
 			if (PIOS_Queue_Receive(queue, &baro, 0) != false) {
 				// we can use the timeval because it contains the current time stamp (PIOS_DELAY_GetRaw())
 				last_baro_update_time = timeval;


### PR DESCRIPTION
Hides fields for which no sensors are present. Also some more fundamental changes: 
- Only initialize BaroAltitude UAVO is a barometer is present
- Only initialize Magnetometer and MagBias UAVOs if a magnetometer is present
- Only initialize GPS UAVOs if GPS module is running

Status: bench tested.

Fixes #1040 
