### PR TITLE
naze32: adjust for initcall change

### DIFF
--- a/flight/targets/naze32/link_STM32103CB_Naze32_sections.ld
+++ b/flight/targets/naze32/link_STM32103CB_Naze32_sections.ld
@@ -27,7 +27,7 @@ SECTIONS
     {
         . = ALIGN(4);
         __module_initcall_start = .;
-        KEEP(*(.initcallmodule.init))
+        KEEP(*(SORT_BY_NAME(.initcall.*)))
         . = ALIGN(4);
         __module_initcall_end   = .;
     } >FLASH


### PR DESCRIPTION
Naze32 was missed as part of the #967 (due to its linker script being in
a different place) and was failign to start up.  Now is OK.
