### PR TITLE
pios: fix the build

### DIFF
--- a/flight/PiOS/Common/pios_srxl.c
+++ b/flight/PiOS/Common/pios_srxl.c
@@ -143,6 +143,21 @@ const struct pios_rcvr_driver pios_srxl_rcvr_driver = {
 
 /* Implementation */
 
+/* byte-ordering macros */
+#define ntohl(v) (				\
+	(((v) & 0xFF000000) >> 24) |		\
+	(((v) & 0x00FF0000) >>  8) |		\
+	(((v) & 0x0000FF00) <<  8) |		\
+	(((v) & 0x000000FF) << 24))
+
+#define ntohs(v) (				\
+	(((v) & 0xFF00) >> 8) |			\
+	(((v) & 0x00FF) << 8))
+
+#define htonl(v) ntohl((v))
+
+#define htons(v) ntohs((v))
+
 int32_t PIOS_SRXL_Init(uintptr_t *srxl_id,
 	const struct pios_com_driver *driver, uintptr_t lower_id)
 {

--- a/flight/PiOS/pios.h
+++ b/flight/PiOS/pios.h
@@ -98,7 +98,6 @@
 #endif
 #include <pios_dsm.h>
 #include <pios_sbus.h>
-#include <pios_srxl.h>
 #include <pios_usb_hid.h>
 #include <pios_gpio.h>
 #include <pios_wdg.h>
@@ -109,6 +108,7 @@
 #else
 #include <pios_exti.h>
 #include <pios_usart.h>
+#include <pios_srxl.h>
 #endif  // SIM_POSIX
 
 /* PIOS Hardware Includes (Common) */
@@ -208,21 +208,6 @@
 #include <pios_crc.h>
 
 #define NELEMENTS(x) (sizeof(x) / sizeof(*(x)))
-
-/* byte-ordering macros */
-#define ntohl(v) (				\
-	(((v) & 0xFF000000) >> 24) |		\
-	(((v) & 0x00FF0000) >>  8) |		\
-	(((v) & 0x0000FF00) <<  8) |		\
-	(((v) & 0x000000FF) << 24))
-
-#define ntohs(v) (				\
-	(((v) & 0xFF00) >> 8) |			\
-	(((v) & 0x00FF) << 8))
-
-#define htonl(v) ntohl((v))
-
-#define htons(v) ntohs((v))
 
 #endif /* PIOS_H */
 


### PR DESCRIPTION
The pios sim and srxl changes interacted.  With either alone it was
fine; with both we couldn't build.
