### PR TITLE
gcs: usb: changes to make reboot button better

### DIFF
--- a/ground/gcs/src/plugins/rawhid/rawhid.cpp
+++ b/ground/gcs/src/plugins/rawhid/rawhid.cpp
@@ -46,7 +46,7 @@ static const int READ_SIZE = 64;
 static const int WRITE_TIMEOUT = 1000;
 static const int WRITE_SIZE = 64;
 
-static const int WRITE_RETRIES = 3;
+static const int WRITE_RETRIES = 10;
 
 
 

--- a/ground/gcs/src/plugins/rawhid/usbmonitor.cpp
+++ b/ground/gcs/src/plugins/rawhid/usbmonitor.cpp
@@ -124,8 +124,9 @@ void USBMonitor::periodic() {
         qDebug() << "usbmonitor detection cycle complete.";
     }
 
-    /* Ensure our signals are spaced out.  Also limit our CPU consumption */
-    periodicTimer.start(150);
+    /* Ensure our signals are spaced out by using singleshot mode
+     * and limit our CPU consumption */
+    periodicTimer.start(80);
 }
 
 QList<USBPortInfo> USBMonitor::availableDevices()

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -559,7 +559,7 @@ void UploaderGadgetWidget::haltOrReset(bool halting)
     if(conMngr->getCurrentDevice().connection->shortName() == "USB")
     {
         conMngr->disconnectDevice();
-        timeout.start(200);
+        timeout.start(750);
         loop.exec();
         timeout.stop();
         conMngr->suspendPolling();


### PR DESCRIPTION
This is not 100% reliable, but well over 90%.  There's a remaining
failure category (when GCS never notices the departure) that's not
addressed.

Mitigates #1048 on OSX.  @tracernz, feedback would be very helpful
to see if this helps you.  Tested with sparky2 and revo and lux.
