### PR TITLE
Add CRC16 to logfs

### DIFF
--- a/flight/PiOS/Common/pios_flashfs_logfs.c
+++ b/flight/PiOS/Common/pios_flashfs_logfs.c
@@ -957,6 +957,8 @@ out_exit:
  * @retval -3 if object not found in filesystem
  * @retval -4 if object size in filesystem does not exactly match buffer size
  * @retval -5 if reading the object data from flash fails
+ * @retval -6 if reading the CRC from flash fails
+ * @retval -7 if CRC is incorrect
  */
 int32_t PIOS_FLASHFS_ObjLoad(uintptr_t fs_id, uint32_t obj_id, uint16_t obj_inst_id, uint8_t *obj_data, uint16_t obj_size)
 {

--- a/ground/uavobjgenerator/uavobjectparser.h
+++ b/ground/uavobjgenerator/uavobjectparser.h
@@ -39,10 +39,10 @@
 
 /**
  * The maximum size of UAVOs is limited by the FlashFS filesystem in the flight code
- * The flash slot size is 256 bytes which is comprised of the FlashFS header (12 bytes)
- * and the UAVO. This leaves a maximum of 244 bytes for the UAVO.
+ * The flash slot size is 256 bytes which is comprised of the FlashFS header (12 bytes),
+ * the UAVO, and a 2 byte CRC. This leaves a maximum of 242 bytes for the UAVO.
  */
-#define UAVO_MAX_SIZE 244
+#define UAVO_MAX_SIZE 242
 
 // Types
 typedef enum {


### PR DESCRIPTION
Adds CRC16 to the UAV Objects written to flash. For backwards compatibility, the CRC is written after the object and for now we also accept `0xFFFF` as a valid CRC (as this is the value the flash would have when the CRC isn't written).

Status: Tested on F4 (RE1) checking that objects with and without CRC are saved / loaded correctly.
