### PR TITLE
GCS: Make board plugins semi-portable

### DIFF
--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -60,6 +60,7 @@
 #include <QBitmap>
 #include <QCommandLineParser>
 #include <QCommandLineOption>
+#include <QStandardPaths>
 
 #include "libcrashreporter-qt/libcrashreporter-handler/Handler.h"
 
@@ -168,6 +169,16 @@ static inline QStringList getPluginPaths()
     pluginPath += QLatin1Char('/');
     pluginPath += QLatin1String("Plugins");
     rc.push_back(pluginPath);
+    // 4) add-on plugins (e.g. 3rd party/out-of-tree board plugins)
+    QStringList docPaths = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation);
+    if (docPaths.length() > 0) {
+        pluginPath = docPaths.at(0);
+        pluginPath += QLatin1Char('/');
+        pluginPath += QLatin1String(GCS_PROJECT_BRANDING_PRETTY);
+        pluginPath += QLatin1Char('/');
+        pluginPath += QLatin1String("addons");
+        rc.push_back(pluginPath);
+    }
     return rc;
 }
 

--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -60,7 +60,6 @@
 #include <QBitmap>
 #include <QCommandLineParser>
 #include <QCommandLineOption>
-#include <QStandardPaths>
 
 #include "libcrashreporter-qt/libcrashreporter-handler/Handler.h"
 
@@ -170,15 +169,13 @@ static inline QStringList getPluginPaths()
     pluginPath += QLatin1String("Plugins");
     rc.push_back(pluginPath);
     // 4) add-on plugins (e.g. 3rd party/out-of-tree board plugins)
-    QStringList docPaths = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation);
-    if (docPaths.length() > 0) {
-        pluginPath = docPaths.at(0);
-        pluginPath += QLatin1Char('/');
-        pluginPath += QLatin1String(GCS_PROJECT_BRANDING_PRETTY);
-        pluginPath += QLatin1Char('/');
-        pluginPath += QLatin1String("addons");
+    pluginPath = Utils::PathUtils::getAddonPath();
+    if (pluginPath.length() > 0) {
+        pluginPath += QLatin1String("/plugins");
         rc.push_back(pluginPath);
+        qDebug() << "Loading add-on plugins from: " << pluginPath;
     }
+
     return rc;
 }
 

--- a/ground/gcs/src/libs/utils/pathutils.cpp
+++ b/ground/gcs/src/libs/utils/pathutils.cpp
@@ -30,6 +30,7 @@
 #include "xmlconfig.h"
 #include <qglobal.h>
 #include <QDebug>
+#include <QStandardPaths>
 
 
 namespace Utils {
@@ -153,6 +154,17 @@ QString PathUtils::getSettingsFilename()
 void PathUtils::setSettingsFilename(QString filename)
 {
     PathUtils::settingsFilename = filename;
+}
+
+QString PathUtils::getAddonPath()
+{
+    QString path;
+    QStringList docPaths = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation);
+    if (docPaths.length() > 0) {
+        path = docPaths.at(0);
+        path += "/" GCS_PROJECT_BRANDING_PRETTY "/addons";
+    }
+    return path;
 }
 
 }

--- a/ground/gcs/src/libs/utils/pathutils.h
+++ b/ground/gcs/src/libs/utils/pathutils.h
@@ -51,6 +51,7 @@ public:
     QString InsertStoragePath(QString path);
     QString getSettingsFilename();
     void setSettingsFilename(QString filename);
+    static QString getAddonPath();
 private:
     static QString settingsFilename;
 };

--- a/ground/gcs/src/plugins/boards_aeroquad/aeroquadplugin.cpp
+++ b/ground/gcs/src/plugins/boards_aeroquad/aeroquadplugin.cpp
@@ -27,6 +27,8 @@
 
 #include "aeroquadplugin.h"
 #include "aq32.h"
+#include "uavobjectsinit.h"
+#include "hwaq32.h"
 
 AeroQuadPlugin::AeroQuadPlugin()
 {
@@ -40,9 +42,12 @@ AeroQuadPlugin::~AeroQuadPlugin()
 
 bool AeroQuadPlugin::initialize(const QStringList& args, QString *errMsg)
 {
-   Q_UNUSED(args);
-   Q_UNUSED(errMsg);
-   return true;
+    Q_UNUSED(args);
+    Q_UNUSED(errMsg);
+
+    UAVObjectInitialize<HwAQ32>(new HwAQ32());
+
+    return true;
 }
 
 void AeroQuadPlugin::extensionsInitialized()

--- a/ground/gcs/src/plugins/boards_aeroquad/aq32.cpp
+++ b/ground/gcs/src/plugins/boards_aeroquad/aq32.cpp
@@ -106,17 +106,14 @@ QPixmap AQ32::getBoardPicture()
     return QPixmap(":/aq32/images/aq32.png");
 }
 
-QString AQ32::getHwUAVO()
+QString AQ32::getHwUavoName()
 {
     return "HwAQ32";
 }
 
 int AQ32::queryMaxGyroRate()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwAQ32 *hwAQ32 = HwAQ32::GetInstance(uavoManager);
-    Q_ASSERT(hwAQ32);
+    HwAQ32 *hwAQ32 = getHwUavo<HwAQ32>();
     if (!hwAQ32)
         return 0;
 
@@ -138,10 +135,7 @@ int AQ32::queryMaxGyroRate()
 
 QStringList AQ32::getAdcNames()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwAQ32 *hwAQ32 = HwAQ32::GetInstance(uavoManager);
-    Q_ASSERT(hwAQ32);
+    HwAQ32 *hwAQ32 = getHwUavo<HwAQ32>();
     if (!hwAQ32)
         return QStringList();
 

--- a/ground/gcs/src/plugins/boards_aeroquad/aq32.h
+++ b/ground/gcs/src/plugins/boards_aeroquad/aq32.h
@@ -43,10 +43,9 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
+    virtual QString getHwUavoName();
     virtual int queryMaxGyroRate();
     virtual QStringList getAdcNames();
-
 };
 
 

--- a/ground/gcs/src/plugins/boards_aeroquad/boards_aeroquad.pro
+++ b/ground/gcs/src/plugins/boards_aeroquad/boards_aeroquad.pro
@@ -8,11 +8,13 @@ OTHER_FILES += AeroQuad.json
 
 HEADERS += \
     aeroquadplugin.h \
-	aq32.h
+    aq32.h \
+    $$UAVOBJECT_SYNTHETICS/hwaq32.h
 
 SOURCES += \
     aeroquadplugin.cpp \
-	aq32.cpp
+    aq32.cpp \
+    $$UAVOBJECT_SYNTHETICS/hwaq32.cpp
 
 RESOURCES += \
     aeroquad.qrc

--- a/ground/gcs/src/plugins/boards_brainfpv/boards_brainfpv.pro
+++ b/ground/gcs/src/plugins/boards_brainfpv/boards_brainfpv.pro
@@ -13,14 +13,18 @@ HEADERS += \
     brain.h \
     brainconfiguration.h \
     brainre1.h \
-    brainre1configuration.h
+    brainre1configuration.h \
+    $$UAVOBJECT_SYNTHETICS/hwbrain.h \
+    $$UAVOBJECT_SYNTHETICS/hwbrainre1.h
 
 SOURCES += \
     brainfpvplugin.cpp \
     brain.cpp \
     brainconfiguration.cpp \
     brainre1.cpp \
-    brainre1configuration.cpp
+    brainre1configuration.cpp \
+    $$UAVOBJECT_SYNTHETICS/hwbrain.cpp \
+    $$UAVOBJECT_SYNTHETICS/hwbrainre1.cpp
 
 RESOURCES += \
     brainfpv.qrc

--- a/ground/gcs/src/plugins/boards_brainfpv/brain.cpp
+++ b/ground/gcs/src/plugins/boards_brainfpv/brain.cpp
@@ -110,7 +110,7 @@ QPixmap Brain::getBoardPicture()
     return QPixmap(":/brainfpv/images/brain.png");
 }
 
-QString Brain::getHwUAVO()
+QString Brain::getHwUavoName()
 {
     return "HwBrain";
 }
@@ -129,10 +129,7 @@ bool Brain::isInputConfigurationSupported(enum InputType type = INPUT_TYPE_ANY)
  */
 bool Brain::setInputType(enum InputType type)
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwBrain *hwBrain = HwBrain::GetInstance(uavoManager);
-    Q_ASSERT(hwBrain);
+    HwBrain *hwBrain = getHwUavo<HwBrain>();
     if (!hwBrain)
         return false;
 
@@ -173,10 +170,7 @@ bool Brain::setInputType(enum InputType type)
  */
 enum Core::IBoardType::InputType Brain::getInputType()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwBrain *hwBrain = HwBrain::GetInstance(uavoManager);
-    Q_ASSERT(hwBrain);
+    HwBrain *hwBrain = getHwUavo<HwBrain>();
     if (!hwBrain)
         return INPUT_TYPE_UNKNOWN;
 
@@ -219,10 +213,7 @@ enum Core::IBoardType::InputType Brain::getInputType()
 
 int Brain::queryMaxGyroRate()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwBrain *hwBrain = HwBrain::GetInstance(uavoManager);
-    Q_ASSERT(hwBrain);
+    HwBrain *hwBrain = getHwUavo<HwBrain>();
     if (!hwBrain)
         return 0;
 

--- a/ground/gcs/src/plugins/boards_brainfpv/brain.h
+++ b/ground/gcs/src/plugins/boards_brainfpv/brain.h
@@ -44,7 +44,7 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
+    virtual QString getHwUavoName();
 
     //! Determine if this board supports configuring the receiver
     virtual bool isInputConfigurationSupported(InputType type);

--- a/ground/gcs/src/plugins/boards_brainfpv/brainfpvplugin.cpp
+++ b/ground/gcs/src/plugins/boards_brainfpv/brainfpvplugin.cpp
@@ -30,6 +30,9 @@
 #include "brain.h"
 #include "brainre1.h"
 #include <QtPlugin>
+#include "uavobjectsinit.h"
+#include "hwbrain.h"
+#include "hwbrainre1.h"
 
 
 BrainFPVPlugin::BrainFPVPlugin()
@@ -44,9 +47,13 @@ BrainFPVPlugin::~BrainFPVPlugin()
 
 bool BrainFPVPlugin::initialize(const QStringList& args, QString *errMsg)
 {
-   Q_UNUSED(args);
-   Q_UNUSED(errMsg);
-   return true;
+    Q_UNUSED(args);
+    Q_UNUSED(errMsg);
+
+    UAVObjectInitialize<HwBrain>(new HwBrain());
+    UAVObjectInitialize<HwBrainRE1>(new HwBrainRE1());
+
+    return true;
 }
 
 void BrainFPVPlugin::extensionsInitialized()

--- a/ground/gcs/src/plugins/boards_brainfpv/brainre1.cpp
+++ b/ground/gcs/src/plugins/boards_brainfpv/brainre1.cpp
@@ -116,7 +116,7 @@ bool BrainRE1::isInputConfigurationSupported(enum InputType type = INPUT_TYPE_AN
     }
 }
 
-QString BrainRE1::getHwUAVO()
+QString BrainRE1::getHwUavoName()
 {
     return "HwBrainRE1";
 }
@@ -129,10 +129,7 @@ QString BrainRE1::getHwUAVO()
  */
 bool BrainRE1::setInputType(enum InputType type)
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwBrainRE1 *hwBrainRE1 = HwBrainRE1::GetInstance(uavoManager);
-    Q_ASSERT(hwBrainRE1);
+    HwBrainRE1 *hwBrainRE1 = getHwUavo<HwBrainRE1>();
     if (!hwBrainRE1)
         return false;
 
@@ -171,10 +168,7 @@ bool BrainRE1::setInputType(enum InputType type)
  */
 enum Core::IBoardType::InputType BrainRE1::getInputType()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwBrainRE1 *hwBrainRE1 = HwBrainRE1::GetInstance(uavoManager);
-    Q_ASSERT(hwBrainRE1);
+    HwBrainRE1 *hwBrainRE1 = getHwUavo<HwBrainRE1>();
     if (!hwBrainRE1)
         return INPUT_TYPE_UNKNOWN;
 

--- a/ground/gcs/src/plugins/boards_brainfpv/brainre1.h
+++ b/ground/gcs/src/plugins/boards_brainfpv/brainre1.h
@@ -42,7 +42,7 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
+    virtual QString getHwUavoName();
 
     //! Determine if this board supports configuring the receiver
     virtual bool isInputConfigurationSupported(InputType type);

--- a/ground/gcs/src/plugins/boards_brotronics/boards_brotronics.pro
+++ b/ground/gcs/src/plugins/boards_brotronics/boards_brotronics.pro
@@ -11,12 +11,14 @@ OTHER_FILES += Brotronics.pluginspec
 HEADERS += \
     brotronicsplugin.h \
     lux.h \
-    luxconfiguration.h
+    luxconfiguration.h \
+    $$UAVOBJECT_SYNTHETICS/hwlux.h
 
 SOURCES += \
     brotronicsplugin.cpp \
     lux.cpp \
-    luxconfiguration.cpp
+    luxconfiguration.cpp \
+    $$UAVOBJECT_SYNTHETICS/hwlux.cpp
 
 RESOURCES += \
     brotronics.qrc

--- a/ground/gcs/src/plugins/boards_brotronics/brotronicsplugin.cpp
+++ b/ground/gcs/src/plugins/boards_brotronics/brotronicsplugin.cpp
@@ -30,6 +30,8 @@
 #include "brotronicsplugin.h"
 #include "lux.h"
 #include <QtPlugin>
+#include "uavobjectsinit.h"
+#include "hwlux.h"
 
 
 BrotronicsPlugin::BrotronicsPlugin()
@@ -44,9 +46,12 @@ BrotronicsPlugin::~BrotronicsPlugin()
 
 bool BrotronicsPlugin::initialize(const QStringList& args, QString *errMsg)
 {
-   Q_UNUSED(args);
-   Q_UNUSED(errMsg);
-   return true;
+    Q_UNUSED(args);
+    Q_UNUSED(errMsg);
+
+    UAVObjectInitialize<HwLux>(new HwLux());
+
+    return true;
 }
 
 void BrotronicsPlugin::extensionsInitialized()

--- a/ground/gcs/src/plugins/boards_brotronics/lux.cpp
+++ b/ground/gcs/src/plugins/boards_brotronics/lux.cpp
@@ -101,7 +101,7 @@ QPixmap Lux::getBoardPicture()
     return QPixmap(":/brotronics/images/lux.png");
 }
 
-QString Lux::getHwUAVO()
+QString Lux::getHwUavoName()
 {
     return "HwLux";
 }
@@ -125,10 +125,7 @@ bool Lux::isInputConfigurationSupported(enum InputType type = INPUT_TYPE_ANY)
  */
 bool Lux::setInputType(enum InputType type)
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwLux *hwLux = HwLux::GetInstance(uavoManager);
-    Q_ASSERT(hwLux);
+    HwLux *hwLux = getHwUavo<HwLux>();
     if (!hwLux)
         return false;
 
@@ -166,10 +163,7 @@ bool Lux::setInputType(enum InputType type)
  */
 enum Core::IBoardType::InputType Lux::getInputType()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwLux *hwLux = HwLux::GetInstance(uavoManager);
-    Q_ASSERT(hwLux);
+    HwLux *hwLux = getHwUavo<HwLux>();
     if (!hwLux)
         return INPUT_TYPE_UNKNOWN;
 
@@ -191,10 +185,7 @@ enum Core::IBoardType::InputType Lux::getInputType()
 
 int Lux::queryMaxGyroRate()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwLux *hwLux = HwLux::GetInstance(uavoManager);
-    Q_ASSERT(hwLux);
+    HwLux *hwLux = getHwUavo<HwLux>();
     if (!hwLux)
         return 0;
 

--- a/ground/gcs/src/plugins/boards_brotronics/lux.h
+++ b/ground/gcs/src/plugins/boards_brotronics/lux.h
@@ -44,7 +44,7 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
+    virtual QString getHwUavoName();
     virtual int queryMaxGyroRate();
 
     //! Determine if this board supports configuring the receiver

--- a/ground/gcs/src/plugins/boards_dronin/boards_dronin.pro
+++ b/ground/gcs/src/plugins/boards_dronin/boards_dronin.pro
@@ -11,12 +11,14 @@ OTHER_FILES += Dronin.pluginspec
 HEADERS += \
     droninplugin.h \
     simulation.h \
-    simulationconfiguration.h
+    simulationconfiguration.h \
+    $$UAVOBJECT_SYNTHETICS/hwsimulation.h
 
 SOURCES += \
     droninplugin.cpp \
     simulation.cpp \
-    simulationconfiguration.cpp
+    simulationconfiguration.cpp \
+    $$UAVOBJECT_SYNTHETICS/hwsimulation.cpp
 
 RESOURCES += \
     dronin.qrc

--- a/ground/gcs/src/plugins/boards_dronin/droninplugin.cpp
+++ b/ground/gcs/src/plugins/boards_dronin/droninplugin.cpp
@@ -31,6 +31,8 @@
 #include "droninplugin.h"
 #include "simulation.h"
 #include <QtPlugin>
+#include "uavobjectsinit.h"
+#include "hwsimulation.h"
 
 
 DroninPlugin::DroninPlugin()
@@ -43,9 +45,12 @@ DroninPlugin::~DroninPlugin()
 
 bool DroninPlugin::initialize(const QStringList &arguments, QString *errorString)
 {
-   Q_UNUSED(arguments);
-   Q_UNUSED(errorString);
-   return true;
+    Q_UNUSED(arguments);
+    Q_UNUSED(errorString);
+
+    UAVObjectInitialize<HwSimulation>(new HwSimulation());
+
+    return true;
 }
 
 void DroninPlugin::extensionsInitialized()

--- a/ground/gcs/src/plugins/boards_dronin/simulation.cpp
+++ b/ground/gcs/src/plugins/boards_dronin/simulation.cpp
@@ -72,7 +72,7 @@ QPixmap Simulation::getBoardPicture()
     return QPixmap(":/images/gcs_logo_256.png");
 }
 
-QString Simulation::getHwUAVO()
+QString Simulation::getHwUavoName()
 {
     return "HwSimulation";
 }

--- a/ground/gcs/src/plugins/boards_dronin/simulation.h
+++ b/ground/gcs/src/plugins/boards_dronin/simulation.h
@@ -46,7 +46,7 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
+    virtual QString getHwUavoName();
     QWidget *getBoardConfiguration(QWidget *parent, bool connected);
 
 };

--- a/ground/gcs/src/plugins/boards_dtf/boards_dtf.pro
+++ b/ground/gcs/src/plugins/boards_dtf/boards_dtf.pro
@@ -11,12 +11,14 @@ OTHER_FILES += dtfuhf.pluginspec
 HEADERS += \
     dtfplugin.h \
     dtfc.h \
-    dtfcconfiguration.h
+    dtfcconfiguration.h \
+    $$UAVOBJECT_SYNTHETICS/hwdtfc.h
 
 SOURCES += \
     dtfplugin.cpp \
     dtfc.cpp \
-    dtfcconfiguration.cpp
+    dtfcconfiguration.cpp \
+    $$UAVOBJECT_SYNTHETICS/hwdtfc.cpp
 
 RESOURCES += \
     dtfuhf.qrc

--- a/ground/gcs/src/plugins/boards_dtf/dtfc.cpp
+++ b/ground/gcs/src/plugins/boards_dtf/dtfc.cpp
@@ -37,7 +37,6 @@
 #include "uavobjectutil/uavobjectutilmanager.h"
 #include <extensionsystem/pluginmanager.h>
 
-#include "hwdtfc.h"
 #include "dtfcconfiguration.h"
 
 /**
@@ -116,9 +115,16 @@ QPixmap Dtfc::getBoardPicture()
     return QPixmap(":/dtf/images/dtfc.png");
 }
 
-QString Dtfc::getHwUAVO()
+QString Dtfc::getHwUavoName()
 {
     return "HwDtfc";
+}
+
+HwDtfc *Dtfc::getHwUavo()
+{
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
+    return qobject_cast<HwDtfc *>(uavoManager->getObject(HwDtfc::NAME));
 }
 
 //! Determine if this board supports configuring the receiver
@@ -139,10 +145,7 @@ bool Dtfc::isInputConfigurationSupported(enum InputType type = INPUT_TYPE_ANY)
  */
 bool Dtfc::setInputType(enum InputType type)
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwDtfc *hwDtfc = HwDtfc::GetInstance(uavoManager);
-    Q_ASSERT(hwDtfc);
+    HwDtfc *hwDtfc = getHwUavo();
     if (!hwDtfc)
         return false;
 
@@ -176,10 +179,7 @@ bool Dtfc::setInputType(enum InputType type)
  */
 enum Core::IBoardType::InputType Dtfc::getInputType()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwDtfc *hwDtfc = HwDtfc::GetInstance(uavoManager);
-    Q_ASSERT(hwDtfc);
+    HwDtfc *hwDtfc = getHwUavo();
     if (!hwDtfc)
         return INPUT_TYPE_UNKNOWN;
 
@@ -220,10 +220,7 @@ enum Core::IBoardType::InputType Dtfc::getInputType()
 
 int Dtfc::queryMaxGyroRate()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwDtfc *hwDtfc = HwDtfc::GetInstance(uavoManager);
-    Q_ASSERT(hwDtfc);
+    HwDtfc *hwDtfc = getHwUavo();
     if (!hwDtfc)
         return 0;
 

--- a/ground/gcs/src/plugins/boards_dtf/dtfc.cpp
+++ b/ground/gcs/src/plugins/boards_dtf/dtfc.cpp
@@ -120,13 +120,6 @@ QString Dtfc::getHwUavoName()
     return "HwDtfc";
 }
 
-HwDtfc *Dtfc::getHwUavo()
-{
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    return qobject_cast<HwDtfc *>(uavoManager->getObject(HwDtfc::NAME));
-}
-
 //! Determine if this board supports configuring the receiver
 bool Dtfc::isInputConfigurationSupported(enum InputType type = INPUT_TYPE_ANY)
 {
@@ -145,7 +138,7 @@ bool Dtfc::isInputConfigurationSupported(enum InputType type = INPUT_TYPE_ANY)
  */
 bool Dtfc::setInputType(enum InputType type)
 {
-    HwDtfc *hwDtfc = getHwUavo();
+    HwDtfc *hwDtfc = getHwUavo<HwDtfc>();
     if (!hwDtfc)
         return false;
 
@@ -179,7 +172,7 @@ bool Dtfc::setInputType(enum InputType type)
  */
 enum Core::IBoardType::InputType Dtfc::getInputType()
 {
-    HwDtfc *hwDtfc = getHwUavo();
+    HwDtfc *hwDtfc = getHwUavo<HwDtfc>();
     if (!hwDtfc)
         return INPUT_TYPE_UNKNOWN;
 
@@ -220,7 +213,7 @@ enum Core::IBoardType::InputType Dtfc::getInputType()
 
 int Dtfc::queryMaxGyroRate()
 {
-    HwDtfc *hwDtfc = getHwUavo();
+    HwDtfc *hwDtfc = getHwUavo<HwDtfc>();
     if (!hwDtfc)
         return 0;
 

--- a/ground/gcs/src/plugins/boards_dtf/dtfc.h
+++ b/ground/gcs/src/plugins/boards_dtf/dtfc.h
@@ -83,10 +83,6 @@ public:
      * @return a string with the name of the resource for this board diagram
      */
     virtual QString getConnectionDiagram() { return ":/dtf/images/dtfc-connection.svg"; }
-
-protected:
-    HwDtfc *getHwUavo();
-
 };
 
 

--- a/ground/gcs/src/plugins/boards_dtf/dtfc.h
+++ b/ground/gcs/src/plugins/boards_dtf/dtfc.h
@@ -35,6 +35,7 @@
 #define DTFC_H
 
 #include <coreplugin/iboardtype.h>
+#include "hwdtfc.h"
 
 class IBoardType;
 
@@ -49,7 +50,7 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
+    virtual QString getHwUavoName();
     virtual int queryMaxGyroRate();
 
     //! Determine if this board supports configuring the receiver
@@ -82,6 +83,9 @@ public:
      * @return a string with the name of the resource for this board diagram
      */
     virtual QString getConnectionDiagram() { return ":/dtf/images/dtfc-connection.svg"; }
+
+protected:
+    HwDtfc *getHwUavo();
 
 };
 

--- a/ground/gcs/src/plugins/boards_dtf/dtfplugin.cpp
+++ b/ground/gcs/src/plugins/boards_dtf/dtfplugin.cpp
@@ -34,6 +34,10 @@
 #include "dtfplugin.h"
 #include "dtfc.h"
 #include <QtPlugin>
+#include "uavobjectsinit.h"
+#include "hwdtfc.h"
+#include "uavobjectmanager.h"
+#include "extensionsystem/pluginmanager.h"
 
 
 DTFPlugin::DTFPlugin()
@@ -48,9 +52,12 @@ DTFPlugin::~DTFPlugin()
 
 bool DTFPlugin::initialize(const QStringList& args, QString *errMsg)
 {
-   Q_UNUSED(args);
-   Q_UNUSED(errMsg);
-   return true;
+    Q_UNUSED(args);
+    Q_UNUSED(errMsg);
+
+    UAVObjectInitialize<HwDtfc>(new HwDtfc());
+
+    return true;
 }
 
 void DTFPlugin::extensionsInitialized()

--- a/ground/gcs/src/plugins/boards_naze/boards_naze.pro
+++ b/ground/gcs/src/plugins/boards_naze/boards_naze.pro
@@ -8,11 +8,13 @@ OTHER_FILES += Naze.pluginspec
 
 HEADERS += \
     nazeplugin.h \
-    naze.h
+    naze.h \
+    $$UAVOBJECT_SYNTHETICS/hwnaze.h
 
 SOURCES += \
     nazeplugin.cpp \
-    naze.cpp
+    naze.cpp \
+    $$UAVOBJECT_SYNTHETICS/hwnaze.cpp
 
 RESOURCES += \
     naze.qrc

--- a/ground/gcs/src/plugins/boards_naze/naze.cpp
+++ b/ground/gcs/src/plugins/boards_naze/naze.cpp
@@ -96,17 +96,14 @@ QPixmap Naze::getBoardPicture()
     return QPixmap(":/naze/images/nazev6.png");
 }
 
-QString Naze::getHwUAVO()
+QString Naze::getHwUavoName()
 {
     return "HwNaze";
 }
 
 int Naze::queryMaxGyroRate()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwNaze *hwNaze = HwNaze::GetInstance(uavoManager);
-    Q_ASSERT(hwNaze);
+    HwNaze *hwNaze = getHwUavo<HwNaze>();
     if (!hwNaze)
         return 0;
 
@@ -141,10 +138,7 @@ bool Naze::isInputConfigurationSupported(enum InputType type = INPUT_TYPE_ANY)
  */
 bool Naze::setInputType(enum InputType type)
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwNaze *hwNaze = HwNaze::GetInstance(uavoManager);
-    Q_ASSERT(hwNaze);
+    HwNaze *hwNaze = getHwUavo<HwNaze>();
     if (!hwNaze)
         return false;
 
@@ -183,10 +177,7 @@ bool Naze::setInputType(enum InputType type)
  */
 enum Core::IBoardType::InputType Naze::getInputType()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwNaze *hwNaze = HwNaze::GetInstance(uavoManager);
-    Q_ASSERT(hwNaze);
+    HwNaze *hwNaze = getHwUavo<HwNaze>();
     if (!hwNaze)
         return INPUT_TYPE_UNKNOWN;
 
@@ -214,10 +205,7 @@ enum Core::IBoardType::InputType Naze::getInputType()
 
 QStringList Naze::getAdcNames()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwNaze *hwNaze = HwNaze::GetInstance(uavoManager);
-    Q_ASSERT(hwNaze);
+    HwNaze *hwNaze = getHwUavo<HwNaze>();
     if (!hwNaze)
         return QStringList();
 

--- a/ground/gcs/src/plugins/boards_naze/naze.h
+++ b/ground/gcs/src/plugins/boards_naze/naze.h
@@ -43,7 +43,7 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
+    virtual QString getHwUavoName();
     virtual int queryMaxGyroRate();
     virtual bool isInputConfigurationSupported(enum InputType type);
     virtual bool setInputType(enum InputType type);

--- a/ground/gcs/src/plugins/boards_naze/nazeplugin.cpp
+++ b/ground/gcs/src/plugins/boards_naze/nazeplugin.cpp
@@ -29,6 +29,8 @@
 #include "nazeplugin.h"
 #include "naze.h"
 #include <QtPlugin>
+#include "uavobjectsinit.h"
+#include "hwnaze.h"
 
 
 NazePlugin::NazePlugin()
@@ -43,9 +45,12 @@ NazePlugin::~NazePlugin()
 
 bool NazePlugin::initialize(const QStringList& args, QString *errMsg)
 {
-   Q_UNUSED(args);
-   Q_UNUSED(errMsg);
-   return true;
+    Q_UNUSED(args);
+    Q_UNUSED(errMsg);
+
+    UAVObjectInitialize<HwNaze>(new HwNaze());
+
+    return true;
 }
 
 void NazePlugin::extensionsInitialized()

--- a/ground/gcs/src/plugins/boards_openpilot/boards_openpilot.pro
+++ b/ground/gcs/src/plugins/boards_openpilot/boards_openpilot.pro
@@ -13,13 +13,17 @@ HEADERS += \
     openpilotplugin.h \
     cc3d.h \
     config_cc_hw_widget.h \
-    revolution.h 
+    revolution.h \
+    $$UAVOBJECT_SYNTHETICS/hwcoptercontrol.h \
+    $$UAVOBJECT_SYNTHETICS/hwrevolution.h
 
 SOURCES += \
     openpilotplugin.cpp \
     cc3d.cpp \
     config_cc_hw_widget.cpp \
-    revolution.cpp 
+    revolution.cpp  \
+    $$UAVOBJECT_SYNTHETICS/hwcoptercontrol.cpp \
+    $$UAVOBJECT_SYNTHETICS/hwrevolution.cpp
 
 RESOURCES += \
     openpilot.qrc \

--- a/ground/gcs/src/plugins/boards_openpilot/cc3d.cpp
+++ b/ground/gcs/src/plugins/boards_openpilot/cc3d.cpp
@@ -104,7 +104,7 @@ QPixmap CC3D::getBoardPicture()
     return QPixmap(":/openpilot/images/cc3d.png");
 }
 
-QString CC3D::getHwUAVO()
+QString CC3D::getHwUavoName()
 {
     return "HwCopterControl";
 }
@@ -124,10 +124,7 @@ bool CC3D::isInputConfigurationSupported(enum InputType type = INPUT_TYPE_ANY)
  */
 bool CC3D::setInputType(enum InputType type)
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwCopterControl *hwCopterControl = HwCopterControl::GetInstance(uavoManager);
-    Q_ASSERT(hwCopterControl);
+    HwCopterControl *hwCopterControl = getHwUavo<HwCopterControl>();
     if (!hwCopterControl)
         return false;
 
@@ -168,10 +165,7 @@ bool CC3D::setInputType(enum InputType type)
  */
 enum Core::IBoardType::InputType CC3D::getInputType()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwCopterControl *hwCopterControl = HwCopterControl::GetInstance(uavoManager);
-    Q_ASSERT(hwCopterControl);
+    HwCopterControl *hwCopterControl = getHwUavo<HwCopterControl>();
     if (!hwCopterControl)
         return INPUT_TYPE_UNKNOWN;
 
@@ -208,12 +202,7 @@ enum Core::IBoardType::InputType CC3D::getInputType()
 
 int CC3D::queryMaxGyroRate()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwCopterControl *hwCopterControl = HwCopterControl::GetInstance(uavoManager);
-    UAVObjectUtilManager* utilMngr = pm->getObject<UAVObjectUtilManager>();
-    Q_ASSERT(hwCopterControl);
-    Q_ASSERT(utilMngr);
+    HwCopterControl *hwCopterControl = getHwUavo<HwCopterControl>();
     if (!hwCopterControl)
         return 0;
     HwCopterControl::DataFields settings = hwCopterControl->getData();

--- a/ground/gcs/src/plugins/boards_openpilot/cc3d.h
+++ b/ground/gcs/src/plugins/boards_openpilot/cc3d.h
@@ -43,7 +43,7 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
+    virtual QString getHwUavoName();
 
     //! Determine if this board supports configuring the receiver
     virtual bool isInputConfigurationSupported(enum InputType type);

--- a/ground/gcs/src/plugins/boards_openpilot/openpilotplugin.cpp
+++ b/ground/gcs/src/plugins/boards_openpilot/openpilotplugin.cpp
@@ -31,6 +31,9 @@
 #include "cc3d.h"
 #include "revolution.h"
 #include <QtPlugin>
+#include "uavobjectsinit.h"
+#include "hwcoptercontrol.h"
+#include "hwrevolution.h"
 
 
 OpenPilotPlugin::OpenPilotPlugin()
@@ -45,9 +48,13 @@ OpenPilotPlugin::~OpenPilotPlugin()
 
 bool OpenPilotPlugin::initialize(const QStringList& args, QString *errMsg)
 {
-   Q_UNUSED(args);
-   Q_UNUSED(errMsg);
-   return true;
+    Q_UNUSED(args);
+    Q_UNUSED(errMsg);
+
+    UAVObjectInitialize<HwCopterControl>(new HwCopterControl());
+    UAVObjectInitialize<HwRevolution>(new HwRevolution());
+
+    return true;
 }
 
 void OpenPilotPlugin::extensionsInitialized()

--- a/ground/gcs/src/plugins/boards_openpilot/revolution.cpp
+++ b/ground/gcs/src/plugins/boards_openpilot/revolution.cpp
@@ -120,22 +120,11 @@ QPixmap Revolution::getBoardPicture()
     return QPixmap(":/openpilot/images/revolution.png");
 }
 
-QString Revolution::getHwUAVO()
+QString Revolution::getHwUavoName()
 {
     return "HwRevolution";
 }
 
-//! Get the settings object
-HwRevolution * Revolution::getSettings()
-{
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-
-    HwRevolution *hwRevolution = HwRevolution::GetInstance(uavoManager);
-    Q_ASSERT(hwRevolution);
-
-    return hwRevolution;
-}
 //! Determine if this board supports configuring the receiver
 bool Revolution::isInputConfigurationSupported(enum InputType type = INPUT_TYPE_ANY)
 {
@@ -150,10 +139,7 @@ bool Revolution::isInputConfigurationSupported(enum InputType type = INPUT_TYPE_
  */
 bool Revolution::setInputType(enum InputType type)
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwRevolution *hwRevolution = HwRevolution::GetInstance(uavoManager);
-    Q_ASSERT(hwRevolution);
+    HwRevolution *hwRevolution = getHwUavo<HwRevolution>();
     if (!hwRevolution)
         return false;
 
@@ -194,10 +180,7 @@ bool Revolution::setInputType(enum InputType type)
  */
 enum Core::IBoardType::InputType Revolution::getInputType()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwRevolution *hwRevolution = HwRevolution::GetInstance(uavoManager);
-    Q_ASSERT(hwRevolution);
+    HwRevolution *hwRevolution = getHwUavo<HwRevolution>();
     if (!hwRevolution)
         return INPUT_TYPE_UNKNOWN;
 
@@ -245,10 +228,7 @@ enum Core::IBoardType::InputType Revolution::getInputType()
 
 int Revolution::queryMaxGyroRate()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwRevolution *hwRevolution = HwRevolution::GetInstance(uavoManager);
-    Q_ASSERT(hwRevolution);
+    HwRevolution *hwRevolution = getHwUavo<HwRevolution>();
     if (!hwRevolution)
         return 0;
 
@@ -294,7 +274,10 @@ quint32 Revolution::getRfmID()
 bool Revolution::bindRadio(quint32 id, quint32 baud_rate, float rf_power,
                          Core::IBoardType::LinkMode linkMode, quint8 min, quint8 max)
 {
-    HwRevolution::DataFields settings = getSettings()->getData();
+    HwRevolution *hwRevolution = getHwUavo<HwRevolution>();
+    if (!hwRevolution)
+        return false;
+    HwRevolution::DataFields settings = hwRevolution->getData();
 
     settings.CoordID = id;
 
@@ -366,8 +349,8 @@ bool Revolution::bindRadio(quint32 id, quint32 baud_rate, float rf_power,
     settings.MinChannel = min;
     settings.MaxChannel = max;
 
-    getSettings()->setData(settings);
-    uavoUtilManager->saveObjectToFlash(getSettings());
+    hwRevolution->setData(settings);
+    uavoUtilManager->saveObjectToFlash(hwRevolution);
 
     return true;
 }

--- a/ground/gcs/src/plugins/boards_openpilot/revolution.h
+++ b/ground/gcs/src/plugins/boards_openpilot/revolution.h
@@ -46,8 +46,7 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
-    HwRevolution * getSettings();
+    virtual QString getHwUavoName();
 
     //! Determine if this board supports configuring the receiver
     virtual bool isInputConfigurationSupported(InputType type);

--- a/ground/gcs/src/plugins/boards_quantec/boards_quantec.pro
+++ b/ground/gcs/src/plugins/boards_quantec/boards_quantec.pro
@@ -8,11 +8,13 @@ OTHER_FILES += Quantec.pluginspec
 
 HEADERS += \
     quantecplugin.h \
-    quanton.h
+    quanton.h \
+    $$UAVOBJECT_SYNTHETICS/hwquanton.h
 
 SOURCES += \
     quantecplugin.cpp \
-    quanton.cpp
+    quanton.cpp \
+    $$UAVOBJECT_SYNTHETICS/hwquanton.cpp
 
 RESOURCES += \
     quantec.qrc

--- a/ground/gcs/src/plugins/boards_quantec/quantecplugin.cpp
+++ b/ground/gcs/src/plugins/boards_quantec/quantecplugin.cpp
@@ -29,6 +29,8 @@
 #include "quantecplugin.h"
 #include "quanton.h"
 #include <QtPlugin>
+#include "uavobjectsinit.h"
+#include "hwquanton.h"
 
 
 QuantecPlugin::QuantecPlugin()
@@ -43,9 +45,12 @@ QuantecPlugin::~QuantecPlugin()
 
 bool QuantecPlugin::initialize(const QStringList& args, QString *errMsg)
 {
-   Q_UNUSED(args);
-   Q_UNUSED(errMsg);
-   return true;
+    Q_UNUSED(args);
+    Q_UNUSED(errMsg);
+
+    UAVObjectInitialize<HwQuanton>(new HwQuanton());
+
+    return true;
 }
 
 void QuantecPlugin::extensionsInitialized()

--- a/ground/gcs/src/plugins/boards_quantec/quanton.cpp
+++ b/ground/gcs/src/plugins/boards_quantec/quanton.cpp
@@ -111,17 +111,14 @@ QPixmap Quanton::getBoardPicture()
     return QPixmap(":/quantec/images/quanton.png");
 }
 
-QString Quanton::getHwUAVO()
+QString Quanton::getHwUavoName()
 {
     return "HwQuanton";
 }
 
 int Quanton::queryMaxGyroRate()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwQuanton *hwQuanton = HwQuanton::GetInstance(uavoManager);
-    Q_ASSERT(hwQuanton);
+    HwQuanton *hwQuanton = getHwUavo<HwQuanton>();
     if (!hwQuanton)
         return 0;
 
@@ -143,10 +140,7 @@ int Quanton::queryMaxGyroRate()
 
 QStringList Quanton::getAdcNames()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwQuanton *hwQuanton = HwQuanton::GetInstance(uavoManager);
-    Q_ASSERT(hwQuanton);
+    HwQuanton *hwQuanton = getHwUavo<HwQuanton>();
     if (!hwQuanton)
         return QStringList();
 

--- a/ground/gcs/src/plugins/boards_quantec/quanton.h
+++ b/ground/gcs/src/plugins/boards_quantec/quanton.h
@@ -44,7 +44,7 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
+    virtual QString getHwUavoName();
     virtual int queryMaxGyroRate();
     virtual QStringList getAdcNames();
 };

--- a/ground/gcs/src/plugins/boards_stm/boards_stm.pro
+++ b/ground/gcs/src/plugins/boards_stm/boards_stm.pro
@@ -8,11 +8,13 @@ OTHER_FILES += Stm.pluginspec
 
 HEADERS += \
     stmplugin.h \
-    discoveryf4.h
+    discoveryf4.h \
+    $$UAVOBJECT_SYNTHETICS/hwdiscoveryf4.h
 
 SOURCES += \
     stmplugin.cpp \
-    discoveryf4.cpp
+    discoveryf4.cpp \
+    $$UAVOBJECT_SYNTHETICS/hwdiscoveryf4.cpp
 
 RESOURCES += \
     stm.qrc

--- a/ground/gcs/src/plugins/boards_stm/discoveryf4.cpp
+++ b/ground/gcs/src/plugins/boards_stm/discoveryf4.cpp
@@ -83,7 +83,7 @@ QPixmap DiscoveryF4::getBoardPicture()
     return QPixmap();
 }
 
-QString DiscoveryF4::getHwUAVO()
+QString DiscoveryF4::getHwUavoName()
 {
     return "HwDiscoveryF4";
 }

--- a/ground/gcs/src/plugins/boards_stm/discoveryf4.h
+++ b/ground/gcs/src/plugins/boards_stm/discoveryf4.h
@@ -43,7 +43,7 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
+    virtual QString getHwUavoName();
 };
 
 

--- a/ground/gcs/src/plugins/boards_stm/stmplugin.cpp
+++ b/ground/gcs/src/plugins/boards_stm/stmplugin.cpp
@@ -30,6 +30,8 @@
 #include "stmplugin.h"
 #include "discoveryf4.h"
 #include <QtPlugin>
+#include "uavobjectsinit.h"
+#include "hwdiscoveryf4.h"
 
 
 StmPlugin::StmPlugin()
@@ -44,9 +46,12 @@ StmPlugin::~StmPlugin()
 
 bool StmPlugin::initialize(const QStringList& args, QString *errMsg)
 {
-   Q_UNUSED(args);
-   Q_UNUSED(errMsg);
-   return true;
+    Q_UNUSED(args);
+    Q_UNUSED(errMsg);
+
+    UAVObjectInitialize<HwDiscoveryF4>(new HwDiscoveryF4());
+
+    return true;
 }
 
 void StmPlugin::extensionsInitialized()

--- a/ground/gcs/src/plugins/boards_taulabs/boards_taulabs.pro
+++ b/ground/gcs/src/plugins/boards_taulabs/boards_taulabs.pro
@@ -12,13 +12,19 @@ HEADERS += \
     taulabsplugin.h \
     sparky.h \
     sparky2.h \
-    taulink.h
+    taulink.h \
+    $$UAVOBJECT_SYNTHETICS/hwsparky.h \
+    $$UAVOBJECT_SYNTHETICS/hwsparky2.h \
+    $$UAVOBJECT_SYNTHETICS/hwtaulink.h
 
 SOURCES += \
     taulabsplugin.cpp \
     sparky.cpp \
     sparky2.cpp \
-    taulink.cpp
+    taulink.cpp \
+    $$UAVOBJECT_SYNTHETICS/hwsparky.cpp \
+    $$UAVOBJECT_SYNTHETICS/hwsparky2.cpp \
+    $$UAVOBJECT_SYNTHETICS/hwtaulink.cpp
 
 RESOURCES += \
     taulabs.qrc

--- a/ground/gcs/src/plugins/boards_taulabs/sparky.cpp
+++ b/ground/gcs/src/plugins/boards_taulabs/sparky.cpp
@@ -108,7 +108,7 @@ QPixmap Sparky::getBoardPicture()
     return QPixmap(":/taulabs/images/sparky.png");
 }
 
-QString Sparky::getHwUAVO()
+QString Sparky::getHwUavoName()
 {
     return "HwSparky";
 }
@@ -132,10 +132,7 @@ bool Sparky::isInputConfigurationSupported(enum InputType type = INPUT_TYPE_ANY)
  */
 bool Sparky::setInputType(enum InputType type)
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwSparky *hwSparky = HwSparky::GetInstance(uavoManager);
-    Q_ASSERT(hwSparky);
+    HwSparky *hwSparky = getHwUavo<HwSparky>();
     if (!hwSparky)
         return false;
 
@@ -173,10 +170,7 @@ bool Sparky::setInputType(enum InputType type)
  */
 enum Core::IBoardType::InputType Sparky::getInputType()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwSparky *hwSparky = HwSparky::GetInstance(uavoManager);
-    Q_ASSERT(hwSparky);
+    HwSparky *hwSparky = getHwUavo<HwSparky>();
     if (!hwSparky)
         return INPUT_TYPE_UNKNOWN;
 
@@ -200,10 +194,7 @@ enum Core::IBoardType::InputType Sparky::getInputType()
 
 int Sparky::queryMaxGyroRate()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwSparky *hwSparky = HwSparky::GetInstance(uavoManager);
-    Q_ASSERT(hwSparky);
+    HwSparky *hwSparky = getHwUavo<HwSparky>();
     if (!hwSparky)
         return 0;
 
@@ -225,10 +216,7 @@ int Sparky::queryMaxGyroRate()
 
 QStringList Sparky::getAdcNames()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwSparky *hwSparky = HwSparky::GetInstance(uavoManager);
-    Q_ASSERT(hwSparky);
+    HwSparky *hwSparky = getHwUavo<HwSparky>();
     if (!hwSparky)
         return QStringList();
 

--- a/ground/gcs/src/plugins/boards_taulabs/sparky.h
+++ b/ground/gcs/src/plugins/boards_taulabs/sparky.h
@@ -42,7 +42,7 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
+    virtual QString getHwUavoName();
 
     //! Determine if this board supports configuring the receiver
     virtual bool isInputConfigurationSupported(InputType type);

--- a/ground/gcs/src/plugins/boards_taulabs/sparky2.cpp
+++ b/ground/gcs/src/plugins/boards_taulabs/sparky2.cpp
@@ -122,21 +122,9 @@ QPixmap Sparky2::getBoardPicture()
     return QPixmap(":/taulabs/images/sparky2.png");
 }
 
-QString Sparky2::getHwUAVO()
+QString Sparky2::getHwUavoName()
 {
     return "HwSparky2";
-}
-
-//! Get the settings object
-HwSparky2 * Sparky2::getSettings()
-{
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-
-    HwSparky2 *hwSparky2 = HwSparky2::GetInstance(uavoManager);
-    Q_ASSERT(hwSparky2);
-
-    return hwSparky2;
 }
 
 //! Determine if this board supports configuring the receiver
@@ -159,10 +147,7 @@ bool Sparky2::isInputConfigurationSupported(enum InputType type = INPUT_TYPE_ANY
  */
 bool Sparky2::setInputType(enum InputType type)
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwSparky2 *hwSparky2 = HwSparky2::GetInstance(uavoManager);
-    Q_ASSERT(hwSparky2);
+    HwSparky2 *hwSparky2 = getHwUavo<HwSparky2>();
     if (!hwSparky2)
         return false;
 
@@ -194,10 +179,7 @@ bool Sparky2::setInputType(enum InputType type)
  */
 enum Core::IBoardType::InputType Sparky2::getInputType()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwSparky2 *hwSparky2 = HwSparky2::GetInstance(uavoManager);
-    Q_ASSERT(hwSparky2);
+    HwSparky2 *hwSparky2 = getHwUavo<HwSparky2>();
     if (!hwSparky2)
         return INPUT_TYPE_UNKNOWN;
 
@@ -217,10 +199,7 @@ enum Core::IBoardType::InputType Sparky2::getInputType()
 
 int Sparky2::queryMaxGyroRate()
 {
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-    HwSparky2 *hwSparky2 = HwSparky2::GetInstance(uavoManager);
-    Q_ASSERT(hwSparky2);
+    HwSparky2 *hwSparky2 = getHwUavo<HwSparky2>();
     if (!hwSparky2)
         return 0;
 
@@ -266,7 +245,10 @@ quint32 Sparky2::getRfmID()
 bool Sparky2::bindRadio(quint32 id, quint32 baud_rate, float rf_power,
                         Core::IBoardType::LinkMode linkMode, quint8 min, quint8 max)
 {
-    HwSparky2::DataFields settings = getSettings()->getData();
+    HwSparky2 *hwSparky2 = getHwUavo<HwSparky2>();
+    if (!hwSparky2)
+        return false;
+    HwSparky2::DataFields settings = hwSparky2->getData();
 
     settings.CoordID = id;
 
@@ -338,8 +320,8 @@ bool Sparky2::bindRadio(quint32 id, quint32 baud_rate, float rf_power,
     settings.MinChannel = min;
     settings.MaxChannel = max;
 
-    getSettings()->setData(settings);
-    uavoUtilManager->saveObjectToFlash(getSettings());
+    hwSparky2->setData(settings);
+    uavoUtilManager->saveObjectToFlash(hwSparky2);
 
     return true;
 }

--- a/ground/gcs/src/plugins/boards_taulabs/sparky2.h
+++ b/ground/gcs/src/plugins/boards_taulabs/sparky2.h
@@ -44,8 +44,7 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
-    HwSparky2 * getSettings();
+    virtual QString getHwUavoName();
 
     //! Determine if this board supports configuring the receiver
     virtual bool isInputConfigurationSupported(InputType type);

--- a/ground/gcs/src/plugins/boards_taulabs/taulabsplugin.cpp
+++ b/ground/gcs/src/plugins/boards_taulabs/taulabsplugin.cpp
@@ -30,6 +30,10 @@
 #include "sparky.h"
 #include "sparky2.h"
 #include "taulink.h"
+#include "uavobjectsinit.h"
+#include "hwsparky.h"
+#include "hwsparky2.h"
+#include "hwtaulink.h"
 
 
 TauLabsPlugin::TauLabsPlugin()
@@ -44,9 +48,14 @@ TauLabsPlugin::~TauLabsPlugin()
 
 bool TauLabsPlugin::initialize(const QStringList& args, QString *errMsg)
 {
-   Q_UNUSED(args);
-   Q_UNUSED(errMsg);
-   return true;
+    Q_UNUSED(args);
+    Q_UNUSED(errMsg);
+
+    UAVObjectInitialize<HwSparky>(new HwSparky());
+    UAVObjectInitialize<HwSparky2>(new HwSparky2());
+    UAVObjectInitialize<HwTauLink>(new HwTauLink());
+
+    return true;
 }
 
 void TauLabsPlugin::extensionsInitialized()

--- a/ground/gcs/src/plugins/boards_taulabs/taulink.cpp
+++ b/ground/gcs/src/plugins/boards_taulabs/taulink.cpp
@@ -97,22 +97,11 @@ QPixmap TauLink::getBoardPicture()
     return QPixmap(":/images/taulink.png");
 }
 
-QString TauLink::getHwUAVO()
+QString TauLink::getHwUavoName()
 {
     return "HwTauLink";
 }
 
-//! Get the settings object
-HwTauLink * TauLink::getSettings()
-{
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
-
-    HwTauLink *wwTauLink = HwTauLink::GetInstance(uavoManager);
-    Q_ASSERT(wwTauLink);
-
-    return wwTauLink;
-}
 /**
  * Get the RFM22b device ID this modem
  * @return RFM22B device ID or 0 if not supported
@@ -137,7 +126,10 @@ quint32 TauLink::getRfmID()
  */
 bool TauLink::bindRadio(quint32 id, quint32 baud_rate, float rf_power, Core::IBoardType::LinkMode linkMode, quint8 min, quint8 max)
 {
-    HwTauLink::DataFields settings = getSettings()->getData();
+    HwTauLink *hwTauLink = getHwUavo<HwTauLink>();
+    if (!hwTauLink)
+        return false;
+    HwTauLink::DataFields settings = hwTauLink->getData();
 
     settings.CoordID = id;
 
@@ -209,8 +201,8 @@ bool TauLink::bindRadio(quint32 id, quint32 baud_rate, float rf_power, Core::IBo
     settings.MinChannel = min;
     settings.MaxChannel = max;
 
-    getSettings()->setData(settings);
-    uavoUtilManager->saveObjectToFlash( getSettings());
+    hwTauLink->setData(settings);
+    uavoUtilManager->saveObjectToFlash(hwTauLink);
 
     return true;
 }

--- a/ground/gcs/src/plugins/boards_taulabs/taulink.h
+++ b/ground/gcs/src/plugins/boards_taulabs/taulink.h
@@ -44,8 +44,7 @@ public:
     virtual bool queryCapabilities(BoardCapabilities capability);
     virtual QStringList getSupportedProtocols();
     virtual QPixmap getBoardPicture();
-    virtual QString getHwUAVO();
-    HwTauLink * getSettings();
+    virtual QString getHwUavoName();
 
     /**
      * Get the RFM22b device ID this modem

--- a/ground/gcs/src/plugins/config/configautotunewidget.cpp
+++ b/ground/gcs/src/plugins/config/configautotunewidget.cpp
@@ -259,7 +259,7 @@ QJsonDocument ConfigAutotuneWidget::getResultsJson(
         UAVObjectUtilManager* uavoUtilManager = pm->getObject<UAVObjectUtilManager>();
         Core::IBoardType* board = uavoUtilManager->getBoardType();
         if (board != NULL) {
-            QString hwSettingsName = board->getHwUAVO();
+            QString hwSettingsName = board->getHwUavoName();
 
             UAVObject *hwSettings = getObjectManager()->getObject(hwSettingsName);
             rawSettings[hwSettings->getName()] = hwSettings->getJsonRepresentation();

--- a/ground/gcs/src/plugins/config/configgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.cpp
@@ -277,7 +277,7 @@ void ConfigGadgetWidget::onAutopilotConnect() {
             if (qwd) {
                 valid_board = true;
             } else {
-                UAVObject *settingsObj = utilMngr->getObjectManager()->getObject(board->getHwUAVO());
+                UAVObject *settingsObj = utilMngr->getObjectManager()->getObject(board->getHwUavoName());
                 if (settingsObj) {
                     qwd = new DefaultHwSettingsWidget(settingsObj, this);
                     valid_board = true;

--- a/ground/gcs/src/plugins/coreplugin/boardmanager.cpp
+++ b/ground/gcs/src/plugins/coreplugin/boardmanager.cpp
@@ -118,6 +118,16 @@ void BoardManager::aboutToRemoveObject(QObject *obj)
         m_boardTypesList.removeAt(m_boardTypesList.indexOf(board));
 }
 
+IBoardType *BoardManager::getBoardType(qint32 type)
+{
+    foreach (IBoardType *board, m_boardTypesList) {
+        if (board->getBoardType() == type)
+            return board;
+    }
+
+    return Q_NULLPTR;
+}
+
 
 
 } // Core

--- a/ground/gcs/src/plugins/coreplugin/boardmanager.h
+++ b/ground/gcs/src/plugins/coreplugin/boardmanager.h
@@ -68,6 +68,12 @@ public:
      */
     QList<IBoardType::USBInfo*> getKnownUSBInfo();
 
+    /**
+     * @brief Get a board plugin by type (8-bit identifier)
+     * @returns IBoardType * on success, null pointer on failure
+     */
+    IBoardType *getBoardType(qint32 type);
+
 
 
 protected:

--- a/ground/gcs/src/plugins/coreplugin/iboardtype.h
+++ b/ground/gcs/src/plugins/coreplugin/iboardtype.h
@@ -38,6 +38,8 @@
 #include <QPixmap>
 
 #include "core_global.h"
+#include "extensionsystem/pluginmanager.h"
+#include "uavobjects/uavobjectmanager.h"
 
 namespace Core {
 
@@ -138,7 +140,7 @@ public:
      * Get name of the HW Configuration UAVObject
      *
      */
-    virtual QString getHwUAVO() = 0;
+    virtual QString getHwUavoName() = 0;
 
     /**
      * Get USB descriptors to detect the board
@@ -256,6 +258,15 @@ protected:
 
     //! The channel groups that are driven by timers
     QVector< QVector<qint32> > channelBanks;
+
+    template <typename T> T *getHwUavo() const
+    {
+        ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+        UAVObjectManager *uavoManager = pm->getObject<UAVObjectManager>();
+        T *obj = qobject_cast<T *>(uavoManager->getObject(T::NAME));
+        Q_ASSERT(obj);
+        return obj;
+    }
 
 };
 

--- a/ground/gcs/src/plugins/rawhid/rawhidplugin.h
+++ b/ground/gcs/src/plugins/rawhid/rawhidplugin.h
@@ -34,7 +34,6 @@
 #include "usbsignalfilter.h"
 #include "extensionsystem/pluginmanager.h"
 #include "coreplugin/iconnection.h"
-#include "coreplugin/iboardtype.h"
 #include "coreplugin/boardmanager.h"
 #include <extensionsystem/iplugin.h>
 

--- a/ground/gcs/src/plugins/rfmbindwizard/pages/radioprobepage.cpp
+++ b/ground/gcs/src/plugins/rfmbindwizard/pages/radioprobepage.cpp
@@ -49,7 +49,7 @@ RadioProbePage::RadioProbePage(RfmBindWizard *wizard, QWidget *parent) :
     boardPluginMap.clear();
     foreach (Core::IBoardType *board, boards) {
         if (board->queryCapabilities(Core::IBoardType::BOARD_CAPABILITIES_RADIO) ) {
-            UAVObject *obj = objMngr->getObject(board->getHwUAVO());
+            UAVObject *obj = objMngr->getObject(board->getHwUavoName());
             if (obj != NULL) {
                 boardPluginMap.insert(obj, board);
                 connect(obj, SIGNAL(transactionCompleted(UAVObject*,bool)),

--- a/ground/gcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
+++ b/ground/gcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
@@ -129,7 +129,7 @@ void VehicleConfigurationHelper::applyHardwareConfiguration()
 
     if (success) {
         UAVDataObject* hwSettings = dynamic_cast<UAVDataObject*>(
-                    m_uavoManager->getObject(boardPlugin->getHwUAVO()));
+                    m_uavoManager->getObject(boardPlugin->getHwUavoName()));
         Q_ASSERT(hwSettings);
         if (hwSettings)
             addModifiedObject(hwSettings, tr("Writing hardware settings"));

--- a/ground/gcs/src/plugins/uavobjects/uavobjectmanager.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectmanager.cpp
@@ -54,6 +54,8 @@ UAVObjectManager::~UAVObjectManager()
  */
 bool UAVObjectManager::registerObject(UAVDataObject* obj)
 {
+    if (!obj)
+        return false;
     // Check if this object type is already in the list
     quint32 objID = obj->getObjID();
     if (objects.contains(objID))//Known object ID

--- a/ground/gcs/src/plugins/uavobjects/uavobjects.pro
+++ b/ground/gcs/src/plugins/uavobjects/uavobjects.pro
@@ -26,4 +26,6 @@ OTHER_FILES += UAVObjects.pluginspec \
 
 # Add in all of the synthetic/generated uavobject files
 HEADERS += $$files($$UAVOBJECT_SYNTHETICS/*.h)
+HEADERS -= $$files($$UAVOBJECT_SYNTHETICS/hw*.h)
 SOURCES += $$files($$UAVOBJECT_SYNTHETICS/*.cpp)
+SOURCES -= $$files($$UAVOBJECT_SYNTHETICS/hw*.cpp)

--- a/ground/gcs/src/plugins/uavobjects/uavobjects_dependencies.pri
+++ b/ground/gcs/src/plugins/uavobjects/uavobjects_dependencies.pri
@@ -8,3 +8,5 @@ UAVOBJECT_SYNTHETICS=$${GCS_BUILD_TREE}/../../uavobject-synthetics/gcs
 # Add the include path to the auto-generated uavobject include files.
 INCLUDEPATH *= $$UAVOBJECT_SYNTHETICS
 DEPENDPATH *= $$UAVOBJECT_SYNTHETICS
+
+QT += qml

--- a/ground/gcs/src/plugins/uavobjects/uavobjectsinit.h
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectsinit.h
@@ -29,7 +29,24 @@
 #define UAVOBJECTSINIT_H
 
 #include "uavobjectmanager.h"
+#include "extensionsystem/pluginmanager.h"
+#include <QtQml>
 
 void UAVObjectsInitialize(UAVObjectManager* objMngr);
+template <typename T> void UAVObjectInitialize(T *obj, UAVObjectManager *objMngr = 0)
+{
+    // register the class with QML
+    QString qmlName = obj->getName() + "Class";
+    QByteArray bytes = qmlName.toLatin1();
+    const char *cname = bytes.data();
+    qmlRegisterType<T>("com.dronin.uavo", 1, 0, cname);
+
+    // register with UAVO manager
+    if (!objMngr) {
+        ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+        objMngr = pm->getObject<UAVObjectManager>();
+    }
+    objMngr->registerObject(obj);
+}
 
 #endif // UAVOBJECTSINIT_H

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -45,6 +45,7 @@
 #include <coreplugin/modemanager.h>
 #include <coreplugin/actionmanager/actionmanager.h>
 #include "rawhid/rawhidplugin.h"
+#include "utils/pathutils.h"
 
 using namespace uploader;
 
@@ -1447,7 +1448,7 @@ void UploaderGadgetWidget::onBootloaderDetected()
             QString name;
             m_widget->partitionBrowserGB->setEnabled(true);
             m_widget->partitionBrowserTW->setRowCount(dev.PartitionSizes.length());
-            foreach (int i, dev.PartitionSizes) {
+            foreach (quint32 i, dev.PartitionSizes) {
                 switch (index) {
                 case DFU_PARTITION_FW:
                     name = "Firmware";
@@ -1482,14 +1483,13 @@ void UploaderGadgetWidget::onBootloaderDetected()
             m_widget->partitionBrowserTW->setRowCount(0);
         }
         deviceInfo info;
-        QList <Core::IBoardType *> boards = pm->getObjects<Core::IBoardType>();
-        foreach (Core::IBoardType *board, boards) {
-            if (board->getBoardType() == (dev.ID>>8))
-            {
-                info.board = board;
-                break;
-            }
+        Core::BoardManager *boardMgr = Core::ICore::instance()->boardManager();
+        if (!boardMgr) {
+            qWarning() << "UploaderGadgetWidget::onBootloaderDetected" << "Could not get BoardManager!";
+            return;
         }
+
+        info.board = boardMgr->getBoardType(dev.ID >> 8);
         info.bl_version = QString::number(dev.BL_Version, 16);
         info.cpu_serial = "Not Available";
         info.hw_revision = QString::number(dev.HW_Rev);
@@ -1962,7 +1962,8 @@ QString UploaderGadgetWidget::getImagePath(QString boardName, QString imageType)
         << "../../../../build"                  // windows / linux build
         << "../../../../../../../build"         // OSX build
         << "../Resources/firmware"              // OSX app bundle
-        << "/usr/local/" GCS_PROJECT_BRANDING_PRETTY "/firmware"; // leenucks deb
+        << "/usr/local/" GCS_PROJECT_BRANDING_PRETTY "/firmware" // leenucks deb
+        << Utils::PathUtils::getAddonPath() + "/firmware";       // add-on path for out-of-tree boards
 
     foreach (QString path, paths) {
         QDir pathDir = QDir(QCoreApplication::applicationDirPath());
@@ -2005,24 +2006,47 @@ bool UploaderGadgetWidget::FirmwareLoadFromFile(QString filename,
 
 bool UploaderGadgetWidget::FirmwareCheckForUpdate(deviceDescriptorStruct device)
 {
-    const QString gcsRev(GCS_REVISION);
-    if (gcsRev.contains(':')) {
-        QString gcsShort = gcsRev.mid(gcsRev.indexOf(':') + 1, 8);
-        if ((gcsShort != device.gitHash) && (ignoredRev != device.gitHash)) {
-            QMessageBox msgBox;
-            msgBox.setText(tr("The firmware version on your board does not match this version of GCS."));
-            msgBox.setInformativeText(tr("Do you want to upgrade the firmware to a compatible version?"));
-            msgBox.setDetailedText(QString("Firmware git hash: %1\nGCS git hash: %2").arg(device.gitHash).arg(gcsShort));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::Ignore);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-
-            int val = msgBox.exec();
-
-            if (val == QMessageBox::Yes)
-                return true;
-            else if (val == QMessageBox::Ignore)
-                ignoredRev = device.gitHash;
-        }
+    Core::BoardManager *boardMgr = Core::ICore::instance()->boardManager();
+    if (!boardMgr) {
+        qWarning() << "UploaderGadgetWidget::FirmwareCheckForUpdate" << "BoardManager unavailable!";
+        return false;
     }
+
+    Core::IBoardType *board = boardMgr->getBoardType(device.boardID() >> 8);
+    if (!board) {
+        qDebug() << "UploaderGadgetWidget::FirmwareCheckForUpdate" << "Don't know about this board";
+        return false;
+    }
+
+    QString file = getImagePath(board->shortName(), "fw");
+    if (!file.length()) {
+        qDebug() << "UploaderGadgetWidget::FirmwareCheckForUpdate" << "Don't have any firmware for this board";
+        return false;
+    }
+
+    QByteArray latestFw;
+    FirmwareLoadFromFile(file, &latestFw);
+    deviceDescriptorStruct latestDesc;
+    if(!utilMngr->descriptionToStructure(latestFw.right(100), latestDesc)) {
+        qDebug() << "UploaderGadgetWidget::FirmwareCheckForUpdate" << "Error parsing firmware metadata";
+        return false;
+    }
+
+    if ((latestDesc.gitHash != device.gitHash) && (ignoredRev != device.gitHash)) {
+        QMessageBox msgBox;
+        msgBox.setText(tr("The firmware version on your board does not match the version available with this GCS."));
+        msgBox.setInformativeText(tr("Do you want to upgrade the firmware?"));
+        msgBox.setDetailedText(QString("Board firmware git hash: %1\nGCS firmware git hash: %2").arg(device.gitHash).arg(latestDesc.gitHash));
+        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::Ignore);
+        msgBox.setDefaultButton(QMessageBox::Yes);
+
+        int val = msgBox.exec();
+
+        if (val == QMessageBox::Yes)
+            return true;
+        else if (val == QMessageBox::Ignore)
+            ignoredRev = device.gitHash;
+    }
+
     return false;
 }

--- a/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.cpp
+++ b/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.cpp
@@ -67,9 +67,11 @@ bool UAVObjectGeneratorGCS::generate(UAVObjectParser* parser,QString templatepat
         ObjectInfo* info=parser->getObjectByIndex(objidx);
         process_object(info);
 
-        gcsObjInit.append("    objMngr->registerObject( new " + info->name + "() );\n");
-        gcsObjInit.append("    qmlRegisterType<" + info->name + ">(\"com.dronin.uavo\", 1, 0, \"" + info->name + "Class\");\n");
-        objInc.append("#include \"" + info->namelc + ".h\"\n");
+        // exclude hardware settings objects (they are compiled and inited by board plugins)
+        if (!info->name.startsWith("Hw")) {
+            gcsObjInit.append("    UAVObjectInitialize<" + info->name + ">(new " + info->name + "(), objMngr);\n");
+            objInc.append("#include \"" + info->namelc + ".h\"\n");
+        }
     }
 
     // Write the gcs object inialization files


### PR DESCRIPTION
Opened for visibility. Puts hardware UAVOs inside board plugins. Will allow third parties (e.g. @jihlein) to distribute standalone board packages that work with dRonin GCS.

TODO:
- [x] Check addons directory for firmware images (uploader/upgrader)
- [x] Use githash of available firmware image rather than GCS githash for upgrader
- [ ] Manage plugin version/compatibility (maybe it's possible to automatically bump plugin versions (in .pluginspec) when commits that change public interfaces are made?)
- [ ] Packaging for board plugins 
