### PR TITLE
RE1: Remove AltitudeHold

### DIFF
--- a/flight/targets/brainre1/fw/Makefile
+++ b/flight/targets/brainre1/fw/Makefile
@@ -43,7 +43,6 @@ MODULES += Telemetry
 
 OPTMODULES += GPS
 OPTMODULES += PathPlanner
-OPTMODULES += AltitudeHold
 OPTMODULES += VtolPathFollower
 OPTMODULES += FixedWingPathFollower
 OPTMODULES += FlightStats


### PR DESCRIPTION
Don't compile-in this module as RE1 doesn't have a barometer and probably does something crazy if AH is enabled.
