### PR TITLE
RE1: Add FlashID

### DIFF
--- a/flight/PiOS/Common/pios_flash_jedec.c
+++ b/flight/PiOS/Common/pios_flash_jedec.c
@@ -470,7 +470,7 @@ static int32_t PIOS_Flash_Jedec_ReadData(uintptr_t chip_id, uint32_t chip_offset
  * @return Zero if success or error code
  * @retval -1 Unable to claim SPI bus
  */
-int32_t PIOS_Flash_Jedec_ReadOPTData(uintptr_t chip_id, uint32_t chip_offset, uint8_t *data, uint16_t len)
+int32_t PIOS_Flash_Jedec_ReadOTPData(uintptr_t chip_id, uint32_t chip_offset, uint8_t *data, uint16_t len)
 {
 	struct jedec_flash_dev *flash_dev = (struct jedec_flash_dev *)chip_id;
 

--- a/flight/PiOS/inc/pios_flash_jedec_priv.h
+++ b/flight/PiOS/inc/pios_flash_jedec_priv.h
@@ -48,6 +48,6 @@ struct pios_flash_jedec_cfg {
 };
 
 int32_t PIOS_Flash_Jedec_Init(uintptr_t *flash_id, uint32_t spi_id, uint32_t slave_num, const struct pios_flash_jedec_cfg *cfg);
-int32_t PIOS_Flash_Jedec_ReadOPTData(uintptr_t chip_id, uint32_t chip_offset, uint8_t *data, uint16_t len);
+int32_t PIOS_Flash_Jedec_ReadOTPData(uintptr_t chip_id, uint32_t chip_offset, uint8_t *data, uint16_t len);
 
 #endif	/* PIOS_FLASH_JEDEC_H_ */

--- a/flight/PiOS/inc/pios_flash_jedec_priv.h
+++ b/flight/PiOS/inc/pios_flash_jedec_priv.h
@@ -48,5 +48,6 @@ struct pios_flash_jedec_cfg {
 };
 
 int32_t PIOS_Flash_Jedec_Init(uintptr_t *flash_id, uint32_t spi_id, uint32_t slave_num, const struct pios_flash_jedec_cfg *cfg);
+int32_t PIOS_Flash_Jedec_ReadOPTData(uintptr_t chip_id, uint32_t chip_offset, uint8_t *data, uint16_t len);
 
 #endif	/* PIOS_FLASH_JEDEC_H_ */

--- a/flight/targets/brainre1/fw/pios_board.c
+++ b/flight/targets/brainre1/fw/pios_board.c
@@ -47,6 +47,8 @@
 #include <openpilot.h>
 #include <misc_math.h>
 #include <uavobjectsinit.h>
+#include "pios_flash_jedec_priv.h"
+
 #include "hwbrainre1.h"
 #include "flightbatterysettings.h"
 #include "flightstatus.h"
@@ -286,6 +288,11 @@ void PIOS_Board_Init(void) {
 	/* Set the HW revision, this also invokes the callback */
 	uint8_t hw_rev = PIOS_RE1FPGA_GetHWRevision();
 	HwBrainRE1HWRevisionSet(&hw_rev);
+
+	/* Get the flash ID (random number) */
+	uint8_t flashid[16] = {0};
+	PIOS_Flash_Jedec_ReadOPTData(pios_external_flash_id, 0, flashid, 16);
+	HwBrainRE1FlashIDSet(flashid);
 
 	/* Connect callback for buzzer */
 	FlightStatusInitialize();

--- a/flight/targets/brainre1/fw/pios_board.c
+++ b/flight/targets/brainre1/fw/pios_board.c
@@ -291,7 +291,7 @@ void PIOS_Board_Init(void) {
 
 	/* Get the flash ID (random number) */
 	uint8_t flashid[16] = {0};
-	PIOS_Flash_Jedec_ReadOPTData(pios_external_flash_id, 0, flashid, 16);
+	PIOS_Flash_Jedec_ReadOTPData(pios_external_flash_id, 0, flashid, 16);
 	HwBrainRE1FlashIDSet(flashid);
 
 	/* Connect callback for buzzer */

--- a/shared/uavobjectdefinition/hwbrainre1.xml
+++ b/shared/uavobjectdefinition/hwbrainre1.xml
@@ -95,6 +95,7 @@
 	<field name="BMI160FOC" units="" type="enum" elements="1" options="Disabled,Do_FOC" defaultvalue="Disabled">
 		<description>Peform BMI160 fast offset compensation on next boot. Should not be performed by users. Can only be done a limited number of times.</description>
 	</field>
+	<field name="FlashID" units="" type="uint8" elements="16" defaultvalue="0"/>
 
 	<access gcs="readwrite" flight="readwrite"/>
 	<telemetrygcs acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
Adds function to read OPT (one-time programmable) data from SPI flash (works for some Spansion devices, not sure about others). The function is used to read a 16-byte random number from Flash, which we will use for flight controller registration. The STM32 ID could also be used for this but it does not seem to be random enough.
