### PR TITLE
sparky: work around PPM suck by forcing 1MHz

### DIFF
--- a/flight/targets/sparky/board-info/board_hw_defs.c
+++ b/flight/targets/sparky/board-info/board_hw_defs.c
@@ -985,6 +985,22 @@ struct pios_servo_cfg pios_servo_cfg = {
 	.num_channels = NELEMENTS(pios_tim_servoport_v02_pins),
 };
 
+struct pios_servo_cfg pios_servo_slow_cfg = {
+	.tim_oc_init = {
+		.TIM_OCMode = TIM_OCMode_PWM1,
+		.TIM_OutputState = TIM_OutputState_Enable,
+		.TIM_OutputNState = TIM_OutputNState_Disable,
+		.TIM_Pulse = PIOS_SERVOS_INITIAL_POSITION,
+		.TIM_OCPolarity = TIM_OCPolarity_High,
+		.TIM_OCNPolarity = TIM_OCPolarity_High,
+		.TIM_OCIdleState = TIM_OCIdleState_Reset,
+		.TIM_OCNIdleState = TIM_OCNIdleState_Reset,
+	},
+	.force_1MHz = true,
+	.channels = pios_tim_servoport_v02_pins,
+	.num_channels = NELEMENTS(pios_tim_servoport_v02_pins),
+};
+
 #endif	/* PIOS_INCLUDE_SERVO && PIOS_INCLUDE_TIM */
 
 

--- a/flight/targets/sparky/fw/pios_board.c
+++ b/flight/targets/sparky/fw/pios_board.c
@@ -392,7 +392,7 @@ void PIOS_Board_Init(void)
 	/* Configure the rcvr port */
 	uint8_t hw_rcvrport;
 	HwSparkyRcvrPortGet(&hw_rcvrport);
-	
+
 	PIOS_HAL_ConfigurePort(hw_rcvrport,          // port type protocol
 	        &pios_rcvr_usart_cfg,                // usart_port_cfg
 	        &pios_usart_com_driver,              // com_driver
@@ -451,10 +451,16 @@ void PIOS_Board_Init(void)
 		PIOS_Assert(0);
 		break;
 	}
+
 #ifndef PIOS_DEBUG_ENABLE_DEBUG_PINS
 #ifdef PIOS_INCLUDE_SERVO
 	pios_servo_cfg.num_channels = number_of_pwm_outputs;
-	PIOS_Servo_Init(&pios_servo_cfg);
+
+	if (hw_rcvrport != HWSHARED_PORTTYPES_PPM) {
+		PIOS_Servo_Init(&pios_servo_cfg);
+	} else {
+		PIOS_Servo_Init(&pios_servo_slow_cfg);
+	}
 #endif
 #else
 	PIOS_DEBUG_Init(&pios_tim_servo_all_channels, NELEMENTS(pios_tim_servo_all_channels));


### PR DESCRIPTION
(only when appropriate).

Fixes #1071
