### PR TITLE
gcs: hidapi_mac: add bcdDevice to path info

### DIFF
--- a/ground/gcs/src/plugins/rawhid/hidapi/hidapi_mac.c
+++ b/ground/gcs/src/plugins/rawhid/hidapi/hidapi_mac.c
@@ -269,6 +269,7 @@ static int make_path(IOHIDDeviceRef device, char *buf, size_t len)
 {
 	int res;
 	unsigned short vid, pid;
+	int rel_num;
 	char transport[32];
 	int32_t location;
 
@@ -285,9 +286,10 @@ static int make_path(IOHIDDeviceRef device, char *buf, size_t len)
 	vid = get_vendor_id(device);
 	pid = get_product_id(device);
 
-	res = snprintf(buf, len, "%s_%04hx_%04hx_%x",
-			transport, vid, pid, location);
+	rel_num = get_int_property(device, CFSTR(kIOHIDVersionNumberKey));
 
+	res = snprintf(buf, len, "%s_%04hx_%04hx_%x_%x",
+			transport, vid, pid, location, rel_num);
 
 	buf[len-1] = '\0';
 	return res+1;

--- a/ground/gcs/src/plugins/rawhid/usbmonitor.cpp
+++ b/ground/gcs/src/plugins/rawhid/usbmonitor.cpp
@@ -130,6 +130,7 @@ void USBMonitor::periodic() {
 
 QList<USBPortInfo> USBMonitor::availableDevices()
 {
+    periodic();
     return knowndevices;
 }
 
@@ -146,6 +147,8 @@ QList<USBPortInfo> USBMonitor::availableDevices()
   */
 QList<USBPortInfo> USBMonitor::availableDevices(int vid, int pid, int bcdDeviceMSB, int bcdDeviceLSB)
 {
+    periodic();
+
     QList<USBPortInfo> thePortsWeWant;
 
     foreach (USBPortInfo port, knowndevices) {


### PR DESCRIPTION
So that if we re-enumerate and there's a different function (bootloader
vs. firmware) we don't connect to the wrong one.
