### PR TITLE
DTFc: Fix plugin metadata

### DIFF
--- a/ground/gcs/src/plugins/boards_dtf/dtfuhf.pluginspec
+++ b/ground/gcs/src/plugins/boards_dtf/dtfuhf.pluginspec
@@ -1,5 +1,5 @@
 <plugin name="DTFUHF" version="1.0.0" compatVersion="1.0.0">
-    <vendor>Tau Labs</vendor>
+    <vendor>dRonin</vendor>
     <copyright>(C) 2012-2015 Tau Labs, (C) 2016 dRonin</copyright>
     <license>The GNU Public License (GPL) Version 3</license>
     <description>Hardware definitions for DTFUHF boards</description>


### PR DESCRIPTION
Slipped through the cracks / the plugin was based on a really old rev.
