### PR TITLE
FIX: PPM timer frequency on F4 targets

### DIFF
--- a/flight/PiOS/Common/pios_servo.c
+++ b/flight/PiOS/Common/pios_servo.c
@@ -161,6 +161,10 @@ void PIOS_Servo_SetMode(const uint16_t *out_rate, const int banks, const uint16_
 	TIM_TimeBaseStructure.TIM_ClockDivision = TIM_CKD_DIV1;
 	TIM_TimeBaseStructure.TIM_CounterMode = TIM_CounterMode_Up;
 	for (int i = 0; i < banks_found; i++) {
+		// Skip the bank if no outputs are configured
+		if (timer_banks[i].max_pulse == 0)
+			continue;
+
 		/* Calculate the maximum clock frequency for the timer */
 		uint32_t max_tim_clock = max_timer_clock(timer_banks[i].timer);
 		// check if valid timer

--- a/flight/PiOS/inc/pios_stm32.h
+++ b/flight/PiOS/inc/pios_stm32.h
@@ -63,6 +63,11 @@ struct stm32_gpio {
 	uint8_t pin_source;
 };
 
+#if defined(STM32F40_41xxx) || defined(STM32F446xx) /*  F4 */
+#define PIOS_PERIPHERAL_APB1_COUNTER_CLOCK (PIOS_PERIPHERAL_APB1_CLOCK * 2)
+#define PIOS_PERIPHERAL_APB2_COUNTER_CLOCK (PIOS_PERIPHERAL_APB2_CLOCK * 2)
+#endif
+
 /**
   * @}
   * @}

--- a/flight/targets/aq32/board-info/board_hw_defs.c
+++ b/flight/targets/aq32/board-info/board_hw_defs.c
@@ -991,7 +991,7 @@ void PIOS_RTC_IRQ_Handler (void)
 
 // Set up timers that only have outputs on APB1
 static const TIM_TimeBaseInitTypeDef tim_4_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = 0xFFFF,
@@ -1015,7 +1015,7 @@ static const struct pios_tim_clock_cfg tim_4_cfg = {
 
 // Set up timers that only have outputs on APB1
 static const TIM_TimeBaseInitTypeDef tim_2_3_time_base = {
-	.TIM_Prescaler         = (PIOS_PERIPHERAL_APB1_CLOCK / 1000000) - 1,
+	.TIM_Prescaler         = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision     = TIM_CKD_DIV1,
 	.TIM_CounterMode       = TIM_CounterMode_Up,
 	.TIM_Period            = ((1000000 / PIOS_SERVO_UPDATE_HZ) - 1),
@@ -1024,7 +1024,7 @@ static const TIM_TimeBaseInitTypeDef tim_2_3_time_base = {
 
 // Set up timers that only have outputs on APB2
 static const TIM_TimeBaseInitTypeDef tim_1_8_time_base = {
-	.TIM_Prescaler         = (PIOS_PERIPHERAL_APB2_CLOCK / 1000000) - 1,
+	.TIM_Prescaler         = (PIOS_PERIPHERAL_APB2_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision     = TIM_CKD_DIV1,
 	.TIM_CounterMode       = TIM_CounterMode_Up,
 	.TIM_Period            = ((1000000 / PIOS_SERVO_UPDATE_HZ) - 1),

--- a/flight/targets/brain/board-info/board_hw_defs.c
+++ b/flight/targets/brain/board-info/board_hw_defs.c
@@ -736,7 +736,7 @@ void PIOS_RTC_IRQ_Handler (void)
 //Timers used for inputs (8, 12)
 
 static const TIM_TimeBaseInitTypeDef tim_8_time_base = {
-    .TIM_Prescaler = (PIOS_PERIPHERAL_APB2_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_COUNTER_CLOCK / 1000000) - 1,
     .TIM_ClockDivision = TIM_CKD_DIV1,
     .TIM_CounterMode = TIM_CounterMode_Up,
     .TIM_Period = 0xFFFF,
@@ -744,7 +744,7 @@ static const TIM_TimeBaseInitTypeDef tim_8_time_base = {
 };
 
 static const TIM_TimeBaseInitTypeDef tim_12_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = 0xFFFF,
@@ -781,7 +781,7 @@ static const struct pios_tim_clock_cfg tim_12_cfg = {
 
 // Set up timers that only have inputs on APB1
 static const TIM_TimeBaseInitTypeDef tim_5_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = ((1000000 / PIOS_SERVO_UPDATE_HZ) - 1),

--- a/flight/targets/brainre1/board-info/board_hw_defs.c
+++ b/flight/targets/brainre1/board-info/board_hw_defs.c
@@ -849,7 +849,7 @@ static const struct pios_usart_cfg pios_usart6_cfg = {
 #include <pios_ppm_priv.h>
 
 static const TIM_TimeBaseInitTypeDef tim_12_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = 0xFFFF,
@@ -926,7 +926,7 @@ static const struct pios_dsm_cfg pios_rxport_dsm_cfg = {
 
 // TIme base for timers on APB1 (45MHz)
 static const TIM_TimeBaseInitTypeDef tim_apb1_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = ((1000000 / PIOS_SERVO_UPDATE_HZ) - 1),
@@ -961,7 +961,7 @@ static const struct pios_tim_clock_cfg tim_8_cfg = {
 
 // TIme base for timers on APB2 (90MHz)
 static const TIM_TimeBaseInitTypeDef tim_apb2_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = ((1000000 / PIOS_SERVO_UPDATE_HZ) - 1),

--- a/flight/targets/quanton/board-info/board_hw_defs.c
+++ b/flight/targets/quanton/board-info/board_hw_defs.c
@@ -1082,7 +1082,7 @@ void PIOS_RTC_IRQ_Handler (void)
 //Timers used for inputs (1, 2, 5, 8)
 
 static const TIM_TimeBaseInitTypeDef tim_2_5_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = 0xFFFF,
@@ -1090,7 +1090,7 @@ static const TIM_TimeBaseInitTypeDef tim_2_5_time_base = {
 };
 
 static const TIM_TimeBaseInitTypeDef tim_1_8_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = 0xFFFF,
@@ -1169,7 +1169,7 @@ static const struct pios_tim_clock_cfg tim_8_cfg = {
 
 // Set up timers that only have inputs on APB1
 static const TIM_TimeBaseInitTypeDef tim_3_12_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = ((1000000 / PIOS_SERVO_UPDATE_HZ) - 1),
@@ -1178,7 +1178,7 @@ static const TIM_TimeBaseInitTypeDef tim_3_12_time_base = {
 
 // Set up timers that only have inputs on APB2
 static const TIM_TimeBaseInitTypeDef tim_10_11_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = ((1000000 / PIOS_SERVO_UPDATE_HZ) - 1),

--- a/flight/targets/revolution/board-info/board_hw_defs.c
+++ b/flight/targets/revolution/board-info/board_hw_defs.c
@@ -1039,14 +1039,14 @@ void PIOS_RTC_IRQ_Handler (void)
 #include "pios_tim_priv.h"
 
 static const TIM_TimeBaseInitTypeDef tim_3_5_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = ((1000000 / PIOS_SERVO_UPDATE_HZ) - 1),
 	.TIM_RepetitionCounter = 0x0000,
 };
 static const TIM_TimeBaseInitTypeDef tim_9_10_11_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = ((1000000 / PIOS_SERVO_UPDATE_HZ) - 1),
@@ -1121,7 +1121,7 @@ static const struct pios_tim_clock_cfg tim_11_cfg = {
 // Set up timers that only have inputs on APB1
 // TIM2,3,4,5,6,7,12,13,14
 static const TIM_TimeBaseInitTypeDef tim_apb1_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = 0xFFFF,
@@ -1132,7 +1132,7 @@ static const TIM_TimeBaseInitTypeDef tim_apb1_time_base = {
 // Set up timers that only have inputs on APB2
 // TIM1,8,9,10,11
 static const TIM_TimeBaseInitTypeDef tim_apb2_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = 0xFFFF,

--- a/flight/targets/sparky2/board-info/board_hw_defs.c
+++ b/flight/targets/sparky2/board-info/board_hw_defs.c
@@ -1193,7 +1193,7 @@ void PIOS_RTC_IRQ_Handler (void)
 // Set up timers on APB1
 // TIM2,3,4,5,6,7,12,13,14
 static const TIM_TimeBaseInitTypeDef tim_apb1_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = 0xFFFF,
@@ -1204,7 +1204,7 @@ static const TIM_TimeBaseInitTypeDef tim_apb1_time_base = {
 // Set up timers on APB2
 // TIM1,8,9,10,11
 static const TIM_TimeBaseInitTypeDef tim_apb2_time_base = {
-	.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_CLOCK / 1000000) - 1,
+	.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_COUNTER_CLOCK  / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
 	.TIM_Period = 0xFFFF,


### PR DESCRIPTION
Tested on Brain, BrainRE1, Sparky2. On Sparky2 the PPM input timer is shared with the brushes motor outputs, so it only works if those outputs are disabled.

Fixes #1091 
