### PR TITLE
gcs: map: set minimum zoom based on width

### DIFF
--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/mapgraphicitem.cpp
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/mapgraphicitem.cpp
@@ -68,6 +68,16 @@ namespace mapcontrol
             this->setRotation(rotation);
         }
 
+        if ((maprect.width() > 1024) || (maprect.height() > 1024)) {
+            minZoom = 3;
+        } else {
+            minZoom = 2;
+        }
+
+        if (Zoom() < minZoom) {
+            SetZoom(minZoom);
+        }
+
         core->OnMapSizeChanged(maprect.width(),maprect.height());
         core->SetCurrentRegion(internals::Rectangle(0, 0, maprect.width(), maprect.height()));
         if(isVisible())

--- a/ground/gcs/src/libs/tlmapcontrol/mapwidget/mapgraphicitem.h
+++ b/ground/gcs/src/libs/tlmapcontrol/mapwidget/mapgraphicitem.h
@@ -122,15 +122,7 @@ namespace mapcontrol
         * @param value zoom value
         */
         void SetZoomStep(qint32 const& value);
-
-        /**
-        * @brief Ask Stacey
-        *
-        * @param value
-        */
-        void SetShowDragons(bool const& value);
     private:
-        bool showDragons;
         bool SetZoomToFitRect(internals::RectLatLng const& rect);
         internals::Core *core;
         Configuration *config;


### PR DESCRIPTION
If we're really wide such that all the map tiles won't fit at zoom 2,
use zoom 3.
