### PR TITLE
POSIX: Fix flash file length check

### DIFF
--- a/flight/targets/simulation/fw/pios_board.c
+++ b/flight/targets/simulation/fw/pios_board.c
@@ -123,14 +123,14 @@ void PIOS_Board_Init(void) {
 	int32_t retval = PIOS_Flash_Posix_Init(&pios_posix_flash_id, &flash_config);
 	if (retval != 0) {
 		printf("Flash file doesn't exist or is too small, creating a new one\n");
-	    /* create an empty, appropriately sized flash filesystem */
-	    FILE * theflash = fopen("theflash.bin", "w");
-	    uint8_t sector[flash_config.size_of_sector];
-	    memset(sector, 0xFF, sizeof(sector));
-	    for (uint32_t i = 0; i < flash_config.size_of_flash / flash_config.size_of_sector; i++) {
-	      fwrite(sector, sizeof(sector), 1, theflash);
-	    }
-	    fclose(theflash);
+		/* create an empty, appropriately sized flash filesystem */
+		FILE * theflash = fopen("theflash.bin", "w");
+		uint8_t sector[flash_config.size_of_sector];
+		memset(sector, 0xFF, sizeof(sector));
+		for (uint32_t i = 0; i < flash_config.size_of_flash / flash_config.size_of_sector; i++) {
+			fwrite(sector, sizeof(sector), 1, theflash);
+		}
+		fclose(theflash);
 
 		retval = PIOS_Flash_Posix_Init(&pios_posix_flash_id, &flash_config);
 

--- a/flight/targets/simulation/fw/pios_board.c
+++ b/flight/targets/simulation/fw/pios_board.c
@@ -122,7 +122,7 @@ void PIOS_Board_Init(void) {
 
 	int32_t retval = PIOS_Flash_Posix_Init(&pios_posix_flash_id, &flash_config);
 	if (retval != 0) {
-
+		printf("Flash file doesn't exist or is too small, creating a new one\n");
 	    /* create an empty, appropriately sized flash filesystem */
 	    FILE * theflash = fopen("theflash.bin", "w");
 	    uint8_t sector[flash_config.size_of_sector];

--- a/flight/tests/logfs/pios_flash_posix.c
+++ b/flight/tests/logfs/pios_flash_posix.c
@@ -48,9 +48,9 @@ int32_t PIOS_Flash_Posix_Init(uintptr_t * chip_id, const struct pios_flash_posix
 		return -1;
 	}
 
-	if (fseek (flash_dev->flash_file, flash_dev->cfg->size_of_flash, SEEK_SET) != 0) {
+	fseek(flash_dev->flash_file, 0, SEEK_END); // SEEK_END not portable
+	if (ftell(flash_dev->flash_file) != flash_dev->cfg->size_of_flash)
 		return -2;
-	}
 
 	*chip_id = (uintptr_t)flash_dev;
 

--- a/flight/tests/logfs/pios_flash_posix.c
+++ b/flight/tests/logfs/pios_flash_posix.c
@@ -49,8 +49,10 @@ int32_t PIOS_Flash_Posix_Init(uintptr_t * chip_id, const struct pios_flash_posix
 	}
 
 	fseek(flash_dev->flash_file, 0, SEEK_END); // SEEK_END not portable
-	if (ftell(flash_dev->flash_file) != flash_dev->cfg->size_of_flash)
+	if (ftell(flash_dev->flash_file) != flash_dev->cfg->size_of_flash) {
+		fclose(flash_dev->flash_file);
 		return -2;
+	}
 
 	*chip_id = (uintptr_t)flash_dev;
 


### PR DESCRIPTION
fseek happily seeks past the end of the file so the old check failed (and ftell will happily return the same value even if it's past the end). Exposed by the change in flash size in #980. SEEK_END is not portable but I don't expect that will ever be an issue.

@mlyle Feel free to defer from Samsara if you want.
