### PR TITLE
gcs: rawhid: catch recursion

### DIFF
--- a/ground/gcs/src/plugins/rawhid/usbmonitor.h
+++ b/ground/gcs/src/plugins/rawhid/usbmonitor.h
@@ -131,5 +131,6 @@ private:
 
     struct hid_device_info *prevDevList;
 
+    bool enumerating;
 };
 #endif // USBMONITOR_H


### PR DESCRIPTION
On OS X, process_pending_events can fire QT timers.  This caused us to
recurse and corrupt data structures.  So bail out in that case.
