### PR TITLE
Breakpad: Use binary dist., get all symbol info on OSX

### DIFF
--- a/make/system-id.mk
+++ b/make/system-id.mk
@@ -9,6 +9,9 @@ ifneq (,$(filter $(ARCH), x86_64 amd64))
   X86-64 := 1
   X86_64 := 1
   AMD64 := 1
+  ARCHFAMILY := x86_64
+else
+  ARCHFAMILY := $(ARCH)
 endif
 
 # configure some variables dependent upon what type of system this is

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -600,27 +600,27 @@ endif
 openssl_clean:
 	$(V1) [ ! -d "$(OPENSSL_DIR)" ] || $(RM) -rf $(OPENSSL_DIR)
 
-
-BREAKPAD_URL := https://google-breakpad.googlecode.com/svn/trunk
-BREAKPAD_REV := 1498
+# Google Breakpad
+DUMP_SYMBOLS_TOOL := $(TOOLS_DIR)/breakpad/$(OSFAMILY)-$(ARCHFAMILY)/dump_syms
+BREAKPAD_URL := http://dronin.tracer.nz/tools/breakpad.zip
+BREAKPAD_DL_FILE := $(DL_DIR)/$(notdir $(BREAKPAD_URL))
 BREAKPAD_DIR := $(TOOLS_DIR)/breakpad
 
 .PHONY: breakpad_install
 breakpad_install: | $(DL_DIR) $(TOOLS_DIR)
 breakpad_install: breakpad_clean
-	$(V0) @echo " DOWNLOAD     $(BREAKPAD_URL) @ r$(BREAKPAD_REV)"
-	$(V1) svn export -q -r "$(BREAKPAD_REV)" "$(BREAKPAD_URL)" "$(BREAKPAD_DIR)"
-
-	$(V0) @echo " BUILD        $(BREAKPAD_DIR)"
-	$(V1) cd "$(BREAKPAD_DIR)" ; \
-	$(V1) ./configure --prefix="$(BREAKPAD_DIR)" ; \
-	$(V1) $(MAKE) --silent ; \
-	$(V1) $(MAKE) --silent install
+	$(V0) @echo " DOWNLOAD     $(BREAKPAD_URL)"
+	$(V1) $(V1) curl -L -k -z "$(BREAKPAD_DL_FILE)" -o "$(BREAKPAD_DL_FILE)" "$(BREAKPAD_URL)"
+	$(V0) @echo " EXTRACT      $(notdir $(BREAKPAD_DL_FILE))"
+	$(V1) mkdir -p "$(BREAKPAD_DIR)"
+	$(V1) unzip -q -d $(BREAKPAD_DIR) "$(BREAKPAD_DL_FILE)"
 
 .PHONY: breakpad_clean
 breakpad_clean:
 	$(V0) @echo " CLEAN        $(BREAKPAD_DIR)"
 	$(V1) [ ! -d "$(BREAKPAD_DIR)" ] || $(RM) -rf $(BREAKPAD_DIR)
+	$(V0) @echo " CLEAN        $(BREAKPAD_DL_FILE)"
+	$(V1) $(RM) -f $(BREAKPAD_DL_FILE)
 
 
 .PHONY: sdl_install

--- a/package/osx/libraries
+++ b/package/osx/libraries
@@ -12,7 +12,7 @@ QMLDIR="${APP}/Contents/Resources/welcome"
 
 pushd "${QT_SDK_BIN_PATH}"
 
-./macdeployqt "${APP}" -verbose=2 -no-strip -always-overwrite -qmldir="$QMLDIR"
+./macdeployqt "${APP}" -verbose=2 -no-strip -always-overwrite -qmldir="$QMLDIR" -executable="${APP}/Contents/MacOS/crashreporterapp"
 
 popd
 
@@ -31,6 +31,7 @@ if [ -d "../tools/SDL.framework" ]; then
 else
 	cp -r "/Library/Frameworks/SDL.framework" "${APP}/Contents/Frameworks/"
 fi
+
 # these are optional
 echo "Changing package identification of SDL"
 install_name_tool -id \

--- a/package/osx_extract_debug_symbols.sh
+++ b/package/osx_extract_debug_symbols.sh
@@ -25,12 +25,14 @@ function generateSymbols()
 {
   filename=$(basename "$1")
   debugfile="$debugdir/$filename.sym"
+  dsymfile="$debugdir/$filename.dSYM"
   if [ ! -d "${debugdir}" ] ; then
     echo "creating dir ${debugdir}"
     mkdir -p "${debugdir}"
   fi
   echo "Generating symbols for $1, putting them in ${debugfile}"
-  ${DUMP_SYMBOLS_TOOL} ${SOURCE_DIR}/${1} > ${debugfile}
+  dsymutil -o ${dsymfile} ${SOURCE_DIR}/${1}
+  ${DUMP_SYMBOLS_TOOL} -g ${dsymfile} ${SOURCE_DIR}/${1} > ${debugfile}
   echo "Striping debug information from $1"
   strip -S "${SOURCE_DIR}/${1}"
 }

--- a/package/osx_extract_debug_symbols.sh
+++ b/package/osx_extract_debug_symbols.sh
@@ -35,6 +35,8 @@ function generateSymbols()
   ${DUMP_SYMBOLS_TOOL} -g ${dsymfile} ${SOURCE_DIR}/${1} > ${debugfile}
   echo "Striping debug information from $1"
   strip -S "${SOURCE_DIR}/${1}"
+  echo "Removing dSYM file for $1"
+  rm -f ${dsymfile}
 }
 if [[ -f ${1} ]] ; then
   echo dump_syms tool found.


### PR DESCRIPTION
Binary dist. is hosted by me at the moment which we may like to change. That can happen after Samsara though, need to get this on Jenkins ASAP.

Now gets all the symbol info and unmangles symbols on OSX.

Need to test that everything works on Linux. Would be nice to get Windows also but I don't have a working Windows build env. ATM.

To build package this environment var. needs set: `EXPORT_SYMBOLS=YES`

I might add something to zip up the symbols package so we can collect them easily with the Jenkins artifacts thing. (-e- package_all_compress already does this)

edit by mpl: fixes #476
