### PR TITLE
Package: Make breakpad symbol dump work

### DIFF
--- a/ground/gcs/gcs.pri
+++ b/ground/gcs/gcs.pri
@@ -166,3 +166,12 @@ unix {
 }
 
 CONFIG += c++11
+
+# need debug info when we are collecting symbols for breakpad
+# should be stripped by packaging makefiles for release builds
+# as a temporary workaround until Jenkins script can be updated,
+# always generate debug info in release config
+#RELEASE_WITH_SYMBOLS {
+CONFIG(release, debug|release) {
+    CONFIG += force_debug_info
+}

--- a/package/osx_extract_debug_symbols.sh
+++ b/package/osx_extract_debug_symbols.sh
@@ -33,10 +33,14 @@ function generateSymbols()
   echo "Generating symbols for $1, putting them in ${debugfile}"
   dsymutil -o ${dsymfile} ${SOURCE_DIR}/${1}
   ${DUMP_SYMBOLS_TOOL} -g ${dsymfile} ${SOURCE_DIR}/${1} > ${debugfile}
+  if [ ! -s ${debugfile} ] ; then
+    # binary didn't have debug info, have another go to get public symbols at least
+    ${DUMP_SYMBOLS_TOOL} ${SOURCE_DIR}/${1} > ${debugfile}
+  fi
+  echo "Removing dSYM file for $1"
+  rm -rf ${dsymfile}
   echo "Striping debug information from $1"
   strip -S "${SOURCE_DIR}/${1}"
-  echo "Removing dSYM file for $1"
-  rm -f ${dsymfile}
 }
 if [[ -f ${1} ]] ; then
   echo dump_syms tool found.


### PR DESCRIPTION
This gets debug symbols for all our stuff, and public symbols from Qt libs, on both Linux and OSX. Forcing debug info in release config isn't pretty but it means no change to Jenkins is required. We need to clean the whole thing up once Samsara ships anyhow.
Future stuff:
- Get symbols from debug versions of Qt libs
- Keep a set of artifacts from before debug info is stripped
- Tidy-up of packaging scripts/makefiles
- Possibly a nice mechanism/script to upload symbols to autotown like Mozilla uses
- ...?

@mlyle Jenkins may need to archive the symbols as well. `./build/package-*/*_symbols.*` ?

Example packages built using the same build sequence/targets as Jenkins (as much as possible without wiping out stuff I want to keep in my dev tree ;-)), complete with symbols:

```
make all_clean

GCS_BUILD_CONF=release FLIGHT_BUILD_CONF=release make -j8 all package_flight

EXPORT_SYMBOLS=YES make package_all_compress

make package_installer
```

http://dronin.tracer.nz/temp/package-20160714-cb8da3ca-osx.zip
http://dronin.tracer.nz/temp/package-20160714-cb8da3ca-linux.tar.xz
