### PR TITLE
osx zip pkg: ensure yyyymmdd.p packages get .zip suffix

### DIFF
--- a/package/Makefile.osx
+++ b/package/Makefile.osx
@@ -45,7 +45,7 @@ ifeq ($(EXPORT_SYMBOLS),YES)
 endif
 
 package_all_compress: package_all
-	$(V1)cd $(PACKAGE_DIR)/../ && $(ZIPBIN) -9 -r --exclude=*.zip $(BUILD_DIR)/dronin-$(PACKAGE_LBL) $(notdir $(PACKAGE_DIR))
+	$(V1)cd $(PACKAGE_DIR)/../ && $(ZIPBIN) -9 -r --exclude=*.zip $(BUILD_DIR)/dronin-$(PACKAGE_LBL).zip $(notdir $(PACKAGE_DIR))
 
 .PHONY: standalone installer_package
 .PHONY: package_ground_compress


### PR DESCRIPTION
Before we were letting `zip` fill in the .zip suffix, which it won't do if
there's a .1 on the end of the filename.

Unfortunately, this is a blocker.  Before, this didn't matter, because we didn't use the .zip in the release process.   But now we do for crash analysis, and jenkins only will preserve this artifact if it ends with .zip.
