### PR TITLE
flight: osd: properly display reset reason

### DIFF
--- a/flight/Modules/OnScreenDisplay/onscreendisplay.c
+++ b/flight/Modules/OnScreenDisplay/onscreendisplay.c
@@ -737,10 +737,12 @@ void draw_alarms(int x, int y, int xs, int ys, int va, int ha, int flags, int fo
 	int32_t len = AlarmString(&alarm, buf + pos, sizeof(buf) - 1 - pos,
 			blink, &state);
 
-	len += pos;
-
 	if (len > 0) {
-		buf[len] = '\0';
+		pos += len;
+	}
+
+	if (pos > 0) {
+		buf[pos] = '\0';
 		write_string(buf, x, y, xs, ys, va, ha, flags, font);
 	}
 }

--- a/flight/Modules/OnScreenDisplay/onscreendisplay.c
+++ b/flight/Modules/OnScreenDisplay/onscreendisplay.c
@@ -731,11 +731,13 @@ void draw_alarms(int x, int y, int xs, int ys, int va, int ha, int flags, int fo
 		buf[strlen(boot_reason)] = '\0';
 		pos = strlen(boot_reason);
 		buf[pos++] = ' ';
-		return;
 	}
 
 	uint8_t state;
-	int32_t len = AlarmString(&alarm, buf, sizeof(buf) - 1, blink, &state);
+	int32_t len = AlarmString(&alarm, buf + pos, sizeof(buf) - 1 - pos,
+			blink, &state);
+
+	len += pos;
 
 	if (len > 0) {
 		buf[len] = '\0';


### PR DESCRIPTION
We immediately returned before which prevented it from working.
