### PR TITLE
python-api: parse xml files iteratively

### DIFF
--- a/python/dronin/uavo.py
+++ b/python/dronin/uavo.py
@@ -196,7 +196,7 @@ def make_class(collection, xml_file, update_globals=True):
 
     from lxml import etree
 
-    tree = etree.parse(xml_file)
+    tree = etree.fromstring(xml_file)
 
     subs = {
         'tree'            : tree,


### PR DESCRIPTION
This change properly handles parent dependencies between arbitrary
uavos.

Fixes #1118
