### PR TITLE
brain/brainre1: make RCC flags like other targets

### DIFF
--- a/flight/targets/brain/fw/pios_board.c
+++ b/flight/targets/brain/fw/pios_board.c
@@ -263,8 +263,6 @@ void PIOS_Board_Init(void) {
 		PIOS_HAL_Panic(PIOS_LED_ALARM, PIOS_HAL_PANIC_FILESYS);
 #endif	/* PIOS_INCLUDE_FLASH */
 
-	RCC_ClearFlag(); // The flags cleared after use
-
 	/* Initialize UAVObject libraries */
 	UAVObjInitialize();
 
@@ -285,6 +283,7 @@ void PIOS_Board_Init(void) {
 
 	/* Initialize the alarms library */
 	AlarmsInitialize();
+	PIOS_RESET_Clear();
 
 	/* Initialize the task monitor library */
 	TaskMonitorInitialize();

--- a/flight/targets/brainre1/fw/pios_board.c
+++ b/flight/targets/brainre1/fw/pios_board.c
@@ -275,8 +275,6 @@ void PIOS_Board_Init(void) {
 
 #endif	/* PIOS_INCLUDE_FLASH */
 
-	RCC_ClearFlag(); // The flags cleared after use
-
 	/* Initialize UAVObject libraries */
 	UAVObjInitialize();
 
@@ -316,6 +314,7 @@ void PIOS_Board_Init(void) {
 
 	/* Initialize the alarms library */
 	AlarmsInitialize();
+	PIOS_RESET_Clear();
 
 	/* Initialize the task monitor library */
 	TaskMonitorInitialize();


### PR DESCRIPTION
This was preventing reset reasons from properly displaying-- because
the reset reason flags were cleared before the alarms library was
initialized.
