### PR TITLE
python: fixups

### DIFF
--- a/python/dronin/uavo.py
+++ b/python/dronin/uavo.py
@@ -144,7 +144,7 @@ class UAVTupleClass():
 
             field_value = raw_dict[field_name]
 
-            if isinstance(field_value, tuple):
+            if isinstance(field_value, tuple) or isinstance(field_value, list):
                 text_value = ','.join( [ self.elem_to_string(field_name, v) for v in field_value ] )
             else:
                 text_value = self.elem_to_string(field_name, field_value)

--- a/python/shell.py
+++ b/python/shell.py
@@ -26,6 +26,7 @@ def main():
         'githash'   : uavo_list.githash,
         'uavo_defs' : uavo_list.uavo_defs,
         'uavo_list' : uavo_list,
+        '__name__'  : 'dronin'
         }
 
     # Extend the shell environment to include all of the uavo.UAVO_* classes that were
@@ -34,8 +35,7 @@ def main():
     user_module.__dict__.update(uavo_classes)
 
     # Instantiate an ipython shell to interact with the log data.
-    import IPython
-    from IPython.frontend.terminal.embed import InteractiveShellEmbed
+    from IPython.terminal.embed import InteractiveShellEmbed
     e = InteractiveShellEmbed(user_ns = user_ns, user_module = user_module)
     e.enable_pylab(import_all = True)
     e("Analyzing log file: %s" % uavo_list.filename)


### PR DESCRIPTION
ipython:
- it needs the `__name__` attribute in the namespace to survive
- changing the interactive shell embed import removes a deprecation warning.

uavo.py:
- join attributes when we encounter lists, not just tuples.  fixes #1127
