### PR TITLE
GCS: Fix MSVC regressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ $(BUILD_DIR):
 
 USE_MSVC ?= NO
 ifeq ($(USE_MSVC), YES)
-QT_SPEC=win32-msvc2013
+QT_SPEC=win32-msvc2015
 endif
 .PHONY: all_ground
 all_ground: gcs

--- a/ground/gcs/gcs.pri
+++ b/ground/gcs/gcs.pri
@@ -126,10 +126,8 @@ unix {
 }
 
 
+# use ccache with gcc
 CONFIG(debug, debug|release):*-g++* {
-    # Unfortunately this is ineffective on OSX, due to
-    # https://bugreports.qt.io/browse/QTBUG-39417
-    # Should use it once upstream defect resolved
     QMAKE_CXX=$$(CCACHE_BIN) g++
 }
 

--- a/ground/gcs/gcs.pri
+++ b/ground/gcs/gcs.pri
@@ -126,7 +126,7 @@ unix {
 }
 
 
-CONFIG(debug, debug|release) {
+CONFIG(debug, debug|release):*-g++* {
     # Unfortunately this is ineffective on OSX, due to
     # https://bugreports.qt.io/browse/QTBUG-39417
     # Should use it once upstream defect resolved

--- a/ground/gcs/src/libs/utils/winutils.cpp
+++ b/ground/gcs/src/libs/utils/winutils.cpp
@@ -94,7 +94,9 @@ QTCREATOR_UTILS_EXPORT QString winGetDLLVersion(WinDLLVersionType t,
     }
     VS_FIXEDFILEINFO  *versionInfo;
     UINT len = 0;
-    if (!(*verQueryValueW)(data, TEXT("\\"), &versionInfo, &len)) {
+    WCHAR tmp1[] = TEXT("\\");
+    LPWSTR tmp = tmp1;
+    if (!(*verQueryValueW)(data, tmp, &versionInfo, &len)) {
         *errorMessage = QString::fromLatin1("Unable to determine version string of %1: %2").arg(name, winErrorMessage(GetLastError()));
         return QString();
     }    

--- a/ground/gcs/src/plugins/uploader/tl_dfu.cpp
+++ b/ground/gcs/src/plugins/uploader/tl_dfu.cpp
@@ -34,10 +34,7 @@
 #include "tl_dfu.h"
 
 #include <QApplication>
-
-extern "C" {
-#include <unistd.h>
-}
+#include <QThread>
 
 #define TL_DFU_DEBUG
 #ifdef TL_DFU_DEBUG
@@ -754,7 +751,7 @@ int DFUObject::SendData(bl_messages data)
 
         if (ret < 0) {
             qDebug() << "hid_write returned error" << ret;
-            usleep(2000);
+            QThread::usleep(2000);
         } else {
             break;
         }

--- a/ground/uavobjgenerator/uavobjgenerator.pro
+++ b/ground/uavobjgenerator/uavobjgenerator.pro
@@ -7,10 +7,12 @@ macx {
 
 cache()
 
-# Unfortunately this is ineffective on OSX, due to
-# https://bugreports.qt.io/browse/QTBUG-39417
-# Should use it once upstream defect resolved
-QMAKE_CXX=$$(CCACHE_BIN) g++
+*-g++* {
+    # Unfortunately this is ineffective on OSX, due to
+    # https://bugreports.qt.io/browse/QTBUG-39417
+    # Should use it once upstream defect resolved
+    QMAKE_CXX=$$(CCACHE_BIN) g++
+}
 
 TARGET = uavobjgenerator
 CONFIG += console

--- a/ground/uavobjgenerator/uavobjgenerator.pro
+++ b/ground/uavobjgenerator/uavobjgenerator.pro
@@ -7,10 +7,8 @@ macx {
 
 cache()
 
+# use ccache with gcc
 *-g++* {
-    # Unfortunately this is ineffective on OSX, due to
-    # https://bugreports.qt.io/browse/QTBUG-39417
-    # Should use it once upstream defect resolved
     QMAKE_CXX=$$(CCACHE_BIN) g++
 }
 


### PR DESCRIPTION
Can build with MSVC 2015 Community Edition and Qt5.6.1 with MSVC2015 kit. It even runs. I changed to MSVC 2015 because that is the most easily available community edition.
