### PR TITLE
RE1: Remove CCM section in Linker Definition

### DIFF
--- a/flight/targets/brainre1/fw/sections_chibios.ld
+++ b/flight/targets/brainre1/fw/sections_chibios.ld
@@ -139,27 +139,6 @@ SECTIONS
         __main_thread_stack_end__ = .;
     } > ram
 
-    .ccm :
-    {
-        PROVIDE(_cmm_start = .);
-        . = ALIGN(4);
-        *(.bss.mainthread.*)
-        . = ALIGN(4);
-        *(.bss._idle_thread_wa)
-        . = ALIGN(4);
-        *(.bss.rlist)
-        . = ALIGN(4);
-        *(.bss.vtlist)
-        . = ALIGN(4);
-        *(.bss.endmem)
-        . = ALIGN(4);
-        *(.bss.nextmem)
-        . = ALIGN(4);
-        *(.bss.default_heap)
-        . = ALIGN(4);
-        PROVIDE(_cmm_end = .);
-    } > ram
-
     .data :
     {
         . = ALIGN(4);


### PR DESCRIPTION
References #1140. confirmed @ 565a761
![1469236611](https://cloud.githubusercontent.com/assets/6873/17074896/d4d14d1a-50d7-11e6-94f1-50e8f7d40dd3.png)
![1469236602](https://cloud.githubusercontent.com/assets/6873/17074895/d4d150da-50d7-11e6-97ff-00b539bd5f8e.png)
![1469236593](https://cloud.githubusercontent.com/assets/6873/17074897/d4d4d98a-50d7-11e6-8d11-b416a46af44b.png)

Edit by mpl: Fixes #1139
