### PR TITLE
logging: log everything at start, not just settings

### DIFF
--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -97,6 +97,7 @@ static uint16_t get_minimum_logging_period();
 static void unregister_object(UAVObjHandle obj);
 static void register_object(UAVObjHandle obj);
 static void register_default_profile();
+static void logAll(UAVObjHandle obj);
 static void logSettings(UAVObjHandle obj);
 static void writeHeader();
 static void updateSettings();
@@ -323,7 +324,9 @@ static void loggingTask(void *parameters)
 			writeHeader();
 
 			// Log settings
-			if (settings.LogSettingsOnStart == LOGGINGSETTINGS_LOGSETTINGSONSTART_TRUE){
+			if (settings.InitiallyLog == LOGGINGSETTINGS_INITIALLYLOG_ALLOBJECTS) {
+				UAVObjIterate(&logAll);
+			} else if (settings.InitiallyLog == LOGGINGSETTINGS_INITIALLYLOG_SETTINGSOBJECTS) {
 				UAVObjIterate(&logSettings);
 			}
 
@@ -421,15 +424,25 @@ static void loggingTask(void *parameters)
 }
 
 /**
- * Log all settings objects
+ * Log all objects' initial value.
  * \param[in] obj Object to log
 */
+static void logAll(UAVObjHandle obj)
+{
+	UAVTalkSendObjectTimestamped(uavTalkCon, obj, 0, false, 0);
+}
+
+ /**
+  * Log all settings objects
+  * \param[in] obj Object to log
+  */
 static void logSettings(UAVObjHandle obj)
 {
 	if (UAVObjIsSettings(obj)) {
 		UAVTalkSendObjectTimestamped(uavTalkCon, obj, 0, false, 0);
 	}
 }
+
 
 /**
  * Forward data from UAVTalk out the serial port

--- a/shared/uavobjectdefinition/loggingsettings.xml
+++ b/shared/uavobjectdefinition/loggingsettings.xml
@@ -2,7 +2,7 @@
 	<object name="LoggingSettings" singleinstance="true" settings="true">
 		<description>Settings for the logging module</description>
 		<field name="LogBehavior" units="" type="enum" options="LogOnStart,LogOnArm,LogOff" elements="1" defaultvalue="LogOnArm"/>
-		<field name="LogSettingsOnStart" units="" type="enum" options="True,False" elements="1" defaultvalue="True"/>
+		<field name="InitiallyLog" units="" type="enum" options="AllObjects,SettingsObjects,None" elements="1" defaultvalue="AllObjects"/>
 		<field name="MaxLogRate" units="Hz" type="enum" options="5,10,25,50,100,250,500,1000" elements="1" defaultvalue="25"/>
 		<field name="Profile" units="" type="enum" options="Default,Custom,Fullbore" elements="1" defaultvalue="Default"/>
 		<access gcs="readwrite" flight="readwrite"/>


### PR DESCRIPTION
This is necessary to avoid ambiguity in initial state--- especiallly with fullbore logging in order to know initial flight modes etc.

I'm working on the log viewer-- in order to notice flight 'events' relevant to analysis, like flight mode switch changes and arming/disarming.  But in logfiles provided by @ufoDziner, I noticed that the initial flight mode and arming event was not there.
