### PR TITLE
Add closing braces for doxygen groups in license template

### DIFF
--- a/LicenseTemplate.txt
+++ b/LicenseTemplate.txt
@@ -27,3 +27,10 @@
  * must be maintained in each individual source file that is a derivative work
  * of this source file; otherwise redistribution is prohibited.
  */
+
+
+
+/**
+ * @}
+ * @}
+ */


### PR DESCRIPTION
To help this out http://jenkins.tracer.nz/job/dronin-docs/lastSuccessfulBuild/artifact/stderr.log (`warning: end of file while inside a group`)
