### PR TITLE
Revert "vtolfollower/deadbands: fix a critical parens bug."

### DIFF
--- a/flight/Libraries/math/misc_math.c
+++ b/flight/Libraries/math/misc_math.c
@@ -234,7 +234,7 @@ float cubic_deadband(float in, float w, float b, float m, float r)
 		return in-w+r;
 	}
 
-	return m * powf(in, 3) + b * in;
+	return powf(m*in, 3)+b*in;
 }
 
 /**
@@ -252,7 +252,7 @@ void cubic_deadband_setup(float w, float b, float *m, float *r)
 	 ** work b isn't doing. */
 	*m = cbrtf((1-b)/(3*powf(w,2)));
 
-	*r = *m * powf(w, 3) + b * w;
+	*r = powf(*m*w, 3)+b*w;
 }
 
 /**


### PR DESCRIPTION
This reverts commit 2aa56fa69d7fefe33dfdc874002ddb457f07323f.

Not sure how I convinced myself this was correct.

https://www.desmos.com/calculator/k0qnkyxoh0

Thanks to TripleDes from IRC for pointing this out.
