### PR TITLE
Flight: AQ32 - ADC input cleanup.

### DIFF
--- a/flight/targets/aq32/board-info/board_hw_defs.c
+++ b/flight/targets/aq32/board-info/board_hw_defs.c
@@ -1555,12 +1555,12 @@ struct pios_internal_adc_cfg pios_adc_cfg = {
 	.full_flag = DMA_IT_TCIF4,
 
 	.adc_dev_master = ADC1,
-	.adc_pins =  {                                                                                \
-		{ GPIOC, GPIO_Pin_0,     ADC_Channel_10 },                /* Internal Voltage Monitor */  \
-		{ GPIOC, GPIO_Pin_4,     ADC_Channel_14 },                /* External Voltage Monitor */  \
-		{ GPIOC, GPIO_Pin_5,     ADC_Channel_15 },                /* External Current Monitor */  \
-		{ NULL,  0,              ADC_Channel_Vrefint },           /* Voltage reference */         \
-		{ NULL,  0,              ADC_Channel_TempSensor },        /* Temperature sensor */        \
+	.adc_pins =  {                                                              \
+		{ GPIOC, GPIO_Pin_4, ADC_Channel_14 },  /* AI2                      */  \
+		{ GPIOC, GPIO_Pin_0, ADC_Channel_10 },  /* Internal Voltage Monitor */  \
+		{ GPIOB, GPIO_Pin_1, ADC_Channel_9  },  /* AI3                      */  \
+		{ GPIOC, GPIO_Pin_5, ADC_Channel_15 },  /* AI4                      */  \
+		{ GPIOC, GPIO_Pin_2, ADC_Channel_12 },  /* AI5                      */  \
 	},
 	.adc_pin_count = 5,
 };

--- a/ground/gcs/src/plugins/boards_aeroquad/aq32.cpp
+++ b/ground/gcs/src/plugins/boards_aeroquad/aq32.cpp
@@ -147,8 +147,8 @@ QStringList AQ32::getAdcNames()
 
     HwAQ32::DataFields settings = hwAQ32->getData();
     if (settings.ADCInputs == HwAQ32::ADCINPUTS_ENABLED) {
-        return QStringList() << "BM" << "Analog AI2" << "Analog AI4";
+        return QStringList() << "AI2" << "BM" << "AI3" << "AI4" << "AI5";
     }
 
-    return QStringList() << "Disabled" << "Disabled" << "Disabled";
+    return QStringList() << "Disabled" << "Disabled" << "Disabled" << "Disabled" << "Disabled";
 }


### PR DESCRIPTION
Reordered and changed the ADC inputs.  ADC0 becomes AI2 and ADC1 becomes BM.  ADC 2, 3, and 4 become AI3, AI4, and AI5 respectively.

This matches the standard ordering seen in other targets where current is monitored via ADC0 and battery voltage is monitored via ADC1.

Tested to work properly on AQ32 hardware.
