### PR TITLE
PID deadband code.

### DIFF
--- a/flight/Libraries/math/pid.c
+++ b/flight/Libraries/math/pid.c
@@ -47,7 +47,7 @@ static float deriv_gamma = 1.0;
  * @param[in] dT  The time step
  * @returns Output the computed controller value
  */
-float pid_apply(struct pid *pid, float err, float dT)
+float pid_apply(struct pid *pid, const float err, float dT)
 {	
 	if (pid->i == 0) {
 		// If Ki is zero, do not change the integrator. We do not reset to zero
@@ -82,7 +82,7 @@ float pid_apply(struct pid *pid, float err, float dT)
  * @Note based on "Feedback Systems" by Astrom and Murray, PID control
  *  chapter.
  */
-float pid_apply_antiwindup(struct pid *pid, float err,
+float pid_apply_antiwindup(struct pid *pid, const float err,
 	float min_bound, float max_bound, float dT)
 {	
 	if (pid->i == 0) {
@@ -136,7 +136,6 @@ float pid_apply_setpoint(struct pid *pid, struct pid_deadband *deadband, const f
 	float err = setpoint - measured;
 	float err_d = (deriv_gamma * setpoint - measured);
 
-#ifndef SMALLF1
 	if(deadband && deadband->width > 0)
 	{
 		err = cubic_deadband(err, deadband->width, deadband->slope, deadband->cubic_weight,
@@ -144,7 +143,6 @@ float pid_apply_setpoint(struct pid *pid, struct pid_deadband *deadband, const f
 		err_d = cubic_deadband(err_d, deadband->width, deadband->slope, deadband->cubic_weight,
 			deadband->integrated_response);
 	}
-#endif
 
 	if (pid->i == 0) {
 		// If Ki is zero, do not change the integrator. We do not reset to zero
@@ -218,7 +216,6 @@ void pid_configure(struct pid *pid, float p, float i, float d, float iLim)
  */
 void pid_configure_deadband(struct pid_deadband *deadband, float width, float slope)
 {
-#ifndef SMALLF1
 	if(!deadband)
 		return;
 
@@ -240,7 +237,6 @@ void pid_configure_deadband(struct pid_deadband *deadband, float width, float sl
 
 	cubic_deadband_setup(width, slope, &deadband->cubic_weight,
 		&deadband->integrated_response);
-#endif
 }
 
 /**

--- a/flight/Libraries/math/pid.c
+++ b/flight/Libraries/math/pid.c
@@ -47,7 +47,7 @@ static float deriv_gamma = 1.0;
  * @param[in] dT  The time step
  * @returns Output the computed controller value
  */
-float pid_apply(struct pid *pid, const float err, float dT)
+float pid_apply(struct pid *pid, float err, float dT)
 {	
 	if (pid->i == 0) {
 		// If Ki is zero, do not change the integrator. We do not reset to zero
@@ -82,7 +82,7 @@ float pid_apply(struct pid *pid, const float err, float dT)
  * @Note based on "Feedback Systems" by Astrom and Murray, PID control
  *  chapter.
  */
-float pid_apply_antiwindup(struct pid *pid, const float err,
+float pid_apply_antiwindup(struct pid *pid, float err,
 	float min_bound, float max_bound, float dT)
 {	
 	if (pid->i == 0) {
@@ -130,10 +130,22 @@ float pid_apply_antiwindup(struct pid *pid, const float err,
  * This version of apply uses setpoint weighting for the derivative component so the gain
  * on the gyro derivative can be different than the gain on the setpoint derivative
  */
-float pid_apply_setpoint(struct pid *pid, const float setpoint, const float measured, float dT)
+float pid_apply_setpoint(struct pid *pid, struct pid_deadband *deadband, const float setpoint,
+	const float measured, float dT)
 {
 	float err = setpoint - measured;
-	
+	float err_d = (deriv_gamma * setpoint - measured);
+
+#ifndef SMALLF1
+	if(deadband && deadband->width > 0)
+	{
+		err = cubic_deadband(err, deadband->width, deadband->slope, deadband->cubic_weight,
+			deadband->integrated_response);
+		err_d = cubic_deadband(err_d, deadband->width, deadband->slope, deadband->cubic_weight,
+			deadband->integrated_response);
+	}
+#endif
+
 	if (pid->i == 0) {
 		// If Ki is zero, do not change the integrator. We do not reset to zero
 		// because sometimes the accumulator term is set externally
@@ -144,8 +156,8 @@ float pid_apply_setpoint(struct pid *pid, const float setpoint, const float meas
 
 	// Calculate DT1 term,
 	float dterm = 0;
-	float diff = ((deriv_gamma * setpoint - measured) - pid->lastErr);
-	pid->lastErr = (deriv_gamma * setpoint - measured);
+	float diff = (err_d - pid->lastErr);
+	pid->lastErr = err_d;
 	if(pid->d && dT)
 	{
 		dterm = pid->lastDer +  dT / ( dT + deriv_tau) * ((diff * pid->d / dT) - pid->lastDer);
@@ -196,6 +208,39 @@ void pid_configure(struct pid *pid, float p, float i, float d, float iLim)
 	pid->i = i;
 	pid->d = d;
 	pid->iLim = iLim;
+}
+
+/**
+ * Set the deadband values
+ * @param[out] pid The PID structure to configure
+ * @param[in] deadband Deadband width in degrees per second
+ * @param[in] slope Deadband slope (0..1)
+ */
+void pid_configure_deadband(struct pid_deadband *deadband, float width, float slope)
+{
+#ifndef SMALLF1
+	if(!deadband)
+		return;
+
+	if(width < 0.1f)
+	{
+		// Below 0.1deg/s, we can assume that we don't want it.
+		// Also something something float zeroes...
+		deadband->width = deadband->slope = deadband->cubic_weight =
+			deadband->integrated_response = 0;
+		return;
+	}
+
+	// Clamp slope to positive, otherwise it'll cause drama.
+	if(slope < 0.0f) slope = 0.0f;
+	else if(slope > 1.0f) slope = 1.0f;
+
+	deadband->width = width;
+	deadband->slope = slope;
+
+	cubic_deadband_setup(width, slope, &deadband->cubic_weight,
+		&deadband->integrated_response);
+#endif
 }
 
 /**

--- a/flight/Libraries/math/pid.h
+++ b/flight/Libraries/math/pid.h
@@ -33,7 +33,7 @@
 #define PID_H
 
 struct pid_deadband {
-	float width;				// Deadband width in degrees.
+	float width;				// Deadband width in degrees per second.
 	float slope;				// Deadband slope (0..1).
 	float cubic_weight;			// Cubic weight.
 	float integrated_response;	// Response at deadband edge.

--- a/flight/Libraries/math/pid.h
+++ b/flight/Libraries/math/pid.h
@@ -32,6 +32,13 @@
 #ifndef PID_H
 #define PID_H
 
+struct pid_deadband {
+	float width;				// Deadband width in degrees.
+	float slope;				// Deadband slope (0..1).
+	float cubic_weight;			// Cubic weight.
+	float integrated_response;	// Response at deadband edge.
+};
+
 //! 
 struct pid {
 	float p;
@@ -44,12 +51,13 @@ struct pid {
 };
 
 //! Methods to use the pid structures
-float pid_apply(struct pid *pid, const float err, float dT);
-float pid_apply_antiwindup(struct pid *pid, const float err, float min_bound, float max_bound, float dT);
-float pid_apply_setpoint(struct pid *pid, const float setpoint, const float measured, float dT);
+float pid_apply(struct pid *pid, float err, float dT);
+float pid_apply_antiwindup(struct pid *pid, float err, float min_bound, float max_bound, float dT);
+float pid_apply_setpoint(struct pid *pid, struct pid_deadband *deadband, const float setpoint, const float measured, float dT);
 void pid_zero(struct pid *pid);
 void pid_configure(struct pid *pid, float p, float i, float d, float iLim);
 void pid_configure_derivative(float cutoff, float gamma);
+void pid_configure_deadband(struct pid_deadband *deadband, float width, float slope);
 
 #endif /* PID_H */
 

--- a/flight/Libraries/math/pid.h
+++ b/flight/Libraries/math/pid.h
@@ -51,8 +51,8 @@ struct pid {
 };
 
 //! Methods to use the pid structures
-float pid_apply(struct pid *pid, float err, float dT);
-float pid_apply_antiwindup(struct pid *pid, float err, float min_bound, float max_bound, float dT);
+float pid_apply(struct pid *pid, const float err, float dT);
+float pid_apply_antiwindup(struct pid *pid, const float err, float min_bound, float max_bound, float dT);
 float pid_apply_setpoint(struct pid *pid, struct pid_deadband *deadband, const float setpoint, const float measured, float dT);
 void pid_zero(struct pid *pid);
 void pid_configure(struct pid *pid, float p, float i, float d, float iLim);

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -136,7 +136,7 @@ static void calculate_pids(void);
 static void SettingsUpdatedCb(UAVObjEvent * objEv, void *ctx, void *obj, int len);
 static float get_throttle(StabilizationDesiredData *stabilization_desired, SystemSettingsAirframeTypeOptions *airframe_type);
 
-#ifndef SMALLF1
+#ifndef NO_CONTROL_DEADBANDS
 #define get_deadband(axis) (deadbands ? (deadbands + axis) : NULL)
 #else
 #define get_deadband(axis) NULL
@@ -964,7 +964,7 @@ static void calculate_pids()
 	// Set up the derivative term
 	pid_configure_derivative(settings.DerivativeCutoff, settings.DerivativeGamma);
 
-#ifndef SMALLF1
+#ifndef NO_CONTROL_DEADBANDS	
 	if(deadbands ||
 		settings.DeadbandWidth[STABILIZATIONSETTINGS_DEADBANDWIDTH_ROLL] ||
 		settings.DeadbandWidth[STABILIZATIONSETTINGS_DEADBANDWIDTH_PITCH] ||

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -562,7 +562,7 @@ static void stabilizationTask(void* parameters)
 
 					// Compute desired rate as input biased towards leveling
 					rateDesiredAxis[i] = stabDesiredAxis[i] + weak_leveling;
-					actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], NULL,  rateDesiredAxis[i],  gyro_filtered[i], dT);
+					actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], dT);
 					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 
 					break;
@@ -696,7 +696,7 @@ static void stabilizationTask(void* parameters)
 						rateDesiredAxis[i] = bound_sym(rateDesiredAxis[i], settings.MaximumRate[i]);
 
 						// Compute the inner loop
-						actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], NULL, rateDesiredAxis[i],  gyro_filtered[i], dT);
+						actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i), rateDesiredAxis[i],  gyro_filtered[i], dT);
 						actuatorDesiredAxis[i] += ident_offsets[i];
 						actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 					} else {
@@ -704,7 +704,7 @@ static void stabilizationTask(void* parameters)
 						rateDesiredAxis[i] = bound_sym(stabDesiredAxis[i], settings.ManualRate[i]);
 
 						// Compute the inner loop only for yaw
-						actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], NULL, rateDesiredAxis[i],  gyro_filtered[i], dT);
+						actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i), rateDesiredAxis[i],  gyro_filtered[i], dT);
 						actuatorDesiredAxis[i] += ident_offsets[i];
 						actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 					}
@@ -824,7 +824,7 @@ static void stabilizationTask(void* parameters)
 					rateDesiredAxis[i] = bound_sym(rateDesiredAxis[i], settings.PoiMaximumRate[i]);
 
 					// Compute the inner loop
-					actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], NULL, rateDesiredAxis[i], gyro_filtered[i], dT);
+					actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i), rateDesiredAxis[i], gyro_filtered[i], dT);
 					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 
 					break;

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -119,7 +119,7 @@ bool lowThrottleZeroIntegral;
 float vbar_decay = 0.991f;
 float gyro_alpha = 0.6;
 struct pid pids[PID_MAX];
-#ifndef SMALLF1
+#ifndef NO_CONTROL_DEADBANDS
 struct pid_deadband *deadbands = NULL;
 #endif
 

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -965,7 +965,8 @@ static void calculate_pids()
 	pid_configure_derivative(settings.DerivativeCutoff, settings.DerivativeGamma);
 
 #ifndef SMALLF1
-	if(settings.DeadbandWidth[STABILIZATIONSETTINGS_DEADBANDWIDTH_ROLL] ||
+	if(deadbands ||
+		settings.DeadbandWidth[STABILIZATIONSETTINGS_DEADBANDWIDTH_ROLL] ||
 		settings.DeadbandWidth[STABILIZATIONSETTINGS_DEADBANDWIDTH_PITCH] ||
 		settings.DeadbandWidth[STABILIZATIONSETTINGS_DEADBANDWIDTH_YAW])
 	{

--- a/flight/Modules/Stabilization/virtualflybar.c
+++ b/flight/Modules/Stabilization/virtualflybar.c
@@ -54,7 +54,7 @@ int stabilization_virtual_flybar(float gyro, float command, float *output, float
 	vbar_integral[axis] = bound(vbar_integral[axis], settings->VbarMaxAngle);
 
 	// Compute the normal PID controller output
-	float pid_out = pid_apply_setpoint(pid,  0,  gyro, dT);
+	float pid_out = pid_apply_setpoint(pid, NULL,  0,  gyro, dT);
 
 	// Command signal can indicate how much to disregard the gyro feedback (fast flips)
 	if (settings->VbarGyroSuppress > 0.0f) {

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -48,6 +48,13 @@
 	<field name="CameraTilt" units="deg" type="float" elements="1" defaultvalue="0" limits="%BE:-85:85">
 		<description>Only applicable when CameraAngle selected as Reprojection mode in Input settings. This should be the actual tilt angle of your camera. If your camera is tilted upwards, use positive tilt.</description>
 	</field>
+
+	<field name="DeadbandWidth" units="deg/s" type="uint8" elementnames="Roll,Pitch,Yaw" defaultvalue="0,0,0" limits="%BE:0:20,%BE:0:20,%BE:0:20">
+		<description>Sets the width of the deadband in the PID controller. An axis set to zero disables the relevant deadband.</description>
+	</field>
+	<field name="DeadbandSlope" units="%" type="uint8" elementnames="Roll,Pitch,Yaw" defaultvalue="60,60,50" limits="%BE:0:100,%BE:0:100,%BE:0:100">
+		<description>Sets the slope of the deadband area in the PID controller.</description>
+	</field>
   
 	<access gcs="readwrite" flight="readwrite"/>
 	<telemetrygcs acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
This runs the error in the PID controller through a cubic deadband function and should influence very low rate flight dynamics, specifically lingering PID responses ending harder maneuvers. The widths and slopes of the roll, pitch and yaw deadbands can be configured via two fields in the StabilizationSettings UAVO (DeadbandWidth and DeadbandSlope, each three elements). The width is clamped in code to 0-20°/s, as is the slope to 0-100%. Zero width is a disabled deadband on the axis.

F1 targets have been tentatively excluded. The UAVO additions rack up to 18 bytes, the necessary variables in memory would add up another 88 bytes to that. Up to debate I guess, with the RAM scarcity and all that.

Currently the deadbands, when non-zero width, are applied to following axis modes:
- Rate
- Acro Plus
- Attitude (inner loop)
- Axis lock (final rate desired, not the axis accumulator stuff)
- Horizon

Some values to start with would be 10°/s and 50-60% slope for roll and pitch, and _maybe_ 5°/s and 50% for yaw. Decent starting values will probably emerge during testing and tinkering.
