### PR TITLE
Coordinated flight PID gets configured twice.

### DIFF
--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -941,13 +941,6 @@ static void calculate_pids()
 	              0, /* No derivative term */
 	              settings.CoordinatedFlightYawPI[STABILIZATIONSETTINGS_COORDINATEDFLIGHTYAWPI_ILIMIT]);
 
-	// Set the coordinated flight settings
-	pid_configure(&pids[PID_COORDINATED_FLIGHT_YAW],
-	              settings.CoordinatedFlightYawPI[STABILIZATIONSETTINGS_COORDINATEDFLIGHTYAWPI_KP],
-	              settings.CoordinatedFlightYawPI[STABILIZATIONSETTINGS_COORDINATEDFLIGHTYAWPI_KI],
-	              0, /* No derivative term */
-	              settings.CoordinatedFlightYawPI[STABILIZATIONSETTINGS_COORDINATEDFLIGHTYAWPI_ILIMIT]);
-
 	// Set up the derivative term
 	pid_configure_derivative(settings.DerivativeCutoff, settings.DerivativeGamma);
 


### PR DESCRIPTION
Some older copypasta mistake, I figure.
