### PR TITLE
GCS:Welcome: Only show buttons for loaded workspaces

### DIFF
--- a/ground/gcs/share/welcome/main.qml
+++ b/ground/gcs/share/welcome/main.qml
@@ -61,44 +61,52 @@ Rectangle {
 
             Grid {
                 id: buttons
+                objectName: "modeButtons"
                 columns: 3
                 spacing: 4
                 anchors.verticalCenter: parent.verticalCenter
+                property variant modeNames: []
 
                 WelcomePageButton {
                     baseIconName: "flightdata"
                     label: "Flight Data"
                     onClicked: welcomePlugin.openPage("Flight data")
+                    visible: parent.modeNames.indexOf("Flight data") >= 0
                 }
 
                 WelcomePageButton {
                     baseIconName: "config"
                     label: "Configuration"
                     onClicked: welcomePlugin.openPage("Configuration")
+                    visible: parent.modeNames.indexOf("Configuration") >= 0
                 }
 
                 WelcomePageButton {
                     baseIconName: "system"
                     label: "System"
                     onClicked: welcomePlugin.openPage("System")
+                    visible: parent.modeNames.indexOf("System") >= 0
                 }
 
                WelcomePageButton {
                     baseIconName: "scopes"
                     label: "Scopes"
                     onClicked: welcomePlugin.openPage("Scopes")
+                    visible: parent.modeNames.indexOf("Scopes") >= 0
                 }
 
                 WelcomePageButton {
                     baseIconName: "advanced"
                     label: "Advanced"
                     onClicked: welcomePlugin.openPage("Advanced")
+                    visible: parent.modeNames.indexOf("Advanced") >= 0
                 }
 
                 WelcomePageButton {
                     baseIconName: "firmware"
                     label: "Firmware"
                     onClicked: welcomePlugin.openPage("Firmware")
+                    visible: parent.modeNames.indexOf("Firmware") >= 0
                 }
             } //icons grid
 

--- a/ground/gcs/src/plugins/coreplugin/modemanager.cpp
+++ b/ground/gcs/src/plugins/coreplugin/modemanager.cpp
@@ -166,6 +166,8 @@ void ModeManager::objectAdded(QObject *obj)
 
     m_signalMapper->setMapping(shortcut, mode->uniqueModeName());
     connect(shortcut, SIGNAL(activated()), m_signalMapper, SLOT(map()));
+
+    emit modesChanged();
 }
 
 void ModeManager::setDefaultKeyshortcuts() {
@@ -216,6 +218,8 @@ void ModeManager::aboutToRemoveObject(QObject *obj)
     connect(m_modeStack, SIGNAL(currentChanged(int)), this, SLOT(currentTabChanged(int)));
 
     m_mainWindow->removeContextObject(mode);
+
+    emit modesChanged();
 }
 
 void ModeManager::addAction(Command *command, int priority, QMenu *menu)

--- a/ground/gcs/src/plugins/coreplugin/modemanager.h
+++ b/ground/gcs/src/plugins/coreplugin/modemanager.h
@@ -74,7 +74,8 @@ public:
 signals:
     void currentModeAboutToChange(Core::IMode *mode);
     void currentModeChanged(Core::IMode *mode);
-    void newModeOrder(QVector<IMode*> modes);
+    void newModeOrder(QVector<IMode *> modes);
+    void modesChanged();
 
 public slots:
     void activateMode(const QString &id);

--- a/ground/gcs/src/plugins/welcome/welcomemode.h
+++ b/ground/gcs/src/plugins/welcome/welcomemode.h
@@ -67,7 +67,12 @@ public slots:
     void openPage(const QString &page);
     void triggerAction(const QString &actionId);
 
+private slots:
+    void modesChanged();
+
 private:
+    QStringList getModeNames();
+
     WelcomeModePrivate *m_d;
     QWidget *m_container;
     int m_priority;


### PR DESCRIPTION
Fixes #1194 
