### PR TITLE
Pulldown TX pins for F3 UARTs.

### DIFF
--- a/flight/targets/dtfc/board-info/board_hw_defs.c
+++ b/flight/targets/dtfc/board-info/board_hw_defs.c
@@ -336,7 +336,7 @@ static const struct pios_usart_cfg pios_uart1_usart_cfg = {
 			.GPIO_Speed = GPIO_Speed_2MHz,
 			.GPIO_Mode  = GPIO_Mode_AF,
 			.GPIO_OType = GPIO_OType_PP,
-			.GPIO_PuPd  = GPIO_PuPd_UP
+			.GPIO_PuPd  = GPIO_PuPd_DOWN
 		},
 		.pin_source = GPIO_PinSource6,
 	},
@@ -371,7 +371,7 @@ static const struct pios_usart_cfg pios_uart2_usart_cfg = {
 			.GPIO_Speed = GPIO_Speed_2MHz,
 			.GPIO_Mode  = GPIO_Mode_AF,
 			.GPIO_OType = GPIO_OType_PP,
-			.GPIO_PuPd  = GPIO_PuPd_UP
+			.GPIO_PuPd  = GPIO_PuPd_DOWN
 		},
 		.pin_source = GPIO_PinSource2,
 	},
@@ -406,7 +406,7 @@ static const struct pios_usart_cfg pios_uart3_usart_cfg = {
 			.GPIO_Speed = GPIO_Speed_2MHz,
 			.GPIO_Mode  = GPIO_Mode_AF,
 			.GPIO_OType = GPIO_OType_PP,
-			.GPIO_PuPd  = GPIO_PuPd_UP
+			.GPIO_PuPd  = GPIO_PuPd_DOWN
 		},
 		.pin_source = GPIO_PinSource10,
 	},

--- a/flight/targets/lux/board-info/board_hw_defs.c
+++ b/flight/targets/lux/board-info/board_hw_defs.c
@@ -320,7 +320,7 @@ static const struct pios_usart_cfg pios_uart2_cfg = {
 			.GPIO_Speed = GPIO_Speed_2MHz,
 			.GPIO_Mode  = GPIO_Mode_AF,
 			.GPIO_OType = GPIO_OType_PP,
-			.GPIO_PuPd  = GPIO_PuPd_UP
+			.GPIO_PuPd  = GPIO_PuPd_DOWN
 		},
 		.pin_source = GPIO_PinSource14,
 	},
@@ -355,7 +355,7 @@ static const struct pios_usart_cfg pios_uart3_cfg = {
 			.GPIO_Speed = GPIO_Speed_2MHz,
 			.GPIO_Mode  = GPIO_Mode_AF,
 			.GPIO_OType = GPIO_OType_PP,
-			.GPIO_PuPd  = GPIO_PuPd_UP
+			.GPIO_PuPd  = GPIO_PuPd_DOWN
 		},
 		.pin_source = GPIO_PinSource10,
 	},
@@ -390,7 +390,7 @@ static const struct pios_usart_cfg pios_rxport_usart_cfg = {
 			.GPIO_Speed = GPIO_Speed_2MHz,
 			.GPIO_Mode  = GPIO_Mode_AF,
 			.GPIO_OType = GPIO_OType_PP,
-			.GPIO_PuPd  = GPIO_PuPd_UP
+			.GPIO_PuPd  = GPIO_PuPd_DOWN
 		},
 		.pin_source = GPIO_PinSource4,
 	},

--- a/flight/targets/sparky/board-info/board_hw_defs.c
+++ b/flight/targets/sparky/board-info/board_hw_defs.c
@@ -479,7 +479,7 @@ static const struct pios_usart_cfg pios_flexi_usart_cfg = {
 			.GPIO_Speed = GPIO_Speed_2MHz,
 			.GPIO_Mode  = GPIO_Mode_AF,
 			.GPIO_OType = GPIO_OType_PP,
-			.GPIO_PuPd  = GPIO_PuPd_UP
+			.GPIO_PuPd  = GPIO_PuPd_DOWN
 		},
 		.pin_source = GPIO_PinSource6,
 	},
@@ -514,7 +514,7 @@ static const struct pios_usart_cfg pios_main_usart_cfg = {
 			.GPIO_Speed = GPIO_Speed_2MHz,
 			.GPIO_Mode  = GPIO_Mode_AF,
 			.GPIO_OType = GPIO_OType_PP,
-			.GPIO_PuPd  = GPIO_PuPd_UP
+			.GPIO_PuPd  = GPIO_PuPd_DOWN
 		},
 		.pin_source = GPIO_PinSource10,
 	},


### PR DESCRIPTION
This appears to be necessary for single-wire usage with Frsky S.Port
telemetry.

Closes #1034
