### PR TITLE
sparky2: include HSUM

### DIFF
--- a/flight/targets/sparky2/fw/pios_config.h
+++ b/flight/targets/sparky2/fw/pios_config.h
@@ -93,7 +93,7 @@
 /* Supported receiver interfaces */
 #define PIOS_INCLUDE_RCVR
 #define PIOS_INCLUDE_DSM
-//#define PIOS_INCLUDE_HSUM
+#define PIOS_INCLUDE_HSUM
 #define PIOS_INCLUDE_SBUS
 #define PIOS_INCLUDE_PPM
 #define PIOS_INCLUDE_PWM


### PR DESCRIPTION
No idea why this was originally omitted.
