### PR TITLE
flyingpio: rearrange servo pins to match silkscreen

### DIFF
--- a/flight/targets/flyingpio/board-info/board_hw_defs.c
+++ b/flight/targets/flyingpio/board-info/board_hw_defs.c
@@ -300,35 +300,51 @@ static const struct pios_tim_channel pios_tim_rcvrport_pin = {
 
 static const struct pios_tim_channel pios_tim_servoport_pins[] = {
 	{
-		.timer = TIM1,
-		.timer_chan = TIM_Channel_1,
-		.remap = GPIO_AF_2,
+		.timer = TIM3,
+		.timer_chan = TIM_Channel_2,
+		.remap = GPIO_AF_1,
 		.pin = {
 			.gpio = GPIOA,
 			.init = {
-				.GPIO_Pin   = GPIO_Pin_8,
+				.GPIO_Pin   = GPIO_Pin_7,
 				.GPIO_Mode  = GPIO_Mode_AF,
 				.GPIO_PuPd  = GPIO_PuPd_UP,
 				.GPIO_OType = GPIO_OType_PP,
 				.GPIO_Speed = GPIO_Speed_50MHz,
 			},
-			.pin_source = GPIO_PinSource8,
+			.pin_source = GPIO_PinSource7,
+		},
+	},
+	{
+		.timer = TIM3,
+		.timer_chan = TIM_Channel_1,
+		.remap = GPIO_AF_1,
+		.pin = {
+			.gpio = GPIOA,
+			.init = {
+				.GPIO_Pin   = GPIO_Pin_6,
+				.GPIO_Mode  = GPIO_Mode_AF,
+				.GPIO_PuPd  = GPIO_PuPd_UP,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_Speed = GPIO_Speed_50MHz,
+			},
+			.pin_source = GPIO_PinSource6,
 		},
 	},
 	{
 		.timer = TIM1,
-		.timer_chan = TIM_Channel_2,
+		.timer_chan = TIM_Channel_4,
 		.remap = GPIO_AF_2,
 		.pin = {
 			.gpio = GPIOA,
 			.init = {
-				.GPIO_Pin   = GPIO_Pin_9,
+				.GPIO_Pin   = GPIO_Pin_11,
 				.GPIO_Mode  = GPIO_Mode_AF,
 				.GPIO_PuPd  = GPIO_PuPd_UP,
 				.GPIO_OType = GPIO_OType_PP,
 				.GPIO_Speed = GPIO_Speed_50MHz,
 			},
-			.pin_source = GPIO_PinSource9,
+			.pin_source = GPIO_PinSource11,
 		},
 	},
 	{
@@ -349,50 +365,34 @@ static const struct pios_tim_channel pios_tim_servoport_pins[] = {
 	},
 	{
 		.timer = TIM1,
-		.timer_chan = TIM_Channel_4,
+		.timer_chan = TIM_Channel_2,
 		.remap = GPIO_AF_2,
 		.pin = {
 			.gpio = GPIOA,
 			.init = {
-				.GPIO_Pin   = GPIO_Pin_11,
+				.GPIO_Pin   = GPIO_Pin_9,
 				.GPIO_Mode  = GPIO_Mode_AF,
 				.GPIO_PuPd  = GPIO_PuPd_UP,
 				.GPIO_OType = GPIO_OType_PP,
 				.GPIO_Speed = GPIO_Speed_50MHz,
 			},
-			.pin_source = GPIO_PinSource11,
+			.pin_source = GPIO_PinSource9,
 		},
 	},
 	{
-		.timer = TIM3,
+		.timer = TIM1,
 		.timer_chan = TIM_Channel_1,
-		.remap = GPIO_AF_1,
+		.remap = GPIO_AF_2,
 		.pin = {
 			.gpio = GPIOA,
 			.init = {
-				.GPIO_Pin   = GPIO_Pin_6,
+				.GPIO_Pin   = GPIO_Pin_8,
 				.GPIO_Mode  = GPIO_Mode_AF,
 				.GPIO_PuPd  = GPIO_PuPd_UP,
 				.GPIO_OType = GPIO_OType_PP,
 				.GPIO_Speed = GPIO_Speed_50MHz,
 			},
-			.pin_source = GPIO_PinSource6,
-		},
-	},
-	{
-		.timer = TIM3,
-		.timer_chan = TIM_Channel_2,
-		.remap = GPIO_AF_1,
-		.pin = {
-			.gpio = GPIOA,
-			.init = {
-				.GPIO_Pin   = GPIO_Pin_7,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_PuPd  = GPIO_PuPd_UP,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_Speed = GPIO_Speed_50MHz,
-			},
-			.pin_source = GPIO_PinSource7,
+			.pin_source = GPIO_PinSource8,
 		},
 	},
 };

--- a/flight/targets/flyingpio/hw/revA/readme.txt
+++ b/flight/targets/flyingpio/hw/revA/readme.txt
@@ -14,3 +14,6 @@ two.  Use caution and refer to datasheet when assembling.  The board art
 has cathode lines, but the middle LED has an anode line on the package.
 * Schematic: text refers to receiverport pin as PB0 when it's in fact PB1.
 It's electrically fine, though.
+* Schematic and board layout have PWM pins in opposite order.  Electrically
+correct, but PWM0 is labelled on board art (and in firmware) as Servo6,
+PWM1 as Servo5, ...

--- a/ground/gcs/src/plugins/boards_dronin/simulation.cpp
+++ b/ground/gcs/src/plugins/boards_dronin/simulation.cpp
@@ -40,6 +40,13 @@
 Simulation::Simulation(void)
 {
     boardType = 0x7F;
+
+    /* For now assuming flyingpio bank configuration.  This may not hold
+     * true in the long term...
+     */
+    channelBanks.resize(2);
+    channelBanks[0] = QVector<int> () << 1 << 2;      // TIM3
+    channelBanks[1] = QVector<int> () << 3 << 4 << 5 << 6; // TIM1
 }
 
 Simulation::~Simulation()


### PR DESCRIPTION
There was a discrepancy between silkscreen and board art that is
errata'd here and the firmware now matches the silkscreen.
