### PR TITLE
simulation/pios-posix: yield cpu when "idle"

### DIFF
--- a/flight/PiOS/Common/Libraries/ChibiOS/os/ports/GCC/SIMIA32/chcore.c
+++ b/flight/PiOS/Common/Libraries/ChibiOS/os/ports/GCC/SIMIA32/chcore.c
@@ -163,6 +163,7 @@ void port_enable(void) {
  *          modes.
  */
 void port_wait_for_interrupt(void) {
+	select(0, NULL, NULL, NULL, NULL);
 }
 
 /**


### PR DESCRIPTION
This results in a yellow CPU alarm, because uh, we don't use CPU when
we're idle.  Will need a more sophisticated mechanism for that
ultimately.  But it's much friendlier in CPU use.

(Ultimately will want to track idle based on the time spent sleeping here.)

Tested on mac and on hard-realtime environment.  This really helps not-crowding-out-other-stuff for hard RT (else you need to push a bunch of kernel irq tasks to higher priority for things to work and not get wonky).
