### PR TITLE
sparky2: don't shadow the SPI telem flash id global

### DIFF
--- a/flight/targets/revolution/fw/pios_board.c
+++ b/flight/targets/revolution/fw/pios_board.c
@@ -153,7 +153,7 @@ void PIOS_Board_Init(void) {
 	PIOS_LED_Init(led_cfg);
 #endif	/* PIOS_INCLUDE_LED */
 
-	uint32_t pios_spi_gyro_id, pios_spi_telem_flash_id;
+	uint32_t pios_spi_gyro_id;
 	/* Set up the SPI interface to the gyro/acelerometer */
 	if (PIOS_SPI_Init(&pios_spi_gyro_id, &pios_spi_gyro_cfg)) {
 		PIOS_DEBUG_Assert(0);

--- a/flight/targets/sparky2/fw/pios_board.c
+++ b/flight/targets/sparky2/fw/pios_board.c
@@ -377,7 +377,7 @@ void PIOS_Board_Init(void) {
 	PIOS_LED_Init(led_cfg);
 #endif	/* PIOS_INCLUDE_LED */
 	
-	uint32_t pios_spi_gyro_id, pios_spi_telem_flash_id;
+	uint32_t pios_spi_gyro_id;
 
 	/* Set up the SPI interface to the gyro/acelerometer */
 	if (PIOS_SPI_Init(&pios_spi_gyro_id, &pios_spi_gyro_cfg)) {


### PR DESCRIPTION
Because it's also used for RFM22.

Maybe fixes #1229 

Found by inspection; needs test.
