### PR TITLE
Packaging:Windows: Handle symbol collection in MinGW builds

### DIFF
--- a/package/Makefile.winx86
+++ b/package/Makefile.winx86
@@ -52,7 +52,9 @@ package_symbols_compress: package_ground_symbols package_flight_symbols
 	# blow away old symbols
 	$(V1)rm -rf $(BUILD_DIR)/dronin-$(PACKAGE_LBL)-symbols.zip $(BUILD_DIR)/dronin-$(PACKAGE_LBL)-breakpad.zip
 	$(V1)cd $(PACKAGE_DIR)-symbols && $(ZIPBIN) -9 -r $(BUILD_DIR)/dronin-$(PACKAGE_LBL)-symbols.zip *
+ifeq ($(USE_MSVC), YES)
 	$(V1)cd $(PACKAGE_DIR)-symbols/breakpad && $(ZIPBIN) -9 -r $(BUILD_DIR)/dronin-$(PACKAGE_LBL)-breakpad.zip *
+endif
 
 .PHONY: standalone
 .PHONY: package_ground_compress package_symbols_compress

--- a/package/package_symbols.py
+++ b/package/package_symbols.py
@@ -237,6 +237,10 @@ def main():
 	elif platform.system() == "Darwin":
 		dumper = MacOSSymbolDump(args.binpath)
 	elif platform.system() == "Windows":
+		# sadly have to deal with MinGW builds for now, ick
+		if 'USE_MSVC' in os.environ and os.environ['USE_MSVC'] == 'NO':
+			info('MinGW build, not collecting symbols (Note: MinGW support is deprecated)')
+			return 0
 		dumper = WindowsSymbolDump(args.binpath)
 	else:
 		raise NotImplementedError("Unsupported OS")


### PR DESCRIPTION
Probably fixes #1224. I don't have a MinGW environment to test, and we use MSVC for all our automated builds so MinGW sees little test now. Perhaps we should just drop support for MinGW instead? I hate adding special-cases to this stuff too, bound to break at some point. :/
