### PR TITLE
transmitter_control: update edge detector

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -653,7 +653,9 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 		set_armed_if_changed(FLIGHTSTATUS_ARMED_DISARMED);
 
 		// last_arm used for detecting a rising edge to trigger switch arming
-		static bool last_arm = false;
+		// It's set to true here, so that we need to hear a valid,
+		// 'disarmed' signal before looking for arming.
+		static bool last_arm = true;
 		bool arm = arming_position(cmd, settings) && valid;
 
 		if (arm && (settings->Arming == MANUALCONTROLSETTINGS_ARMING_SWITCH ||

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -673,7 +673,10 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 			arm_state = ARM_STATE_ARMING;
 		}
 
-		last_arm = arm;
+		if (valid) {
+			// Only update arming edge detector on valid rx
+			last_arm = arm;
+		}
 	}
 		break;
 


### PR DESCRIPTION
If we are disarmed (e.g. from RX timeout or low-throttle timeout) but
an arming switch in armed position, we attempt to spot a positive switch
edge.

However, a failsafe is considered as the arming switch in the disarmed
position.

It's important that we not "remember" that failsafe state for the edge
detector.

Fixes #1236
