### PR TITLE
logging: support a couple more data rates

### DIFF
--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -511,8 +511,14 @@ static uint16_t get_minimum_logging_period()
 		case LOGGINGSETTINGS_MAXLOGRATE_100:
 			min_period = 10;
 			break;
+		case LOGGINGSETTINGS_MAXLOGRATE_166:
+			min_period = 6;
+			break;
 		case LOGGINGSETTINGS_MAXLOGRATE_250:
 			min_period = 4;
+			break;
+		case LOGGINGSETTINGS_MAXLOGRATE_333:
+			min_period = 3;
 			break;
 		case LOGGINGSETTINGS_MAXLOGRATE_500:
 			min_period = 2;

--- a/shared/uavobjectdefinition/loggingsettings.xml
+++ b/shared/uavobjectdefinition/loggingsettings.xml
@@ -3,7 +3,7 @@
 		<description>Settings for the logging module</description>
 		<field name="LogBehavior" units="" type="enum" options="LogOnStart,LogOnArm,LogOff" elements="1" defaultvalue="LogOnArm"/>
 		<field name="InitiallyLog" units="" type="enum" options="AllObjects,SettingsObjects,None" elements="1" defaultvalue="AllObjects"/>
-		<field name="MaxLogRate" units="Hz" type="enum" options="5,10,25,50,100,250,500,1000" elements="1" defaultvalue="25"/>
+		<field name="MaxLogRate" units="Hz" type="enum" options="5,10,25,50,100,166,250,333,500,1000" elements="1" defaultvalue="25"/>
 		<field name="Profile" units="" type="enum" options="Default,Custom,Fullbore" elements="1" defaultvalue="Default"/>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
Before, it was rather blunt between 100Hz and 250Hz (2.5x difference),
and between 250Hz and 500Hz (2x difference).  Introduce 333Hz and 166Hz
to help out.
