### PR TITLE
autotune: buffer some more points.

### DIFF
--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -85,7 +85,13 @@ static void af_predict(float X[AF_NUMX], float P[AF_NUMP], const float u_in[3], 
 static void af_init(float X[AF_NUMX], float P[AF_NUMP]);
 
 #ifndef AT_QUEUE_NUMELEM
+
+#ifdef SMALLF1
 #define AT_QUEUE_NUMELEM 18
+#else
+#define AT_QUEUE_NUMELEM 30
+#endif
+
 #endif
 
 /**


### PR DESCRIPTION
On BrainRE1 (1600Hz) with heavy logging, points spilled for @ufodZiner.
Make the queue just a little deeper on non-F1 targets where we have the
memory to fight this.
