### PR TITLE
hack: "trend" display for centermark in OSD

### DIFF
--- a/flight/Modules/OnScreenDisplay/onscreendisplay.c
+++ b/flight/Modules/OnScreenDisplay/onscreendisplay.c
@@ -1072,7 +1072,7 @@ static void plot_trend_centermark(int max_pitch)
 #define INNER_GAP 2
 #define INNER_MARK_LEN 2
 #define OUTER_GAP 4
-#define OUTER_MARK_LEN 3
+#define OUTER_MARK_LEN 6
 
 #define TREND_FORECAST_LEN 0.3f
 

--- a/shared/uavobjectdefinition/onscreendisplaypagesettings.xml
+++ b/shared/uavobjectdefinition/onscreendisplaypagesettings.xml
@@ -52,7 +52,7 @@
 		<field name="BatteryChargeStatePosX" units="" type="int16" elements="1" defaultvalue="325"/>
 		<field name="BatteryChargeStatePosY" units="" type="int16" elements="1" defaultvalue="38"/>
 
-		<field name="CenterMark" units="" type="enum" elements="1" options="Disabled,Middle,CameraPitch" defaultvalue="Middle"/>
+		<field name="CenterMark" units="" type="enum" elements="1" options="Disabled,Middle,CameraPitch,Trend" defaultvalue="Middle"/>
 
 		<field name="ClimbRate" units="" type="enum" elements="1" options="Disabled,Enabled" defaultvalue="Enabled"/>
 		<field name="ClimbRatePosX" units="" type="int16" elements="1" defaultvalue="350"/>

--- a/shared/uavobjectdefinition/onscreendisplaypagesettings2.xml
+++ b/shared/uavobjectdefinition/onscreendisplaypagesettings2.xml
@@ -52,7 +52,7 @@
 		<field name="BatteryChargeStatePosX" units="" type="int16" elements="1" defaultvalue="325"/>
 		<field name="BatteryChargeStatePosY" units="" type="int16" elements="1" defaultvalue="38"/>
 
-		<field name="CenterMark" units="" type="enum" elements="1" options="Disabled,Middle,CameraPitch" defaultvalue="Middle"/>
+		<field name="CenterMark" units="" type="enum" elements="1" options="Disabled,Middle,CameraPitch,Trend" defaultvalue="Middle"/>
 
 		<field name="ClimbRate" units="" type="enum" elements="1" options="Disabled,Enabled" defaultvalue="Enabled"/>
 		<field name="ClimbRatePosX" units="" type="int16" elements="1" defaultvalue="350"/>

--- a/shared/uavobjectdefinition/onscreendisplaypagesettings3.xml
+++ b/shared/uavobjectdefinition/onscreendisplaypagesettings3.xml
@@ -52,7 +52,7 @@
 		<field name="BatteryChargeStatePosX" units="" type="int16" elements="1" defaultvalue="325"/>
 		<field name="BatteryChargeStatePosY" units="" type="int16" elements="1" defaultvalue="38"/>
 
-		<field name="CenterMark" units="" type="enum" elements="1" options="Disabled,Middle,CameraPitch" defaultvalue="Middle"/>
+		<field name="CenterMark" units="" type="enum" elements="1" options="Disabled,Middle,CameraPitch,Trend" defaultvalue="Middle"/>
 
 		<field name="ClimbRate" units="" type="enum" elements="1" options="Disabled,Enabled" defaultvalue="Enabled"/>
 		<field name="ClimbRatePosX" units="" type="int16" elements="1" defaultvalue="350"/>

--- a/shared/uavobjectdefinition/onscreendisplaypagesettings4.xml
+++ b/shared/uavobjectdefinition/onscreendisplaypagesettings4.xml
@@ -52,7 +52,7 @@
 		<field name="BatteryChargeStatePosX" units="" type="int16" elements="1" defaultvalue="325"/>
 		<field name="BatteryChargeStatePosY" units="" type="int16" elements="1" defaultvalue="38"/>
 
-		<field name="CenterMark" units="" type="enum" elements="1" options="Disabled,Middle,CameraPitch" defaultvalue="Middle"/>
+		<field name="CenterMark" units="" type="enum" elements="1" options="Disabled,Middle,CameraPitch,Trend" defaultvalue="Middle"/>
 
 		<field name="ClimbRate" units="" type="enum" elements="1" options="Disabled,Enabled" defaultvalue="Enabled"/>
 		<field name="ClimbRatePosX" units="" type="int16" elements="1" defaultvalue="350"/>


### PR DESCRIPTION
```
// XXX right now looks at command and does not consider at all
// "what's happening" -- should weight both [with filtering]
// XXX for now assumes reprojection-- should inverse-reproject if no reproj
// XXX assumes angles are small and doesn't integrate the 3D rotation
// properly
```

Set centermark to "trend"

Set ArtificialHorizonMaxPitch to half the VFOV or 30% of the diagonal FOV of the camera.
