### PR TITLE
autotune: properly save vehicle size

### DIFF
--- a/ground/gcs/src/plugins/config/configautotunewidget.cpp
+++ b/ground/gcs/src/plugins/config/configautotunewidget.cpp
@@ -347,7 +347,7 @@ void ConfigAutotuneWidget::persistShareForm(AutotuneFinalPage *autotuneShareForm
     settings->setESCs(autotuneShareForm->acEscs->text());
     settings->setProps(autotuneShareForm->acProps->text());
     settings->setWeight(autotuneShareForm->acWeight->text().toInt());
-    settings->setVehicleSize(autotuneShareForm->acWeight->text().toInt());
+    settings->setVehicleSize(autotuneShareForm->acVehicleSize->text().toInt());
     settings->setVehicleType(autotuneShareForm->acType->currentText());
     settings->setBatteryCells(autotuneShareForm->acBatteryCells->currentText().toInt());
 }


### PR DESCRIPTION
Fixes #1184 
Also responsible for when we get vehicle size in weight.

Unfortunately, this is on the save not the restore size, so even after the fix is applied people with old saved settings will trip over this for some time.
