### PR TITLE
revolution/pios_flash: handle variable capacity flash

### DIFF
--- a/flight/PiOS/Common/pios_flash.c
+++ b/flight/PiOS/Common/pios_flash.c
@@ -42,6 +42,63 @@ static uint8_t num_partitions;
 #define PIOS_Assert(x) do { } while (!(x))
 #define MIN(x,y) ((x) < (y) ? (x) : (y))
 
+/** Adjust partition tables to extend to the end of a variable-sized flash.
+ * Used on platforms with variable-length flash.  Requires that the partition
+ * table be mutable (not const/in flash).
+ * @param partition_table the partition table
+ * @param partition_table_len the number of entries in the partition table
+ * @param descriptor the descriptor of the variable-length flash
+ * @param num_bytes the actual length of the flash
+ */
+void PIOS_FLASH_fixup_partitions_for_capacity(
+		struct pios_flash_partition *partition_table,
+		uint8_t partition_table_len,
+		const struct pios_flash_chip *descriptor,
+		struct pios_flash_sector_range *sectors,
+		uint32_t num_bytes)
+{
+	PIOS_Assert(descriptor->sector_blocks == sectors);
+
+	uint32_t basic_capacity = 0;
+
+	for (int i=0; i < descriptor->num_blocks; i++) {
+		basic_capacity +=
+			(sectors[i].last_sector - sectors[i].base_sector + 1) *
+			sectors[i].sector_size;
+	}
+
+	PIOS_Assert(num_bytes >= basic_capacity);
+
+	if (num_bytes == basic_capacity) {
+		return;		// nothing to see here.
+	}
+
+	/* Select the last group of sectors */
+	sectors += descriptor->num_blocks - 1;
+
+	uint32_t old_last_sector = sectors->last_sector;
+
+	uint32_t additional_bytes = num_bytes - basic_capacity;
+	uint32_t additional_sectors = additional_bytes / sectors->sector_size;
+
+	PIOS_Assert(additional_bytes ==
+			(additional_sectors * sectors->sector_size));
+
+	sectors->last_sector += additional_sectors;
+
+	// iterate partitions.. where descriptor and old last sector
+	// matches, increase the size.
+	for (int i = 0; i < partition_table_len; i++) {
+		if (partition_table[i].last_sector == old_last_sector) {
+			if (partition_table[i].chip_desc == descriptor) {
+				partition_table[i].last_sector =
+					sectors->last_sector;
+				partition_table[i].size += additional_bytes;
+			}
+		}
+	}
+}
+
 /**
  * @brief Registers a new partition table with the block device layer
  * @param[in] partition_table array of partitions to be registered

--- a/flight/PiOS/Common/pios_flash.c
+++ b/flight/PiOS/Common/pios_flash.c
@@ -61,7 +61,7 @@ void PIOS_FLASH_fixup_partitions_for_capacity(
 
 	uint32_t basic_capacity = 0;
 
-	for (int i=0; i < descriptor->num_blocks; i++) {
+	for (int i = 0; i < descriptor->num_blocks; i++) {
 		basic_capacity +=
 			(sectors[i].last_sector - sectors[i].base_sector + 1) *
 			sectors[i].sector_size;

--- a/flight/PiOS/Common/pios_flash_jedec.c
+++ b/flight/PiOS/Common/pios_flash_jedec.c
@@ -66,6 +66,7 @@ enum pios_jedec_dev_magic {
 struct jedec_flash_dev {
 	uint32_t spi_id;
 	uint32_t slave_num;
+	uint32_t capacity_bytes;
 
 	uint8_t manufacturer;
 	uint8_t memorytype;
@@ -113,6 +114,16 @@ static int32_t PIOS_Flash_Jedec_Validate(struct jedec_flash_dev *flash_dev) {
 	if (flash_dev->spi_id == 0)
 		return -3;
 	return 0;
+}
+
+uint32_t PIOS_Flash_Jedec_GetCapacity(uintptr_t chip_id)
+{
+	struct jedec_flash_dev *flash_dev = (struct jedec_flash_dev *)chip_id;
+
+	if (PIOS_Flash_Jedec_Validate(flash_dev) != 0)
+		return 0;
+
+	return flash_dev->capacity_bytes;
 }
 
 /**
@@ -263,6 +274,8 @@ static int32_t PIOS_Flash_Jedec_ReadID(struct jedec_flash_dev *flash_dev)
 	flash_dev->manufacturer = in[1];
 	flash_dev->memorytype   = in[2];
 	flash_dev->capacity     = in[3];
+
+	flash_dev->capacity_bytes = 1 << flash_dev->capacity;
 
 	return flash_dev->manufacturer;
 }

--- a/flight/PiOS/inc/pios_flash_jedec_priv.h
+++ b/flight/PiOS/inc/pios_flash_jedec_priv.h
@@ -53,5 +53,6 @@ struct pios_flash_jedec_cfg {
 
 int32_t PIOS_Flash_Jedec_Init(uintptr_t *flash_id, uint32_t spi_id, uint32_t slave_num, const struct pios_flash_jedec_cfg *cfg);
 int32_t PIOS_Flash_Jedec_ReadOTPData(uintptr_t chip_id, uint32_t chip_offset, uint8_t *data, uint16_t len);
+uint32_t PIOS_Flash_Jedec_GetCapacity(uintptr_t chip_id);
 
 #endif	/* PIOS_FLASH_JEDEC_H_ */

--- a/flight/PiOS/inc/pios_flash_priv.h
+++ b/flight/PiOS/inc/pios_flash_priv.h
@@ -99,4 +99,11 @@ struct pios_flash_partition {
 
 extern void PIOS_FLASH_register_partition_table(const struct pios_flash_partition partition_table[], uint8_t num_partitions);
 
+void PIOS_FLASH_fixup_partitions_for_capacity(
+		struct pios_flash_partition *partition_table,
+		uint8_t partition_table_len,
+		const struct pios_flash_chip *descriptor,
+		struct pios_flash_sector_range *sectors,
+		uint32_t num_bytes);
+
 #endif	/* PIOS_FLASH_PRIV_H_ */

--- a/flight/targets/revolution/bl/pios_board.c
+++ b/flight/targets/revolution/bl/pios_board.c
@@ -46,9 +46,9 @@ void PIOS_Board_Init()
 {
 	/* Delay system */
 	PIOS_DELAY_Init();
-	
+
 	const struct pios_board_info * bdinfo = &pios_board_info_blob;
-	
+
 #if defined(PIOS_INCLUDE_LED)
 	const struct pios_led_cfg * led_cfg = PIOS_BOARD_HW_DEFS_GetLedCfg(bdinfo->board_rev);
 	PIOS_Assert(led_cfg);
@@ -73,8 +73,13 @@ void PIOS_Board_Init()
 
 	PIOS_Flash_Internal_Init(&pios_internal_flash_id, &flash_internal_cfg);
 
+	const struct pios_flash_partition * flash_partition_table;
+	uint32_t num_partitions;
+
+	flash_partition_table = PIOS_BOARD_HW_DEFS_GetPartitionTable(bdinfo->board_rev, &num_partitions);
+
 	/* Register the partition table */
-	PIOS_FLASH_register_partition_table(pios_flash_partition_table, NELEMENTS(pios_flash_partition_table));
+	PIOS_FLASH_register_partition_table(flash_partition_table, num_partitions);
 #endif	/* PIOS_INCLUDE_FLASH */
 
 #if defined(PIOS_INCLUDE_USB)

--- a/flight/targets/revolution/board-info/board-info.mk
+++ b/flight/targets/revolution/board-info/board-info.mk
@@ -3,7 +3,8 @@ BOARD_REVISION      := 0x03
 # Previous version was 0x081, 0x082 introduces partition extensions
 # and forced boot from bkp registers; 0x83 changed bootdelay to 2ms for dsm bind
 # 0x84 increases firmware to 384k
-BOOTLOADER_VERSION  := 0x85
+# 0x86 allows custom 128mbit flash
+BOOTLOADER_VERSION  := 0x86
 HW_TYPE             := 0x00
 
 CHIP                := STM32F405RGT

--- a/flight/targets/revolution/board-info/board_hw_defs.c
+++ b/flight/targets/revolution/board-info/board_hw_defs.c
@@ -455,7 +455,7 @@ static const struct pios_flash_chip pios_flash_chip_internal = {
 #endif	/* PIOS_INCLUDE_FLASH_INTERNAL */
 
 #if defined(PIOS_INCLUDE_FLASH_JEDEC)
-static const struct pios_flash_sector_range m25p16_sectors[] = {
+static struct pios_flash_sector_range m25p16_sectors[] = {
 	{
 		.base_sector = 0,
 		.last_sector = 31,
@@ -473,7 +473,7 @@ static const struct pios_flash_chip pios_flash_chip_external = {
 };
 #endif /* PIOS_INCLUDE_FLASH_JEDEC */
 
-static const struct pios_flash_partition pios_flash_partition_table[] = {
+static struct pios_flash_partition pios_flash_partition_table[] = {
 #if defined(PIOS_INCLUDE_FLASH_INTERNAL)
 	{
 		.label        = FLASH_PARTITION_LABEL_BL,
@@ -534,6 +534,17 @@ const struct pios_flash_partition * PIOS_BOARD_HW_DEFS_GetPartitionTable (uint32
 	PIOS_Assert(num_partitions);
 
 	*num_partitions = NELEMENTS(pios_flash_partition_table);
+
+#ifdef PIOS_INCLUDE_FLASH_JEDEC
+	uint32_t capacity = PIOS_Flash_Jedec_GetCapacity(pios_external_flash_id);
+
+	PIOS_FLASH_fixup_partitions_for_capacity(pios_flash_partition_table,
+			NELEMENTS(pios_flash_partition_table),
+			&pios_flash_chip_external,
+			m25p16_sectors,
+			capacity);
+#endif
+
 	return pios_flash_partition_table;
 }
 

--- a/flight/targets/revolution/fw/pios_board.c
+++ b/flight/targets/revolution/fw/pios_board.c
@@ -179,6 +179,7 @@ void PIOS_Board_Init(void) {
 	/* Register the partition table */
 	const struct pios_flash_partition * flash_partition_table;
 	uint32_t num_partitions;
+
 	flash_partition_table = PIOS_BOARD_HW_DEFS_GetPartitionTable(bdinfo->board_rev, &num_partitions);
 	PIOS_FLASH_register_partition_table(flash_partition_table, num_partitions);
 


### PR DESCRIPTION
Be willing to extend last partition.  Useful for clone revos with 128mbit flash chips for bigger logs.
