### PR TITLE
uavos: change f4 default mpu rates to 1KHz

### DIFF
--- a/shared/uavobjectdefinition/hwaq32.xml
+++ b/shared/uavobjectdefinition/hwaq32.xml
@@ -126,7 +126,7 @@
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="1000"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>
-		<field name="MPU6000Rate" units="" type="enum" elements="1" options="200,250,333,500,1000" defaultvalue="500"/>
+		<field name="MPU6000Rate" units="" type="enum" elements="1" options="200,250,333,500,1000" defaultvalue="1000"/>
 		<field name="MPU6000DLPF" units="" type="enum" elements="1" options="188,98,42,20,10,5" defaultvalue="188"/>
 	
 		<field name="Magnetometer" units="function" type="enum" elements="1" options="Disabled,Internal,External" defaultvalue="Internal"/>

--- a/shared/uavobjectdefinition/hwbrain.xml
+++ b/shared/uavobjectdefinition/hwbrain.xml
@@ -104,7 +104,7 @@
 	<field name="DSMxMode" units="mode"  type="enum"  elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 	<field name="GyroFullScale" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="2000"/>
 	<field name="AccelFullScale" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>
-	<field name="MPU9250Rate" units="Hz" type="enum" elements="1" options="200,250,333,500,1000" defaultvalue="500"/>
+	<field name="MPU9250Rate" units="Hz" type="enum" elements="1" options="200,250,333,500,1000" defaultvalue="1000"/>
 	<field name="MPU9250GyroLPF" units="Hz" type="enum" elements="1" options="184,92,41,20,10,5" defaultvalue="184"/>
 	<field name="MPU9250AccelLPF" units="Hz" type="enum" elements="1" options="460,184,92,41,20,10,5" defaultvalue="184"/>
 

--- a/shared/uavobjectdefinition/hwquanton.xml
+++ b/shared/uavobjectdefinition/hwquanton.xml
@@ -187,7 +187,7 @@
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="1000"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>
-		<field name="MPU6000Rate" units="" type="enum" elements="1" options="200,250,333,500,1000" defaultvalue="500"/>
+		<field name="MPU6000Rate" units="" type="enum" elements="1" options="200,250,333,500,1000" defaultvalue="1000"/>
 		<field name="MPU6000DLPF" units="" type="enum" elements="1" options="188,98,42,20,10,5" defaultvalue="188"/>
 		
 		<field name="Magnetometer" units="function" type="enum" elements="1" options="Disabled,Internal,ExternalI2CUart1,ExternalI2CUart3" defaultvalue="Internal"/>

--- a/shared/uavobjectdefinition/hwrevolution.xml
+++ b/shared/uavobjectdefinition/hwrevolution.xml
@@ -115,7 +115,7 @@
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="1000"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>
-		<field name="MPU6000Rate" units="" type="enum" elements="1" options="200,250,333,500,1000" defaultvalue="500"/>
+		<field name="MPU6000Rate" units="" type="enum" elements="1" options="200,250,333,500,1000" defaultvalue="1000"/>
 		<field name="MPU6000DLPF" units="" type="enum" elements="1" options="188,98,42,20,10,5" defaultvalue="188"/>
 
 		<field name="Magnetometer" units="function" type="enum" elements="1" options="Disabled,Internal,ExternalI2CFlexiPort" defaultvalue="Internal"/>

--- a/shared/uavobjectdefinition/hwsparky2.xml
+++ b/shared/uavobjectdefinition/hwsparky2.xml
@@ -88,7 +88,7 @@
 
 		<field name="GyroRange" units="deg/s" type="enum" elements="1" options="250,500,1000,2000" defaultvalue="2000"/>
 		<field name="AccelRange" units="*gravity m/s^2" type="enum" elements="1" options="2G,4G,8G,16G" defaultvalue="8G"/>
-		<field name="MPU9250Rate" units="Hz" type="enum" elements="1" options="200,250,333,500,1000" defaultvalue="500"/>
+		<field name="MPU9250Rate" units="Hz" type="enum" elements="1" options="200,250,333,500,1000" defaultvalue="1000"/>
 		<field name="MPU9250GyroLPF" units="Hz" type="enum" elements="1" options="184,92,41,20,10,5" defaultvalue="184"/>
 		<field name="MPU9250AccelLPF" units="Hz" type="enum" elements="1" options="460,184,92,41,20,10,5" defaultvalue="184"/>
 


### PR DESCRIPTION
We tell everyone to do this anyways.  Seems pretty slam-dunk.  The one
that's most marginal is hwbrain, but there's lot of people running that
at 1KHz too.
