### PR TITLE
attitude: bound dT

### DIFF
--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -585,6 +585,12 @@ static int32_t updateAttitudeComplementary(bool first_run, bool secondary, bool 
 	dT = PIOS_DELAY_DiffuS(timeval) / 1000000.0f;
 	timeval = PIOS_DELAY_GetRaw();
 
+	// This should only happen at start up or at mode switches
+	if(dT > 0.01f)
+		dT = 0.01f;
+	else if(dT <= 0.0005f)
+		dT = 0.0005f;
+
 	float grot[3];
 	float accel_err[3];
 	float *grot_filtered = complementary_filter_state.grot_filtered;
@@ -1174,8 +1180,8 @@ static int32_t updateAttitudeINSGPS(bool first_run, bool outdoor_mode)
 	// This should only happen at start up or at mode switches
 	if(dT > 0.01f)
 		dT = 0.01f;
-	else if(dT <= 0.001f)
-		dT = 0.001f;
+	else if(dT <= 0.0005f)
+		dT = 0.0005f;
 
 	// When the sensor settings are updated, reset the biases. Also
 	// while warming up, lock these at zero.


### PR DESCRIPTION
It was bounded in the INS, but we can now get smaller values (RE1).
And it wasn't bounded at all.

This is a candidate for what could cause NaN run away for cfvert, found
by light manual audit.

Connects to #1230
