### PR TITLE
pios_tcp: bind listening socket using PF_INET6

### DIFF
--- a/flight/PiOS/pios.h
+++ b/flight/PiOS/pios.h
@@ -32,6 +32,10 @@
 #ifndef PIOS_H
 #define PIOS_H
 
+#ifdef SIM_POSIX
+#include <pios_posix.h>
+#endif
+
 /* PIOS Feature Selection */
 #include "pios_config.h"
 
@@ -102,10 +106,7 @@
 #endif
 #include <pios_wdg.h>
 
-#ifdef SIM_POSIX
-#include <pios_posix.h>
-
-#else
+#ifndef SIM_POSIX
 #include <pios_gpio.h>
 #include <pios_exti.h>
 #include <pios_usart.h>

--- a/flight/PiOS/posix/inc/pios_posix.h
+++ b/flight/PiOS/posix/inc/pios_posix.h
@@ -37,6 +37,8 @@
 #define PIOS_SERVO_NUM_TIMERS PIOS_SERVO_NUM_OUTPUTS
 
 #if (defined(_WIN32) || defined(WIN32) || defined(__MINGW32__))
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #include <dronin-strsep.h>
 #endif
 

--- a/flight/PiOS/posix/inc/pios_tcp_priv.h
+++ b/flight/PiOS/posix/inc/pios_tcp_priv.h
@@ -40,6 +40,8 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#else
+#include <ws2tcpip.h>
 #endif
 
 #include <stdlib.h>

--- a/flight/PiOS/posix/pios_tcp.c
+++ b/flight/PiOS/posix/pios_tcp.c
@@ -55,8 +55,8 @@ typedef struct {
 	const struct pios_tcp_cfg * cfg;
 
 	int socket;
-	struct sockaddr_in server;
-	struct sockaddr_in client;
+	struct sockaddr_in6 server;
+	struct sockaddr_in6 client;
 	int socket_connection;
 
 	pios_com_callback tx_out_cb;
@@ -195,7 +195,7 @@ int32_t PIOS_TCP_Init(uintptr_t *tcp_id, const struct pios_tcp_cfg * cfg)
 	tcp_dev->cfg=cfg;
 	
 	/* assign socket */
-	tcp_dev->socket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+	tcp_dev->socket = socket(PF_INET6, SOCK_STREAM, IPPROTO_TCP);
 	tcp_dev->socket_connection = INVALID_SOCKET;
 
 #if defined(_WIN32) || defined(WIN32) || defined(__MINGW32__)
@@ -213,9 +213,9 @@ int32_t PIOS_TCP_Init(uintptr_t *tcp_id, const struct pios_tcp_cfg * cfg)
 	memset(&tcp_dev->server, 0, sizeof(tcp_dev->server));
 	memset(&tcp_dev->client, 0, sizeof(tcp_dev->client));
 
-	tcp_dev->server.sin_family = AF_INET;
-	tcp_dev->server.sin_addr.s_addr = INADDR_ANY; //inet_addr(tcp_dev->cfg->ip);
-	tcp_dev->server.sin_port = htons(tcp_dev->cfg->port);
+	tcp_dev->server.sin6_family = AF_INET6;
+	tcp_dev->server.sin6_addr = in6addr_any;
+	tcp_dev->server.sin6_port = htons(tcp_dev->cfg->port);
 
 	/* set socket options */
 	int value = 1;


### PR DESCRIPTION
This way we can receive either ipv6 or ipv4 connections.  Makes things
easier on my home network where both ipv6 and ipv4 addresses end up in
DNS.  (GCS already does the right thing.)
