### PR TITLE
GCS:Serial: Display USB description where available

### DIFF
--- a/ground/gcs/src/plugins/serialconnection/serialplugin.cpp
+++ b/ground/gcs/src/plugins/serialconnection/serialplugin.cpp
@@ -146,7 +146,11 @@ QList <IDevice *> SerialConnection::availableDevices()
             }
             if(!port_exists) {
                 SerialDevice* d = new SerialDevice();
-                d->setDisplayName(port.portName());
+                QStringList disp;
+                if (port.description().length())
+                    disp.append(port.description());
+                disp.append(port.portName());
+                d->setDisplayName(disp.join(" - "));
                 d->setName(port.portName());
                 m_available_device_list.append(d);
             }


### PR DESCRIPTION
Much easier to identify than /dev/tty.usbmodem1411 etc.

https://imgur.com/Nzadlou

Verified that it does the right thing with and without description.
