### PR TITLE
PiOS:F4:USB: Only init vsense pin when it's defined

### DIFF
--- a/flight/PiOS/STM32F4xx/pios_usb.c
+++ b/flight/PiOS/STM32F4xx/pios_usb.c
@@ -195,7 +195,8 @@ void USB_OTG_BSP_Init(USB_OTG_CORE_HANDLE *pdev)
 	GPIO_PinAFConfig(GPIOA, GPIO_PinSource12, GPIO_AF_OTG1_FS);
 
 	/* Configure VBUS sense pin */
-	GPIO_Init(usb_dev->cfg->vsense.gpio, (GPIO_InitTypeDef*)&usb_dev->cfg->vsense.init);
+	if (usb_dev->cfg->vsense)
+		GPIO_Init(usb_dev->cfg->vsense.gpio, (GPIO_InitTypeDef*)&usb_dev->cfg->vsense.init);
 
 	/* Enable USB OTG Clock */
 	RCC_AHB2PeriphClockCmd(RCC_AHB2Periph_OTG_FS, ENABLE);


### PR DESCRIPTION
Found floating around on my PC.. Think I needed this to get something going that didn't have vsense at one point.
