### PR TITLE
GCS: Link right OpenGL lib on windows

### DIFF
--- a/ground/gcs/src/libs/glc_lib/glc_lib.pro
+++ b/ground/gcs/src/libs/glc_lib/glc_lib.pro
@@ -490,6 +490,8 @@ OTHER_FILES += \
     qtc_packaging/debian_harmattan/compat \
     qtc_packaging/debian_harmattan/changelog
 
-win32 {
-    LIBS += -lopengl32
+win32-msvc* {
+	LIBS += opengl32.lib
+} else:win32 {
+	LIBS += -lopengl32
 }

--- a/ground/gcs/src/plugins/modelview/modelview.pro
+++ b/ground/gcs/src/plugins/modelview/modelview.pro
@@ -25,6 +25,8 @@ FORMS += modelviewoptionspage.ui
 RESOURCES += \
     modelview.qrc
 
-win32 {
+win32-msvc* {
+    LIBS += opengl32.lib
+} else:win32 {
     LIBS += -lopengl32
 }


### PR DESCRIPTION
Doesn't make things worse for me (can run with ANGLE under RDP or with NVIDIA drivers and a real screen still). This is the correct lib for MSVC (as opposed to MinGW) according to http://doc.qt.io/qt-5/windows-requirements.html
