### PR TITLE
Add link for OpenPilot Revolution at RTFQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [dronin.org](http://dronin.org) for more details.
 - [BrainFPV](http://brainfpv.com/)
 - [Lumenier Lux](http://www.getfpv.com/lumenier-lux-flight-controller.html)
 - [DTFUHF DTFc](http://www.dtfuhf.com/)
-- OpenPilot Revolution
+- [OpenPilot Revolution](http://www.readytoflyquads.com/openpilot-cc3d-revolution-acro)
 - Quantec Quanton
 - Tau Labs Sparky
 - [Tau Labs Sparky2](https://github.com/TauLabs/TauLabs/wiki/Sparky2)


### PR DESCRIPTION
RTFQ (ready to fly quads [dot] com) is a pretty reliable place to get the cheapest revo FC around. It seems right to me that it should be where the link goes. 

Thoughts?
