### PR TITLE
GCS: Allow linux-clang builds

### DIFF
--- a/ground/gcs/gcs.pri
+++ b/ground/gcs/gcs.pri
@@ -1,4 +1,4 @@
-include (tools.pri)
+include (../tools.pri)
 
 isEmpty(BRANDING_PATH) {
 BRANDING_PATH = $$PWD/../../branding
@@ -120,18 +120,13 @@ unix {
     UI_DIR = $${OUT_PWD}/.uic
 }
 
-
-# use ccache with gcc
-CONFIG(debug, debug|release):*-g++* {
-    QMAKE_CXX=$$(CCACHE_BIN) g++
-}
-
-
-linux-g++* {
+linux {
     # Bail out on non-selfcontained libraries. Just a security measure
     # to prevent checking in code that does not compile on other platforms.
     QMAKE_LFLAGS += -Wl,--allow-shlib-undefined -Wl,--no-undefined
+}
 
+linux-g++* {
     # Enable -Werror on Linux, should do this for all platforms once warnings are all eliminated
     QMAKE_CXXFLAGS_WARN_ON += -Werror
 }

--- a/ground/gcs/gcs.pro
+++ b/ground/gcs/gcs.pro
@@ -7,6 +7,8 @@ contains(QT_VERSION, ^[0-4]\\..*) {
 cache()
 
 include(gcs.pri)
+!build_pass:message("QMAKE_CXX = $$QMAKE_CXX")
+!build_pass:message("QMAKE_CC = $$QMAKE_CC")
 
 TEMPLATE  = subdirs
 CONFIG   += ordered

--- a/ground/gcs/src/plugins/rawhid/rawhid.pro
+++ b/ground/gcs/src/plugins/rawhid/rawhid.pro
@@ -35,11 +35,7 @@ macx {
     LIBS += -framework IOKit \
         -framework CoreFoundation
 }
-linux-g++ {
-    SOURCES += hidapi/hidapi_linux.c
-    LIBS += -ludev -lrt
-}
-linux-g++-64 {
+linux {
     SOURCES += hidapi/hidapi_linux.c
     LIBS += -ludev -lrt
 }

--- a/ground/tools.pri
+++ b/ground/tools.pri
@@ -10,5 +10,6 @@ isEmpty(PYTHON_LOCAL) {
 
 # use ccache with gcc and clang in debug config
 CONFIG(debug, debug|release):*-g++*|*-clang* {
+    QMAKE_CC=$$(CCACHE_BIN) $$QMAKE_CC
     QMAKE_CXX=$$(CCACHE_BIN) $$QMAKE_CXX
 }

--- a/ground/tools.pri
+++ b/ground/tools.pri
@@ -7,3 +7,8 @@ isEmpty(PYTHON_LOCAL) {
     win32: PYTHON_LOCAL = python
     macx: PYTHON_LOCAL = python
 }
+
+# use ccache with gcc and clang in debug config
+CONFIG(debug, debug|release):*-g++*|*-clang* {
+    QMAKE_CXX=$$(CCACHE_BIN) $$QMAKE_CXX
+}

--- a/ground/uavobjgenerator/uavobjgenerator.pro
+++ b/ground/uavobjgenerator/uavobjgenerator.pro
@@ -1,3 +1,5 @@
+include(../tools.pri)
+
 QT += xml
 QT -= gui
 
@@ -6,11 +8,6 @@ macx {
 }
 
 cache()
-
-# use ccache with gcc
-*-g++* {
-    QMAKE_CXX=$$(CCACHE_BIN) g++
-}
 
 TARGET = uavobjgenerator
 CONFIG += console


### PR DESCRIPTION
Doesn't make us do that by default, but allows it by setting env. var `QT_SPEC=linux-clang`. This is good because
- We have the option in future to move to just 2 compilers (clang on linux/mac, and MSVC on windows)
- I can capture and trend all the extra diagnostics clang generates without setting up an OSX build server ;)

Moves ccache into tools.pri which is now shared between gcs and uavobjgenerator. Also uses ccache for C compiling as well (hidapi etc.). Note: GCS will print the values of `QMAKE_CC` and `QMAKE_CXX` at the beginning of the build for history/log purposes :smile: .

Note: CCACHE_BIN should really be set in the QMake files rather than the top level Makefile so it can be used with QtCreator too... the workaround is just to set that var in your QtCreator build environment.
