### PR TITLE
GCS: Allow disabling of debug gadget by env var

### DIFF
--- a/ground/gcs/src/plugins/debuggadget/debuggadgetfactory.cpp
+++ b/ground/gcs/src/plugins/debuggadget/debuggadgetfactory.cpp
@@ -29,6 +29,7 @@
 #include "debuggadget.h"
 #include <coreplugin/iuavgadget.h>
 #include <QTextStream>
+#include <QProcessEnvironment>
 
 void customMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
@@ -48,6 +49,7 @@ void customMessageHandler(QtMsgType type, const QMessageLogContext &context, con
     case QtFatalMsg:
         debugengine::getInstance()->writeFatal(msg);
         QTextStream(stderr) << "[FATAL] " << msg << endl;
+        break;
     default:
         debugengine::getInstance()->writeDebug(msg);
     }
@@ -64,7 +66,11 @@ DebugGadgetFactory::~DebugGadgetFactory()
 
 IUAVGadget *DebugGadgetFactory::createGadget(QWidget *parent)
 {
-    qInstallMessageHandler(customMessageHandler);
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    if (env.contains("NO_DEBUG_GADGET"))
+        debugengine::getInstance()->writeDebug("Debug gadget disabled by NO_DEBUG_GADGET env. var.");
+    else
+        qInstallMessageHandler(customMessageHandler);
 
     DebugGadgetWidget *gadgetWidget = new DebugGadgetWidget(parent);
 


### PR DESCRIPTION
Setting NO_DEBUG_GADGET allows it to be disabled so QDebug messages will go through to QtCreator or shell. This allows use of QT_MESSAGE_PATTERN to get originating file/line/function etc. Super helpful for debugging!

Example with QT_MESSAGE_PATTERN = `[%{file}:%{line}] %{function}: %{message}`
`[/home/mike/dev/dronin2/ground/gcs/src/plugins/systemhealth/systemhealthgadgetwidget.cpp:128] SystemHealthGadgetWidget::updateAlarms: [SystemHealth] Warning: The SystemHealth SVG does not contain a graphical element for the  "GyroBias"  alarm.`
