### PR TITLE
GCS:Debug: Improve debug widget, connect usagestats

### DIFF
--- a/ground/gcs/gcs.pri
+++ b/ground/gcs/gcs.pri
@@ -109,6 +109,9 @@ DEFINES += QT_NO_CAST_TO_ASCII
 #DEFINES += QT_USE_FAST_OPERATOR_PLUS
 #DEFINES += QT_USE_FAST_CONCATENATION
 
+# include additional information in debug log (file/line/function)
+DEFINES += QT_MESSAGELOGCONTEXT
+
 unix {
     CONFIG(debug, debug|release):OBJECTS_DIR = $${OUT_PWD}/.obj/debug-shared
     CONFIG(release, debug|release):OBJECTS_DIR = $${OUT_PWD}/.obj/release-shared

--- a/ground/gcs/src/plugins/debuggadget/debugengine.cpp
+++ b/ground/gcs/src/plugins/debuggadget/debugengine.cpp
@@ -1,31 +1,45 @@
+/**
+ ******************************************************************************
+ *
+ * @file       debugengine.h
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
+ * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
+ * @addtogroup GCSPlugins GCS Plugins
+ * @{
+ * @addtogroup DebugGadgetPlugin Debug Gadget Plugin
+ * @{
+ * @brief A place holder gadget plugin
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
 #include "debugengine.h"
 
-debugengine::debugengine()
+DebugEngine::DebugEngine()
 {
+    qRegisterMetaType<DebugEngine::Level>("DebugEngine::Level");
 }
 
-debugengine *debugengine::getInstance()
+DebugEngine *DebugEngine::getInstance()
 {
-    static debugengine objectInstance;
+    static DebugEngine objectInstance;
     return &objectInstance;
 }
 
-void debugengine::writeWarning(const QString &message)
-{
-    emit warning(message);
-}
-
-void debugengine::writeDebug(const QString &message)
-{
-    emit debug(message);
-}
-
-void debugengine::writeCritical(const QString &message)
-{
-    emit critical(message);
-}
-
-void debugengine::writeFatal(const QString &message)
-{
-    emit fatal(message);
-}
+/**
+ * @}
+ * @}
+ */

--- a/ground/gcs/src/plugins/debuggadget/debugengine.h
+++ b/ground/gcs/src/plugins/debuggadget/debugengine.h
@@ -1,27 +1,61 @@
+/**
+ ******************************************************************************
+ *
+ * @file       debugengine.h
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
+ * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
+ * @addtogroup GCSPlugins GCS Plugins
+ * @{
+ * @addtogroup DebugGadgetPlugin Debug Gadget Plugin
+ * @{
+ * @brief A place holder gadget plugin
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
 #ifndef DEBUGENGINE_H
 #define DEBUGENGINE_H
 #include <QTextBrowser>
 #include <QPointer>
 #include <QObject>
+#include "debuggadget_global.h"
 
 
-class debugengine : public QObject {
+class DEBUGGADGET_EXPORT DebugEngine : public QObject {
     Q_OBJECT
     // Add all missing constructor etc... to have singleton
-    debugengine();
+    DebugEngine();
 public:
-    static debugengine *getInstance();
-    void writeWarning(const QString &message);
-    void writeDebug(const QString &message);
-    void writeCritical(const QString &message);
-    void writeFatal(const QString &message);
+    enum Level {
+        DEBUG,
+        INFO,
+        WARNING,
+        CRITICAL,
+        FATAL,
+    };
+
+    static DebugEngine *getInstance();
 
 signals:
-    void warning(QString);
-    void debug(QString);
-    void critical(QString);
-    void fatal(QString);
-
+    void message(DebugEngine::Level level, const QString &msg, const QString &file = "", const int line = 0, const QString &function = "");
 };
 
 #endif // DEBUGENGINE_H
+
+/**
+ * @}
+ * @}
+ */

--- a/ground/gcs/src/plugins/debuggadget/debuggadget.pri
+++ b/ground/gcs/src/plugins/debuggadget/debuggadget.pri
@@ -1,4 +1,1 @@
-include(../../gcsplugin.pri)
-include(../../plugins/coreplugin/coreplugin.pri)
-
 LIBS *= -l$$qtLibraryName(DebugGadget)

--- a/ground/gcs/src/plugins/debuggadget/debuggadget.pri
+++ b/ground/gcs/src/plugins/debuggadget/debuggadget.pri
@@ -1,0 +1,4 @@
+include(../../gcsplugin.pri)
+include(../../plugins/coreplugin/coreplugin.pri)
+
+LIBS *= -l$$qtLibraryName(DebugGadget)

--- a/ground/gcs/src/plugins/debuggadget/debuggadget.pro
+++ b/ground/gcs/src/plugins/debuggadget/debuggadget.pro
@@ -5,6 +5,8 @@ QT += widgets
 include(../../gcsplugin.pri)
 include(../../plugins/coreplugin/coreplugin.pri)
 
+DEFINES += DEBUGGADGET_LIBRARY
+
 HEADERS += debugplugin.h \
     debugengine.h
 HEADERS += debuggadget.h

--- a/ground/gcs/src/plugins/debuggadget/debuggadget_global.h
+++ b/ground/gcs/src/plugins/debuggadget/debuggadget_global.h
@@ -1,0 +1,47 @@
+/**
+ ******************************************************************************
+ * @file       debuggadget_global.h
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
+ * @addtogroup GCSPlugins GCS Plugins
+ * @{
+ * @addtogroup DebugGadgetPlugin Debug Gadget Plugin
+ * @{
+ * @brief Handle debug messages from QDebug and place them in a widget
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
+ */
+
+#ifndef DEBUGGADGET_GLOBAL_H
+#define DEBUGGADGET_GLOBAL_H
+
+#include <QtCore/qglobal.h>
+
+#if defined(DEBUGGADGET_LIBRARY)
+#define DEBUGGADGET_EXPORT Q_DECL_EXPORT
+#else
+#define DEBUGGADGET_EXPORT Q_DECL_IMPORT
+#endif
+
+#endif // DEBUGGADGET_GLOBAL_H
+
+/**
+ * @}
+ * @}
+ */

--- a/ground/gcs/src/plugins/debuggadget/debuggadgetfactory.cpp
+++ b/ground/gcs/src/plugins/debuggadget/debuggadgetfactory.cpp
@@ -34,7 +34,7 @@
 
 void customMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
-    DebugEngine::Level level;
+    DebugEngine::Level level = DebugEngine::DEBUG;
     switch (type) {
     case QtDebugMsg:
         level = DebugEngine::DEBUG;

--- a/ground/gcs/src/plugins/debuggadget/debuggadgetfactory.cpp
+++ b/ground/gcs/src/plugins/debuggadget/debuggadgetfactory.cpp
@@ -2,6 +2,7 @@
  ******************************************************************************
  *
  * @file       debuggadgetfactory.cpp
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @addtogroup GCSPlugins GCS Plugins
  * @{
@@ -33,26 +34,28 @@
 
 void customMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
-    Q_UNUSED(context)
+    DebugEngine::Level level;
     switch (type) {
     case QtDebugMsg:
-        debugengine::getInstance()->writeDebug(msg);
+        level = DebugEngine::DEBUG;
+        break;
+    case QtInfoMsg:
+        level = DebugEngine::INFO;
         break;
     case QtWarningMsg:
-        debugengine::getInstance()->writeWarning(msg);
+        level = DebugEngine::WARNING;
         QTextStream(stderr) << "[Warning] " << msg << endl;
         break;
     case QtCriticalMsg:
-        debugengine::getInstance()->writeCritical(msg);
+        level = DebugEngine::CRITICAL;
         QTextStream(stderr) << "[Critical] " << msg << endl;
         break;
     case QtFatalMsg:
-        debugengine::getInstance()->writeFatal(msg);
+        level = DebugEngine::FATAL;
         QTextStream(stderr) << "[FATAL] " << msg << endl;
         break;
-    default:
-        debugengine::getInstance()->writeDebug(msg);
     }
+    DebugEngine::getInstance()->message(level, msg, QString(context.file), context.line, QString(context.function));
 }
 
 DebugGadgetFactory::DebugGadgetFactory(QObject *parent) :
@@ -68,7 +71,7 @@ IUAVGadget *DebugGadgetFactory::createGadget(QWidget *parent)
 {
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     if (env.contains("NO_DEBUG_GADGET"))
-        debugengine::getInstance()->writeDebug("Debug gadget disabled by NO_DEBUG_GADGET env. var.");
+        DebugEngine::getInstance()->message(DebugEngine::INFO, "Debug gadget disabled by NO_DEBUG_GADGET env. var.");
     else
         qInstallMessageHandler(customMessageHandler);
 
@@ -76,3 +79,8 @@ IUAVGadget *DebugGadgetFactory::createGadget(QWidget *parent)
 
     return new DebugGadget(QString("DebugGadget"), gadgetWidget, parent);
 }
+
+/**
+ * @}
+ * @}
+ */

--- a/ground/gcs/src/plugins/debuggadget/debuggadgetfactory.cpp
+++ b/ground/gcs/src/plugins/debuggadget/debuggadgetfactory.cpp
@@ -62,19 +62,19 @@ DebugGadgetFactory::DebugGadgetFactory(QObject *parent) :
     IUAVGadgetFactory(QString("DebugGadget"),
                       tr("DebugGadget"),
                       parent)
-{}
-
-DebugGadgetFactory::~DebugGadgetFactory()
-{}
-
-IUAVGadget *DebugGadgetFactory::createGadget(QWidget *parent)
 {
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     if (env.contains("NO_DEBUG_GADGET"))
         DebugEngine::getInstance()->message(DebugEngine::INFO, "Debug gadget disabled by NO_DEBUG_GADGET env. var.");
     else
         qInstallMessageHandler(customMessageHandler);
+}
 
+DebugGadgetFactory::~DebugGadgetFactory()
+{}
+
+IUAVGadget *DebugGadgetFactory::createGadget(QWidget *parent)
+{
     DebugGadgetWidget *gadgetWidget = new DebugGadgetWidget(parent);
 
     return new DebugGadget(QString("DebugGadget"), gadgetWidget, parent);

--- a/ground/gcs/src/plugins/debuggadget/debuggadgetfactory.h
+++ b/ground/gcs/src/plugins/debuggadget/debuggadgetfactory.h
@@ -2,6 +2,7 @@
  ******************************************************************************
  *
  * @file       debuggadgetfactory.h
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @addtogroup GCSPlugins GCS Plugins
  * @{
@@ -47,3 +48,8 @@ public:
 };
 
 #endif // DEBUGGADGETFACTORY_H_
+
+/**
+ * @}
+ * @}
+ */

--- a/ground/gcs/src/plugins/debuggadget/debuggadgetwidget.cpp
+++ b/ground/gcs/src/plugins/debuggadget/debuggadgetwidget.cpp
@@ -113,6 +113,8 @@ void DebugGadgetWidget::message(DebugEngine::Level level, const QString &msg, co
     QString source;
 #ifdef QT_DEBUG // only display this extended info to devs
     source = QString("[%0:%1 %2]").arg(file).arg(line).arg(function);
+#else
+    Q_UNUSED(file); Q_UNUSED(line); Q_UNUSED(function);
 #endif
 
     m_config->plainTextEdit->setTextColor(color);

--- a/ground/gcs/src/plugins/debuggadget/debuggadgetwidget.h
+++ b/ground/gcs/src/plugins/debuggadget/debuggadgetwidget.h
@@ -2,6 +2,7 @@
  ******************************************************************************
  *
  * @file       debuggadgetwidget.h
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2016
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @addtogroup GCSPlugins GCS Plugins
  * @{
@@ -42,10 +43,11 @@ private:
 private slots:
     void saveLog();
     void clearLog();
-    void dbgMsgDebug(QString msg);
-    void dbgMsgWarning(QString msg);
-    void dbgMsgCritical(QString msg);
-    void dbgMsgFatal(QString msg);
-
+    void message(DebugEngine::Level level, const QString &msg, const QString &file, const int line, const QString &function);
 };
 #endif /* DEBUGGADGETWIDGET_H_ */
+
+/**
+ * @}
+ * @}
+ */

--- a/ground/gcs/src/plugins/uploader/uploader.pro
+++ b/ground/gcs/src/plugins/uploader/uploader.pro
@@ -4,6 +4,7 @@ DEFINES += UPLOADER_LIBRARY
 QT += svg widgets
 QT += testlib
 QT += network
+include(../../gcsplugin.pri)
 include(uploader_dependencies.pri)
 include(../../libs/glc_lib/glc_lib.pri)
 

--- a/ground/gcs/src/plugins/uploader/uploader_dependencies.pri
+++ b/ground/gcs/src/plugins/uploader/uploader_dependencies.pri
@@ -1,4 +1,3 @@
-include(../../gcsplugin.pri)
 include(../../plugins/coreplugin/coreplugin.pri)
 include(../../plugins/uavobjects/uavobjects.pri)
 include(../../plugins/uavtalk/uavtalk.pri)

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestats_dependencies.pri
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestats_dependencies.pri
@@ -1,2 +1,2 @@
 include(../../plugins/uploader/uploader.pri)
-
+include(../../plugins/debuggadget/debuggadget.pri)

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsgadget.pro
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsgadget.pro
@@ -2,6 +2,7 @@ QT += network
 TEMPLATE = lib
 TARGET = UsageStats
 DEFINES += USAGESTATS_LIBRARY
+include(../../gcsplugin.pri)
 include(usagestats_dependencies.pri)
 HEADERS += \
     usagestatsplugin.h \

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsoptionpage.cpp
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsoptionpage.cpp
@@ -1,7 +1,7 @@
 /**
  ******************************************************************************
  * @file       usagestatsoptionpage.cpp
- * @author     dRonin, http://dRonin.org/, Copyright (C) 2015
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015, 2016
  * @addtogroup GCSPlugins GCS Plugins
  * @{
  * @addtogroup UsageStatsOptionPage
@@ -27,6 +27,7 @@
 #include "usagestatsoptionpage.h"
 #include "ui_usagestatsoptionpage.h"
 #include "usagestatsplugin.h"
+#include "debuggadget/debugengine.h"
 
 UsageStatsOptionPage::UsageStatsOptionPage(QObject *parent) :
     IOptionsPage(parent)
@@ -46,6 +47,18 @@ QWidget *UsageStatsOptionPage::createPage(QWidget *parent)
     m_page->cb_AllowSending->setChecked(m_config->getSendUsageStats());
     m_page->cb_AllowPrivate->setChecked(m_config->getSendPrivateData());
     m_page->label_UUID->setText(QString("UUID: ")+m_config->getInstallationUUID());
+
+    m_page->cbDebugLogLevel->clear();
+    m_page->cbDebugLogLevel->addItem(tr("Debug"), DebugEngine::DEBUG);
+    m_page->cbDebugLogLevel->addItem(tr("Info"), DebugEngine::INFO);
+    m_page->cbDebugLogLevel->addItem(tr("Warning"), DebugEngine::WARNING);
+    m_page->cbDebugLogLevel->addItem(tr("Critical"), DebugEngine::CRITICAL);
+    m_page->cbDebugLogLevel->addItem(tr("Fatal"), DebugEngine::FATAL);
+    for (int i = 0; i < m_page->cbDebugLogLevel->count(); i++) {
+        if (m_page->cbDebugLogLevel->itemData(i).toInt() == m_config->getDebugLogLevel())
+            m_page->cbDebugLogLevel->setCurrentIndex(i);
+    }
+
     return w;
 }
 
@@ -53,6 +66,7 @@ void UsageStatsOptionPage::apply()
 {
     m_config->setSendUsageStats(m_page->cb_AllowSending->isChecked());
     m_config->setSendPrivateData(m_page->cb_AllowPrivate->isChecked());
+    m_config->setDebugLogLevel(m_page->cbDebugLogLevel->currentData().toInt());
     emit settingsUpdated();
 }
 

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsoptionpage.h
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsoptionpage.h
@@ -1,7 +1,7 @@
 /**
  ******************************************************************************
  * @file       usagestatsoptionpage.h
- * @author     dRonin, http://dRonin.org/, Copyright (C) 2015
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015, 2016
  * @addtogroup [Group]
  * @{
  * @addtogroup UsageStatsOptionPage

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsoptionpage.ui
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsoptionpage.ui
@@ -40,6 +40,23 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_AllowSending">
+     <property name="text">
+      <string>Allow sending application usage statistics to the project authors:</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_UUID">
+     <property name="text">
+      <string>&lt;UUID&gt;</string>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="1">
     <widget class="QCheckBox" name="cb_AllowPrivate">
      <property name="sizePolicy">
@@ -59,22 +76,28 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_AllowSending">
+   <item row="2" column="0">
+    <widget class="QLabel" name="lblDebugLogLevel">
      <property name="text">
-      <string>Allow sending application usage statistics to the project authors:</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+      <string>Debug logging level:</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_UUID">
-     <property name="text">
-      <string>&lt;UUID&gt;</string>
+   <item row="3" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-    </widget>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="cbDebugLogLevel"/>
    </item>
   </layout>
  </widget>

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.cpp
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.cpp
@@ -295,6 +295,7 @@ QByteArray UsageStatsPlugin::processJson() {
     QJsonArray debugLogArray;
     foreach (const DebugMessage msg, debugMessageList) {
         QJsonObject d;
+        d["time"] = msg.time.toUTC().toString("yyyy-MM-ddThh:mm:ss.zzzZ");
         d["level"] = msg.level;
         d["levelString"] = msg.levelString;
         d["message"] = msg.message;
@@ -368,6 +369,7 @@ void UsageStatsPlugin::onDebugMessage(DebugEngine::Level level, const QString &m
         break;
     }
 
+    info.time = QDateTime::currentDateTime();
     info.level = level;
     info.message = msg;
     info.file = file;

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.h
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.h
@@ -2,7 +2,7 @@
  ******************************************************************************
  *
  * @file       usagestatsplugin.h
- * @author     dRonin, http://dRonin.org/, Copyright (C) 2015
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2015, 2016
  * @addtogroup GCSPlugins GCS Plugins
  * @{
  * @addtogroup UsageStatsGadgetPlugin UsageStats Gadget Plugin
@@ -33,6 +33,7 @@
 #include <extensionsystem/iplugin.h>
 #include "uploader/uploader_global.h"
 #include "uavobjectutil/devicedescriptorstruct.h"
+#include "debuggadget/debugengine.h"
 #include <QDateTime>
 #include <QAbstractButton>
 #include <QNetworkReply>
@@ -57,6 +58,14 @@ typedef struct widgetActionInfoType {
     QString data1;
     QString data2;
 } widgetActionInfo;
+typedef struct debugMessageStruct {
+    int level;
+    QString levelString;
+    QString message;
+    QString file;
+    int line;
+    QString function;
+} DebugMessage;
 
 class UsageStatsPlugin :  public Core::IConfigurablePlugin {
     Q_OBJECT
@@ -73,9 +82,10 @@ public:
     bool coreAboutToClose();
     bool getSendUsageStats() const;
     void setSendUsageStats(bool value);
-
     bool getSendPrivateData() const;
     void setSendPrivateData(bool value);
+    int getDebugLogLevel() const;
+    void setDebugLogLevel(int value);
 
     QString getInstallationUUID() const;
 public slots:
@@ -84,6 +94,7 @@ private:
     ExtensionSystem::PluginManager *pluginManager;
     QList<boardLog> boardLogList;
     QList<widgetActionInfo> widgetLogList;
+    QList<DebugMessage> debugMessageList;
     QByteArray processJson();
     QString externalIP;
     QNetworkAccessManager netMngr;
@@ -91,6 +102,7 @@ private:
     bool sendUsageStats;
     bool sendPrivateData;
     QUuid installationUUID;
+    int debugLogLevel;
 private slots:
     void pluginsLoadEnded();
     void addNewBoardSeen(deviceInfo, deviceDescriptorStruct);
@@ -98,6 +110,7 @@ private slots:
     void onButtonClicked();
     void onSliderValueChanged(int);
     void onTabCurrentChanged(int);
+    void onDebugMessage(DebugEngine::Level, const QString &, const QString &, const int, const QString &);
 };
 class AppCloseHook : public Core::ICoreListener {
     Q_OBJECT

--- a/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.h
+++ b/ground/gcs/src/plugins/usagestatsgadget/usagestatsplugin.h
@@ -59,6 +59,7 @@ typedef struct widgetActionInfoType {
     QString data2;
 } widgetActionInfo;
 typedef struct debugMessageStruct {
+    QDateTime time;
     int level;
     QString levelString;
     QString message;


### PR DESCRIPTION
Configurable log level in the usage stats settings.

TODO: make sure DEFINES += QT_MESSAGELOGCONTEXT doesn't have a bad impact on release builds.

TODO in future: Make DebugGadget able to filter log messages by severity, source (class?). Then make stuff emit debug messages all the time rather than defined at compile time.
