### PR TITLE
gcs: setupwizard: change defaults

### DIFF
--- a/ground/gcs/src/plugins/setupwizard/pages/inputpage.ui
+++ b/ground/gcs/src/plugins/setupwizard/pages/inputpage.ui
@@ -85,7 +85,7 @@ p, li { white-space: pre-wrap; }
         <bool>true</bool>
        </property>
        <property name="checked">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="autoExclusive">
         <bool>true</bool>
@@ -127,6 +127,9 @@ p, li { white-space: pre-wrap; }
         </size>
        </property>
        <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
         <bool>true</bool>
        </property>
        <property name="autoExclusive">

--- a/ground/gcs/src/plugins/setupwizard/pages/outputpage.ui
+++ b/ground/gcs/src/plugins/setupwizard/pages/outputpage.ui
@@ -86,7 +86,7 @@ p, li { white-space: pre-wrap; }
         <bool>true</bool>
        </property>
        <property name="checked">
-        <bool>false</bool>
+        <bool>true</bool>
        </property>
        <property name="autoExclusive">
         <bool>true</bool>


### PR DESCRIPTION
- select 'PPM' input by default instead of PWM-- will ensure non-PWM
  capable boards start with _something_ selected.
- select 'Turbo PWM' output by default - fixes #1281
