### PR TITLE
gcs build: change how we enforce qt versions

### DIFF
--- a/ground/gcs/gcs.pro
+++ b/ground/gcs/gcs.pro
@@ -20,4 +20,9 @@ unix:!macx:!isEmpty(copydata) {
 	QMAKE_EXTRA_TARGETS += bin_install
 }
 
+!equals(QT_MAJOR_VERSION, 5) | !equals(QT_MINOR_VERSION, 6) | !equals(QT_PATCH_VERSION, 1) {
+message("Cannot build dRonin GCS with Qt version $${QT_VERSION}.")
+error("Use 5.6.1 (make qt_sdk_install).")
+}
+
 copydata.file = copydata.pro

--- a/ground/gcs/gcs.pro
+++ b/ground/gcs/gcs.pro
@@ -1,9 +1,3 @@
-#version check qt
-contains(QT_VERSION, ^[0-4]\\..*) {
-    message("Cannot build GCS with Qt version $${QT_VERSION}.")
-    error("Cannot build GCS with Qt version $${QT_VERSION}. Use at least Qt 5.0.1!")
-}
-
 cache()
 
 include(gcs.pri)
@@ -21,8 +15,8 @@ unix:!macx:!isEmpty(copydata) {
 }
 
 !equals(QT_MAJOR_VERSION, 5) | !equals(QT_MINOR_VERSION, 6) | !equals(QT_PATCH_VERSION, 1) {
-message("Cannot build dRonin GCS with Qt version $${QT_VERSION}.")
-error("Use 5.6.1 (make qt_sdk_install).")
+        message("Cannot build dRonin GCS with Qt version $${QT_VERSION}.")
+        error("Use 5.6.1 (make qt_sdk_install).")
 }
 
 copydata.file = copydata.pro

--- a/ground/uavobjgenerator/uavobjgenerator.pro
+++ b/ground/uavobjgenerator/uavobjgenerator.pro
@@ -7,6 +7,10 @@ macx {
     QMAKE_MACOSX_DEPLOYMENT_TARGET=10.9
 }
 
+!equals(QT_MAJOR_VERSION, 5) {
+error("Use QT5 (make qt_sdk_install).")
+}
+
 cache()
 
 TARGET = uavobjgenerator

--- a/ground/uavobjgenerator/uavobjgenerator.pro
+++ b/ground/uavobjgenerator/uavobjgenerator.pro
@@ -8,7 +8,7 @@ macx {
 }
 
 !equals(QT_MAJOR_VERSION, 5) {
-error("Use QT5 (make qt_sdk_install).")
+    error("Use QT5 (make qt_sdk_install).")
 }
 
 cache()

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -25,14 +25,11 @@ endif
 QT_VERSION := 5.6.1
 QT_SDK_DIR := $(TOOLS_DIR)/Qt$(QT_VERSION)
 
-ifndef IGNORE_MISSING_TOOLCHAIN
-  # On any platform except windows
-  ifndef WINDOWS
-    # Check for a current QT SDK dir, abort without
-    ifeq ($(wildcard $(QT_SDK_DIR)/*),)
-      ifeq (,$(findstring _install,$(MAKECMDGOALS)))
-        $(error "QT SDK not found, please run `make qt_sdk_install`")
-      endif
+ifndef WINDOWS
+# Check for a current QT SDK dir, abort without
+  ifeq ($(wildcard $(QT_SDK_DIR)/*),)
+    ifeq (,$(findstring _install,$(MAKECMDGOALS)))
+      $(warning "QT SDK not found, please run `make qt_sdk_install`")
     endif
   endif
 endif
@@ -642,6 +639,3 @@ sdl_install:
 	$(V1) hdiutil detach /Volumes/SDL;
 	$(V1) rm $(DL_DIR)/$(SDL_FILE);
 endif
-
-
-


### PR DESCRIPTION
- Make sure the exactly correct version is used to build GCS
- Only warn if not in tools dir at beginning of make.

This has a number of purposes.  It allows building flight without
exactly-matching Qt version on Raspberry Pi (because getting the right
Qt version on Pi is often a pain).  It also checks the version used
more strongly where mismatches would be ignroed before (e.g. on
Windows).
