### PR TITLE
chibios f3/f4: don't build hal LLDs

### DIFF
--- a/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32F30x/platform.mk
+++ b/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32F30x/platform.mk
@@ -1,20 +1,6 @@
 # List of all the STM32F30x platform files.
 PLATFORMSRC = ${CHIBIOS}/os/hal/platforms/STM32F30x/stm32_dma.c \
-              ${CHIBIOS}/os/hal/platforms/STM32F30x/hal_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32F30x/adc_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32F30x/ext_lld_isr.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/can_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/ext_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/GPIOv2/pal_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/I2Cv2/i2c_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/RTCv2/rtc_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/SPIv2/spi_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/TIMv1/gpt_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/TIMv1/icu_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/TIMv1/pwm_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/USARTv2/serial_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/USARTv2/uart_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/USBv1/usb_lld.c
+              ${CHIBIOS}/os/hal/platforms/STM32F30x/hal_lld.c
 
 # Required include directories
 PLATFORMINC = ${CHIBIOS}/os/hal/platforms/STM32F30x \

--- a/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32F4xx/platform.mk
+++ b/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32F4xx/platform.mk
@@ -1,22 +1,6 @@
 # List of all the STM32F2xx/STM32F4xx platform files.
 PLATFORMSRC = ${CHIBIOS}/os/hal/platforms/STM32F4xx/stm32_dma.c \
-              ${CHIBIOS}/os/hal/platforms/STM32F4xx/hal_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32F4xx/adc_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32F4xx/ext_lld_isr.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/can_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/ext_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/mac_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/sdc_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/GPIOv2/pal_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/I2Cv1/i2c_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/OTGv1/usb_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/RTCv2/rtc_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/SPIv1/spi_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/TIMv1/gpt_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/TIMv1/icu_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/TIMv1/pwm_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/USARTv1/serial_lld.c \
-              ${CHIBIOS}/os/hal/platforms/STM32/USARTv1/uart_lld.c
+              ${CHIBIOS}/os/hal/platforms/STM32F4xx/hal_lld.c 
 
 # Required include directories
 PLATFORMINC = ${CHIBIOS}/os/hal/platforms/STM32F4xx \


### PR DESCRIPTION
We don't use them, and they make builds take longer / are built many times
for each target.
