### PR TITLE
python-logviewer:  handle empty data series more gracefully

### DIFF
--- a/python/dronin/logviewer/logviewer.py
+++ b/python/dronin/logviewer/logviewer.py
@@ -13,6 +13,9 @@ import six
 def get_data_series(obj_name, fields):
     data = get_series(obj_name)
 
+    if (len(data) < 1):
+        return []
+
     base_fields = [ f.split(':')[0] for f in fields ]
     peeled = data[base_fields]
 


### PR DESCRIPTION
This is important because the default profile doesn't log actuators..
It's better to not crash under these circumstances.  Thanks to Troy
from IRC for the report.
