### PR TITLE
Package: Add package_flight dep on FW_FILES

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -136,6 +136,6 @@ ground_package_common: standalone
 package_flight: $(FLIGHTPKGNAME)
 
 $(FLIGHTPKGNAME): $(PACKAGE_DIR) $(FW_FILES)
-	$(ZIPBIN) -j $@ $(FW_FILES)
+	$(ZIPBIN) -j --must-match $@ $(FW_FILES)
 
 include $(WHEREAMI)/Makefile.$(PLATFORM)

--- a/package/Makefile
+++ b/package/Makefile
@@ -135,7 +135,7 @@ ground_package_common: standalone
 .PHONY: package_flight
 package_flight: $(FLIGHTPKGNAME)
 
-$(FLIGHTPKGNAME): $(PACKAGE_DIR)
+$(FLIGHTPKGNAME): $(PACKAGE_DIR) $(FW_FILES)
 	$(ZIPBIN) -j $@ $(FW_FILES)
 
 include $(WHEREAMI)/Makefile.$(PLATFORM)


### PR DESCRIPTION
a) makes the zip get updated if an FW file changes and it already exists, stops people inadvertantly making packages with old FW (problem for 3rd parties rather than dRonin build machines)
b) stops us unknowingly shipping an incomplete package if something is missing (zip silently ignores missing input files)
