### PR TITLE
Flight: Brain - Correct pios_board.h

### DIFF
--- a/flight/targets/brain/board-info/pios_board.h
+++ b/flight/targets/brain/board-info/pios_board.h
@@ -247,9 +247,6 @@ extern uintptr_t pios_com_debug_id;
 //-------------------------
 #define PIOS_USB_ENABLED				1 /* Should remove all references to this */
 
-#endif /* STM3210E_INS_H_ */
-
-
 #if defined(PIOS_INCLUDE_VIDEO)
 #include <pios.h>
 #include <pios_stm32.h>
@@ -264,7 +261,7 @@ struct pios_osd_bw_cfg_t {
 };
 #endif /* PIOS_INCLUDE_VIDEO */
 
-
+#endif /* STM3210E_INS_H_ */
 /**
  * @}
  * @}


### PR DESCRIPTION
Moved the line "#endif /\* STM3210E_INS_H_ */" to the end of the file so that if pios_board.h is included in multiple files, a structure redefined error won't be generated for pios_osd_bw_cfg_t.

Builds correctly on next.  Not run on Brain hardware since I don't have that target available.  Minimal risk, but best if someone can try it.
