### PR TITLE
hsum: eliminate scaling to 1000-2000 range

### DIFF
--- a/flight/PiOS/Common/pios_hsum.c
+++ b/flight/PiOS/Common/pios_hsum.c
@@ -251,8 +251,7 @@ static int PIOS_HSUM_UnrollChannels(struct pios_hsum_dev *hsum_dev)
 			s += sizeof(uint16_t);
 			/* save the channel value */
 			if (i < PIOS_HSUM_NUM_INPUTS) {
-				/* floating version. channel limits from -100..+100% are mapped to 1000..2000 */
-				state->channel_data[i] = (uint16_t)(word / 6.4f - 375);
+				state->channel_data[i] = word;
 			}
 		} else
 			/* this channel was not received */


### PR DESCRIPTION
Leave it raw, so that we can have maximal resolution.

Fixes #912.

This will screw up upgrade for these users, but A) it's a small population, and B) easily fixed, and C) worth the improvement to the resolution.
