### PR TITLE
pios_servo: fix on CC3D/S1 "fake oneshot" mode

### DIFF
--- a/flight/PiOS/STM32/pios_servo.c
+++ b/flight/PiOS/STM32/pios_servo.c
@@ -248,7 +248,7 @@ void PIOS_Servo_SetMode(const uint16_t *out_rate, const int banks, const uint16_
 			const struct pios_tim_channel *chan = &servo_cfg->channels[j];
 			if (timer_banks[i].timer == chan->timer) {
 				/* save the frequency for these channels */
-				output_channel_mode[j] = (out_rate[i] == 0) ? SYNC_PWM : REGULAR_PWM;
+				output_channel_mode[j] = (rate == 0) ? SYNC_PWM : REGULAR_PWM;
 				output_channel_resolution[j] = timer_banks[i].clk_rate;
 			}
 		}


### PR DESCRIPTION
This was inverted before.  Big woops.
