### PR TITLE
firmwareiap: stop PWM before reset (when appropriate)

### DIFF
--- a/flight/Modules/FirmwareIAP/firmwareiap.c
+++ b/flight/Modules/FirmwareIAP/firmwareiap.c
@@ -8,7 +8,7 @@
  * @file       firmwareiap.c
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2014
- * @author     dRonin, http://dronin.org Copyright (C) 2015
+ * @author     dRonin, http://dronin.org Copyright (C) 2015-2016
  * @brief      In Application Programming module to support firmware upgrades by
  *             providing a means to enter the bootloader.
  *
@@ -38,6 +38,7 @@
 #include "firmwareiap.h"
 #include "firmwareiapobj.h"
 #include "flightstatus.h"
+#include "pios_servo.h"
 #include "pios_thread.h"
 
 // Private constants
@@ -57,10 +58,10 @@
 
 #define RESET_DELAY_MS         500 /* delay before sending reset to INS */
 
-const uint32_t    iap_time_2_low_end = 500;
-const uint32_t    iap_time_2_high_end = 5000;
-const uint32_t    iap_time_3_low_end = 500;
-const uint32_t    iap_time_3_high_end = 5000;
+const uint32_t iap_time_2_low_end = 500;
+const uint32_t iap_time_2_high_end = 5000;
+const uint32_t iap_time_3_low_end = 500;
+const uint32_t iap_time_3_high_end = 5000;
 
 // Private types
 
@@ -191,6 +192,7 @@ static void FirmwareIAPCallback(UAVObjEvent* ev, void *ctx, void *obj, int len)
 						UAVObjEvent * ev = PIOS_malloc_no_dma(sizeof(UAVObjEvent));
 						memset(ev,0,sizeof(UAVObjEvent));
 						EventPeriodicCallbackCreate(ev, resetTask, 100);
+						PIOS_Servo_PrepareForReset(); // Stop PWM
 						iap_state = IAP_STATE_RESETTING;
 					} else {
 						iap_state = IAP_STATE_READY;

--- a/flight/PiOS/inc/pios_servo.h
+++ b/flight/PiOS/inc/pios_servo.h
@@ -53,6 +53,7 @@ extern void PIOS_Servo_SetFraction(uint8_t servo, uint16_t fraction,
 		uint16_t max_val, uint16_t min_val);
 #endif
 
+extern void PIOS_Servo_PrepareForReset();
 extern void PIOS_Servo_Set(uint8_t servo, float position);
 extern void PIOS_Servo_Update(void);
 

--- a/flight/PiOS/posix/pios_servo.c
+++ b/flight/PiOS/posix/pios_servo.c
@@ -88,4 +88,7 @@ void PIOS_Servo_Update(void)
 	}
 }
 
+void PIOS_Servo_PrepareForReset() {
+}
+
 #endif


### PR DESCRIPTION
Fixes #1216, where @ufoDziner has a reliable repro.

Supersedes #720.

Needs to wait for #1323 / build to be fixed before building artifacts.

Conflicts #1318 
