### PR TITLE
autotune: Remove input scaling.

### DIFF
--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -490,9 +490,9 @@ __attribute__((always_inline)) static inline void af_predict(float X[AF_NUMX], f
 	const float bias3 = X[12];       // bias in the yaw torque
 
 	// inputs to the system (roll, pitch, yaw)
-	const float u1_in = 4*t_in*u_in[0];
-	const float u2_in = 4*t_in*u_in[1];
-	const float u3_in = 4*t_in*u_in[2];
+	const float u1_in = u_in[0];
+	const float u2_in = u_in[1];
+	const float u3_in = u_in[2];
 
 	// measurements from gyro
 	const float gyro_x = gyro[0];


### PR DESCRIPTION
After a few words with @mlyle on IRC, I removed the input scaling in the autotune predictor, since it was deemed meh. There are no unreasonable ill-effects from what I can tell.

What's noticeable though is that it had an effect on the roll and pitch gains here. Before on this H-frame, tri-blades ended up with tunes where the pitch PIDs end up slightly higher than roll, as you'd expect with such a frame, however quad-blades ended up with higher roll PIDs than pitch. Now without input scaling, it's the opposite.

With either of the tunes referred, old or new, the quad flies just fine. The only odd effect are what sounds like motor oscillations in hangtime with the new quadblade tune (might be prop deflections, since the Q5040 are prone to that, have to investigate).

**HQProp S5x4x3**

Old tune: 
http://dronin-autotown.appspot.com/at/tune/ahFzfmRyb25pbi1hdXRvdG93bnIYCxILVHVuZVJlc3VsdHMYgICAoPOvigkM

New tune:
http://dronin-autotown.appspot.com/at/tune/ahFzfmRyb25pbi1hdXRvdG93bnIYCxILVHVuZVJlc3VsdHMYgICAoM-w0AsM

**DALprop Q5040**

Old tune:
http://dronin-autotown.appspot.com/at/tune/ahFzfmRyb25pbi1hdXRvdG93bnIYCxILVHVuZVJlc3VsdHMYgICAoPWT8AgM

New tune:
http://dronin-autotown.appspot.com/at/tune/ahFzfmRyb25pbi1hdXRvdG93bnIYCxILVHVuZVJlc3VsdHMYgICAoM2AsQoM
