### PR TITLE
Tools: Build breakpad on Mac and Linux, use repo copy on win

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,10 @@ help:
 	@echo "     uncrustify_install   - Install the uncrustify code formatter"
 	@echo "     openssl_install      - Install the openssl libraries on windows machines"	
 	@echo "     sdl_install          - Install the SDL libraries"
+ifndef WINDOWS
+	@echo "     depot_tools_install  - Install Google depot-tools for building breakpad tools"
+endif
+	@echo "     breakpad_install     - Install Google Breakpad tools for GCS crash symbol generation"
 
 	@echo
 	@echo "   [Big Hammer]"

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -540,15 +540,15 @@ depot_tools_clean:
 # Google breakpad
 BREAKPAD_REPO := https://github.com/d-ronin/breakpad.git
 BREAKPAD_REV := 20160909
-BREAKPAD_DIR := $(TOOLS_DIR)/breakpad
+BREAKPAD_DIR := $(TOOLS_DIR)/breakpad/$(BREAKPAD_REV)
 BREAKPAD_BUILD_DIR := $(DL_DIR)/breakpad
 
-.PHONY: breakpad_install breakpad_clean breakpad_build_clean
+.PHONY: breakpad_install breakpad_clean breakpad_dist_clean
 
 ifndef WINDOWS
 
 breakpad_install: | $(DL_DIR) $(TOOLS_DIR)
-breakpad_install: | breakpad_clean
+breakpad_install: | breakpad_clean depot_tools_install
 	$(V0) @echo " DOWNLOAD     $(BREAKPAD_REPO) @ $(BREAKPAD_REV)"
 	$(V1) mkdir -p "$(BREAKPAD_BUILD_DIR)"
 
@@ -562,7 +562,7 @@ breakpad_install: | breakpad_clean
 	$(V0) @echo " BUILD        $(BREAKPAD_DIR)"
 	$(V1) ( \
 		cd "$(BREAKPAD_BUILD_DIR)/src/src" ; \
-		$(MAKE) distclean ; \
+		$(MAKE) distclean > /dev/null 2>&1 ; \
 		../configure --prefix="$(BREAKPAD_DIR)"; \
 		$(MAKE) ; \
 		$(MAKE) install ; \
@@ -597,7 +597,7 @@ breakpad_install: | breakpad_clean
 
 endif # WINDOWS
 
-breakpad_build_clean:
+breakpad_dist_clean:
 	$(V0) @echo " CLEAN        $(BREAKPAD_BUILD_DIR)"
 	$(V1) [ ! -d "$(BREAKPAD_BUILD_DIR)" ] || $(RM) -rf $(BREAKPAD_BUILD_DIR)
 
@@ -672,6 +672,11 @@ endif
 ifeq ($(shell [ -d "$(BREAKPAD_DIR)" ] && echo "exists"), exists)
   DUMP_SYMBOLS_TOOL := $(BREAKPAD_DIR)/bin/dump_syms
 else
+  ifndef IGNORE_MISSING_TOOLCHAIN
+    ifneq (,$(filter package%, $(MAKECMDGOALS)))
+      $(error **ERROR** breakpad not in $(BREAKPAD_DIR)! Please run 'make breakpad_install')
+    endif
+  endif
   DUMP_SYMBOLS_TOOL := dump_syms
 endif
 


### PR DESCRIPTION
I did build it with MSVC on Windows but it's not really possible in our build environment (msys doesn't handle the paths, it needs a lot more MSVC env. stuff than we have etc.). Instead the Windows binary that is already checked into upstream repo is pulled (or a newer one if we decide that is needed at some point). On Mac and Linux we need Google depot-tools to fetch all the deps and prepare the repo for configure/build.

On Windows (doesn't build, fetches pre-built binary from repo):

```
make breakpad_install
```

On Linux/macOS (installs/updates depot_tools, fetches, builds and installs breakpad):

```
make breakpad_install
```

I am thinking about adding `depot_tools_install` dep to `breakpad_install` so it only needs the one step. If depot-tools is already installed it will just fetch the rev defined in the Makefile and check it out (either doing nothing, or upgrading), so harmless or possibly even beneficial. What do you think @mlyle ?

Fixes #1267
