### PR TITLE
hw uavos: f1: disable PWM/PPM by default

### DIFF
--- a/shared/uavobjectdefinition/hwcoptercontrol.xml
+++ b/shared/uavobjectdefinition/hwcoptercontrol.xml
@@ -2,7 +2,7 @@
 	<object name="HwCopterControl" singleinstance="true" settings="true" category="HardwareSettings">
 		<description>Selection of optional hardware configurations.</description>
 
-		<field name="RcvrPort" units="function" type="enum" elements="1" defaultvalue="PWM">
+		<field name="RcvrPort" units="function" type="enum" elements="1" defaultvalue="Disabled">
 			<options>
 				<option>Disabled</option>
 				<option>Outputs</option>

--- a/shared/uavobjectdefinition/hwnaze.xml
+++ b/shared/uavobjectdefinition/hwnaze.xml
@@ -9,7 +9,7 @@
 			</options>
 		</field>
 
-		<field name="RcvrPort" units="function" type="enum" elements="1" defaultvalue="PPM">
+		<field name="RcvrPort" units="function" type="enum" elements="1" defaultvalue="Disabled">
 			<options>
 				<option>Disabled</option>
 				<option>Outputs</option>


### PR DESCRIPTION
Don't waste resources, don't get timer conflicts right off the bat.
Let the user / wizard select that if needed.
