### PR TITLE
GCS:Uploader: Make Export Config button work while connected

### DIFF
--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -1290,13 +1290,17 @@ void UploaderGadgetWidget::onExportButtonClick()
         /* select the UAV-oriented export thing */
         Core::ActionManager *am = Core::ICore::instance()->actionManager();
 
-        if (!am) return;
+        if (!am) {
+            qWarning() << "Could not get ActionManager instance!";
+            return;
+        }
 
         Core::Command *cmd = am->command("UAVSettingsImportExportPlugin.UAVSettingsExport");
 
-        if (cmd) {
-            cmd->action();
-        }
+        if (cmd)
+            cmd->action()->trigger();
+        else
+            qWarning() << "Could find UAVSettingsExport action!";
 
         return;
     }


### PR DESCRIPTION
Export Config button didn't work while connected to board because it only fetched the action but never actually triggered it (inb4 SJWs). Also left a couple of warnings behind that might be useful to log in future.
