### PR TITLE
attitude: remove yaw bias rate

### DIFF
--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -519,7 +519,6 @@ static int32_t updateAttitudeComplementary(bool first_run, bool secondary, bool 
 		// For first 7 seconds use accels to get gyro bias
 		attitudeSettings.AccelKp = 0.1f + 0.1f * (PIOS_Thread_Systime() < 4000);
 		attitudeSettings.AccelKi = 0.1f;
-		attitudeSettings.YawBiasRate = 0.1f;
 		attitudeSettings.MagKp = 0.1f;
 	} else if ((attitudeSettings.ZeroDuringArming == ATTITUDESETTINGS_ZERODURINGARMING_TRUE) && 
 	           (flightStatus.Armed == FLIGHTSTATUS_ARMED_ARMING)) {
@@ -534,7 +533,6 @@ static int32_t updateAttitudeComplementary(bool first_run, bool secondary, bool 
 
 		// Set the other parameters to drive faster convergence
 		attitudeSettings.AccelKi = 0.1f;
-		attitudeSettings.YawBiasRate = 0.1f;
 		attitudeSettings.MagKp = 0.1f;
 
 		// Don't apply LPF to the accels during arming

--- a/ground/gcs/src/plugins/hitl/simulator.cpp
+++ b/ground/gcs/src/plugins/hitl/simulator.cpp
@@ -512,7 +512,6 @@ void Simulator::updateUAVOs(Output2Hardware out){
 
         AttitudeSettings::DataFields attitudeSettingsData = attitudeSettings->getData();
         float accelKp = attitudeSettingsData.AccelKp * 0.1666666666666667;
-        float yawBiasRate = attitudeSettingsData.YawBiasRate;
 
         // calibrate sensors on arming
         if (flightStatus->getData().Armed == FlightStatus::ARMED_ARMING) {
@@ -526,6 +525,8 @@ void Simulator::updateUAVOs(Output2Hardware out){
         float *accels = attRawAcc;
         float grot[3];
         float accel_err[3];
+
+        // XXX this is no longer accurate attitude code from the atti module.
 
         // Rotate gravity to body frame and cross with accels
         grot[0] = -(2 * (q[1] * q[3] - q[0] * q[2]));
@@ -544,9 +545,6 @@ void Simulator::updateUAVOs(Output2Hardware out){
         accel_err[0] /= accel_mag;
         accel_err[1] /= accel_mag;
         accel_err[2] /= accel_mag;
-
-        // Accumulate integral of error.  Scale here so that units are (deg/s) but Ki has units of s
-        gyro_correct_int2 += -gyro[2] * yawBiasRate;
 
         // Correct rates based on error, integral component dealt with in updateSensors
         gyro[0] += accel_err[0] * accelKp / dT;

--- a/shared/uavobjectdefinition/attitudesettings.xml
+++ b/shared/uavobjectdefinition/attitudesettings.xml
@@ -23,9 +23,6 @@
 		<field name="VertPositionTau" units="" type="float" elements="1" defaultvalue="2">
 			<description/>
 		</field>
-		<field name="YawBiasRate" units="channel" type="float" elements="1" defaultvalue="0.000001">
-			<description/>
-		</field>
 		<field name="ZeroDuringArming" units="channel" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="TRUE">
 			<description>Zero the attitude estimate during arming when enabled.</description>
 		</field>


### PR DESCRIPTION
It was unused/removed  on F3/F4, and practically unused on F1 (default value
was very, very, very, very low).
