### PR TITLE
androidgcs: scrape last 18 uavo versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,7 +421,8 @@ androidgcs_sign:
 # change in a hotfix the release does not need to be listed here.
 UAVO_GIT_VERSIONS := HEAD \
 	Release-20160720.1 \
-	Release-20160409.2
+	Release-20160409.2 \
+	$(shell git log --merges --pretty=tformat:%h -n 18 shared/uavobjectdefinition/)
 
 # All versions includes a pseudo collection called "working" which represents
 # the UAVOs in the source tree


### PR DESCRIPTION
This is a kind of crude way to support more versions from next.

It means that for development users that have a uavo version from along
next, some number of future versions of the Android GCS will work with
that revision.  But:
- It won't necessarily work with builds from PR branches that have UAVO
  changes unless that exact version of UAVOs showed up on next.
- It won't work with future versions.
- It only looks at merge commits, not squashes.  (But the next merge
  commit after UAVOs change would get it-- it's only wrong if there was
  a squash commit that changes UAVOs followed by a merge commit that
  change UAVOs.

It slows down the androidgcs build and makes the app significantly
bigger (3.5M vs. 1.5M), but I think it may still be worth it.
