### PR TITLE
GCS: Make updating translations work/easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,14 @@ gcs_clean:
 	$(V0) @echo " CLEAN      $@"
 	$(V1) [ ! -d "$(BUILD_DIR)/ground/gcs" ] || $(RM) -rf "$(BUILD_DIR)/ground/gcs"
 
+.PHONY: gcs_ts
+gcs_ts:
+	$(V1) mkdir -p $(BUILD_DIR)/ground/gcs/share/translations
+	$(V1) ( cd $(BUILD_DIR)/ground/gcs/share/translations && \
+	  PYTHON=$(PYTHON) $(QMAKE) $(ROOT_DIR)/ground/gcs/share/translations/translations.pro -spec $(QT_SPEC) -r CONFIG+="$(GCS_BUILD_CONF) $(GCS_SILENT)" $(GCS_QMAKE_OPTS) && \
+	  $(MAKE) --no-print-directory -w ts ; \
+	)
+
 ifndef WINDOWS
 # unfortunately the silent linking command is broken on windows
 ifeq ($(V), 1)

--- a/ground/gcs/share/translations/translations.pro
+++ b/ground/gcs/share/translations/translations.pro
@@ -24,7 +24,7 @@ MIMETYPES_FILES = \"$$join(MIMETYPES_FILES, |)\"
 
 QMAKE_SUBSTITUTES += extract-mimetypes.xq.in
 ts.commands += \
-    $$XMLPATTERNS -output $$MIME_TR_H $$PWD/extract-mimetypes.xq && \
+    $$XMLPATTERNS -output $$MIME_TR_H $$OUT_PWD/extract-mimetypes.xq && \
     (cd $$GCS_SOURCE_TREE && $$LUPDATE src $$MIME_TR_H -ts $$TRANSLATIONS) && \
     $$QMAKE_DEL_FILE $$targetPath($$MIME_TR_H)
 


### PR DESCRIPTION
First commit is good, second one I'm not sure of it's wisdom. 
First one:
- Fixes translations.pro so ts target actually works
- Adds gcs_ts target to main Makefile so people can easily update translation sources

Note:
To actually perform translation, run ./tools/Qt5.6.1/gcc_64/bin/linguist and open appropriate ts file in ./ground/gcs/share/translations/dronin_*.ts
