### PR TITLE
annunciators: ignore EVENTSYSTEM nuisance alarms

### DIFF
--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -286,6 +286,11 @@ static inline uint8_t indicate_error(const char **sequence)
 			thresh = SYSTEMALARMS_ALARM_CRITICAL;
 		}
 
+		if (i == SYSTEMALARMS_ALARM_EVENTSYSTEM) {
+			// Skip event system alarms-- nuisance
+			continue;
+		}
+
 		if (alarms.Alarm[i] < thresh) {
 			continue;
 		}


### PR DESCRIPTION
Else you can get .- 'a' generic alarm interspersed between your 'armed' or 'disarmed' flashes.
