### PR TITLE
input wizard: Allow a higher max channel value

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -63,7 +63,7 @@
 #define STICK_MAX_MOVE 8
 
 #define MIN_SANE_CHANNEL_VALUE 50
-#define MAX_SANE_CHANNEL_VALUE 10000
+#define MAX_SANE_CHANNEL_VALUE 32768
 #define MIN_SANE_RANGE 125
 
 // Should exceed "MIN_MEANINGFUL_RANGE" in transmitter_control.c (40)


### PR DESCRIPTION
SUMD scaling was removed in 12075d77865c5023d7f544e349a0ded848c5df1d and
my effective SUMD range is 7872 - 16128.  In the wizard, any time you
move the stick above the middle when trying to find the range, it kind
of freaks out and considers stuff failed.
