### PR TITLE
vbar: Move settings to separate object.

### DIFF
--- a/flight/Modules/Stabilization/inc/virtualflybar.h
+++ b/flight/Modules/Stabilization/inc/virtualflybar.h
@@ -35,7 +35,7 @@
 #include "openpilot.h"
 #include "stabilizationsettings.h"
 
-int stabilization_virtual_flybar(float gyro, float command, float *output, float dT, bool reinit, uint32_t axis, struct pid *pid, StabilizationSettingsData *settings);
+int stabilization_virtual_flybar(float gyro, float command, float *output, float dT, bool reinit, uint32_t axis, struct pid *pid, VbarSettingsData *settings);
 int stabilization_virtual_flybar_pirocomp(float z_gyro, float dT);
 
 #endif /* VIRTUALFLYBAR_H */

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -59,6 +59,7 @@
 #include "subtrimsettings.h"
 #include "systemsettings.h"
 #include "manualcontrolcommand.h"
+#include "vbarsettings.h"
 
 // Math libraries
 #include "coordinate_conversions.h"
@@ -108,6 +109,8 @@ enum {
 // Private variables
 static struct pios_thread *taskHandle;
 static StabilizationSettingsData settings;
+static VbarSettingsData vbar_settings;
+
 static SubTrimData subTrim;
 static struct pios_queue *queue;
 float axis_lock_accum[3] = {0,0,0};
@@ -167,6 +170,7 @@ int32_t StabilizationStart()
 
 	// Connect settings callback
 	StabilizationSettingsConnectCallback(SettingsUpdatedCb);
+	VbarSettingsConnectCallback(SettingsUpdatedCb);
 	SubTrimSettingsConnectCallback(SettingsUpdatedCb);
 
 	// Watchdog must be registered before starting task
@@ -280,10 +284,10 @@ static void stabilizationTask(void* parameters)
 			}
 
 			// Compute time constant for vbar decay term
-			if (settings.VbarTau < 0.001f) {
+			if (vbar_settings.VbarTau < 0.001f) {
 				vbar_decay = 0;
 			} else {
-				vbar_decay = expf(-dT_filtered / settings.VbarTau);
+				vbar_decay = expf(-dT_filtered / vbar_settings.VbarTau);
 			}
 
 			gyro_filter_updated = false;
@@ -547,7 +551,7 @@ static void stabilizationTask(void* parameters)
 					rateDesiredAxis[i] = stabDesiredAxis[i];
 
 					// Run a virtual flybar stabilization algorithm on this axis
-					stabilization_virtual_flybar(gyro_filtered[i], rateDesiredAxis[i], &actuatorDesiredAxis[i], dT, reinit, i, &pids[PID_GROUP_VBAR + i], &settings);
+					stabilization_virtual_flybar(gyro_filtered[i], rateDesiredAxis[i], &actuatorDesiredAxis[i], dT, reinit, i, &pids[PID_GROUP_VBAR + i], &vbar_settings);
 
 					break;
 				case STABILIZATIONDESIRED_STABILIZATIONMODE_WEAKLEVELING:
@@ -839,7 +843,7 @@ static void stabilizationTask(void* parameters)
 			}
 		}
 
-		if (settings.VbarPiroComp == STABILIZATIONSETTINGS_VBARPIROCOMP_TRUE)
+		if (vbar_settings.VbarPiroComp == VBARSETTINGS_VBARPIROCOMP_TRUE)
 			stabilization_virtual_flybar_pirocomp(gyro_filtered[2], dT);
 
 #if defined(RATEDESIRED_DIAGNOSTICS)
@@ -927,23 +931,23 @@ static void calculate_pids()
 
 	// Set the vbar roll settings
 	pid_configure(&pids[PID_VBAR_ROLL],
-	              settings.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KP],
-	              settings.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KI],
-	              settings.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KD],
+	              vbar_settings.VbarRollPID[VBARSETTINGS_VBARROLLPID_KP],
+	              vbar_settings.VbarRollPID[VBARSETTINGS_VBARROLLPID_KI],
+	              vbar_settings.VbarRollPID[VBARSETTINGS_VBARROLLPID_KD],
 	              0);
 
 	// Set the vbar pitch settings
 	pid_configure(&pids[PID_VBAR_PITCH],
-	              settings.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KP],
-	              settings.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KI],
-	              settings.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KD],
+	              vbar_settings.VbarPitchPID[VBARSETTINGS_VBARPITCHPID_KP],
+	              vbar_settings.VbarPitchPID[VBARSETTINGS_VBARPITCHPID_KI],
+	              vbar_settings.VbarPitchPID[VBARSETTINGS_VBARPITCHPID_KD],
 	              0);
 
 	// Set the vbar yaw settings
 	pid_configure(&pids[PID_VBAR_YAW],
-	              settings.VbarYawPID[STABILIZATIONSETTINGS_VBARYAWPID_KP],
-	              settings.VbarYawPID[STABILIZATIONSETTINGS_VBARYAWPID_KI],
-	              settings.VbarYawPID[STABILIZATIONSETTINGS_VBARYAWPID_KD],
+	              vbar_settings.VbarYawPID[VBARSETTINGS_VBARYAWPID_KP],
+	              vbar_settings.VbarYawPID[VBARSETTINGS_VBARYAWPID_KI],
+	              vbar_settings.VbarYawPID[VBARSETTINGS_VBARYAWPID_KD],
 	              0);
 
 	// Set the coordinated flight settings
@@ -1010,6 +1014,13 @@ static void SettingsUpdatedCb(UAVObjEvent * ev, void *ctx, void *obj, int len)
 		lowThrottleZeroIntegral = settings.LowThrottleZeroIntegral == STABILIZATIONSETTINGS_LOWTHROTTLEZEROINTEGRAL_TRUE;
 
 		gyro_filter_updated = true;
+	}
+
+	if (ev == NULL || ev->obj == VbarSettingsHandle())
+	{
+		VbarSettingsGet(&vbar_settings);
+
+		calculate_pids();
 	}
 }
 

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -189,11 +189,12 @@ int32_t StabilizationStart()
 int32_t StabilizationInitialize()
 {
 	// Initialize variables
-	if (StabilizationSettingsInitialize() == -1 \
-		|| ActuatorDesiredInitialize() == -1 \
-		|| SubTrimInitialize() == -1 \
-		|| SubTrimSettingsInitialize() == -1 \
-		|| ManualControlCommandInitialize() == -1) {
+	if (StabilizationSettingsInitialize() == -1
+		|| ActuatorDesiredInitialize() == -1
+		|| SubTrimInitialize() == -1
+		|| SubTrimSettingsInitialize() == -1
+		|| ManualControlCommandInitialize() == -1
+		|| VbarSettingsInitialize() == -1) {
 		return -1;
 	}
 

--- a/flight/Modules/Stabilization/virtualflybar.c
+++ b/flight/Modules/Stabilization/virtualflybar.c
@@ -33,7 +33,7 @@
 #include "physical_constants.h"
 #include "pid.h"
 #include "stabilization.h"
-#include "stabilizationsettings.h"
+#include "vbarsettings.h"
 
 //! Private variables
 static float vbar_integral[MAX_AXES];
@@ -42,7 +42,7 @@ extern float vbar_decay;
 //! Private methods
 static float bound(float val, float range);
 
-int stabilization_virtual_flybar(float gyro, float command, float *output, float dT, bool reinit, uint32_t axis, struct pid *pid, StabilizationSettingsData *settings)
+int stabilization_virtual_flybar(float gyro, float command, float *output, float dT, bool reinit, uint32_t axis, struct pid *pid, VbarSettingsData *settings)
 {
 	float gyro_gain = 1.0f;
 

--- a/flight/Modules/TxPID/txpid.c
+++ b/flight/Modules/TxPID/txpid.c
@@ -53,6 +53,7 @@
 #include "accessorydesired.h"
 #include "manualcontrolcommand.h"
 #include "stabilizationsettings.h"
+#include "vbarsettings.h"
 #ifndef SMALLF1
 #include "vtolpathfollowersettings.h"
 #endif
@@ -77,6 +78,7 @@
 struct txpid_struct {
 	TxPIDSettingsData inst;
 	StabilizationSettingsData stab;
+	VbarSettingsData vbar;
 	AccessoryDesiredData accessory;
 #ifndef SMALLF1
 	VtolPathFollowerSettingsData vtolPathFollowerSettingsData;
@@ -199,6 +201,7 @@ static void updatePIDs(UAVObjEvent* ev, void *ctx, void *obj, int len)
 		return;
 
 	StabilizationSettingsGet(&txpid_data->stab);
+	VbarSettingsGet(&txpid_data->vbar);
 
 #ifndef SMALLF1
 	// Check to make sure the settings UAVObject has been instantiated
@@ -210,6 +213,7 @@ static void updatePIDs(UAVObjEvent* ev, void *ctx, void *obj, int len)
 #endif
 
 	bool stabilizationSettingsNeedsUpdate = false;
+	bool vbarSettingsNeedsUpdate = false;
 
 	// Loop through every enabled instance
 	for (uint8_t i = 0; i < TXPIDSETTINGS_PIDS_NUMELEM; i++) {
@@ -324,57 +328,57 @@ static void updatePIDs(UAVObjEvent* ev, void *ctx, void *obj, int len)
 				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.GyroCutoff, value);
 				break;
 			case TXPIDSETTINGS_PIDS_ROLLVBARSENSITIVITY:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarSensitivity[STABILIZATIONSETTINGS_VBARSENSITIVITY_ROLL], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarSensitivity[VBARSETTINGS_VBARSENSITIVITY_ROLL], value);
 				break;
 			case TXPIDSETTINGS_PIDS_PITCHVBARSENSITIVITY:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarSensitivity[STABILIZATIONSETTINGS_VBARSENSITIVITY_PITCH], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarSensitivity[VBARSETTINGS_VBARSENSITIVITY_PITCH], value);
 				break;
 			case TXPIDSETTINGS_PIDS_ROLLPITCHVBARSENSITIVITY:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarSensitivity[STABILIZATIONSETTINGS_VBARSENSITIVITY_ROLL], value);
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarSensitivity[STABILIZATIONSETTINGS_VBARSENSITIVITY_PITCH], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarSensitivity[VBARSETTINGS_VBARSENSITIVITY_ROLL], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarSensitivity[VBARSETTINGS_VBARSENSITIVITY_PITCH], value);
 				break;
 			
 			case TXPIDSETTINGS_PIDS_YAWVBARSENSITIVITY:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarSensitivity[STABILIZATIONSETTINGS_VBARSENSITIVITY_YAW], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarSensitivity[VBARSETTINGS_VBARSENSITIVITY_YAW], value);
 				break;
 			case TXPIDSETTINGS_PIDS_ROLLVBARKP:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KP], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarRollPID[VBARSETTINGS_VBARROLLPID_KP], value);
 				break;
 			case TXPIDSETTINGS_PIDS_ROLLVBARKI:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KI], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarRollPID[VBARSETTINGS_VBARROLLPID_KI], value);
 				break;	
 			case TXPIDSETTINGS_PIDS_ROLLVBARKD:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KD], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarRollPID[VBARSETTINGS_VBARROLLPID_KD], value);
 				break;
 			case TXPIDSETTINGS_PIDS_PITCHVBARKP:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KP], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarPitchPID[VBARSETTINGS_VBARPITCHPID_KP], value);
 				break;
 			case TXPIDSETTINGS_PIDS_PITCHVBARKI:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KI], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarPitchPID[VBARSETTINGS_VBARPITCHPID_KI], value);
 				break;
 			case TXPIDSETTINGS_PIDS_PITCHVBARKD:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KD], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarPitchPID[VBARSETTINGS_VBARPITCHPID_KD], value);
 				break;
 			case TXPIDSETTINGS_PIDS_ROLLPITCHVBARKP:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KP], value);
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KP], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarRollPID[VBARSETTINGS_VBARROLLPID_KP], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarPitchPID[VBARSETTINGS_VBARPITCHPID_KP], value);
 				break;
 			case TXPIDSETTINGS_PIDS_ROLLPITCHVBARKI:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KI], value);
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KI], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarRollPID[VBARSETTINGS_VBARROLLPID_KI], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarPitchPID[VBARSETTINGS_VBARPITCHPID_KI], value);
 				break;
 			case TXPIDSETTINGS_PIDS_ROLLPITCHVBARKD:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarRollPID[STABILIZATIONSETTINGS_VBARROLLPID_KD], value);
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarPitchPID[STABILIZATIONSETTINGS_VBARPITCHPID_KD], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarRollPID[VBARSETTINGS_VBARROLLPID_KD], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarPitchPID[VBARSETTINGS_VBARPITCHPID_KD], value);
 				break;
 			case TXPIDSETTINGS_PIDS_YAWVBARKP:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarYawPID[STABILIZATIONSETTINGS_VBARYAWPID_KP], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarYawPID[VBARSETTINGS_VBARYAWPID_KP], value);
 				break;
 			case TXPIDSETTINGS_PIDS_YAWVBARKI:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarYawPID[STABILIZATIONSETTINGS_VBARYAWPID_KI], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarYawPID[VBARSETTINGS_VBARYAWPID_KI], value);
 				break;
 			case TXPIDSETTINGS_PIDS_YAWVBARKD:
-				stabilizationSettingsNeedsUpdate |= update(&txpid_data->stab.VbarYawPID[STABILIZATIONSETTINGS_VBARYAWPID_KD], value);
+				vbarSettingsNeedsUpdate |= update(&txpid_data->vbar.VbarYawPID[VBARSETTINGS_VBARYAWPID_KD], value);
 				break;
 #ifndef SMALLF1
 			case TXPIDSETTINGS_PIDS_HORIZONTALPOSKP:
@@ -408,6 +412,10 @@ static void updatePIDs(UAVObjEvent* ev, void *ctx, void *obj, int len)
 	// Update UAVOs, if necessary
 	if (stabilizationSettingsNeedsUpdate) {
 		StabilizationSettingsSet(&txpid_data->stab);
+	}
+
+	if (vbarSettingsNeedsUpdate) {
+		VbarSettingsSet(&txpid_data->vbar);
 	}
 
 #ifndef SMALLF1

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -18,14 +18,6 @@
 		<field name="RollPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
 		<field name="PitchPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
 		<field name="YawPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
-		<field name="VbarSensitivity" units="frac" type="float" elementnames="Roll,Pitch,Yaw" defaultvalue="0.5,0.5,0.5"/>
-		<field name="VbarRollPID" units="1/(deg/s)" type="float" elementnames="Kp,Ki,Kd" defaultvalue="0.005,0.002,0"/>
-		<field name="VbarPitchPID" units="1/(deg/s)" type="float" elementnames="Kp,Ki,Kd" defaultvalue="0.005,0.002,0"/>
-		<field name="VbarYawPID" units="1/(deg/s)" type="float" elementnames="Kp,Ki,Kd" defaultvalue="0.005,0.002,0"/>
-		<field name="VbarTau" units="sec" type="float" elements="1" defaultvalue="0.5"/>
-		<field name="VbarGyroSuppress" units="%" type="int8" elements="1" defaultvalue="30"/>
-		<field name="VbarPiroComp" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
-		<field name="VbarMaxAngle" units="deg" type="uint8" elements="1" defaultvalue="10"/>
 		<field name="GyroCutoff" units="Hz" type="float" elements="1" defaultvalue="55.0"/>
 		<field name="DerivativeCutoff" units="Hz" type="uint8" elements="1" defaultvalue="20"/>
 		<field name="DerivativeGamma" units="" type="float" elements="1" defaultvalue="1"/>

--- a/shared/uavobjectdefinition/vbarsettings.xml
+++ b/shared/uavobjectdefinition/vbarsettings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<xml>
+	<object name="VbarSettings" singleinstance="true" settings="true">
+		<description>Settings for the virtualbar flight mode</description>
+
+		<field name="VbarSensitivity" units="frac" type="float" elementnames="Roll,Pitch,Yaw" defaultvalue="0.5,0.5,0.5"/>
+		<field name="VbarRollPID" units="1/(deg/s)" type="float" elementnames="Kp,Ki,Kd" defaultvalue="0.005,0.002,0"/>
+		<field name="VbarPitchPID" units="1/(deg/s)" type="float" elementnames="Kp,Ki,Kd" defaultvalue="0.005,0.002,0"/>
+		<field name="VbarYawPID" units="1/(deg/s)" type="float" elementnames="Kp,Ki,Kd" defaultvalue="0.005,0.002,0"/>
+		<field name="VbarTau" units="sec" type="float" elements="1" defaultvalue="0.5"/>
+		<field name="VbarGyroSuppress" units="%" type="int8" elements="1" defaultvalue="30"/>
+		<field name="VbarPiroComp" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE"/>
+		<field name="VbarMaxAngle" units="deg" type="uint8" elements="1" defaultvalue="10"/>
+		<access gcs="readwrite" flight="readwrite"/>
+		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
+		<telemetryflight acked="true" updatemode="onchange" period="0"/>
+		<logging updatemode="manual" period="0"/>
+	</object>
+</xml>
+


### PR DESCRIPTION
StabilizationSettings is getting too big, and these are decoupled
from everything else.
- StabilizationSettings is too big with the virtualbar stuff to fit acrodyne stuff too.  Makes more sense for vbar to get its own object
- Likely a subsequent PR will drop virtualbar support from F1, which will get us a fair bit of breathing room for other projects.
