### PR TITLE
receiver activity -- attempt to improve

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -948,7 +948,7 @@ group_completed:
 	fsm->sample_count = 0;
 
 	/* Find the next active group, but limit search so we can't loop forever here */
-	for (uint8_t i = 0; i < MANUALCONTROLSETTINGS_CHANNELGROUPS_NONE; i++) {
+	for (uint8_t i = 0; i <= MANUALCONTROLSETTINGS_CHANNELGROUPS_NONE; i++) {
 		/* Move to the next group */
 		fsm->group++;
 		if (fsm->group >= MANUALCONTROLSETTINGS_CHANNELGROUPS_NONE) {

--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -874,7 +874,7 @@ static bool updateRcvrActivityCompare(uintptr_t rcvr_id, struct rcvr_activity_fs
 	int rssi_group = rssitype_to_channelgroup();
 
 	/* If so, see if it's what we're processing */
-	if (pios_rcvr_group_map[rssi_group] == rcvr_id) {
+	if ((rssi_group >= 0) && (pios_rcvr_group_map[rssi_group] == rcvr_id)) {
 		// Yup.  So let's skip the configured RSSI channel
 		rssi_channel = settings.RssiChannelNumber;
 	}


### PR DESCRIPTION
- Fix a negative array index (not the bug we're looking for but not good)
- Don't only check "every other manual control cycle" for activity
- Check each receiver group twice in a row to catch smaller movements, be more responsive, and not be as vulnerable to beat-effects if a receiver doesn't update every time.
  cc/ @jihlein
