### PR TITLE
GCS:Input: Show current values on slider, add reverse button

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -122,6 +122,7 @@ ConfigInputWidget::ConfigInputWidget(QWidget *parent) : ConfigTaskWidget(parent)
         int index2 = manualCommandObj->getField("Channel")->getElementNames().indexOf(name);
         if (index2 >= 0) {
             addUAVObjectToWidgetRelation("ManualControlCommand", "Channel", inpForm->ui->channelCurrent, index2);
+            addUAVObjectToWidgetRelation("ManualControlCommand", "Channel", inpForm->sbChannelCurrent, index2);
         }
         ++index;
     }

--- a/ground/gcs/src/plugins/config/inputchannelform.cpp
+++ b/ground/gcs/src/plugins/config/inputchannelform.cpp
@@ -37,10 +37,16 @@ inputChannelForm::inputChannelForm(QWidget *parent, bool showlegend, bool showSl
         ui->channelNeutral->setHidden(true);
     }
 
+    // setup a hidden widget to track channel value without too much pain
+    sbChannelCurrent = new QSpinBox(this);
+    sbChannelCurrent->setVisible(false);
+    sbChannelCurrent->setMaximum(65535);
+
     // Connect slots
     connect(ui->channelMin,SIGNAL(valueChanged(int)),this,SLOT(minMaxUpdated()));
     connect(ui->channelMax,SIGNAL(valueChanged(int)),this,SLOT(minMaxUpdated()));
     connect(ui->channelGroup,SIGNAL(currentIndexChanged(int)),this,SLOT(groupUpdated()));
+    connect(sbChannelCurrent, SIGNAL(valueChanged(int)), ui->channelNeutral, SLOT(setIndicatorValue(int)));
 
     // This is awkward but since we want the UI to be a dropdown but the field is not an enum
     // so it breaks the UAUVObject widget relation of the task gadget.  Running the data through

--- a/ground/gcs/src/plugins/config/inputchannelform.cpp
+++ b/ground/gcs/src/plugins/config/inputchannelform.cpp
@@ -23,6 +23,7 @@ inputChannelForm::inputChannelForm(QWidget *parent, bool showlegend, bool showSl
         layout()->removeWidget(ui->legend4);
         layout()->removeWidget(ui->legend5);
         layout()->removeWidget(ui->legend6);
+        layout()->removeWidget(ui->lblReverse);
         delete ui->legend0;
         delete ui->legend1;
         delete ui->legend2;
@@ -30,6 +31,7 @@ inputChannelForm::inputChannelForm(QWidget *parent, bool showlegend, bool showSl
         delete ui->legend4;
         delete ui->legend5;
         delete ui->legend6;
+        delete ui->lblReverse;
     }
 
     if(!showSlider)
@@ -47,6 +49,7 @@ inputChannelForm::inputChannelForm(QWidget *parent, bool showlegend, bool showSl
     connect(ui->channelMax,SIGNAL(valueChanged(int)),this,SLOT(minMaxUpdated()));
     connect(ui->channelGroup,SIGNAL(currentIndexChanged(int)),this,SLOT(groupUpdated()));
     connect(sbChannelCurrent, SIGNAL(valueChanged(int)), ui->channelNeutral, SLOT(setIndicatorValue(int)));
+    connect(ui->btnReverse, SIGNAL(released()), this, SLOT(reverseChannel()));
 
     // This is awkward but since we want the UI to be a dropdown but the field is not an enum
     // so it breaks the UAUVObject widget relation of the task gadget.  Running the data through
@@ -254,4 +257,19 @@ void inputChannelForm::channelDropdownUpdated(int newval)
 void inputChannelForm::channelNumberUpdated(int newval)
 {
     ui->channelNumberDropdown->setCurrentIndex(newval);
+}
+
+/**
+ * @brief Switch the channel min and max
+ */
+void inputChannelForm::reverseChannel()
+{
+    int min = ui->channelMin->value();
+    int neutral = ui->channelNeutral->value();
+    int max = ui->channelMax->value();
+    ui->channelMax->setValue(min);
+    ui->channelMin->setValue(max);
+    if (ui->channelName->text() == "Throttle") // this is bad... but...
+        neutral = max - (neutral - min);
+    ui->channelNeutral->setValue(neutral);
 }

--- a/ground/gcs/src/plugins/config/inputchannelform.h
+++ b/ground/gcs/src/plugins/config/inputchannelform.h
@@ -23,6 +23,7 @@ private slots:
     void groupUpdated();
     void channelDropdownUpdated(int);
     void channelNumberUpdated(int);
+    void reverseChannel();
 
 private:
     Ui::inputChannelForm *ui;

--- a/ground/gcs/src/plugins/config/inputchannelform.h
+++ b/ground/gcs/src/plugins/config/inputchannelform.h
@@ -27,6 +27,7 @@ private slots:
 private:
     Ui::inputChannelForm *ui;
     ChannelFunc m_chanType;
+    QSpinBox *sbChannelCurrent;
 };
 
 #endif // INPUTCHANNELFORM_H

--- a/ground/gcs/src/plugins/config/inputchannelform.ui
+++ b/ground/gcs/src/plugins/config/inputchannelform.ui
@@ -424,7 +424,7 @@ margin:1px;</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="11">
+   <item row="2" column="12">
     <spacer name="horizontalSpacer_4">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -491,6 +491,9 @@ margin:1px;</string>
      <property name="text">
       <string>Current</string>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
     </widget>
    </item>
    <item row="2" column="9">
@@ -526,6 +529,49 @@ margin:1px;</string>
      <property name="text">
       <string>TextLabel</string>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="11">
+    <widget class="QPushButton" name="btnReverse">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>85</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="configgadget.qrc">
+       <normaloff>:/configgadget/images/swap.svg</normaloff>:/configgadget/images/swap.svg</iconset>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="11">
+    <widget class="QLabel" name="lblReverse">
+     <property name="styleSheet">
+      <string notr="true">background-color: qlineargradient(spread:reflect, x1:0.507, y1:0, x2:0.507, y2:0.772, stop:0.208955 rgba(74, 74, 74, 255), stop:0.78607 rgba(36, 36, 36, 255));
+color: rgb(255, 255, 255);
+border-radius: 5;
+font:bold;
+margin:1px;</string>
+     </property>
+     <property name="text">
+      <string>Reverse</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
     </widget>
    </item>
   </layout>
@@ -545,6 +591,8 @@ margin:1px;</string>
   <tabstop>channelNeutral</tabstop>
   <tabstop>channelMax</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="configgadget.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/ground/gcs/src/plugins/config/textbubbleslider.h
+++ b/ground/gcs/src/plugins/config/textbubbleslider.h
@@ -50,6 +50,7 @@ public slots:
 
 protected:
     void paintEvent ( QPaintEvent * event );
+    qreal sliderPosFromValue(const int val);
 
 private:
     void setMaxPixelWidth();

--- a/ground/gcs/src/plugins/config/textbubbleslider.h
+++ b/ground/gcs/src/plugins/config/textbubbleslider.h
@@ -45,6 +45,9 @@ public:
     void setMaximum(int);
     void setHidden(bool);
 
+public slots:
+    void setIndicatorValue(int us);
+
 protected:
     void paintEvent ( QPaintEvent * event );
 
@@ -57,7 +60,7 @@ private:
     int slideHandleWidth;
     int slideHandleMargin;
     bool hidden;
-
+    int indicatorValue;
 };
 
 #endif // TEXTBUBBLESLIDER_H


### PR DESCRIPTION
As per title. The logic for neutral when reversing is to preserve it's current value except for throttle, where it is switched to the other end (so actually, it stays in the same place graphically). Feedback wanted on this behaviour.

<img width="1515" alt="newchans" src="https://cloud.githubusercontent.com/assets/9995998/19218075/e886057e-8e4b-11e6-9fd9-b62452eaaa80.png">

The response is a little slow because ManualControlCommand only updates every 1s by default. Should we reduce that?

Fixes the main part of #70.
