### PR TITLE
sim: realtime: fix sched_setaffinity call

### DIFF
--- a/flight/PiOS/posix/pios_sys.c
+++ b/flight/PiOS/posix/pios_sys.c
@@ -297,7 +297,7 @@ static void go_realtime() {
 
 	CPU_SET(0, &allowable_cpus);
 
-	rc = sched_setaffinity(0, CPU_SETSIZE, &allowable_cpus);
+	rc = sched_setaffinity(0, sizeof(allowable_cpus), &allowable_cpus);
 
 	if (rc) {
 		perror("sched_setaffinity");


### PR DESCRIPTION
We had used CPU_SETSIZE before which is dimensioned in bits... but
the affinity call expects the size of the set to be dimensioned in
bytes.  Bypass, just use sizeof().

Reported by @mhvdrone, unknown why I don't see it.
