### PR TITLE
Flight: BrainRE1 - Move to new buzzer infrastructure.

### DIFF
--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -52,10 +52,6 @@
 #include "systemstats.h"
 #include "watchdogstatus.h"
 
-#if defined(PIOS_INCLUDE_RE1_FPGA)
-#include "fpga_drv.h"
-#endif
-
 #if defined(PIOS_INCLUDE_DEBUG_CONSOLE) && defined(DEBUG_THIS_FILE)
 #define DEBUG_MSG(format, ...) PIOS_COM_SendFormattedString(PIOS_COM_DEBUG, format, ## __VA_ARGS__)
 #else

--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -52,6 +52,10 @@
 #include "systemstats.h"
 #include "watchdogstatus.h"
 
+#if defined(PIOS_INCLUDE_RE1_FPGA)
+#include "fpga_drv.h"
+#endif
+
 #if defined(PIOS_INCLUDE_DEBUG_CONSOLE) && defined(DEBUG_THIS_FILE)
 #define DEBUG_MSG(format, ...) PIOS_COM_SendFormattedString(PIOS_COM_DEBUG, format, ## __VA_ARGS__)
 #else
@@ -363,11 +367,26 @@ static inline void consider_annunc(AnnunciatorSettingsData *annunciatorSettings,
 		}
 	}
 
+#if defined(PIOS_INCLUDE_RE1_FPGA)
+	if (prio_sufficient && is_active) {
+		if (annunc_id == PIOS_ANNUNCIATOR_BUZZER)
+			PIOS_RE1FPGA_Buzzer(true);
+		else
+			PIOS_ANNUNC_On(annunc_id);
+	} else {
+		if (annunc_id == PIOS_ANNUNCIATOR_BUZZER)
+			PIOS_RE1FPGA_Buzzer(false);
+		else
+			PIOS_ANNUNC_Off(annunc_id);
+	}	
+#else	
 	if (prio_sufficient && is_active) {
 		PIOS_ANNUNC_On(annunc_id);
 	} else {
 		PIOS_ANNUNC_Off(annunc_id);
 	}
+#endif	
+
 }
 #endif
 

--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -367,26 +367,11 @@ static inline void consider_annunc(AnnunciatorSettingsData *annunciatorSettings,
 		}
 	}
 
-#if defined(PIOS_INCLUDE_RE1_FPGA)
-	if (prio_sufficient && is_active) {
-		if (annunc_id == PIOS_ANNUNCIATOR_BUZZER)
-			PIOS_RE1FPGA_Buzzer(true);
-		else
-			PIOS_ANNUNC_On(annunc_id);
-	} else {
-		if (annunc_id == PIOS_ANNUNCIATOR_BUZZER)
-			PIOS_RE1FPGA_Buzzer(false);
-		else
-			PIOS_ANNUNC_Off(annunc_id);
-	}	
-#else	
 	if (prio_sufficient && is_active) {
 		PIOS_ANNUNC_On(annunc_id);
 	} else {
 		PIOS_ANNUNC_Off(annunc_id);
 	}
-#endif	
-
 }
 #endif
 

--- a/flight/PiOS/inc/pios_annunc_priv.h
+++ b/flight/PiOS/inc/pios_annunc_priv.h
@@ -34,9 +34,14 @@
 #include <pios.h>
 #include <pios_stm32.h>
 
+typedef int32_t (*pios_annunc_func_t)(bool active);
+
 struct pios_annunc {
 	struct stm32_gpio pin;
 	uint32_t remap;
+
+	pios_annunc_func_t handler;
+
 	bool active_high;
 };
 

--- a/flight/targets/brainre1/board-info/board_hw_defs.c
+++ b/flight/targets/brainre1/board-info/board_hw_defs.c
@@ -33,9 +33,12 @@
  * must be maintained in each individual source file that is a derivative work
  * of this source file; otherwise redistribution is prohibited.
  */
- 
+
+#include <pios.h>
 #include <pios_config.h>
 #include <pios_board_info.h>
+
+#include <fpga_drv.h>
 
 #if defined(PIOS_INCLUDE_ANNUNC)
 
@@ -68,7 +71,12 @@ static const struct pios_annunc pios_annuncs[] = {
 		},
 		.remap = 0,
 		.active_high = true,
-	}
+	},
+#if defined(PIOS_INCLUDE_RE1_FPGA)
+	[PIOS_ANNUNCIATOR_BUZZER] = {
+		.handler = PIOS_RE1FPGA_Buzzer
+	},
+#endif
 };
 
 static const struct pios_annunc_cfg pios_annunc_cfg = {

--- a/flight/targets/brainre1/board-info/pios_board.h
+++ b/flight/targets/brainre1/board-info/pios_board.h
@@ -85,12 +85,12 @@ TIM8  |           |           |           |
 //------------------------
 // PIOS_LED
 //------------------------
-#define PIOS_LED_GREEN		     0
-#define PIOS_LED_RED		     1
+#define PIOS_LED_GREEN           0
+#define PIOS_LED_RED             1
 #define PIOS_ANNUNCIATOR_BUZZER  2
 
-#define PIOS_LED_HEARTBEAT	PIOS_LED_GREEN
-#define PIOS_LED_ALARM		PIOS_LED_RED
+#define PIOS_LED_HEARTBEAT       PIOS_LED_GREEN
+#define PIOS_LED_ALARM           PIOS_LED_RED
 
 
 //------------------------

--- a/flight/targets/brainre1/board-info/pios_board.h
+++ b/flight/targets/brainre1/board-info/pios_board.h
@@ -85,8 +85,9 @@ TIM8  |           |           |           |
 //------------------------
 // PIOS_LED
 //------------------------
-#define PIOS_LED_GREEN		0
-#define PIOS_LED_RED		1
+#define PIOS_LED_GREEN		     0
+#define PIOS_LED_RED		     1
+#define PIOS_ANNUNCIATOR_BUZZER  2
 
 #define PIOS_LED_HEARTBEAT	PIOS_LED_GREEN
 #define PIOS_LED_ALARM		PIOS_LED_RED

--- a/flight/targets/brainre1/fw/pios_board.c
+++ b/flight/targets/brainre1/fw/pios_board.c
@@ -155,42 +155,16 @@ static void settingdUpdatedCb(UAVObjEvent * ev, void *ctx, void *obj, int len)
 			break;
 	}
 
-	/* Configure the failsafe buzzer */
-	if (hwre1data->FailsafeBuzzer == HWBRAINRE1_FAILSAFEBUZZER_4KHZ_BUZZER) {
+	/* Configure the buzzer type */
+	if (hwre1data->BuzzerType == HWBRAINRE1_BUZZERTYPE_4KHZ_BUZZER) {
 		PIOS_RE1FPGA_SetBuzzerType(PIOS_RE1FPGA_BUZZER_AC);
 	}
-	else {
+	else if (hwre1data->BuzzerType == HWBRAINRE1_BUZZERTYPE_DC_BUZZER) {
 		PIOS_RE1FPGA_SetBuzzerType(PIOS_RE1FPGA_BUZZER_DC);
 	}
 
 	/* Set video sync detector threshold */
 	PIOS_RE1FPGA_SetSyncThreshold(hwre1data->VideoSyncDetectorThreshold);
-}
-
-/**
- * flightStatusUpdatedCb()
- * Used to toggle buzzer
- */
-static void flightStatusUpdatedCb(UAVObjEvent * ev, void *ctx, void *obj, int len)
-{
-	(void) ev; (void) ctx; (void) len;
-	static bool was_armed = false;
-
-	FlightStatusData * data = (FlightStatusData *)obj;
-
-	if (data->Armed == FLIGHTSTATUS_ARMED_ARMED) {
-		was_armed = true;
-	}
-
-	if (was_armed && (data->FlightMode == FLIGHTSTATUS_FLIGHTMODE_FAILSAFE)) {
-		uint8_t buzzer_setting;
-		HwBrainRE1FailsafeBuzzerGet(&buzzer_setting);
-		PIOS_RE1FPGA_Buzzer(buzzer_setting != HWBRAINRE1_FAILSAFEBUZZER_DISABLED);
-	}
-	else {
-		PIOS_RE1FPGA_Buzzer(false);
-	}
-
 }
 
 /**
@@ -321,10 +295,6 @@ void PIOS_Board_Init(void) {
 	uint8_t flashid[16] = {0};
 	PIOS_Flash_Jedec_ReadOTPData(pios_external_flash_id, 0, flashid, 16);
 	HwBrainRE1FlashIDSet(flashid);
-
-	/* Connect callback for buzzer */
-	FlightStatusInitialize();
-	FlightStatusConnectCallback(flightStatusUpdatedCb);
 
 	ModuleSettingsInitialize();
 

--- a/flight/targets/brainre1/re1fpga/fpga_drv.h
+++ b/flight/targets/brainre1/re1fpga/fpga_drv.h
@@ -33,7 +33,8 @@
 
 #ifndef PIOS_RE1FPGA_H
 #define PIOS_RE1FPGA_H
-#include "pios_video.h"
+
+#include <pios_video.h>
 
 struct pios_re1fpga_cfg {
 	struct stm32_gpio mco_pin; /* pin used for clock output to FPGA */

--- a/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.cpp
+++ b/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.cpp
@@ -75,7 +75,7 @@ BrainRE1Configuration::BrainRE1Configuration(QWidget *parent) :
     connect(re1_settings_obj, SIGNAL(CustomLEDColor_2Changed(quint8)), this, SLOT(getCustomLedColor()));
     connect(ui->clrbCustomLEDColor, SIGNAL(colorChanged(const QColor)), this, SLOT(setCustomLedColor(const QColor)));
 
-    addUAVObjectToWidgetRelation("HwBrainRE1", "FailsafeBuzzer", ui->cmbFailsafeBuzzer);
+    addUAVObjectToWidgetRelation("HwBrainRE1", "BuzzerType", ui->cmbBuzzerType);
     addUAVObjectToWidgetRelation("HwBrainRE1", "VideoSyncDetectorThreshold", ui->sbVideoSyncDetectorThreshold);
 
     // Load UAVObjects to widget relations from UI file

--- a/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.ui
+++ b/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.ui
@@ -57,10 +57,10 @@
      <widget class="QWidget" name="scrollAreaWidgetContents">
       <property name="geometry">
        <rect>
-        <x>-80</x>
+        <x>0</x>
         <y>0</y>
-        <width>968</width>
-        <height>800</height>
+        <width>970</width>
+        <height>781</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -758,11 +758,11 @@
            <item row="3" column="0">
             <widget class="QGroupBox" name="groupBox_3">
              <property name="title">
-              <string>Failsafe Buzzer</string>
+              <string>Buzzer Type</string>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_4">
               <item>
-               <widget class="QComboBox" name="cmbFailsafeBuzzer"/>
+               <widget class="QComboBox" name="cmbBuzzerType"/>
               </item>
               <item>
                <widget class="QLabel" name="label_14">
@@ -773,7 +773,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>Note: Buzzer sounds on failsafe after vehicle has been armed.</string>
+                 <string>Note: When enabled, buzzer sounds on failsafe after vehicle has been armed.</string>
                 </property>
                </widget>
               </item>
@@ -843,7 +843,6 @@
         </layout>
        </item>
       </layout>
-      <zorder>frame</zorder>
       <zorder></zorder>
       <zorder></zorder>
      </widget>

--- a/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.ui
+++ b/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.ui
@@ -773,7 +773,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>Note: When enabled, buzzer sounds on failsafe after vehicle has been armed.</string>
+                 <string>Note: When enabled, buzzer beeps 'R' in morse code when in failsafe after vehicle has been armed.</string>
                 </property>
                </widget>
               </item>

--- a/shared/uavobjectdefinition/hwbrainre1.xml
+++ b/shared/uavobjectdefinition/hwbrainre1.xml
@@ -105,7 +105,7 @@
 		</field>
 		<field name="IRIDTrackmate" units="" type="uint16" elements="1" defaultvalue="0" limits="%BE:0:9999"/>
 		<field name="IRIDILap" units="" type="uint32" elements="1" defaultvalue="0" limits="%BE:0:9999999"/>
-		<field name="FailsafeBuzzer" units="" type="enum" elements="1" options="Disabled,DC_Buzzer,4kHz_Buzzer" defaultvalue="Disabled"/>
+		<field name="BuzzerType" units="" type="enum" elements="1" options="Disabled,DC_Buzzer,4kHz_Buzzer" defaultvalue="Disabled"/>
 		<field name="HWRevision" units="" type="uint8" elements="1" defaultvalue="0"/>
 		<field name="VideoSyncDetectorThreshold" units="" type="uint8" elements="1" defaultvalue="120">
 			<description>Threshold for the video sync pulse detector. It should not be necessary for the user to change this value from the default (120).</description>


### PR DESCRIPTION
Moves BrainRE1 buzzer control to new annunciator infrastructure.

Tested failsafe after initial arm, buzzed out "R" in morse as expected.

Changed the buzzer severity level, and it buzzed out "T" when disarmed and "I" when armed, again as expected.
