### PR TITLE
CC3D: Attempt to fix PWM channel 1 input (plus some general bugfixes)

### DIFF
--- a/flight/PiOS/STM32/pios_servo.c
+++ b/flight/PiOS/STM32/pios_servo.c
@@ -220,7 +220,7 @@ void PIOS_Servo_SetMode(const uint16_t *out_rate, const int banks, const uint16_
 		} else {
 			// assume 16-bit timer
 			if (servo_cfg->force_1MHz) {
-				timer_banks[i].prescaler = max_tim_clock / 1000000;
+				timer_banks[i].prescaler = max_tim_clock / 1000000 - 1;
 			} else {
 				float num_ticks = (float)max_tim_clock / (float)rate;
 

--- a/flight/PiOS/STM32F10x/pios_tim.c
+++ b/flight/PiOS/STM32F10x/pios_tim.c
@@ -161,7 +161,16 @@ out_fail:
 static void PIOS_TIM_generic_irq_handler(TIM_TypeDef * timer)
 {
 	uint16_t flags = timer->SR;
-	timer->SR = ~(TIM_IT_Update | TIM_IT_CC1 | TIM_IT_CC2 | TIM_IT_CC3 | TIM_IT_CC4);
+
+	/* While the datasheet is not 100% clear that this (very common
+	 * paradigm) is correct TIM_ClearITPendingBit from stdperiph shows
+	 * that software is unable to set bits in this register.
+	 *
+	 * Therefore, clear only the events we're going to process. 
+	 * Otherwise we could lose an overflow just after a rising edge,
+	 * which would offset our count.
+	 */
+	timer->SR = ~flags;
 
 	/* Check for an overflow event on this timer */
 	bool overflow_event;


### PR DESCRIPTION
Comments in commit messages. PIOS_PWM now handles timer overflow correctly which allows the force_1MHz config option to work properly. Still lose an overflow event once every few seconds, but much less frequently than before. The result is pulse measurement short by ARR (400 us on CC3D). Happens when overflow event occurs between these two lines I believe:

``` c
uint16_t flags = timer->SR;
timer->SR = ~(TIM_IT_Update | TIM_IT_CC1 | TIM_IT_CC2 | TIM_IT_CC3 | TIM_IT_CC4);
```

Fixes #1435.
