### PR TITLE
GCS: Elide serial port names

### DIFF
--- a/ground/gcs/src/plugins/serialconnection/serialplugin.cpp
+++ b/ground/gcs/src/plugins/serialconnection/serialplugin.cpp
@@ -35,6 +35,7 @@
 #include <QMainWindow>
 #include <coreplugin/icore.h>
 #include <QDebug>
+#include <QFontMetrics>
 
 
 
@@ -147,8 +148,10 @@ QList <IDevice *> SerialConnection::availableDevices()
             if(!port_exists) {
                 SerialDevice* d = new SerialDevice();
                 QStringList disp;
-                if (port.description().length())
-                    disp.append(port.description());
+                if (port.description().length()) {
+                    QFontMetrics font((QFont()));
+                    disp.append(font.elidedText(port.description(), Qt::ElideRight, 150));
+                }
                 disp.append(port.portName());
                 d->setDisplayName(disp.join(" - "));
                 d->setName(port.portName());


### PR DESCRIPTION
Can make dropdown really big on OSX with long names..

Now looks like:
<img width="821" alt="untitled" src="https://cloud.githubusercontent.com/assets/9995998/19506771/a5850752-962a-11e6-8ecf-ad93ae6d5b5a.png">
