### PR TITLE
WS2811: bare bones DMA driver

### DIFF
--- a/flight/PiOS/STM32F4xx/pios_ws2811.c
+++ b/flight/PiOS/STM32F4xx/pios_ws2811.c
@@ -177,11 +177,16 @@ int PIOS_WS2811_init(ws2811_dev_t *dev_out, const struct pios_ws2811_cfg *cfg,
 	TIM_DMACmd(cfg->timer, TIM_DMA_CC1, ENABLE);
 	TIM_DMACmd(cfg->timer, TIM_DMA_CC2, ENABLE);
 	TIM_DMACmd(cfg->timer, TIM_DMA_CC4, ENABLE);
-	//TIM_SelectCCDMA(cfg->timer, ENABLE);
 
 	TIM_SetCompare4(cfg->timer, 1);
 	TIM_SetCompare1(cfg->timer, cfg->fall_time_l);
 	TIM_SetCompare2(cfg->timer, cfg->fall_time_h);
+
+	// Disable all timer interrupts, in case someone inited this timer
+	// before.
+	TIM_ITConfig(cfg->timer, TIM_IT_Update | TIM_IT_CC1 | TIM_IT_CC2 |
+			TIM_IT_CC3 | TIM_IT_CC4 | TIM_IT_COM | TIM_IT_Trigger |
+			TIM_IT_Break, DISABLE);
 
 	dev->in_progress = false;
 

--- a/flight/PiOS/STM32F4xx/pios_ws2811.c
+++ b/flight/PiOS/STM32F4xx/pios_ws2811.c
@@ -1,0 +1,198 @@
+/**
+ ******************************************************************************
+ * @addtogroup PIOS PIOS Core hardware abstraction layer
+ * @{
+ * @addtogroup PIOS_WS2811 Driver for WS2811 LEDs.
+ * @brief Driver for WS2811 LEDs.  Uses one timer (generally TIM1
+ * advanced control timer) and two DMAs.  First DMA sets the bit high at
+ * the beginning of each cycle.  Next DMA picks one of two phases to lower
+ * the bit at.
+ * @{
+ *
+ * @file       pios_ws2811.c
+ * @author     dRonin, http://dRonin.org, Copyright (C) 2016.
+ * @see        The GNU Public License (GPL) Version 3
+ *
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
+ */
+
+#include "pios_config.h"
+
+#if defined(PIOS_INCLUDE_WS2811)
+
+#include "pios.h"
+#include <pios_stm32.h>
+#include "stm32f4xx_tim.h"
+#include "pios_tim_priv.h"
+
+#include "pios_ws2811.h"
+
+struct ws2811_pixel_data_s {
+	uint8_t r;
+	uint8_t g;
+	uint8_t b;
+};
+
+// Each DMA side is 6 LEDs, 24 bits per pixel, 2 bytes per bit, for 288
+// bytes.
+//
+// This corresponds to 300us worth of pixel data on each side, or an
+// interrupt rate of 3.33KHz.
+#define WS2811_DMA_BUFSIZE (6*24*2)
+
+struct ws2811_dev_s {
+#define WS2811_MAGIC 0x31313832		/* '2811' */
+	uint32_t magic;
+
+	struct pios_ws2811_cfg *cfg;
+
+	uint16_t max_leds;
+
+	// This gets clocked out at timer update event to BSRRH
+	uint8_t lame_dma_buf[1];
+
+	// These are the buffers.  We clock out a byte to BSRRL at each
+	// of the two times that the value can fall.  Every odd value of this
+	// is always the gpio bit index.  For a '0', the corresponding even
+	// value is the gpio bit index.
+	//
+	// We fill both buffers initially, and then when one has been clocked
+	// out, we fill the other half in the interrupt handler.
+	//
+	// These are declared as uint32_t for alignment reasons (so we can
+	// do 32 bit DMA operations with them and conserve bus cycles).
+	uint32_t dma_buf_1[WS2811_DMA_BUFSIZE / sizeof(uint32_t)];
+	uint32_t dma_buf_2[WS2811_DMA_BUFSIZE / sizeof(uint32_t)];
+
+	// These get fixed up to point to the top half of the port halfword
+	// if necessary.
+	uint8_t *gpio_bsrrh_address;
+	uint8_t *gpio_bsrrl_address;
+
+	volatile bool dma_done;
+
+	uint8_t *pixel_data_pos;
+	uint8_t *pixel_data_end;
+
+	uint8_t gpio_bit;
+
+	struct ws2811_pixel_data_s pixel_data[0];
+};
+
+int PIOS_WS2811_init(ws2811_dev_t *dev_out, struct pios_ws2811_cfg *cfg,
+		int max_leds) 
+{
+	PIOS_Assert(max_leds > 0);
+	PIOS_Assert(max_leds <= 1024);
+
+	ws2811_dev_t dev = PIOS_malloc(sizeof(*dev) +
+			sizeof(struct ws2811_pixel_data_s) * max_leds);
+
+	if (!dev) {
+		return -1;
+	}
+
+	dev->magic = WS2811_MAGIC;
+	dev->cfg = cfg;
+	dev->max_leds = max_leds;
+
+	dev->pixel_data_end = (uint8_t *)(&dev->pixel_data[max_leds]);
+
+	dev->gpio_bit = 1<<3;		// XXX hacked
+
+	PIOS_WS2811_set_all(dev, 0, 0, 0);
+
+	for (int i = 0; i < sizeof(dev->dma_buf_1); i += 2) {
+		dev->dma_buf_1[i]     = 0;
+		dev->dma_buf_2[i]     = 0;
+		dev->dma_buf_1[i + 1] = dev->gpio_bit;
+		dev->dma_buf_2[i + 1] = dev->gpio_bit;
+	}
+
+	*dev_out = dev;
+
+	return 0;
+}
+
+DONT_BUILD_IF((WS2811_DMA_BUFSIZE % 16) == 0, DMABufIntegralBytes);
+
+// Updates pixel_data_ptr to where we are.  returns true if we've reached
+// the end.
+static bool fill_dma_buf(restrict uint8_t *dma_buf, uint8_t **pixel_data_ptr,
+		uint8_t *pixel_data_end, uint8_t gpio_val) {
+	// Our local shadow of this, for efficient blitting.
+	restrict uint8_t *p_d_p = *pixel_data_ptr;
+
+	for (int i = 0; i < WS2811_DMA_BUFSIZE; i += 16) {
+		if (p_d_p >= pixel_data_end) break;
+
+		uint8_t p = *(p_d_p++);
+
+		for (int j = 0; j < 8; j++) {
+			if (!(p & 0x80)) {
+				// It's zero-- therefore the pin has to fall
+				// early.
+				dma_buf[i + j*2] = gpio_val;
+			} else {
+				// It's one.  Therefore we let the prefilled
+				// bit in the odd position clear it; we do
+				// nothing.
+				dma_buf[i + j*2] = 0;
+			}
+
+			// We clock out most significant bit first.
+			p = p << 1;
+		}
+	}
+
+	*pixel_data_ptr = p_d_p;
+
+	return p_d_p >= pixel_data_end;
+}
+
+void PIOS_WS2811_trigger_update(ws2811_dev_t dev)
+{
+	dev->all_leds_queued = false;
+
+	dev->pixel_data_pos = (uint8_t *) dev->pixel_data;
+}
+
+void PIOS_WS2811_set(ws2811_dev_t dev, int idx, uint8_t r, uint8_t g,
+		uint8_t b)
+{
+	PIOS_Assert(dev->magic == WS2811_MAGIC);
+
+	PIOS_Assert(idx < dev->max_leds);
+
+	dev->pixel_data[idx] = { .r = r, .g = g, .b = b };
+}
+
+void PIOS_WS2811_set_all(ws2811_dev_t dev, uint8_t r, uint8_t g,
+		uint8_t b)
+{
+	PIOS_Assert(dev->magic == WS2811_MAGIC);
+
+	for (int i = 0; i < dev->max_leds; i++) {
+		PIOS_WS2811_set(dev, i, r, g, b);
+	}
+}
+
+#endif /* PIOS_INCLUDE_WS2811 */

--- a/flight/PiOS/STM32F4xx/pios_ws2811.c
+++ b/flight/PiOS/STM32F4xx/pios_ws2811.c
@@ -253,8 +253,9 @@ static void ws2811_cue_dma(ws2811_dev_t dev) {
 	dma_init.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
 	dma_init.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
 	dma_init.DMA_MemoryInc = DMA_MemoryInc_Disable;
-	dma_init.DMA_BufferSize = 1;
-	dma_init.DMA_Mode = DMA_Mode_Circular;
+	// XXX If we use this approach, we will be limited to 900ish LEDs :P
+	dma_init.DMA_BufferSize = 144;
+	dma_init.DMA_Mode = DMA_Mode_Normal;
 	dma_init.DMA_Priority = DMA_Priority_VeryHigh;
 	dma_init.DMA_FIFOMode = DMA_FIFOMode_Enable;
 	dma_init.DMA_FIFOThreshold = DMA_FIFOThreshold_HalfFull;
@@ -285,9 +286,6 @@ static void ws2811_cue_dma(ws2811_dev_t dev) {
 	//DMA_DoubleBufferModeCmd(dev->cfg->bit_clear_dma_stream, ENABLE);
 
 	/* XXX: NVIC for the DMA */
-
-	/* Manually drive the GPIO high ourselves just-in-case */
-	GPIO_SetBits(dev->cfg->led_gpio, dev->cfg->gpio_pin);
 
 	DMA_Cmd(dev->cfg->bit_set_dma_stream, ENABLE);
 	DMA_Cmd(dev->cfg->bit_clear_dma_stream, ENABLE);

--- a/flight/PiOS/STM32F4xx/pios_ws2811.c
+++ b/flight/PiOS/STM32F4xx/pios_ws2811.c
@@ -39,6 +39,7 @@
 #if defined(PIOS_INCLUDE_WS2811)
 
 #include "pios.h"
+#include "openpilot.h"
 #include <pios_stm32.h>
 #include "stm32f4xx_tim.h"
 #include "pios_tim_priv.h"
@@ -62,7 +63,7 @@ struct ws2811_dev_s {
 #define WS2811_MAGIC 0x31313832		/* '2811' */
 	uint32_t magic;
 
-	struct pios_ws2811_cfg *cfg;
+	const struct pios_ws2811_cfg *cfg;
 
 	uint16_t max_leds;
 
@@ -76,28 +77,29 @@ struct ws2811_dev_s {
 	//
 	// We fill both buffers initially, and then when one has been clocked
 	// out, we fill the other half in the interrupt handler.
-	//
-	// These are declared as uint32_t for alignment reasons (so we can
-	// do 32 bit DMA operations with them and conserve bus cycles).
-	uint32_t dma_buf_1[WS2811_DMA_BUFSIZE / sizeof(uint32_t)];
-	uint32_t dma_buf_2[WS2811_DMA_BUFSIZE / sizeof(uint32_t)];
+	uint8_t dma_buf_0[WS2811_DMA_BUFSIZE];
+	uint8_t dma_buf_1[WS2811_DMA_BUFSIZE];
 
 	// These get fixed up to point to the top half of the port halfword
 	// if necessary.
-	uint8_t *gpio_bsrrh_address;
-	uint8_t *gpio_bsrrl_address;
+	volatile uint8_t *gpio_bsrrh_address;
+	volatile uint8_t *gpio_bsrrl_address;
 
-	volatile bool dma_done;
+	// And this gets fixed up to be a shifted right image, etc.
+	uint8_t gpio_bit;
+
+	bool cur_buf;
+	bool eof;
+
+	volatile bool in_progress;
 
 	uint8_t *pixel_data_pos;
 	uint8_t *pixel_data_end;
 
-	uint8_t gpio_bit;
-
 	struct ws2811_pixel_data_s pixel_data[0];
 };
 
-int PIOS_WS2811_init(ws2811_dev_t *dev_out, struct pios_ws2811_cfg *cfg,
+int PIOS_WS2811_init(ws2811_dev_t *dev_out, const struct pios_ws2811_cfg *cfg,
 		int max_leds) 
 {
 	PIOS_Assert(max_leds > 0);
@@ -116,30 +118,59 @@ int PIOS_WS2811_init(ws2811_dev_t *dev_out, struct pios_ws2811_cfg *cfg,
 
 	dev->pixel_data_end = (uint8_t *)(&dev->pixel_data[max_leds]);
 
-	dev->gpio_bit = 1<<3;		// XXX hacked
+	dev->gpio_bsrrh_address = (volatile uint8_t *)(&cfg->led_gpio->BSRRH);
+	dev->gpio_bsrrl_address = (volatile uint8_t *)(&cfg->led_gpio->BSRRL);
+
+	if (cfg->gpio_pin & 0xff00) {
+		// It really should only be one bit set, but no matter
+		// what it has to be in only one byte (half of the halfword)
+		// to make sense.
+		PIOS_Assert(!(cfg->gpio_pin & 0xff));
+
+		// Fixup --- store to a byte later (little endian), an
+		// adjusted value.
+		dev->gpio_bit = cfg->gpio_pin >> 8;
+
+		dev->gpio_bsrrh_address++;
+		dev->gpio_bsrrl_address++;
+	} else {
+		dev->gpio_bit = cfg->gpio_pin;
+	}
+
+	for (int i = 0; i < sizeof(dev->dma_buf_0); i += 2) {
+		dev->dma_buf_0[i]     = 0;
+		dev->dma_buf_1[i]     = 0;
+		dev->dma_buf_0[i + 1] = dev->gpio_bit;
+		dev->dma_buf_1[i + 1] = dev->gpio_bit;
+	}
+
+	dev->lame_dma_buf[0] = dev->gpio_bit;
 
 	PIOS_WS2811_set_all(dev, 0, 0, 0);
 
-	for (int i = 0; i < sizeof(dev->dma_buf_1); i += 2) {
-		dev->dma_buf_1[i]     = 0;
-		dev->dma_buf_2[i]     = 0;
-		dev->dma_buf_1[i + 1] = dev->gpio_bit;
-		dev->dma_buf_2[i + 1] = dev->gpio_bit;
-	}
+	GPIO_InitTypeDef gpio_cfg = {
+		.GPIO_Pin = cfg->gpio_pin,
+		.GPIO_Mode = GPIO_Mode_OUT,
+		.GPIO_Speed = GPIO_Fast_Speed,
+		.GPIO_OType = GPIO_OType_OD,
+		.GPIO_PuPd = GPIO_PuPd_NOPULL
+	};
+
+	GPIO_Init(cfg->led_gpio, &gpio_cfg);
 
 	*dev_out = dev;
 
 	return 0;
 }
 
-DONT_BUILD_IF((WS2811_DMA_BUFSIZE % 16) == 0, DMABufIntegralBytes);
+DONT_BUILD_IF((WS2811_DMA_BUFSIZE % 16) != 0, DMABufIntegralBytes);
 
 // Updates pixel_data_ptr to where we are.  returns true if we've reached
 // the end.
-static bool fill_dma_buf(restrict uint8_t *dma_buf, uint8_t **pixel_data_ptr,
+static bool fill_dma_buf(uint8_t * restrict dma_buf, uint8_t **pixel_data_ptr,
 		uint8_t *pixel_data_end, uint8_t gpio_val) {
 	// Our local shadow of this, for efficient blitting.
-	restrict uint8_t *p_d_p = *pixel_data_ptr;
+	uint8_t * restrict p_d_p = *pixel_data_ptr;
 
 	for (int i = 0; i < WS2811_DMA_BUFSIZE; i += 16) {
 		if (p_d_p >= pixel_data_end) break;
@@ -168,11 +199,85 @@ static bool fill_dma_buf(restrict uint8_t *dma_buf, uint8_t **pixel_data_ptr,
 	return p_d_p >= pixel_data_end;
 }
 
+static void ws2811_cue_dma(ws2811_dev_t dev) {
+	// XXX ensure timer stopped
+
+	// XXX clear timer event bits
+
+	DMA_DeInit(dev->cfg->bit_set_dma_stream);
+	DMA_DeInit(dev->cfg->bit_clear_dma_stream);
+
+	DMA_InitTypeDef dma_init;
+
+	DMA_StructInit(&dma_init);
+
+	/* First set up the single-buffered repeating of the BSRRH */
+	dma_init.DMA_Channel = dev->cfg->bit_set_dma_channel; 
+	dma_init.DMA_PeripheralBaseAddr = (uintptr_t) dev->gpio_bsrrh_address;
+	dma_init.DMA_Memory0BaseAddr = (uintptr_t) dev->lame_dma_buf;
+	dma_init.DMA_DIR = DMA_DIR_MemoryToPeripheral;
+	dma_init.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
+	dma_init.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
+	dma_init.DMA_MemoryInc = DMA_MemoryInc_Disable;
+	dma_init.DMA_BufferSize = dev->max_leds;
+	dma_init.DMA_Mode = DMA_Mode_Normal;
+	dma_init.DMA_Priority = DMA_Priority_VeryHigh;
+	dma_init.DMA_FIFOMode = DMA_FIFOMode_Enable;
+	dma_init.DMA_FIFOThreshold = DMA_FIFOThreshold_HalfFull;
+	dma_init.DMA_MemoryBurst = DMA_MemoryBurst_Single;
+	dma_init.DMA_PeripheralBurst = DMA_PeripheralBurst_Single;
+
+	DMA_Init(dev->cfg->bit_set_dma_stream, &dma_init);
+
+	/* Now the tricky one-- set up the double-buffered DMA, to blit to
+	 * BSRRL and clear bits at the appropriate time */
+	dma_init.DMA_Channel = dev->cfg->bit_clear_dma_channel;
+	dma_init.DMA_PeripheralBaseAddr = (uintptr_t) dev->gpio_bsrrl_address;
+	dma_init.DMA_Memory0BaseAddr = (uintptr_t) dev->dma_buf_0;
+	dma_init.DMA_BufferSize = WS2811_DMA_BUFSIZE;
+	dma_init.DMA_Mode = DMA_Mode_Circular;
+
+	/* TODO: Bus performance can be improved by tuning FIFO, memory burst, 
+	 * width, etc behaviors... But let's keep things simple for now. */
+
+	DMA_Init(dev->cfg->bit_clear_dma_stream, &dma_init);
+	DMA_DoubleBufferModeConfig(dev->cfg->bit_clear_dma_stream,
+			(uintptr_t) dev->dma_buf_1,
+			DMA_Memory_0);
+	DMA_DoubleBufferModeCmd(dev->cfg->bit_clear_dma_stream, ENABLE);
+
+	/* XXX: NVIC for the DMA */
+
+	DMA_Cmd(dev->cfg->bit_set_dma_stream, ENABLE);
+	DMA_Cmd(dev->cfg->bit_clear_dma_stream, ENABLE);
+
+	/* XXX: enable the timer's dma request crap, and the timer. */
+}
+
 void PIOS_WS2811_trigger_update(ws2811_dev_t dev)
 {
-	dev->all_leds_queued = false;
+	if (dev->in_progress) {
+		return;
+	}
+
+	dev->in_progress = true;
+
+	dev->eof = false;
 
 	dev->pixel_data_pos = (uint8_t *) dev->pixel_data;
+
+	// Current one to blit is the first
+	dev->cur_buf = false;
+
+	// We always clock out at least 2 bufs to keep the DMA code
+	// simple.
+	fill_dma_buf((uint8_t *) dev->dma_buf_0, &dev->pixel_data_pos,
+			dev->pixel_data_end, dev->gpio_bit);
+
+	fill_dma_buf((uint8_t *) dev->dma_buf_1, &dev->pixel_data_pos,
+			dev->pixel_data_end, dev->gpio_bit);
+
+	ws2811_cue_dma(dev);
 }
 
 void PIOS_WS2811_set(ws2811_dev_t dev, int idx, uint8_t r, uint8_t g,
@@ -182,7 +287,8 @@ void PIOS_WS2811_set(ws2811_dev_t dev, int idx, uint8_t r, uint8_t g,
 
 	PIOS_Assert(idx < dev->max_leds);
 
-	dev->pixel_data[idx] = { .r = r, .g = g, .b = b };
+	dev->pixel_data[idx] = (struct ws2811_pixel_data_s)
+			{ .r = r, .g = g, .b = b };
 }
 
 void PIOS_WS2811_set_all(ws2811_dev_t dev, uint8_t r, uint8_t g,

--- a/flight/PiOS/inc/pios_ws2811.h
+++ b/flight/PiOS/inc/pios_ws2811.h
@@ -43,6 +43,8 @@ struct pios_ws2811_cfg {
 
 	uint8_t fall_time_l, fall_time_h;
 
+	NVIC_InitTypeDef interrupt;
+
 	GPIO_TypeDef *led_gpio;
 
 	uint16_t gpio_pin;
@@ -52,6 +54,7 @@ struct pios_ws2811_cfg {
 
 	DMA_Stream_TypeDef *bit_clear_dma_stream;
 	uint32_t bit_clear_dma_channel;
+	uint32_t bit_clear_dma_tcif;
 };
 
 /**
@@ -90,5 +93,11 @@ void PIOS_WS2811_set(ws2811_dev_t dev, int idx, uint8_t r, uint8_t g,
  */
 void PIOS_WS2811_set_all(ws2811_dev_t dev, uint8_t r, uint8_t g,
 		uint8_t b);
+
+/**
+ * @brief Handles a DMA completion interrupt on bit_clear_dma_stream.
+ * @param[in] dev WS2811 device handle
+ */
+void PIOS_WS2811_dma_interrupt_handler(ws2811_dev_t dev);
 
 #endif /* LIB_MAX7456_MAX7456_H_ */

--- a/flight/PiOS/inc/pios_ws2811.h
+++ b/flight/PiOS/inc/pios_ws2811.h
@@ -1,0 +1,82 @@
+/**
+ ******************************************************************************
+ * @addtogroup PIOS PIOS Core hardware abstraction layer
+ * @{
+ * @addtogroup PIOS_WS2811 WS2811 Functions
+ *
+ * @file       pios_ws2811.h
+ * @author     dRonin, http://dronin.org Copyright (C) 2016
+ * @see        The GNU Public License (GPL) Version 3
+ *
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
+ */
+
+#ifndef _PIOS_WS2811_H
+#define _PIOS_WS2811_H
+
+#include <stdint.h>
+#include <stdio.h>
+
+typedef struct ws2811_dev_s *ws2811_dev_t;
+
+struct pios_ws2811_cfg {
+	// XXX
+	struct pios_tim_clock_cfg clock_cfg;
+};
+
+/**
+ * @brief Allocate and initialise WS2811 device
+ * @param[out] dev_out Device handle, only valid when return value is success
+ * @param[in] cfg Configuration structure
+ * @param[in] max_leds Number of LEDs to update each update cycle.
+ * @retval 0 on success, else failure
+ */
+int PIOS_WS2811_init(ws2811_dev_t *dev_out, struct pios_ws2811_cfg *cfg,
+		int max_leds);
+
+/**
+ * @brief Trigger an update of the LED strand
+ * @param[in] dev WS2811 device handle
+ */
+void PIOS_WS2811_trigger_update(ws2811_dev_t dev);
+
+/**
+ * @brief Set a given LED to a color value.
+ * @param[in] dev WS2811 device handle
+ * @param[in] idx index of the led to update
+ * @param[in] r the red brightness value
+ * @param[in] g the green brightness value
+ * @param[in] b the blue brightness value
+ */
+void PIOS_WS2811_set(ws2811_dev_t dev, int idx, uint8_t r, uint8_t g,
+		uint8_t b);
+
+/**
+ * @brief Sets all LEDs to a color value.
+ * @param[in] dev WS2811 device handle
+ * @param[in] r the red brightness value
+ * @param[in] g the green brightness value
+ * @param[in] b the blue brightness value
+ */
+void PIOS_WS2811_set_all(ws2811_dev_t dev, uint8_t r, uint8_t g,
+		uint8_t b);
+
+#endif /* LIB_MAX7456_MAX7456_H_ */

--- a/flight/PiOS/inc/pios_ws2811.h
+++ b/flight/PiOS/inc/pios_ws2811.h
@@ -38,8 +38,20 @@
 typedef struct ws2811_dev_s *ws2811_dev_t;
 
 struct pios_ws2811_cfg {
-	// XXX
-	struct pios_tim_clock_cfg clock_cfg;
+	TIM_TypeDef *timer;
+	TIM_TimeBaseInitTypeDef clock_cfg;
+
+	uint8_t fall_time_l, fall_time_h;
+
+	GPIO_TypeDef *led_gpio;
+
+	uint16_t gpio_pin;
+
+	DMA_Stream_TypeDef *bit_set_dma_stream;
+	uint32_t bit_set_dma_channel;
+
+	DMA_Stream_TypeDef *bit_clear_dma_stream;
+	uint32_t bit_clear_dma_channel;
 };
 
 /**
@@ -49,8 +61,8 @@ struct pios_ws2811_cfg {
  * @param[in] max_leds Number of LEDs to update each update cycle.
  * @retval 0 on success, else failure
  */
-int PIOS_WS2811_init(ws2811_dev_t *dev_out, struct pios_ws2811_cfg *cfg,
-		int max_leds);
+int PIOS_WS2811_init(ws2811_dev_t *dev_out,
+		const struct pios_ws2811_cfg *cfg, int max_leds);
 
 /**
  * @brief Trigger an update of the LED strand

--- a/flight/targets/quanton/board-info/board_hw_defs.c
+++ b/flight/targets/quanton/board-info/board_hw_defs.c
@@ -2255,6 +2255,32 @@ void PIOS_ADC_DMA_irq_handler(void)
 #endif /* PIOS_INCLUDE_ADC */
 
 /**
+ * Configuration for driving a WS2811 LED out INPORT1
+ */
+
+#if defined(PIOS_INCLUDE_WS2811)
+#include "pios_ws2811.h"
+
+static const struct pios_ws2811_cfg pios_ws2811_cfg = {
+	.timer = TIM1,
+	.clock_cfg = {
+		.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_COUNTER_CLOCK / 12000000) - 1,
+		.TIM_ClockDivision = TIM_CKD_DIV1,
+		.TIM_CounterMode = TIM_CounterMode_Up,
+		.TIM_Period = 25,	/* 2.083us/bit */
+	},
+	.fall_time_l = 4,			/* 333ns */
+	.fall_time_h = 9,			/* 750ns */
+	.led_gpio = GPIOA,
+	.gpio_pin = GPIO_Pin_10,		/* PA10 / IN1 */
+	.bit_set_dma_stream = DMA2_Stream5,
+	.bit_set_dma_channel = DMA_Channel_6,	/* 2/S5/C6: TIM1_UP */
+	.bit_clear_dma_stream = DMA2_Stream6,
+	.bit_clear_dma_channel = DMA_Channel_0,	/* 0/S6/C0: TIM1 CH1|CH2|CH3 */
+};
+#endif
+
+/**
  * Configuration for the MPU6000 chip
  */
 #if defined(PIOS_INCLUDE_MPU)

--- a/flight/targets/quanton/board-info/board_hw_defs.c
+++ b/flight/targets/quanton/board-info/board_hw_defs.c
@@ -2269,12 +2269,12 @@ static const struct pios_ws2811_cfg pios_ws2811_cfg = {
 		.TIM_CounterMode = TIM_CounterMode_Up,
 		.TIM_Period = 25,	/* 2.083us/bit */
 	},
-	.fall_time_l = 4,			/* 333ns */
-	.fall_time_h = 9,			/* 750ns */
+	.fall_time_l = 5,			/* 333ns */
+	.fall_time_h = 10,			/* 750ns */
 	.led_gpio = GPIOA,
 	.gpio_pin = GPIO_Pin_10,		/* PA10 / IN1 */
-	.bit_set_dma_stream = DMA2_Stream5,
-	.bit_set_dma_channel = DMA_Channel_6,	/* 2/S5/C6: TIM1_UP */
+	.bit_set_dma_stream = DMA2_Stream4,
+	.bit_set_dma_channel = DMA_Channel_6,	/* 2/S4/C6: TIM1 CH4|TRIG|COM */
 	.bit_clear_dma_stream = DMA2_Stream6,
 	.bit_clear_dma_channel = DMA_Channel_0,	/* 0/S6/C0: TIM1 CH1|CH2|CH3 */
 };

--- a/flight/targets/quanton/board-info/board_hw_defs.c
+++ b/flight/targets/quanton/board-info/board_hw_defs.c
@@ -2214,29 +2214,29 @@ const struct pios_usb_hid_cfg pios_usb_hid_cfg = {
 #include "pios_internal_adc_priv.h"
 
 void PIOS_ADC_DMA_irq_handler(void);
-void DMA2_Stream4_IRQHandler(void) __attribute__((alias("PIOS_ADC_DMA_irq_handler")));
+void DMA2_Stream0_IRQHandler(void) __attribute__((alias("PIOS_ADC_DMA_irq_handler")));
 struct pios_internal_adc_cfg pios_adc_cfg = {
 	.adc_dev_master = ADC1,
 	.dma = {
 		.irq = {
-			.flags = (DMA_FLAG_TCIF4 | DMA_FLAG_TEIF4 | DMA_FLAG_HTIF4),
+			.flags = (DMA_FLAG_TCIF0 | DMA_FLAG_TEIF0 | DMA_FLAG_HTIF0),
 			.init = {
-				.NVIC_IRQChannel = DMA2_Stream4_IRQn,
+				.NVIC_IRQChannel = DMA2_Stream0_IRQn,
 				.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_LOW,
 				.NVIC_IRQChannelSubPriority = 0,
 				.NVIC_IRQChannelCmd = ENABLE,
 			},
 		},
 		.rx = {
-			.channel = DMA2_Stream4,
+			.channel = DMA2_Stream0,
 			.init = {
 				.DMA_Channel = DMA_Channel_0,
 				.DMA_PeripheralBaseAddr = (uint32_t)&ADC1->DR
 			},
 		}
 	},
-	.half_flag = DMA_IT_HTIF4,
-	.full_flag = DMA_IT_TCIF4,
+	.half_flag = DMA_IT_HTIF0,
+	.full_flag = DMA_IT_TCIF0,
 	.adc_pins = {                                                                                 \
 		{ GPIOA, GPIO_Pin_0,     ADC_Channel_0 },                                                 \
 		{ GPIOA, GPIO_Pin_1,     ADC_Channel_1 },                                                 \

--- a/flight/targets/quanton/board-info/board_hw_defs.c
+++ b/flight/targets/quanton/board-info/board_hw_defs.c
@@ -2261,6 +2261,12 @@ void PIOS_ADC_DMA_irq_handler(void)
 #if defined(PIOS_INCLUDE_WS2811)
 #include "pios_ws2811.h"
 
+ws2811_dev_t pios_ws2811;
+
+void DMA2_Stream6_IRQHandler() {
+	PIOS_WS2811_dma_interrupt_handler(pios_ws2811);
+}
+
 static const struct pios_ws2811_cfg pios_ws2811_cfg = {
 	.timer = TIM1,
 	.clock_cfg = {
@@ -2269,6 +2275,13 @@ static const struct pios_ws2811_cfg pios_ws2811_cfg = {
 		.TIM_CounterMode = TIM_CounterMode_Up,
 		.TIM_Period = 25,	/* 2.083us/bit */
 	},
+	.interrupt = {
+		.NVIC_IRQChannel = DMA2_Stream6_IRQn,
+		.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_LOW,
+		.NVIC_IRQChannelSubPriority = 0,
+		.NVIC_IRQChannelCmd = ENABLE,
+	},
+	.bit_clear_dma_tcif = DMA_IT_TCIF6,
 	.fall_time_l = 5,			/* 333ns */
 	.fall_time_h = 10,			/* 750ns */
 	.led_gpio = GPIOA,

--- a/flight/targets/quanton/board-info/board_hw_defs.c
+++ b/flight/targets/quanton/board-info/board_hw_defs.c
@@ -2123,6 +2123,19 @@ static const struct pios_ppm_cfg pios_ppm_cfg = {
 	.num_channels = 1,
 };
 
+static const struct pios_ppm_cfg pios_ppm_in4_cfg = {
+	.tim_ic_init = {
+		.TIM_ICPolarity = TIM_ICPolarity_Rising,
+		.TIM_ICSelection = TIM_ICSelection_DirectTI,
+		.TIM_ICPrescaler = TIM_ICPSC_DIV1,
+		.TIM_ICFilter = 0x0,
+		.TIM_Channel = TIM_Channel_3,
+	},
+	/* Use only the fourth channel for ppm */
+	.channels = &pios_tim_rcvrport_all_channels[3],
+	.num_channels = 1,
+};
+
 #endif //PPM
 
 

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -560,9 +560,17 @@ void PIOS_Board_Init(void) {
 #ifdef PIOS_INCLUDE_WS2811
 	if (hw_inport == HWQUANTON_INPORT_WS2811SERIALPPMADC) {
 		ws2811_dev_t ws2811;
-		PIOS_WS2811_init(&ws2811, &pios_ws2811_cfg, 6);
+		PIOS_WS2811_init(&ws2811, &pios_ws2811_cfg, 7);
 
-		PIOS_WS2811_set_all(ws2811, 255, 0, 96); // PURPLE!
+		PIOS_DELAY_WaituS(100);
+
+		PIOS_WS2811_set(ws2811, 0, 255, 0, 0); // red
+		PIOS_WS2811_set(ws2811, 1, 0, 255, 0); // green
+		PIOS_WS2811_set(ws2811, 2, 0, 0, 255); // blue
+		PIOS_WS2811_set(ws2811, 3, 255, 255, 0); // yellow
+		PIOS_WS2811_set(ws2811, 4, 255, 0, 255); // purple
+		PIOS_WS2811_set(ws2811, 5, 0, 255, 255); // cyan
+		PIOS_WS2811_set(ws2811, 6, 64, 64, 64); // gray
 		PIOS_WS2811_trigger_update(ws2811);
 	}
 #endif

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -410,6 +410,8 @@ void PIOS_Board_Init(void) {
 				NULL);                                  // sbus_cfg
 		break;
 
+	case HWQUANTON_INPORT_WS2811SERIALPPMADC:
+		/* XXX set up alt ppm, then fall through to set up serial */
 	case HWQUANTON_INPORT_PPMSERIAL:
 	case HWQUANTON_INPORT_PPMSERIALADC:
 	case HWQUANTON_INPORT_SERIAL:
@@ -431,6 +433,9 @@ void PIOS_Board_Init(void) {
 		}
 
 		if (hw_inport == HWQUANTON_INPORT_SERIAL)
+			break;
+
+		if (hw_inport == HWQUANTON_INPORT_WS2811SERIALPPMADC)
 			break;
 
 		// Else fall through to set up PPM.
@@ -525,6 +530,7 @@ void PIOS_Board_Init(void) {
 		case HWQUANTON_INPORT_PPMADC:
 		case HWQUANTON_INPORT_PPMPWM:
 		case HWQUANTON_INPORT_PPMPWMADC:
+		case HWQUANTON_INPORT_WS2811SERIALPPMADC:
 			/* Set up the servo outputs */
 #ifdef PIOS_INCLUDE_SERVO
 			PIOS_Servo_Init(&pios_servo_cfg);
@@ -549,6 +555,16 @@ void PIOS_Board_Init(void) {
 	}
 #else
 	PIOS_DEBUG_Init(&pios_tim_servo_all_channels, NELEMENTS(pios_tim_servo_all_channels));
+#endif
+
+#ifdef PIOS_INCLUDE_WS2811
+	if (hw_inport == HWQUANTON_INPORT_WS2811SERIALPPMADC) {
+		ws2811_dev_t ws2811;
+		PIOS_WS2811_init(&ws2811, &pios_ws2811_cfg, 6);
+
+		PIOS_WS2811_set_all(ws2811, 128, 0, 128); // PURPLE!
+		PIOS_WS2811_trigger_update(ws2811);
+	}
 #endif
 
 /* init sensor queue registration */
@@ -696,7 +712,8 @@ void PIOS_Board_Init(void) {
 		hw_inport == HWQUANTON_INPORT_PPMOUTPUTSADC ||
 		hw_inport == HWQUANTON_INPORT_PPMPWMADC ||
 		hw_inport == HWQUANTON_INPORT_PPMSERIALADC ||
-		hw_inport == HWQUANTON_INPORT_PWMADC)
+		hw_inport == HWQUANTON_INPORT_PWMADC ||
+		hw_inport == HWQUANTON_INPORT_WS2811SERIALPPMADC)
 	{
 		uint32_t internal_adc_id;
 		PIOS_INTERNAL_ADC_Init(&internal_adc_id, &pios_adc_cfg);

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -562,7 +562,7 @@ void PIOS_Board_Init(void) {
 		ws2811_dev_t ws2811;
 		PIOS_WS2811_init(&ws2811, &pios_ws2811_cfg, 6);
 
-		PIOS_WS2811_set_all(ws2811, 128, 0, 128); // PURPLE!
+		PIOS_WS2811_set_all(ws2811, 255, 0, 96); // PURPLE!
 		PIOS_WS2811_trigger_update(ws2811);
 	}
 #endif

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -411,7 +411,18 @@ void PIOS_Board_Init(void) {
 		break;
 
 	case HWQUANTON_INPORT_WS2811SERIALPPMADC:
-		/* XXX set up alt ppm, then fall through to set up serial */
+		/* set up alt ppm, then fall through to set up serial */
+		PIOS_HAL_ConfigurePort(HWSHARED_PORTTYPES_PPM,  // port type protocol
+				NULL,                                   // usart_port_cfg
+				NULL,                                   // com_driver
+				NULL,                                   // i2c_id
+				NULL,                                   // i2c_cfg
+				&pios_ppm_in4_cfg,                      // ppm_cfg
+				NULL,                                   // pwm_cfg
+				PIOS_LED_ALARM,                         // led_id
+				NULL,                                   // dsm_cfg
+				0,                                      // dsm_mode
+				NULL);                                  // sbus_cfg
 	case HWQUANTON_INPORT_PPMSERIAL:
 	case HWQUANTON_INPORT_PPMSERIALADC:
 	case HWQUANTON_INPORT_SERIAL:

--- a/flight/targets/quanton/fw/pios_board.c
+++ b/flight/targets/quanton/fw/pios_board.c
@@ -559,19 +559,18 @@ void PIOS_Board_Init(void) {
 
 #ifdef PIOS_INCLUDE_WS2811
 	if (hw_inport == HWQUANTON_INPORT_WS2811SERIALPPMADC) {
-		ws2811_dev_t ws2811;
-		PIOS_WS2811_init(&ws2811, &pios_ws2811_cfg, 7);
+		PIOS_WS2811_init(&pios_ws2811, &pios_ws2811_cfg, 7);
 
-		PIOS_DELAY_WaituS(100);
-
-		PIOS_WS2811_set(ws2811, 0, 255, 0, 0); // red
-		PIOS_WS2811_set(ws2811, 1, 0, 255, 0); // green
-		PIOS_WS2811_set(ws2811, 2, 0, 0, 255); // blue
-		PIOS_WS2811_set(ws2811, 3, 255, 255, 0); // yellow
-		PIOS_WS2811_set(ws2811, 4, 255, 0, 255); // purple
-		PIOS_WS2811_set(ws2811, 5, 0, 255, 255); // cyan
-		PIOS_WS2811_set(ws2811, 6, 64, 64, 64); // gray
-		PIOS_WS2811_trigger_update(ws2811);
+		// Pending infrastructure for this, drive a fixed
+		// value to the strand once.
+		PIOS_WS2811_set(pios_ws2811, 0, 255, 0, 0); // red
+		PIOS_WS2811_set(pios_ws2811, 1, 0, 255, 0); // green
+		PIOS_WS2811_set(pios_ws2811, 2, 0, 0, 255); // blue
+		PIOS_WS2811_set(pios_ws2811, 3, 255, 255, 0); // yellow
+		PIOS_WS2811_set(pios_ws2811, 4, 255, 0, 255); // purple
+		PIOS_WS2811_set(pios_ws2811, 5, 0, 255, 255); // cyan
+		PIOS_WS2811_set(pios_ws2811, 6, 64, 64, 64); // gray
+		PIOS_WS2811_trigger_update(pios_ws2811);
 	}
 #endif
 

--- a/flight/targets/quanton/fw/pios_config.h
+++ b/flight/targets/quanton/fw/pios_config.h
@@ -56,6 +56,7 @@
 #define PIOS_INCLUDE_FASTHEAP
 #define PIOS_INCLUDE_OPENLOG
 #define PIOS_INCLUDE_STORM32BGC
+#define PIOS_INCLUDE_WS2811
 
 /* Select the sensors to include */
 #define PIOS_INCLUDE_HMC5883

--- a/shared/uavobjectdefinition/hwquanton.xml
+++ b/shared/uavobjectdefinition/hwquanton.xml
@@ -8,6 +8,7 @@
 				<option>Disabled</option>
 				<option>Outputs</option>
 				<option>Outputs+ADC</option>
+				<option>WS2811+Serial+PPM+ADC</option>
 				<option>PPM</option>
 				<option>PPM+ADC</option>
 				<option>PPM+Outputs</option>


### PR DESCRIPTION
Supports lots of LEDs (tested to 7, but should go well beyond).  No real software support.  Support on quanton target.

Changes to Quanton:
- Relocate DMA channel to avoid conflict
- Support new PPM-in location to eliminate dependency on TIM1

For subsequent PRs:
- prevent refreshes before the LEDs have had time to 'reset'
- hook into annunciator subsystem
- other F4 targets
- support setting baseline color
- some trivial animation
