### PR TITLE
Revo/PlayUAV/Sparky2: Fix PLL constant + fix Chibi HSE value

### DIFF
--- a/flight/targets/aq32/fw/board.h
+++ b/flight/targets/aq32/fw/board.h
@@ -38,9 +38,7 @@
 #define STM32_LSECLK                0
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                8000000
-#endif
+#define STM32_HSECLK                HSE_VALUE
 
 /*
  * Board voltages.

--- a/flight/targets/brain/fw/board.h
+++ b/flight/targets/brain/fw/board.h
@@ -38,9 +38,7 @@
 #define STM32_LSECLK                0
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                16000000
-#endif
+#define STM32_HSECLK                HSE_VALUE
 
 /*
  * Board voltages.

--- a/flight/targets/brainre1/fw/board.h
+++ b/flight/targets/brainre1/fw/board.h
@@ -38,9 +38,7 @@
 #define STM32_LSECLK                0
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                16000000
-#endif
+#define STM32_HSECLK                HSE_VALUE
 
 /*
  * Board voltages.

--- a/flight/targets/discoveryf4/fw/board.h
+++ b/flight/targets/discoveryf4/fw/board.h
@@ -38,9 +38,7 @@
 #define STM32_LSECLK                0
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                8000000
-#endif
+#define STM32_HSECLK                HSE_VALUE
 
 /*
  * Board voltages.

--- a/flight/targets/dtfc/fw/board.h
+++ b/flight/targets/dtfc/fw/board.h
@@ -38,9 +38,7 @@
 
 #define STM32_LSEDRV                (3 << 3)
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                8000000
-#endif
+#define STM32_HSECLK                HSE_VALUE
 
 #define STM32_HSE_BYPASS
 

--- a/flight/targets/lux/fw/board.h
+++ b/flight/targets/lux/fw/board.h
@@ -38,9 +38,7 @@
 
 #define STM32_LSEDRV                (3 << 3)
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                8000000
-#endif
+#define STM32_HSECLK                HSE_VALUE
 
 #define STM32_HSE_BYPASS
 

--- a/flight/targets/playuavosd/fw/board.h
+++ b/flight/targets/playuavosd/fw/board.h
@@ -38,9 +38,7 @@
 #define STM32_LSECLK                0
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                16000000
-#endif
+#define STM32_HSECLK                HSE_VALUE
 
 /*
  * Board voltages.

--- a/flight/targets/playuavosd/fw/mcuconf.h
+++ b/flight/targets/playuavosd/fw/mcuconf.h
@@ -41,7 +41,7 @@
 #define STM32_CLOCK48_REQUIRED              TRUE
 #define STM32_SW                            STM32_SW_PLL
 #define STM32_PLLSRC                        STM32_PLLSRC_HSE
-#define STM32_PLLM_VALUE                    16
+#define STM32_PLLM_VALUE                    8
 #define STM32_PLLN_VALUE                    336
 #define STM32_PLLP_VALUE                    2
 #define STM32_PLLQ_VALUE                    7

--- a/flight/targets/quanton/fw/board.h
+++ b/flight/targets/quanton/fw/board.h
@@ -38,9 +38,7 @@
 #define STM32_LSECLK                0
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                16000000
-#endif
+#define STM32_HSECLK                HSE_VALUE
 
 /*
  * Board voltages.

--- a/flight/targets/revolution/fw/board.h
+++ b/flight/targets/revolution/fw/board.h
@@ -38,9 +38,7 @@
 #define STM32_LSECLK                0
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                16000000
-#endif
+#define STM32_HSECLK                HSE_VALUE
 
 /*
  * Board voltages.

--- a/flight/targets/revolution/fw/mcuconf.h
+++ b/flight/targets/revolution/fw/mcuconf.h
@@ -41,7 +41,7 @@
 #define STM32_CLOCK48_REQUIRED              TRUE
 #define STM32_SW                            STM32_SW_PLL
 #define STM32_PLLSRC                        STM32_PLLSRC_HSE
-#define STM32_PLLM_VALUE                    16
+#define STM32_PLLM_VALUE                    8
 #define STM32_PLLN_VALUE                    336
 #define STM32_PLLP_VALUE                    2
 #define STM32_PLLQ_VALUE                    7

--- a/flight/targets/sparky/fw/board.h
+++ b/flight/targets/sparky/fw/board.h
@@ -38,9 +38,7 @@
 
 #define STM32_LSEDRV                (3 << 3)
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                8000000
-#endif
+#define STM32_HSECLK                HSE_VALUE
 
 #define STM32_HSE_BYPASS
 

--- a/flight/targets/sparky2/fw/board.h
+++ b/flight/targets/sparky2/fw/board.h
@@ -38,9 +38,7 @@
 #define STM32_LSECLK                0
 #endif
 
-#if !defined(STM32_HSECLK)
-#define STM32_HSECLK                16000000
-#endif
+#define STM32_HSECLK                HSE_VALUE
 
 /*
  * Board voltages.

--- a/flight/targets/sparky2/fw/mcuconf.h
+++ b/flight/targets/sparky2/fw/mcuconf.h
@@ -41,7 +41,7 @@
 #define STM32_CLOCK48_REQUIRED              TRUE
 #define STM32_SW                            STM32_SW_PLL
 #define STM32_PLLSRC                        STM32_PLLSRC_HSE
-#define STM32_PLLM_VALUE                    16
+#define STM32_PLLM_VALUE                    8
 #define STM32_PLLN_VALUE                    336
 #define STM32_PLLP_VALUE                    2
 #define STM32_PLLQ_VALUE                    7


### PR DESCRIPTION
Minimal fix for revo (although it will be ineffective). Make ChibiOS use the HSE value already defined in board-info.mk