### PR TITLE
GCS: Disable GNU C++ extensions

### DIFF
--- a/ground/gcs/gcs.pri
+++ b/ground/gcs/gcs.pri
@@ -136,7 +136,7 @@ linux-g++* {
 
 win32 {
     # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=52991
-!win32-msvc*:QMAKE_CXXFLAGS += -mno-ms-bitfields
+    !win32-msvc*:QMAKE_CXXFLAGS += -mno-ms-bitfields
 }
 
 unix {
@@ -151,7 +151,8 @@ unix {
 	}
 }
 
-CONFIG += c++11
+# use ISO C++ (no GNU extensions) to ensure maximum portability
+CONFIG += c++11 strict_c++
 
 CONFIG(release, debug|release): unix | win32-msvc* {
     # generate debug info for:

--- a/ground/uavobjgenerator/uavobjgenerator.pro
+++ b/ground/uavobjgenerator/uavobjgenerator.pro
@@ -15,7 +15,8 @@ cache()
 
 TARGET = uavobjgenerator
 CONFIG += console
-CONFIG += c++11
+# use ISO C++ (no GNU extensions) to ensure maximum portability
+CONFIG += c++11 strict_c++
 CONFIG -= app_bundle
 TEMPLATE = app
 SOURCES += main.cpp \


### PR DESCRIPTION
To ensure better portability to other compilers, e.g. MSVC. We don't usually build with anything other than GCC in our CI system so we'd miss if people introduce GNU extensions.

This causes (for GCC/clang) these flags to be inserted in Makefiles:
* Qt 5.6.1 (our current version)
    - `-std=c++0x` rather than `-std=gnu++0x`
* Qt 5.7+ (C++11 is default and enforced as a minimum)
    - `-std=c++11` rather than `-std=gnu++11`

Doesn't affect any other compilers.