### PR TITLE
Fixed address to BrainFPV website

### DIFF
--- a/ground/gcs/src/plugins/boards_brainfpv/brainconfiguration.cpp
+++ b/ground/gcs/src/plugins/boards_brainfpv/brainconfiguration.cpp
@@ -78,5 +78,5 @@ BrainConfiguration::~BrainConfiguration()
 
 void BrainConfiguration::openHelp()
 {
-    QDesktopServices::openUrl( QUrl("http://wwww.brainfpv.com/support", QUrl::StrictMode) );
+    QDesktopServices::openUrl( QUrl("http://www.brainfpv.com/support", QUrl::StrictMode) );
 }

--- a/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.cpp
+++ b/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.cpp
@@ -130,7 +130,7 @@ void BrainRE1Configuration::widgetsContentsChanged()
 
 void BrainRE1Configuration::openHelp()
 {
-    QDesktopServices::openUrl( QUrl("http://wwww.brainfpv.com/support", QUrl::StrictMode) );
+    QDesktopServices::openUrl( QUrl("http://www.brainfpv.com/support", QUrl::StrictMode) );
 }
 
 void BrainRE1Configuration::generateILapID()


### PR DESCRIPTION
Was "**wwww**.brainfpv.com", which doesn't work, obviously.
Well, it could work, but it wasn't intended, probably.