### PR TITLE
Flight: Add settings to control when acro+ resets the integral term.

### DIFF
--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -514,14 +514,14 @@ static void stabilizationTask(void* parameters)
 					}
 
 					// The factor for gyro suppression / mixing raw stick input into the output; scaled by raw stick input
-					float factor = fabsf(raw_input) * settings.AcroInsanityFactor / 100;
+					float factor = fabsf(raw_input) * settings.AcroInsanityFactor / 100.0f;
 
 					// Store to rate desired variable for storing to UAVO
 					rateDesiredAxis[i] = bound_sym(raw_input * settings.ManualRate[i], settings.ManualRate[i]);
 
 					// Zero integral for aggressive maneuvers
-					if ((i < 2 && fabsf(gyro_filtered[i]) > 150.0f) ||
-						(i == 0 && fabsf(raw_input) > 0.2f)) {
+					if ((i < 2 && fabsf(gyro_filtered[i]) > settings.AcroZeroIntegralGyro) ||
+						(i == 0 && fabsf(raw_input) > settings.AcroZeroIntegralStick / 100.0f)) {
 							pids[PID_GROUP_RATE + i].iAccumulator = 0;
 							}
 

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -30,6 +30,12 @@
 		<field name="AcroInsanityFactor" units="percent" type="float" elements="1" defaultvalue="40" limits="%BE:0:100">
 			<description>Only applicable to Acro+ flight mode. Controls the amount of stick input fed directly to the actuators (AKA "gyro suppression"), 100% results in full manual control at full stick deflection. Note: the rate settings are no longer directly applicable, especially with high insanity factors.</description>
 		</field>
+		<field name="AcroZeroIntegralGyro" units="deg/s" type="float" elements="1" defaultvalue="150">
+			<description>Only applicable to Acro+ flight mode. Rates above this value constitute "aggressive" maneuvers and will reset the integral to zero.</description>
+		</field>
+		<field name="AcroZeroIntegralStick" units="%" type="float" elements="1" defaultvalue="20" limits="%BE:0:100">
+			<description>Only applicable to Acro+ flight mode. Stick deflection above this value constitutes an "aggressive" maneuver and will reset the integral to zero. A value of 100% disables the integral reset.</description>
+		</field>
 		<field name="CameraTilt" units="deg" type="float" elements="1" defaultvalue="0" limits="%BE:-85:85">
 			<description>Only applicable when CameraAngle selected as Reprojection mode in Input settings. This should be the actual tilt angle of your camera. If your camera is tilted upwards, use positive tilt.</description>
 		</field>


### PR DESCRIPTION
- AcroZeroIntegralGyro - rates above this reset the integral
- AcroZeroIntegralStick - roll stick percent above this resets the integral
  - 0 to always reset, 100 to never reset; not sure if this is the ideal behavior, thoughts?