### PR TITLE
relocate DONT_BUILD_IF to pios.h

### DIFF
--- a/flight/Modules/CameraStab/camerastab.c
+++ b/flight/Modules/CameraStab/camerastab.c
@@ -43,6 +43,7 @@
  */
 
 #include "openpilot.h"
+#include <eventdispatcher.h>
 #include "misc_math.h"
 #include "physical_constants.h"
 #include "pios_thread.h"

--- a/flight/Modules/FirmwareIAP/firmwareiap.c
+++ b/flight/Modules/FirmwareIAP/firmwareiap.c
@@ -35,6 +35,7 @@
 #include "pios.h"
 #include <pios_board_info.h>
 #include "openpilot.h"
+#include <eventdispatcher.h>
 #include "firmwareiap.h"
 #include "firmwareiapobj.h"
 #include "flightstatus.h"

--- a/flight/Modules/Geofence/geofence.c
+++ b/flight/Modules/Geofence/geofence.c
@@ -31,6 +31,7 @@
 
 
 #include "openpilot.h"
+#include <eventdispatcher.h>
 #include "misc_math.h"
 #include "physical_constants.h"
 

--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -73,6 +73,8 @@
 
 #include "pios_com_priv.h"
 
+#include <uavtalk.h>
+
 // Private constants
 #define STACK_SIZE_BYTES 1200
 #define TASK_PRIORITY PIOS_THREAD_PRIO_LOW

--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -38,11 +38,13 @@
 // ****************
 
 #include <openpilot.h>
+#include <eventdispatcher.h>
 #include <rfm22bstatus.h>
 #include <objectpersistence.h>
 #include <rfm22breceiver.h>
 #include <radiocombridgestats.h>
 #include "hwtaulink.h"
+#include <uavtalk.h>
 #include <uavtalk_priv.h>
 #include <pios_rfm22b.h>
 #if defined(PIOS_INCLUDE_FLASH_EEPROM)

--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -31,6 +31,9 @@
  */
 
 #include "openpilot.h"
+#include <eventdispatcher.h>
+#include <utlist.h>
+
 #include "systemmod.h"
 #include "sanitycheck.h"
 #include "taskinfo.h"
@@ -181,7 +184,6 @@ int32_t SystemModInitialize(void)
 	if (mutex == NULL)
 		return -1;
 
-	// Must registers objects here for system thread because ObjectManager started in OpenPilotInit
 	if (SystemSettingsInitialize() == -1
 			|| SystemStatsInitialize() == -1
 			|| FlightStatusInitialize() == -1

--- a/flight/Modules/Telemetry/telemetry.c
+++ b/flight/Modules/Telemetry/telemetry.c
@@ -34,6 +34,7 @@
  */
 
 #include "openpilot.h"
+#include <eventdispatcher.h>
 #include "flighttelemetrystats.h"
 #include "gcstelemetrystats.h"
 #include "modulesettings.h"
@@ -42,6 +43,8 @@
 #include "pios_queue.h"
 
 #include "pios_hal.h"
+
+#include <uavtalk.h>
 
 // Private constants
 #define MAX_QUEUE_SIZE   TELEM_QUEUE_SIZE

--- a/flight/Modules/TxPID/txpid.c
+++ b/flight/Modules/TxPID/txpid.c
@@ -48,6 +48,7 @@
  */
 
 #include "openpilot.h"
+#include <eventdispatcher.h>
 
 #include "txpidsettings.h"
 #include "accessorydesired.h"

--- a/flight/PiOS/STM32F4xx/pios_ws2811.c
+++ b/flight/PiOS/STM32F4xx/pios_ws2811.c
@@ -39,7 +39,6 @@
 #if defined(PIOS_INCLUDE_WS2811)
 
 #include "pios.h"
-#include "openpilot.h"
 #include <pios_stm32.h>
 #include "stm32f4xx_tim.h"
 #include "pios_tim_priv.h"

--- a/flight/PiOS/openpilot.h
+++ b/flight/PiOS/openpilot.h
@@ -44,8 +44,6 @@
 /* Global Functions */
 void OpenPilotInit(void);
 
-#define DONT_BUILD_IF(COND,MSG) typedef char static_assertion_##MSG[(COND)?-1:1]
-
 #endif /* OPENPILOT_H */
 
 /**

--- a/flight/PiOS/openpilot.h
+++ b/flight/PiOS/openpilot.h
@@ -34,15 +34,9 @@
 #include <pios.h>
 
 /* OpenPilot Libraries */
-#include "utlist.h"
 #include "uavobjectmanager.h"
-#include "eventdispatcher.h"
 #include "alarms.h"
 #include "taskmonitor.h"
-#include "uavtalk.h"
-
-/* Global Functions */
-void OpenPilotInit(void);
 
 #endif /* OPENPILOT_H */
 

--- a/flight/PiOS/pios.h
+++ b/flight/PiOS/pios.h
@@ -214,6 +214,7 @@
 #include <pios_crc.h>
 
 #define NELEMENTS(x) (sizeof(x) / sizeof(*(x)))
+#define DONT_BUILD_IF(COND,MSG) typedef char static_assertion_##MSG[(COND)?-1:1]
 
 #endif /* PIOS_H */
 

--- a/flight/UAVObjects/uavobjectmanager.c
+++ b/flight/UAVObjects/uavobjectmanager.c
@@ -35,6 +35,8 @@
  */
 
 #include "openpilot.h"
+#include <utlist.h>
+
 #include "pios_struct_helper.h"
 #include "pios_heap.h"		/* PIOS_malloc_no_dma */
 #include "pios_mutex.h"

--- a/flight/UAVTalk/uavtalk.c
+++ b/flight/UAVTalk/uavtalk.c
@@ -33,6 +33,7 @@
  */
 
 #include "openpilot.h"
+#include "uavtalk.h"
 #include "uavtalk_priv.h"
 #include "pios_mutex.h"
 #include "pios_thread.h"

--- a/flight/targets/aq32/fw/main.c
+++ b/flight/targets/aq32/fw/main.c
@@ -58,7 +58,6 @@ static void initTask(void *parameters);
 int main()
 {
 	/* NOTE: Do NOT modify the following start-up sequence */
-	/* Any new initialization functions should be added in OpenPilotInit() */
 	PIOS_heap_initialize_blocks();
 
 #if defined(PIOS_INCLUDE_CHIBIOS)

--- a/flight/targets/brain/fw/main.c
+++ b/flight/targets/brain/fw/main.c
@@ -60,7 +60,6 @@ static void initTask(void *parameters);
 int main()
 {
   /* NOTE: Do NOT modify the following start-up sequence */
-  /* Any new initialization functions should be added in OpenPilotInit() */
   PIOS_heap_initialize_blocks();
 
 #if defined(PIOS_INCLUDE_CHIBIOS)

--- a/flight/targets/brainre1/fw/main.c
+++ b/flight/targets/brainre1/fw/main.c
@@ -31,6 +31,7 @@
 
 /* OpenPilot Includes */
 #include "openpilot.h"
+#include <eventdispatcher.h>
 #include "uavobjectsinit.h"
 #include "systemmod.h"
 #include "pios_thread.h"
@@ -68,7 +69,6 @@ static void initTask(void *parameters);
 int main()
 {
 	/* NOTE: Do NOT modify the following start-up sequence */
-	/* Any new initialization functions should be added in OpenPilotInit() */
 	PIOS_heap_initialize_blocks();
 
 #if defined(PIOS_INCLUDE_CHIBIOS)

--- a/flight/targets/cc3d/fw/main.c
+++ b/flight/targets/cc3d/fw/main.c
@@ -59,7 +59,6 @@ extern void Stack_Change(void);
 int main()
 {
 	/* NOTE: Do NOT modify the following start-up sequence */
-	/* Any new initialization functions should be added in OpenPilotInit() */
 
 	/* Brings up System using CMSIS functions, enables the LEDs. */
 	PIOS_SYS_Init();

--- a/flight/targets/discoveryf4/fw/main.c
+++ b/flight/targets/discoveryf4/fw/main.c
@@ -62,7 +62,6 @@ extern void InitModules(void);
 int main()
 {
 	/* NOTE: Do NOT modify the following start-up sequence */
-	/* Any new initialization functions should be added in OpenPilotInit() */
 	PIOS_heap_initialize_blocks();
 
 	halInit();

--- a/flight/targets/dtfc/fw/main.c
+++ b/flight/targets/dtfc/fw/main.c
@@ -66,7 +66,6 @@ extern void InitModules(void);
 int main()
 {
 	/* NOTE: Do NOT modify the following start-up sequence */
-	/* Any new initialization functions should be added in OpenPilotInit() */
 	PIOS_heap_initialize_blocks();
 
 	halInit();

--- a/flight/targets/lux/fw/main.c
+++ b/flight/targets/lux/fw/main.c
@@ -62,7 +62,6 @@ extern void InitModules(void);
 int main()
 {
 	/* NOTE: Do NOT modify the following start-up sequence */
-	/* Any new initialization functions should be added in OpenPilotInit() */
 	PIOS_heap_initialize_blocks();
 
 	halInit();

--- a/flight/targets/naze32/fw/main.c
+++ b/flight/targets/naze32/fw/main.c
@@ -73,7 +73,6 @@ int main()
 	int	result;
 
 	/* NOTE: Do NOT modify the following start-up sequence */
-	/* Any new initialization functions should be added in OpenPilotInit() */
 	vPortInitialiseBlocks();
 
 	/* Brings up System using CMSIS functions, enables the LEDs. */

--- a/flight/targets/pipxtreme/fw/main.c
+++ b/flight/targets/pipxtreme/fw/main.c
@@ -57,7 +57,6 @@ extern void Stack_Change(void);
 int main()
 {
 	/* NOTE: Do NOT modify the following start-up sequence */
-	/* Any new initialization functions should be added in OpenPilotInit() */
 
 	/* Brings up System using CMSIS functions, enables the LEDs. */
 	PIOS_SYS_Init();

--- a/flight/targets/playuavosd/fw/main.c
+++ b/flight/targets/playuavosd/fw/main.c
@@ -60,7 +60,6 @@ static void initTask(void *parameters);
 int main()
 {
   /* NOTE: Do NOT modify the following start-up sequence */
-  /* Any new initialization functions should be added in OpenPilotInit() */
   PIOS_heap_initialize_blocks();
 
 #if defined(PIOS_INCLUDE_CHIBIOS)

--- a/flight/targets/quanton/fw/main.c
+++ b/flight/targets/quanton/fw/main.c
@@ -58,7 +58,6 @@ static void initTask(void *parameters);
 int main()
 {
 	/* NOTE: Do NOT modify the following start-up sequence */
-	/* Any new initialization functions should be added in OpenPilotInit() */
 	PIOS_heap_initialize_blocks();
 
 #if defined(PIOS_INCLUDE_CHIBIOS)

--- a/flight/targets/revolution/fw/main.c
+++ b/flight/targets/revolution/fw/main.c
@@ -62,7 +62,6 @@ extern void InitModules(void);
 int main()
 {
 	/* NOTE: Do NOT modify the following start-up sequence */
-	/* Any new initialization functions should be added in OpenPilotInit() */
 	PIOS_heap_initialize_blocks();
 
 #if defined(PIOS_INCLUDE_CHIBIOS)

--- a/flight/targets/simulation/fw/main.c
+++ b/flight/targets/simulation/fw/main.c
@@ -75,7 +75,6 @@ int main(int argc, char *argv[]) {
 	g_argv = argv;
 
 	/* NOTE: Do NOT modify the following start-up sequence */
-	/* Any new initialization functions should be added in OpenPilotInit() */
 	PIOS_heap_initialize_blocks();
 
 #if defined(PIOS_INCLUDE_CHIBIOS)

--- a/flight/targets/sparky/fw/main.c
+++ b/flight/targets/sparky/fw/main.c
@@ -64,7 +64,6 @@ extern void InitModules(void);
 int main()
 {
 	/* NOTE: Do NOT modify the following start-up sequence */
-	/* Any new initialization functions should be added in OpenPilotInit() */
 	PIOS_heap_initialize_blocks();
 
 	halInit();

--- a/flight/targets/sparky2/fw/main.c
+++ b/flight/targets/sparky2/fw/main.c
@@ -58,7 +58,6 @@ static void initTask(void *parameters);
 int main()
 {
 	/* NOTE: Do NOT modify the following start-up sequence */
-	/* Any new initialization functions should be added in OpenPilotInit() */
 	PIOS_heap_initialize_blocks();  
 
 	halInit();


### PR DESCRIPTION
Necessary if you want to use the pios_ws2811 places where it's not safe to include openpilot.h (e.g. bootloader)