### PR TITLE
pios_sys/stm32f4: wait for VCC to exceed 2.9V

### DIFF
--- a/flight/PiOS/STM32F4xx/pios_sys.c
+++ b/flight/PiOS/STM32F4xx/pios_sys.c
@@ -49,6 +49,12 @@ void SysTick_Handler(void);
 */
 void PIOS_SYS_Init(void)
 {
+	PWR_PVDLevelConfig(PWR_PVDLevel_7);
+	PWR_PVDCmd(ENABLE);
+
+	// Wait for VCC to exceed 2.9V
+	while (PWR_GetFlagStatus(PWR_FLAG_PVDO) == SET);
+
 #if !defined(PIOS_INCLUDE_CHIBIOS)
 	/* Setup STM32 system (RCC, clock, PLL and Flash configuration) - CMSIS Function */
 	SystemInit();


### PR DESCRIPTION
Improve safety on F4 targets by requiring voltage to exceed 2.9V before proceeding with PIOS_SYS_Init.  Helps scenarios where there's slow rising power.  Not a substitute for using the brownout detector on a target, but further increases margin.