### PR TITLE
WIP: Stabilization: Add VirtualBar2 stabilization + flight modes.

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -488,6 +488,7 @@ int32_t transmitter_control_select(bool reset_controller)
 	case FLIGHTSTATUS_FLIGHTMODE_ACROPLUS:
 	case FLIGHTSTATUS_FLIGHTMODE_LEVELING:
 	case FLIGHTSTATUS_FLIGHTMODE_VIRTUALBAR:
+	case FLIGHTSTATUS_FLIGHTMODE_VIRTUALBAR2:
 	case FLIGHTSTATUS_FLIGHTMODE_HORIZON:
 	case FLIGHTSTATUS_FLIGHTMODE_AXISLOCK:
 	case FLIGHTSTATUS_FLIGHTMODE_STABILIZED1:
@@ -979,6 +980,7 @@ static inline float scale_stabilization(StabilizationSettingsData *stabSettings,
 			return 0;
 		case SHAREDDEFS_STABILIZATIONMODE_MANUAL:
 		case SHAREDDEFS_STABILIZATIONMODE_VIRTUALBAR:
+		case SHAREDDEFS_STABILIZATIONMODE_VIRTUALBAR2:
 		case SHAREDDEFS_STABILIZATIONMODE_COORDINATEDFLIGHT:
 			return cmd;
 		case SHAREDDEFS_STABILIZATIONMODE_RATE:
@@ -1029,6 +1031,10 @@ static void update_stabilization_desired(ManualControlCommandData * manual_contr
 	                                    STABILIZATIONDESIRED_STABILIZATIONMODE_VIRTUALBAR,
 	                                    STABILIZATIONDESIRED_STABILIZATIONMODE_VIRTUALBAR,
 	                                    STABILIZATIONDESIRED_STABILIZATIONMODE_AXISLOCK};
+	const uint8_t VIRTUALBAR2_SETTINGS[3] = {
+	                                    STABILIZATIONDESIRED_STABILIZATIONMODE_VIRTUALBAR2,
+	                                    STABILIZATIONDESIRED_STABILIZATIONMODE_VIRTUALBAR2,
+	                                    STABILIZATIONDESIRED_STABILIZATIONMODE_AXISLOCK};
 	const uint8_t HORIZON_SETTINGS[3] = {
 	                                    STABILIZATIONDESIRED_STABILIZATIONMODE_HORIZON,
 	                                    STABILIZATIONDESIRED_STABILIZATIONMODE_HORIZON,
@@ -1066,6 +1072,9 @@ static void update_stabilization_desired(ManualControlCommandData * manual_contr
 			break;
 		case FLIGHTSTATUS_FLIGHTMODE_VIRTUALBAR:
 			stab_modes = VIRTUALBAR_SETTINGS;
+			break;
+		case FLIGHTSTATUS_FLIGHTMODE_VIRTUALBAR2:
+			stab_modes = VIRTUALBAR2_SETTINGS;
 			break;
 		case FLIGHTSTATUS_FLIGHTMODE_HORIZON:
 			stab_modes = HORIZON_SETTINGS;

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -555,6 +555,37 @@ static void stabilizationTask(void* parameters)
 					stabilization_virtual_flybar(gyro_filtered[i], rateDesiredAxis[i], &actuatorDesiredAxis[i], dT, reinit, i, &pids[PID_GROUP_VBAR + i], &vbar_settings);
 
 					break;
+				// VirtualBar mode acts like a stabilization bar; that is, it resists all rate changes whether from the pilot or the environment
+				// VirtualBar2 mode acts more like a paddle flybar, specifically a bell-hiller flybar:
+				// - A component of pilot inputs go straight to the main rotor, enabling minimal control delay (VbarGyroSupress,Rate P-term)
+				// - A component of pilot inputs go to changing the state of the flybar (analogous to changing the pitch of the paddles)(Rate I-term)
+				// - As the flybar accelerates due to the new pilot-commanded paddle pitch, it contributes additional control output (Rate I-component)
+				// - Since the flybar is rotating, it also resists rate changes relative to its current orientation
+				// - Over time, the flybar settles to the position of least resistance, where gyroscopic and aerodynamic forces balance out (Rate I-accumulator decay)
+				case STABILIZATIONDESIRED_STABILIZATIONMODE_VIRTUALBAR2:
+					if(reinit) {
+						pids[PID_GROUP_VBAR + i].iAccumulator = 0;
+					}
+
+					// Store to rate desired variable for storing to UAVO
+					rateDesiredAxis[i] = bound_sym(raw_input * settings.ManualRate[i], settings.ManualRate[i]);
+
+					// The factor for gyro suppression / mixing raw stick input into the output; scaled by raw stick input
+					float gyro_suppress = fabsf(raw_input) * vbar_settings.VbarGyroSuppress / 100.0f;
+
+					// Decay the integral term over time, to simulate the flybar settling
+					pids[PID_GROUP_VBAR + i].iAccumulator *= vbar_decay;
+
+					// Compute the inner loop
+					// This is how much manual input should make it directly to the rotor, regardless of the state of the flybar
+					float manual_component = raw_input * vbar_settings.VbarSensitivity[i];
+					// This is the PID output, suppressed as a function of gyro_suppress above
+					float flybar_component = (1.0f - gyro_suppress) * pid_apply_setpoint(&pids[PID_GROUP_VBAR + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], dT);
+					// Output is the sum of the manual and flybar components
+					actuatorDesiredAxis[i] = manual_component + flybar_component;
+					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
+
+					break;
 				case STABILIZATIONDESIRED_STABILIZATIONMODE_WEAKLEVELING:
 				{
 					if (reinit) {

--- a/shared/uavobjectdefinition/shareddefs.xml
+++ b/shared/uavobjectdefinition/shareddefs.xml
@@ -2,8 +2,8 @@
 <xml>
 	<object name="SharedDefs" singleinstance="true" settings="false">
 		<description>Templates for common enums.</description>
-		<field name="FlightMode" units="" type="enum" elements="1" options="Manual,Acro,Leveling,Horizon,AxisLock,VirtualBar,Stabilized1,Stabilized2,Stabilized3,Autotune,AltitudeHold,PositionHold,ReturnToHome,PathPlanner,TabletControl,AcroPlus,Failsafe"/>
-		<field name="StabilizationMode" units="" type="enum" elements="1" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,Horizon,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled,Failsafe"/>
+		<field name="FlightMode" units="" type="enum" elements="1" options="Manual,Acro,Leveling,Horizon,AxisLock,VirtualBar,VirtualBar2,Stabilized1,Stabilized2,Stabilized3,Autotune,AltitudeHold,PositionHold,ReturnToHome,PathPlanner,TabletControl,AcroPlus,Failsafe"/>
+		<field name="StabilizationMode" units="" type="enum" elements="1" options="Manual,Rate,Attitude,AxisLock,WeakLeveling,VirtualBar,VirtualBar2,Horizon,SystemIdent,POI,CoordinatedFlight,AcroPlus,Disabled,Failsafe"/>
 		<!-- Effort -> Emulate direct stick input; ModeSpecific -> Assume values are pre-scaled with some knowledge about given mode, do not scale -->
 		<field name="ReprojectionMode" units="" type="enum" elements="1" options="None,CameraAngle,HeadFree"/>
 		<field name="OrientationUnit" units="" type="enum" elements="1" options="Effort,ModeSpecific,Degrees,DegreesPerSec,DegreesPerSec2"/>


### PR DESCRIPTION
The current VirtualBar mode acts like a stabilization bar; that is, it resists all rate changes whether from the pilot or the environment. Essentially, you're always fighting the flybar in this mode.

This VirtualBar2 mode acts more like a paddle flybar, specifically a bell-hiller flybar:
- A component of pilot inputs go straight to the main rotor, enabling minimal control delay (VbarGyroSupress,Rate P-term)
- A component of pilot inputs go to changing the state of the flybar (analogous to changing the pitch of the paddles)(Rate I-term)
- As the flybar accelerates due to the new pilot-commanded paddle pitch, it contributes additional control output (Rate I-component)
 - Since the flybar is rotating, it also resists rate changes relative to its current orientation
 - Over time, the flybar settles to the position of least resistance, where gyroscopic and aerodynamic forces balance out (Rate I-accumulator decay)

In terms of implementation, VirtualBar2 is just Rate mode with a constantly decaying I-accumulator, and with the same manual/stabilization mixing as AcroPlus.

Rough simulations of lift force vs angle of attack suggest that using a decaying integral should increase performance at a wide range of rotation rates.