### PR TITLE
Brain/BrainRE1 OSD: set PAL/NTSC settings from OSD task not ISR

### DIFF
--- a/flight/PiOS/STM32F4xx/inc/pios_video.h
+++ b/flight/PiOS/STM32F4xx/inc/pios_video.h
@@ -48,6 +48,13 @@ enum pios_video_3d_mode {
 	PIOS_VIDEO_3D_SBS3D,
 };
 
+enum pios_video_system {
+	PIOS_VIDEO_SYSTEM_NONE,
+	PIOS_VIDEO_SYSTEM_PAL,
+	PIOS_VIDEO_SYSTEM_NTSC,
+};
+
+
 #if defined(PIOS_INCLUDE_VIDEO_QUADSPI)
 #include <stm32f4xx_qspi.h>
 
@@ -116,7 +123,7 @@ extern void PIOS_Video_SetXScale(uint8_t x_scale);
 extern void PIOS_Video_Set3DConfig(enum pios_video_3d_mode mode, uint8_t right_eye_x_shift);
 
 uint16_t PIOS_Video_GetLines(void);
-uint16_t PIOS_Video_GetType(void);
+enum pios_video_system PIOS_Video_GetSystem(void);
 
 // video boundary values
 extern const struct pios_video_type_boundary *pios_video_type_boundary_act;
@@ -128,10 +135,7 @@ extern const struct pios_video_type_boundary *pios_video_type_boundary_act;
 #define GRAPHICS_X_MIDDLE	((GRAPHICS_RIGHT + 1) / 2)
 #define GRAPHICS_Y_MIDDLE	((GRAPHICS_BOTTOM + 1) / 2)
 
-// video type defs for autodetect
-#define VIDEO_TYPE_NONE      0
-#define VIDEO_TYPE_NTSC      1
-#define VIDEO_TYPE_PAL       2
+// for autodetect
 #define VIDEO_TYPE_PAL_ROWS  300
 
 // draw area buffer values, for memory allocation, access and calculations we suppose the larger values for PAL, this also works for NTSC

--- a/flight/PiOS/STM32F4xx/inc/pios_video.h
+++ b/flight/PiOS/STM32F4xx/inc/pios_video.h
@@ -109,10 +109,10 @@ extern bool PIOS_Hsync_ISR();
 
 extern void PIOS_Video_Init(const struct pios_video_cfg *cfg);
 extern void PIOS_Pixel_Init(void);
-extern void PIOS_Video_SetLevels(uint8_t, uint8_t, uint8_t, uint8_t);
+extern void PIOS_Video_SetLevels(uint8_t, uint8_t);
 extern void PIOS_Video_SetXOffset(int8_t);
 extern void PIOS_Video_SetYOffset(int8_t);
-extern void PIOS_Video_SetXScale(uint8_t pal_x_scale, uint8_t ntsc_x_scale);
+extern void PIOS_Video_SetXScale(uint8_t x_scale);
 extern void PIOS_Video_Set3DConfig(enum pios_video_3d_mode mode, uint8_t right_eye_x_shift);
 
 uint16_t PIOS_Video_GetLines(void);

--- a/flight/PiOS/STM32F4xx/pios_video.c
+++ b/flight/PiOS/STM32F4xx/pios_video.c
@@ -95,6 +95,8 @@ volatile uint16_t active_line = 0;
 
 const struct pios_video_type_boundary *pios_video_type_boundary_act = &pios_video_type_boundary_pal;
 
+int8_t video_type_act = VIDEO_TYPE_NONE;
+
 // Private variables
 static int8_t x_offset = 0;
 static int8_t x_offset_new = 0;
@@ -102,13 +104,7 @@ static int8_t y_offset = 0;
 static const struct pios_video_cfg *dev_cfg = NULL;
 static uint16_t num_video_lines = 0;
 static int8_t video_type_tmp = VIDEO_TYPE_PAL;
-static int8_t video_type_act = VIDEO_TYPE_NONE;
 static const struct pios_video_type_cfg *pios_video_type_cfg_act = &pios_video_type_cfg_pal;
-
-uint8_t black_pal = 30;
-uint8_t white_pal = 110;
-uint8_t black_ntsc = 10;
-uint8_t white_ntsc = 110;
 
 // Private functions
 static void swap_buffers();
@@ -144,11 +140,9 @@ bool PIOS_Vsync_ISR()
 		if (video_type_act == VIDEO_TYPE_NTSC) {
 			pios_video_type_boundary_act = &pios_video_type_boundary_ntsc;
 			pios_video_type_cfg_act = &pios_video_type_cfg_ntsc;
-			dev_cfg->set_bw_levels(black_ntsc, white_ntsc);
 		} else {
 			pios_video_type_boundary_act = &pios_video_type_boundary_pal;
 			pios_video_type_cfg_act = &pios_video_type_cfg_pal;
-			dev_cfg->set_bw_levels(black_pal, white_pal);
 		}
 		dev_cfg->pixel_timer.timer->CCR1 = pios_video_type_cfg_act->dc;
 		dev_cfg->pixel_timer.timer->ARR  = pios_video_type_cfg_act->period;
@@ -479,16 +473,11 @@ uint16_t PIOS_Video_GetType(void)
 /**
 *  Set the black and white levels
 */
-void PIOS_Video_SetLevels(uint8_t black_pal_in, uint8_t white_pal_in, uint8_t black_ntsc_in, uint8_t white_ntsc_in)
+void PIOS_Video_SetLevels(uint8_t black, uint8_t white)
 {
-	if (video_type_act == VIDEO_TYPE_PAL)
-		dev_cfg->set_bw_levels(black_pal_in, white_pal_in);
-	else
-		dev_cfg->set_bw_levels(black_ntsc_in, white_ntsc_in);
-	black_pal = black_pal_in;
-	white_pal = white_pal_in;
-	black_ntsc = black_ntsc_in;
-	white_ntsc = white_ntsc_in;
+	if (dev_cfg->set_bw_levels) {
+		dev_cfg->set_bw_levels(black, white);
+	}
 }
 
 /**
@@ -502,7 +491,6 @@ void PIOS_Video_SetXOffset(int8_t x_offset_in)
 		x_offset_in = -20;
 
 	x_offset_new = x_offset_in;
-	//dev_cfg->hsync_capture.timer->ARR = pios_video_type_cfg_act->dc * (pios_video_type_cfg_act->graphics_column_start + x_offset);
 }
 
 /**
@@ -520,7 +508,7 @@ void PIOS_Video_SetYOffset(int8_t y_offset_in)
 /**
 *  Set the x scale
 */
-void PIOS_Video_SetXScale(uint8_t pal_x_scale, uint8_t ntsc_xscale)
+void PIOS_Video_SetXScale(uint8_t x_scale)
 {
 	// Not supported by this driver
 	return;

--- a/flight/PiOS/STM32F4xx/pios_video.c
+++ b/flight/PiOS/STM32F4xx/pios_video.c
@@ -95,7 +95,6 @@ volatile uint16_t active_line = 0;
 
 const struct pios_video_type_boundary *pios_video_type_boundary_act = &pios_video_type_boundary_pal;
 
-int8_t video_type_act = VIDEO_TYPE_NONE;
 
 // Private variables
 static int8_t x_offset = 0;
@@ -103,7 +102,8 @@ static int8_t x_offset_new = 0;
 static int8_t y_offset = 0;
 static const struct pios_video_cfg *dev_cfg = NULL;
 static uint16_t num_video_lines = 0;
-static int8_t video_type_tmp = VIDEO_TYPE_PAL;
+static enum pios_video_system video_system_act = PIOS_VIDEO_SYSTEM_NONE;
+static enum pios_video_system video_system_tmp = PIOS_VIDEO_SYSTEM_PAL;
 static const struct pios_video_type_cfg *pios_video_type_cfg_act = &pios_video_type_cfg_pal;
 
 // Private functions
@@ -131,13 +131,13 @@ bool PIOS_Vsync_ISR()
 
 	// check video type
 	if (num_video_lines > VIDEO_TYPE_PAL_ROWS) {
-		video_type_tmp = VIDEO_TYPE_PAL;
+		video_system_tmp = PIOS_VIDEO_SYSTEM_PAL;
 	}
 
 	// if video type has changed set new active values
-	if (video_type_act != video_type_tmp) {
-		video_type_act = video_type_tmp;
-		if (video_type_act == VIDEO_TYPE_NTSC) {
+	if (video_system_act != video_system_tmp) {
+		video_system_act = video_system_tmp;
+		if (video_system_act == PIOS_VIDEO_SYSTEM_NTSC) {
 			pios_video_type_boundary_act = &pios_video_type_boundary_ntsc;
 			pios_video_type_cfg_act = &pios_video_type_cfg_ntsc;
 		} else {
@@ -154,7 +154,7 @@ bool PIOS_Vsync_ISR()
 		dev_cfg->hsync_capture.timer->ARR = pios_video_type_cfg_act->dc * (pios_video_type_cfg_act->graphics_column_start + x_offset);
 	}
 
-	video_type_tmp = VIDEO_TYPE_NTSC;
+	video_system_tmp = PIOS_VIDEO_SYSTEM_NTSC;
 
 	// Every VSYNC_REDRAW_CNT field: swap buffers and trigger redraw
 	if (++Vsync_update >= VSYNC_REDRAW_CNT) {
@@ -465,9 +465,9 @@ uint16_t PIOS_Video_GetLines(void)
 /**
  *
  */
-uint16_t PIOS_Video_GetType(void)
+enum pios_video_system PIOS_Video_GetSystem(void)
 {
-	return video_type_act;
+	return video_system_act;
 }
 
 /**

--- a/flight/PiOS/STM32F4xx/pios_video_quadspi.c
+++ b/flight/PiOS/STM32F4xx/pios_video_quadspi.c
@@ -98,15 +98,14 @@ uint8_t *disp_buffer;
 
 const struct pios_video_type_boundary *pios_video_type_boundary_act = &pios_video_type_boundary_pal;
 
-int8_t video_type_act = VIDEO_TYPE_NONE;
-
 // Private variables
 static int16_t active_line = 0;
 static uint32_t buffer_offset;
 static int8_t y_offset = 0;
 static const struct pios_video_cfg *dev_cfg = NULL;
 static uint16_t num_video_lines = 0;
-static int8_t video_type_tmp = VIDEO_TYPE_PAL;
+static enum pios_video_system video_system_act = PIOS_VIDEO_SYSTEM_NONE;
+static enum pios_video_system video_system_tmp = PIOS_VIDEO_SYSTEM_PAL;
 static const struct pios_video_type_cfg *pios_video_type_cfg_act = &pios_video_type_cfg_pal;
 
 // Private functions
@@ -130,13 +129,13 @@ bool PIOS_Vsync_ISR()
 
 	// check video type
 	if (num_video_lines > VIDEO_TYPE_PAL_ROWS) {
-		video_type_tmp = VIDEO_TYPE_PAL;
+		video_system_tmp = PIOS_VIDEO_SYSTEM_PAL;
 	}
 
 	// if video type has changed set new active values
-	if (video_type_act != video_type_tmp) {
-		video_type_act = video_type_tmp;
-		if (video_type_act == VIDEO_TYPE_NTSC) {
+	if (video_system_act != video_system_tmp) {
+		video_system_act = video_system_tmp;
+		if (video_system_act == PIOS_VIDEO_SYSTEM_NTSC) {
 			pios_video_type_boundary_act = &pios_video_type_boundary_ntsc;
 			pios_video_type_cfg_act = &pios_video_type_cfg_ntsc;
 		} else {
@@ -145,7 +144,7 @@ bool PIOS_Vsync_ISR()
 		}
 	}
 
-	video_type_tmp = VIDEO_TYPE_NTSC;
+	video_system_tmp = PIOS_VIDEO_SYSTEM_NTSC;
 
 	// Every VSYNC_REDRAW_CNT field: swap buffers and trigger redraw
 	if (++Vsync_update >= VSYNC_REDRAW_CNT) {
@@ -289,9 +288,9 @@ uint16_t PIOS_Video_GetLines(void)
 /**
  *
  */
-uint16_t PIOS_Video_GetType(void)
+enum pios_video_system PIOS_Video_GetSystem(void)
 {
-	return video_type_act;
+	return video_system_act;
 }
 
 /**


### PR DESCRIPTION
Fixes #1254 

When the video system changed between PAL and NTSC, the ISR was setting the black and white levels. For BrainRE1, this resulted in a SPI transfer to the FPGA from the ISR, which could lock up when the SPI was in use (e.g. for logging). This PR moves the calls to the OSD task and cleans up some things. Same changes also applied for Brain for consistency.

Status: Bench tested for RE1 (could not reproduce problem anymore, even with 250Hz logging and a lot of spurious interrupts). Needs test on Brain