### PR TITLE
python: small improvements to the autotune pyapi

### DIFF
--- a/python/dronin/autotune.py
+++ b/python/dronin/autotune.py
@@ -10,6 +10,7 @@ Licensed under the GNU LGPL version 2.1 or any later version (see COPYING.LESSER
 import sys, struct
 
 import pandas as pd
+from scipy import signal
 
 at_flash_header_fmt = struct.Struct('<QHHHH')
 at_measurement_fmt = struct.Struct('<ffffff')
@@ -19,8 +20,7 @@ def process_autotune_lump(contents):
     hdr_tup = at_flash_header_fmt.unpack_from(contents)
 
     if hdr_tup[0] != 0x656e755480008041:
-        print("Invalid magic")
-        sys.exit(1)
+        raise ValueError
 
     offset = at_flash_header_fmt.size
 
@@ -37,30 +37,59 @@ def process_autotune_lump(contents):
     for i in range(hdr_tup[1]):
         d_tup = at_measurement_fmt.unpack_from(contents, offset)
 
-        d_tup = (i * time_step,) + d_tup
+        d_tup = d_tup + (i * time_step, )
 
         pts.append(d_tup)
 
         offset += at_measurement_fmt.size
 
-    return pd.DataFrame.from_records(data = pts, index = 'time',
-            columns = [ 'time', 'gyroX', 'gyroY', 'gyroZ',
-                'desiredX', 'desiredY', 'desiredZ' ])
+    # Don't set the index = 'time' for now, as it often makes things more of a
+    # pain for the caller than it helps
+    frame = pd.DataFrame.from_records(data = pts,
+            columns = [ 'gyroX', 'gyroY', 'gyroZ',
+                'desiredX', 'desiredY', 'desiredZ', 'time' ])
 
+    # Double the data before filtering and differentiating
+    frame = pd.concat([frame, frame], ignore_index=True)
+
+    # corresponds to 55Hz gyrocutoff
+    b, a = signal.iirfilter(1, [55.0 * time_step], btype='lowpass', ftype='butter')
+
+    for col in ['X', 'Y', 'Z']:
+        filtered = signal.lfilter(b, a, frame['gyro' + col], axis=0)
+        frame['filtered' + col] = pd.Series(filtered)
+
+    deriv = frame.diff()
+
+    for col in deriv:
+        frame['deriv' + col] = deriv[col]
+
+    # And then take the last half of the data to un-duplicate it
+    frame = frame.iloc[len(frame) /2:]
+
+    return (frame, time_step)
 
 def read_autotune_lump(f_name):
     """ Given a filename with autotune data, return a time-series panda dataseries """
-    with open(f_name, 'rb') as f:
-        contents = f.read()
+    try:
+        with open(f_name, 'rb') as f:
+            contents = f.read()
 
-    return process_autotune_lump(contents)
+        return process_autotune_lump(contents)
+    except Exception:
+        import gzip
+
+        with gzip.open(f_name, 'rb') as f:
+            contents = f.read()
+
+        return process_autotune_lump(contents)
 
 def main(argv):
     if len(argv) != 1:
         print("nope")
         sys.exit(1)
 
-    frame = read_autotune_lump(argv[0])
+    frame, time_step = read_autotune_lump(argv[0])
 
     print(frame)
 


### PR DESCRIPTION
* don't put an index on the data series, as this is often more trouble
than it's worth
* support reading gzip'd tune files because that's what I use
* add filtered and differentiated columns to the dataframe for
simplified analysis

My current notebooks expect this version.