### PR TITLE
WIP: Stabilization: Add rate precompensation to inner loop

### DIFF
--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -152,7 +152,19 @@ static float compute_inner_loop_precomp(uint32_t pid_group, uint8_t axis, float 
 
 static float compute_inner_loop_precomp(uint32_t pid_group, uint8_t axis, float desired_rate, float measured_rate, float dt)
 {
-	return pid_apply_setpoint(&pids[pid_group + axis], get_deadband(axis), desired_rate, measured_rate, dt) + settings.RatePrecompensation[axis] * desired_rate;
+	// select the rate source for precompensation
+	float precomp_rate = 0;
+	switch (settings.RatePrecompensationSrc) {
+		case STABILIZATIONSETTINGS_RATEPRECOMPENSATIONSRC_DESIRED:
+			precomp_rate = desired_rate;
+			break;
+		case STABILIZATIONSETTINGS_RATEPRECOMPENSATIONSRC_MEASURED:
+			precomp_rate = measured_rate;
+			break;
+		default:
+			break;
+	}
+	return pid_apply_setpoint(&pids[pid_group + axis], get_deadband(axis), desired_rate, measured_rate, dt) + settings.RatePrecompensation[axis] * precomp_rate;
 }
 
 static float get_throttle(StabilizationDesiredData *stabilization_desired, SystemSettingsAirframeTypeOptions *airframe_type)

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -142,12 +142,18 @@ static void zero_pids(void);
 static void calculate_pids(void);
 static void SettingsUpdatedCb(UAVObjEvent * objEv, void *ctx, void *obj, int len);
 static float get_throttle(StabilizationDesiredData *stabilization_desired, SystemSettingsAirframeTypeOptions *airframe_type);
+static float compute_inner_loop_precomp(uint32_t pid_group, uint8_t axis, float desired_rate, float measured_rate, float dt);
 
 #ifndef NO_CONTROL_DEADBANDS
 #define get_deadband(axis) (deadbands ? (deadbands + axis) : NULL)
 #else
 #define get_deadband(axis) NULL
 #endif
+
+static float compute_inner_loop_precomp(uint32_t pid_group, uint8_t axis, float desired_rate, float measured_rate, float dt)
+{
+	return pid_apply_setpoint(&pids[pid_group + axis], get_deadband(axis), desired_rate, measured_rate, dt) + settings.RatePrecompensation[axis] * desired_rate;
+}
 
 static float get_throttle(StabilizationDesiredData *stabilization_desired, SystemSettingsAirframeTypeOptions *airframe_type)
 {
@@ -540,7 +546,7 @@ static void stabilizationTask(void* parameters)
 					rateDesiredAxis[i] = bound_sym(stabDesiredAxis[i], settings.ManualRate[i]);
 
 					// Compute the inner loop
-					actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], dT_expected);
+					actuatorDesiredAxis[i] = compute_inner_loop_precomp(PID_GROUP_RATE, i, rateDesiredAxis[i], gyro_filtered[i], dT_expected);
 					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 
 					break;
@@ -565,7 +571,7 @@ static void stabilizationTask(void* parameters)
 							}
 
 					// Compute the inner loop
-					actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i), rateDesiredAxis[i], gyro_filtered[i], dT_expected);
+					actuatorDesiredAxis[i] = compute_inner_loop_precomp(PID_GROUP_RATE, i, rateDesiredAxis[i], gyro_filtered[i], dT_expected);
 					actuatorDesiredAxis[i] = factor * raw_input + (1.0f - factor) * actuatorDesiredAxis[i];
 					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i], 1.0f);
 
@@ -581,7 +587,7 @@ static void stabilizationTask(void* parameters)
 					rateDesiredAxis[i] = bound_sym(rateDesiredAxis[i], settings.MaximumRate[i]);
 
 					// Compute the inner loop
-					actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], dT_expected);
+					actuatorDesiredAxis[i] = compute_inner_loop_precomp(PID_GROUP_RATE, i, rateDesiredAxis[i], gyro_filtered[i], dT_expected);
 					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 
 					break;
@@ -605,7 +611,7 @@ static void stabilizationTask(void* parameters)
 
 					// Compute desired rate as input biased towards leveling
 					rateDesiredAxis[i] = stabDesiredAxis[i] + weak_leveling;
-					actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], dT_expected);
+					actuatorDesiredAxis[i] = compute_inner_loop_precomp(PID_GROUP_RATE, i, rateDesiredAxis[i], gyro_filtered[i], dT_expected);
 					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 
 					break;
@@ -626,12 +632,13 @@ static void stabilizationTask(void* parameters)
 						axis_lock_accum[i] += (stabDesiredAxis[i] - gyro_filtered[i]) * dT_expected;
 						axis_lock_accum[i] = bound_sym(axis_lock_accum[i], max_axis_lock);
 
-						// Compute the inner loop
+						// Compute the inner loop setpoint
 						float tmpRateDesired = pid_apply(&pids[PID_GROUP_ATT + i], axis_lock_accum[i], dT_expected);
 						rateDesiredAxis[i] = bound_sym(tmpRateDesired, settings.MaximumRate[i]);
 					}
 
-					actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], dT_expected);
+					// Compute the inner loop
+					actuatorDesiredAxis[i] = compute_inner_loop_precomp(PID_GROUP_RATE, i, rateDesiredAxis[i], gyro_filtered[i], dT_expected);
 					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 
 					break;
@@ -657,7 +664,7 @@ static void stabilizationTask(void* parameters)
 					rateDesiredAxis[i] = bound_sym(rateDesiredAxis[i], settings.ManualRate[i]);
 
 					// Compute the inner loop
-					actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], dT_expected);
+					actuatorDesiredAxis[i] = compute_inner_loop_precomp(PID_GROUP_RATE, i, rateDesiredAxis[i], gyro_filtered[i], dT_expected);
 					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 
 					break;
@@ -702,16 +709,13 @@ static void stabilizationTask(void* parameters)
 						// Compute the outer loop
 						rateDesiredAxis[i] = pid_apply(&pids[PID_GROUP_ATT + i], local_attitude_error[i], dT_expected);
 						rateDesiredAxis[i] = bound_sym(rateDesiredAxis[i], settings.MaximumRate[i]);
-
-						// Compute the inner loop
-						actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i), rateDesiredAxis[i],  gyro_filtered[i], dT_expected);
 					} else {
 						// Get the desired rate. yaw is always in rate mode in system ident.
 						rateDesiredAxis[i] = bound_sym(stabDesiredAxis[i], settings.ManualRate[i]);
-
-						// Compute the inner loop only for yaw
-						actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i), rateDesiredAxis[i],  gyro_filtered[i], dT_expected);
 					}
+
+					// Compute the inner loop
+					actuatorDesiredAxis[i] = compute_inner_loop_precomp(PID_GROUP_RATE, i, rateDesiredAxis[i], gyro_filtered[i], dT_expected);
 
 					const float scale = 0.06;
 
@@ -888,7 +892,7 @@ static void stabilizationTask(void* parameters)
 					rateDesiredAxis[i] = bound_sym(rateDesiredAxis[i], settings.PoiMaximumRate[i]);
 
 					// Compute the inner loop
-					actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i), rateDesiredAxis[i], gyro_filtered[i], dT_expected);
+					actuatorDesiredAxis[i] = compute_inner_loop_precomp(PID_GROUP_RATE, i, rateDesiredAxis[i], gyro_filtered[i], dT_expected);
 					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 
 					break;

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -15,6 +15,9 @@
 		<field name="RollRatePID" units="" type="float" elementnames="Kp,Ki,Kd,ILimit" defaultvalue="0.002,0.0015,0,0.3" limits="%BE:0:0.01,%BE:0:0.05,, "/>
 		<field name="PitchRatePID" units="" type="float" elementnames="Kp,Ki,Kd,ILimit" defaultvalue="0.002,0.0015,0,0.3" limits="%BE:0:0.01,%BE:0:0.05,, "/>
 		<field name="YawRatePID" units="" type="float" elementnames="Kp,Ki,Kd,ILimit" defaultvalue="0.0035,0.0035,0,0.3" limits="%BE:0:0.01,%BE:0:0.05,, "/>
+		<field name="RatePrecompensation" units="" type="float" elementnames="Roll,Pitch,Yaw" defaultvalue="0,0,0" limits="%BE:0:0.01,%BE:0:0.01,%BE:0:0.01">
+			<description>An additional P-term to help overcome differences in effective control output with varying angular velocity of the aircraft.</description>
+		</field>
 		<field name="RollPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
 		<field name="PitchPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
 		<field name="YawPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -18,6 +18,13 @@
 		<field name="RatePrecompensation" units="" type="float" elementnames="Roll,Pitch,Yaw" defaultvalue="0,0,0" limits="%BE:0:0.01,%BE:0:0.01,%BE:0:0.01">
 			<description>An additional P-term to help overcome differences in effective control output with varying angular velocity of the aircraft.</description>
 		</field>
+		<field name="RatePrecompensationSrc" type="enum" elements="1" defaultvalue="Desired">
+			<description>Which rate source to use for precomp</description>
+			<options>
+				<option>Desired</option>
+				<option>Measured</option>
+			</options>
+		</field>
 		<field name="RollPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
 		<field name="PitchPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
 		<field name="YawPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>


### PR DESCRIPTION
- During a "fast" flip, as the aircraft's angular velocity increases, its effective AOA decreases since the air entering the rotor already has some velocity. As the aircraft approaches the desired rate, the P-term will decrease (with decreasing error), while the required cyclic output will actually increase (with increasing angular velocity), meaning a P-controller will necessarily undershoot the desired angular velocity. This can be partially remedied with a large I-gain, but that introduces other issues.
- Thus, any cp heli setups out there are likely either "significantly" undershooting desired angular velocity (during acceleration maneuvers) or are abusing the I-term; a simulation of my ~3 lb heli with 380mm blades @ 2750 RPM, +/- 10 degrees cyclic pitch, suggests that the "real world" P-gain for roll (13.75) will undershoot the desired rate by ~20%, and the "max" P-gain for roll (35.00) will undershoot by ~9%, for any non-zero desired rate. The corresponding numbers for pitch are ~7% undershoot at a P-gain of 47.25 ("real-world"), and ~4% undershoot at a P-gain of 95 ("max"). The undershoot percentage decreases as a function of increasing rotor RPM and P-gain, and is roughly linear with respect to the angular velocity of the aircraft for a given rotor RPM and P-gain (increasing rotor RPM increases effective controller output scale and decreases the effects of changes in effective AOA vs angular velocity).
- While an I-term with just the right I-gain (roughly 3x the P-gain for the conditions mentioned) _can_ approximate the undershoot, it introduces other performance issues (for example, at high positive angular momentum, a high negative desired rate causes overshoot at the new rate) and can be hard to determine experimentally.
- A more general solution is to add a second P (or PI) controller that operates on _desired_ rate instead of _error in_ rate, since the extra control output required to eliminate the undershoot is roughly linear with respect to the desired rate, and should only change with rotor RPM (for a given aircraft). A controller using _actual_ rate instead of desired rate would likely perform similarly, but with a slightly longer settling time.
- This applies mostly to cyclic movements, and to a lesser degree to yaw movements (tail rotor spins at higher RPM but also experiences higher relative air velocity during typical maneuvers) and collective movements (not sure if we actually want to filter these, with the exception of althold). It also has the benefit of creating symmetric _effective_ control outputs for both acceleration and deceleration by making the _actual_ control outputs asymmetric as a function of desired angular velocity.
- Quads may see some of these effects, but only at very high angular velocity and/or very low prop RPM.

p-gain | no precompensation | precompensation
-|-|-
"real world" | ![sim-roll-lowp-noprecomp-cropped](https://cloud.githubusercontent.com/assets/666500/20959847/f669e52c-bc11-11e6-8dc9-c89020039639.png) | ![sim-roll-lowp-precomp-cropped](https://cloud.githubusercontent.com/assets/666500/20959880/39a842a2-bc12-11e6-909a-51533ffa4571.png)
"max" | ![sim-roll-highp-noprecomp-cropped](https://cloud.githubusercontent.com/assets/666500/20959900/6587f4c6-bc12-11e6-97f4-b97cfdca15b6.png) | ![sim-roll-highp-precomp-cropped](https://cloud.githubusercontent.com/assets/666500/20959904/6befc118-bc12-11e6-9499-a9988cae159f.png)

description | image
-|-
undershoot at high p-gain | ![sim-roll-steep-highp-noprecomp-cropped](https://cloud.githubusercontent.com/assets/666500/20960637/414be60e-bc16-11e6-84a8-ea3efcda84a7.png)
overshoot at high positive momentum, high negative desired rate | ![sim-roll-steep-highp-highi-cropped](https://cloud.githubusercontent.com/assets/666500/20960588/0b857b16-bc16-11e6-9084-ecd15a811569.png)
precompensation applied | ![sim-roll-steep-highp-precomp-cropped](https://cloud.githubusercontent.com/assets/666500/20960672/69c228b4-bc16-11e6-93f8-2b8decca90c7.png)