### PR TITLE
Flight:PiOS: Cleanup byte ordering macros

### DIFF
--- a/flight/PiOS/Common/pios_openlrs.c
+++ b/flight/PiOS/Common/pios_openlrs.c
@@ -663,12 +663,6 @@ static void beacon_send(struct pios_openlrs_dev *openlrs_dev, bool static_tone)
 // TODO: these should move into device structure, or deleted
 // if not useful to be reported via GCS
 
-#define ntohl(v) (				\
-	(((v) & 0xFF000000) >> 24) |		\
-	(((v) & 0x00FF0000) >>  8) |		\
-	(((v) & 0x0000FF00) <<  8) |		\
-	(((v) & 0x000000FF) << 24))
-
 static uint8_t pios_openlrs_bind_receive(struct pios_openlrs_dev *openlrs_dev, uint32_t timeout)
 {
 	uint32_t start = millis();

--- a/flight/PiOS/Common/pios_srxl.c
+++ b/flight/PiOS/Common/pios_srxl.c
@@ -143,21 +143,6 @@ const struct pios_rcvr_driver pios_srxl_rcvr_driver = {
 
 /* Implementation */
 
-/* byte-ordering macros */
-#define ntohl(v) (				\
-	(((v) & 0xFF000000) >> 24) |		\
-	(((v) & 0x00FF0000) >>  8) |		\
-	(((v) & 0x0000FF00) <<  8) |		\
-	(((v) & 0x000000FF) << 24))
-
-#define ntohs(v) (				\
-	(((v) & 0xFF00) >> 8) |			\
-	(((v) & 0x00FF) << 8))
-
-#define htonl(v) ntohl((v))
-
-#define htons(v) ntohs((v))
-
 int32_t PIOS_SRXL_Init(uintptr_t *srxl_id,
 	const struct pios_com_driver *driver, uintptr_t lower_id)
 {
@@ -263,7 +248,7 @@ static void PIOS_SRXL_ParseFrame(struct pios_srxl_dev *dev)
 			struct pios_srxl_frame_multiplex16 *frame =
 					(struct pios_srxl_frame_multiplex16 *)dev->rx_buffer;
 			for (int i = 0; i < 16; i++)
-				dev->channels[i] = ntohs(frame->chan[i]);
+				dev->channels[i] = BE16_TO_CPU(frame->chan[i]);
 		}
 			break;
 		case PIOS_SRXL_SYNC_MULTIPLEX12:
@@ -271,7 +256,7 @@ static void PIOS_SRXL_ParseFrame(struct pios_srxl_dev *dev)
 			struct pios_srxl_frame_multiplex12 *frame =
 					(struct pios_srxl_frame_multiplex12 *)dev->rx_buffer;
 			for (int i = 0; i < 12; i++)
-				dev->channels[i] = ntohs(frame->chan[i]);
+				dev->channels[i] = BE16_TO_CPU(frame->chan[i]);
 		}
 			break;
 		case PIOS_SRXL_SYNC_WEATRONIC16:
@@ -279,7 +264,7 @@ static void PIOS_SRXL_ParseFrame(struct pios_srxl_dev *dev)
 			struct pios_srxl_frame_weatronic16 *frame =
 					(struct pios_srxl_frame_weatronic16 *)dev->rx_buffer;
 			for (int i = 0; i < 16; i++) {
-				int16_t value = 2000 + ntohs(frame->chan[i]); // centre values around 2000
+				int16_t value = 2000 + BE16_TO_CPU(frame->chan[i]); // centre values around 2000
 				if (value < 0 || value > 4000)
 					dev->channels[i] = PIOS_RCVR_INVALID;
 				else

--- a/flight/PiOS/pios.h
+++ b/flight/PiOS/pios.h
@@ -216,6 +216,35 @@
 #define NELEMENTS(x) (sizeof(x) / sizeof(*(x)))
 #define DONT_BUILD_IF(COND,MSG) typedef char static_assertion_##MSG[(COND)?-1:1]
 
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+	#define CPU_TO_LE16(x) (x)
+	#define CPU_TO_LE32(x) (x)
+
+	#define CPU_TO_BE16(x) ( (((x) & 0xff00) >> 8) | \
+	                         (((x) & 0x00ff) << 8) )
+	#define CPU_TO_BE32(x) ( (((x) & 0xff000000) >> 24) | \
+	                         (((x) & 0x00ff0000) >>  8) | \
+	                         (((x) & 0x0000ff00) <<  8) | \
+	                         (((x) & 0x000000ff) << 24) )
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+	#define CPU_TO_LE16(x) ( (((x) & 0xff00) >> 8) | \
+	                         (((x) & 0x00ff) << 8) )
+	#define CPU_TO_LE32(x) ( (((x) & 0xff000000) >> 24) | \
+	                         (((x) & 0x00ff0000) >>  8) | \
+	                         (((x) & 0x0000ff00) <<  8) | \
+	                         (((x) & 0x000000ff) << 24) )
+
+	#define CPU_TO_BE16(x) (x)
+	#define CPU_TO_BE32(x) (x)
+#else
+	#error Unsupported architecture!
+#endif /* __BYTE_ORDER__ */
+
+#define LE16_TO_CPU(x) CPU_TO_LE16(x)
+#define LE32_TO_CPU(x) CPU_TO_LE32(x)
+#define BE16_TO_CPU(x) CPU_TO_BE16(x)
+#define BE32_TO_CPU(x) CPU_TO_BE32(x)
+
 #endif /* PIOS_H */
 
 /**

--- a/flight/targets/bl/common/bl_messages.h
+++ b/flight/targets/bl/common/bl_messages.h
@@ -58,21 +58,6 @@ enum bl_commands {
 #define BL_MSG_FLAGS_MASK     0xC0
 #define BL_MSG_COMMAND_MASK   0x3F
 
-
-#define ntohl(v) (				\
-	(((v) & 0xFF000000) >> 24) |		\
-	(((v) & 0x00FF0000) >>  8) |		\
-	(((v) & 0x0000FF00) <<  8) |		\
-	(((v) & 0x000000FF) << 24))
-
-#define ntohs(v) (				\
-	(((v) & 0xFF00) >> 8) |			\
-	(((v) & 0x00FF) << 8))
-
-#define htonl(v) ntohl((v))
-
-#define htons(v) ntohs((v))
-
 /*
  * Note: These enum values MUST NOT be changed or backward
  *       compatibility will be broken

--- a/flight/targets/bl/common/main.c
+++ b/flight/targets/bl/common/main.c
@@ -558,8 +558,8 @@ static bool bl_send_capabilities(struct bl_fsm_context * context, uint8_t device
 		struct bl_messages msg = {
 			.flags_command = BL_MSG_CAP_REP,
 			.v.cap_rep_all = {
-				.number_of_devices = htons(1),
-				.wrflags = htons(0x3),
+				.number_of_devices = CPU_TO_BE16(1),
+				.wrflags = CPU_TO_BE16(0x3),
 			},
 		};
 		PIOS_COM_MSG_Send(PIOS_COM_TELEM_USB, (uint8_t *)&msg, sizeof(msg));
@@ -600,7 +600,7 @@ static void process_packet_rx(struct bl_fsm_context * context, const struct bl_m
 		}
 		break;
 	case BL_MSG_JUMP_FW:
-		if (ntohs(msg->v.jump_fw.safe_word) == 0x5afe) {
+		if (BE16_TO_CPU(msg->v.jump_fw.safe_word) == 0x5afe) {
 			/* Force board into safe mode */
 			PIOS_IAP_WriteBootCount(0xFFFF);
 		}


### PR DESCRIPTION
PiOS now provides CPU to either endianess and vice-versa for 16 and 32-bit values. Tested bootloader built from this branch on Quanton.