### PR TITLE
BrainRE1: Use Fancy LED stuff

### DIFF
--- a/flight/Modules/OnScreenDisplay/osd_menu.c
+++ b/flight/Modules/OnScreenDisplay/osd_menu.c
@@ -349,41 +349,13 @@ const static struct menu_fsm_transition menu_fsm[FSM_STATE_NUM_STATES] = {
 		.menu_fn = brainre1_menu,
 		.next_state = {
 			[FSM_EVENT_UP] = FSM_STATE_RE1_EXIT,
-			[FSM_EVENT_DOWN] = FSM_STATE_RE1_LED_COLOR,
-		},
-	},
-	[FSM_STATE_RE1_LED_COLOR] = {
-		.menu_fn = brainre1_menu,
-		.next_state = {
-			[FSM_EVENT_UP] = FSM_STATE_RE1_EXIT,
-			[FSM_EVENT_DOWN] = FSM_STATE_RE1_LED_COLOR_R,
-		},
-	},
-	[FSM_STATE_RE1_LED_COLOR_R] = {
-		.menu_fn = brainre1_menu,
-		.next_state = {
-			[FSM_EVENT_UP] = FSM_STATE_RE1_LED_COLOR,
-			[FSM_EVENT_DOWN] = FSM_STATE_RE1_LED_COLOR_G,
-		},
-	},
-	[FSM_STATE_RE1_LED_COLOR_G] = {
-		.menu_fn = brainre1_menu,
-		.next_state = {
-			[FSM_EVENT_UP] = FSM_STATE_RE1_LED_COLOR_R,
-			[FSM_EVENT_DOWN] = FSM_STATE_RE1_LED_COLOR_B,
-		},
-	},
-	[FSM_STATE_RE1_LED_COLOR_B] = {
-		.menu_fn = brainre1_menu,
-		.next_state = {
-			[FSM_EVENT_UP] = FSM_STATE_RE1_LED_COLOR_G,
 			[FSM_EVENT_DOWN] = FSM_STATE_RE1_IR_PROTOCOL,
 		},
 	},
 	[FSM_STATE_RE1_IR_PROTOCOL] = {
 		.menu_fn = brainre1_menu,
 		.next_state = {
-			[FSM_EVENT_UP] = FSM_STATE_RE1_LED_COLOR_G,
+			[FSM_EVENT_UP] = FSM_STATE_RE1_EXIT,
 			[FSM_EVENT_DOWN] = FSM_STATE_RE1_IR_IDILAP,
 		},
 	},
@@ -1060,19 +1032,6 @@ void main_menu(void)
 #if defined(USE_STM32F4xx_BRAINFPVRE1)
 #include "hwbrainre1.h"
 
-const char * led_color_names[HWBRAINRE1_LEDCOLOR_GLOBAL_MAXOPTVAL + 1] = {
-	[HWBRAINRE1_LEDCOLOR_OFF]    = "OFF",
-	[HWBRAINRE1_LEDCOLOR_CUSTOM] = "Custom",
-	[HWBRAINRE1_LEDCOLOR_WHITE]  = "White",
-	[HWBRAINRE1_LEDCOLOR_RED]    = "Red",
-	[HWBRAINRE1_LEDCOLOR_ORANGE] = "Orange",
-	[HWBRAINRE1_LEDCOLOR_YELLOW] = "Yellow",
-	[HWBRAINRE1_LEDCOLOR_GREEN]  = "Green",
-	[HWBRAINRE1_LEDCOLOR_AQUA]   = "Aqua",
-	[HWBRAINRE1_LEDCOLOR_BLUE]   = "Blue",
-	[HWBRAINRE1_LEDCOLOR_PURPLE] = "Purple",
-};
-
 const char * ir_protocol_names[HWBRAINRE1_IRPROTOCOL_MAXOPTVAL + 1] = {
 	[HWBRAINRE1_IRPROTOCOL_DISABLED] = "OFF",
 	[HWBRAINRE1_IRPROTOCOL_ILAP] = "I-Lap",
@@ -1139,27 +1098,11 @@ void brainre1_menu(void)
 
 	draw_menu_title("BrainFPV RE1 Settings");
 
-	for (enum menu_fsm_state s=FSM_STATE_RE1_LED_COLOR; s <= FSM_STATE_RE1_EXIT; s++) {
+	for (enum menu_fsm_state s=FSM_STATE_RE1_IR_PROTOCOL; s <= FSM_STATE_RE1_EXIT; s++) {
 		if (s == current_state) {
 			draw_selected_icon(MENU_LINE_X - 4, y_pos + 4);
 		}
 		switch (s) {
-			case FSM_STATE_RE1_LED_COLOR:
-				sprintf(tmp_str, "LED Color: %s", led_color_names[data.LEDColor]);
-				write_string(tmp_str, MENU_LINE_X, y_pos, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, MENU_FONT);
-				break;
-			case FSM_STATE_RE1_LED_COLOR_R:
-				sprintf(tmp_str, "Custom LED Color R: %d", (int)data.CustomLEDColor[0]);
-				write_string(tmp_str, MENU_LINE_X, y_pos, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, MENU_FONT);
-				break;
-			case FSM_STATE_RE1_LED_COLOR_G:
-				sprintf(tmp_str, "Custom LED Color G: %d", (int)data.CustomLEDColor[1]);
-				write_string(tmp_str, MENU_LINE_X, y_pos, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, MENU_FONT);
-				break;
-			case FSM_STATE_RE1_LED_COLOR_B:
-				sprintf(tmp_str, "Custom LED Color B: %d", (int)data.CustomLEDColor[2]);
-				write_string(tmp_str, MENU_LINE_X, y_pos, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, MENU_FONT);
-				break;
 			case FSM_STATE_RE1_IR_PROTOCOL:
 				sprintf(tmp_str, "IR Transponder Protocol: %s", ir_protocol_names[data.IRProtocol]);
 				write_string(tmp_str, MENU_LINE_X, y_pos, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, MENU_FONT);
@@ -1185,34 +1128,6 @@ void brainre1_menu(void)
 	}
 
 	switch (current_state) {
-		case FSM_STATE_RE1_LED_COLOR:
-			if (current_event == FSM_EVENT_RIGHT) {
-				data.LEDColor = (data.LEDColor + 1) % (HWBRAINRE1_LEDCOLOR_GLOBAL_MAXOPTVAL + 1);
-				data_changed = true;
-			}
-			if (current_event == FSM_EVENT_LEFT) {
-				if (data.LEDColor == HWBRAINRE1_LEDCOLOR_OFF)
-					data.LEDColor = HWBRAINRE1_LEDCOLOR_GLOBAL_MAXOPTVAL;
-				else
-					data.LEDColor = data.LEDColor - 1;
-				data_changed = true;
-			}
-			break;
-		case FSM_STATE_RE1_LED_COLOR_R:
-		case FSM_STATE_RE1_LED_COLOR_G:
-		case FSM_STATE_RE1_LED_COLOR_B:
-			{
-				int idx = current_state - FSM_STATE_RE1_LED_COLOR_R;
-				if (current_event == FSM_EVENT_RIGHT) {
-					data.CustomLEDColor[idx] += 1;
-					data_changed = true;
-				}
-				if (current_event == FSM_EVENT_LEFT) {
-					data.CustomLEDColor[idx] -= 1;
-					data_changed = true;
-				}
-			}
-			break;
 		case FSM_STATE_RE1_IR_PROTOCOL:
 			if (current_event == FSM_EVENT_RIGHT) {
 				if (data.IRProtocol == HWBRAINRE1_IRPROTOCOL_GLOBAL_MAXOPTVAL)

--- a/flight/targets/brainre1/board-info/pios_board.h
+++ b/flight/targets/brainre1/board-info/pios_board.h
@@ -144,6 +144,9 @@ extern uintptr_t pios_com_debug_id;
 #define PIOS_COM_DEBUG                  (pios_com_debug_id)
 #endif	/* PIOS_INCLUDE_DEBUG_CONSOLE */
 
+#include <pios_ws2811.h>
+extern ws2811_dev_t pios_ws2811;
+
 #if defined(PIOS_INCLUDE_RFM22B)
 extern uint32_t pios_rfm22b_id;
 extern uint32_t pios_spi_telem_flash_id;

--- a/flight/targets/brainre1/fw/Makefile
+++ b/flight/targets/brainre1/fw/Makefile
@@ -34,6 +34,7 @@ ERASE_FLASH ?= NO
 
 # List of modules to include
 MODULES = Sensors
+MODULES += System
 MODULES += Attitude
 MODULES += Actuator
 MODULES += ManualControl
@@ -102,7 +103,6 @@ include $(APPLIBDIR)/ChibiOS/library.mk
 ## MODULES
 SRC += ${foreach MOD, ${MODULES} ${OPTMODULES}, ${wildcard ${OPMODULEDIR}/${MOD}/*.c}}
 ## OPENPILOT CORE:
-SRC += ${OPMODULEDIR}/System/systemmod.c
 SRC += main.c
 SRC += board.c
 SRC += pios_board.c

--- a/flight/targets/brainre1/fw/main.c
+++ b/flight/targets/brainre1/fw/main.c
@@ -116,14 +116,6 @@ void initTask(void *parameters)
 	/* Initialize modules */
 	MODULE_INITIALISE_ALL(PIOS_WDG_Clear);
 
-	/* Schedule a periodic callback to update the LEDs */
-	UAVObjEvent ev = {
-		.obj = HwBrainRE1Handle(),
-		.instId = 0,
-		.event = 0,
-	};
-	EventPeriodicCallbackCreate(&ev, ledUpdatePeridodicCb, 31);
-
 	/* terminate this task */
 	PIOS_Thread_Delete(NULL);
 }

--- a/flight/targets/brainre1/fw/pios_config.h
+++ b/flight/targets/brainre1/fw/pios_config.h
@@ -126,6 +126,7 @@
 //#define PIOS_QUATERNION_STABILIZATION   /* Stabilization options */
 #define PIOS_GPS_SETS_HOMELOCATION      /* GPS options */
 #define AUTOTUNE_AVERAGING_MODE
+#define SYSTEMMOD_RGBLED_SUPPORT
 
 #define CAMERASTAB_POI_MODE
 

--- a/flight/targets/brainre1/re1fpga/fpga_drv.h
+++ b/flight/targets/brainre1/re1fpga/fpga_drv.h
@@ -73,7 +73,6 @@ int32_t PIOS_RE1FPGA_SetSyncThreshold(uint8_t threshold);
 void PIOS_RE1FPGA_SetXOffset(int8_t x_offset);
 void PIOS_RE1FPGA_SetXScale(uint8_t x_scale);
 void PIOS_RE1FPGA_Set3DConfig(enum pios_video_3d_mode mode, uint8_t x_shift_right);
-int32_t PIOS_RE1FPGA_SetLEDColor(uint16_t n_leds, uint8_t red, uint8_t green, uint8_t blue);
 int32_t PIOS_RE1FPGA_SetIRProtocol(enum pios_re1fpga_ir_protocols ir_protocol);
 int32_t PIOS_RE1FPGA_SetIRData(const uint8_t * ir_data, uint8_t n_bytes);
 

--- a/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.cpp
+++ b/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.cpp
@@ -67,14 +67,6 @@ BrainRE1Configuration::BrainRE1Configuration(QWidget *parent) :
     connect(ui->pbGenerateILap ,SIGNAL(clicked()) ,this, SLOT(generateILapID()));
     connect(ui->pbGenerateTrackmate ,SIGNAL(clicked()) ,this, SLOT(generateTrackmateID()));
 
-    addUAVObjectToWidgetRelation("HwBrainRE1", "NumberOfLEDs", ui->sbNumberOfLEDs);
-    addUAVObjectToWidgetRelation("HwBrainRE1", "LEDColor", ui->cmbLEDColor);
-
-    connect(re1_settings_obj, SIGNAL(CustomLEDColor_0Changed(quint8)), this, SLOT(getCustomLedColor()));
-    connect(re1_settings_obj, SIGNAL(CustomLEDColor_1Changed(quint8)), this, SLOT(getCustomLedColor()));
-    connect(re1_settings_obj, SIGNAL(CustomLEDColor_2Changed(quint8)), this, SLOT(getCustomLedColor()));
-    connect(ui->clrbCustomLEDColor, SIGNAL(colorChanged(const QColor)), this, SLOT(setCustomLedColor(const QColor)));
-
     addUAVObjectToWidgetRelation("HwBrainRE1", "BuzzerType", ui->cmbBuzzerType);
     addUAVObjectToWidgetRelation("HwBrainRE1", "VideoSyncDetectorThreshold", ui->sbVideoSyncDetectorThreshold);
 
@@ -87,9 +79,6 @@ BrainRE1Configuration::BrainRE1Configuration(QWidget *parent) :
     populateWidgets();
     refreshWidgetsValues();
     forceConnectedState();
-
-    // update the color button
-    getCustomLedColor();
 
     QPixmap img;
     img = QPixmap(":/brainfpv/images/brainre1.png");
@@ -166,21 +155,6 @@ int BrainRE1Configuration::generateRandomNumber(int max)
     std::uniform_int_distribution<int> distribution(0, max);
     //generator.seed(QTime::currentTime().msec());
     return distribution(generator);
-}
-
-void BrainRE1Configuration::getCustomLedColor()
-{
-    QColor color = QColor::fromRgb(re1_settings_obj->getCustomLEDColor(0),
-                                   re1_settings_obj->getCustomLEDColor(1),
-                                   re1_settings_obj->getCustomLEDColor(2));
-    ui->clrbCustomLEDColor->setColor(color);
-}
-
-void BrainRE1Configuration::setCustomLedColor(const QColor color)
-{
-    re1_settings_obj->setCustomLEDColor(0, color.red());
-    re1_settings_obj->setCustomLEDColor(1, color.green());
-    re1_settings_obj->setCustomLEDColor(2, color.blue());
 }
 
 void BrainRE1Configuration::mpChanged(int idx)

--- a/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.h
+++ b/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.h
@@ -50,8 +50,6 @@ private slots:
     void widgetsContentsChanged();
     void generateILapID();
     void generateTrackmateID();
-    void getCustomLedColor();
-    void setCustomLedColor(const QColor);
     void mpChanged(int idx);
     void extMagChanged(int idx);
 

--- a/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.ui
+++ b/ground/gcs/src/plugins/boards_brainfpv/brainre1configuration.ui
@@ -59,8 +59,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>970</width>
-        <height>781</height>
+        <width>968</width>
+        <height>774</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -696,66 +696,6 @@
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QGroupBox" name="groupBox_2">
-             <property name="title">
-              <string>Programmable LEDs</string>
-             </property>
-             <layout class="QHBoxLayout" name="horizontalLayout_8">
-              <item>
-               <widget class="QLabel" name="label_11">
-                <property name="text">
-                 <string>Number of LEDs</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QSpinBox" name="sbNumberOfLEDs">
-                <property name="maximum">
-                 <number>1024</number>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="label_8">
-                <property name="text">
-                 <string>LED Color</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QComboBox" name="cmbLEDColor"/>
-              </item>
-              <item>
-               <widget class="QLabel" name="label_12">
-                <property name="text">
-                 <string>Custom LED Color</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="Utils::QtColorButton" name="clrbCustomLEDColor">
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="horizontalSpacer_6">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item row="3" column="0">
             <widget class="QGroupBox" name="groupBox_3">
              <property name="title">
               <string>Buzzer Type</string>
@@ -793,7 +733,7 @@
              </layout>
             </widget>
            </item>
-           <item row="4" column="0">
+           <item row="3" column="0">
             <widget class="QGroupBox" name="groupBox_4">
              <property name="title">
               <string>Video System</string>
@@ -1087,13 +1027,6 @@ Beware of not locking yourself out!</string>
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>Utils::QtColorButton</class>
-   <extends>QToolButton</extends>
-   <header>utils/qtcolorbutton.h</header>
-  </customwidget>
- </customwidgets>
  <tabstops>
   <tabstop>help</tabstop>
   <tabstop>applySettings</tabstop>

--- a/shared/uavobjectdefinition/hwbrainre1.xml
+++ b/shared/uavobjectdefinition/hwbrainre1.xml
@@ -86,22 +86,6 @@
 		<field name="DSMxMode" units="mode" type="enum" elements="1" parent="HwShared.DSMxMode" defaultvalue="Autodetect"/>
 		<field name="USB_HIDPort" units="function" type="enum" elements="1" parent="HwShared.USB_HIDPort" defaultvalue="USBTelemetry"/>
 		<field name="USB_VCPPort" units="function" type="enum" elements="1" parent="HwShared.USB_VCPPort" defaultvalue="Disabled"/>
-		<field name="NumberOfLEDs" units="" type="uint16" elements="1" defaultvalue="0" limits="%BE:0:1024"/>
-		<field name="CustomLEDColor" units="" type="uint8" elements="3" defaultvalue="255,0,0"/>
-		<field name="LEDColor" units="function" type="enum" elements="1" defaultvalue="Red">
-			<options>
-				<option>Off</option>
-				<option>Custom</option>
-				<option>White</option>
-				<option>Red</option>
-				<option>Orange</option>
-				<option>Yellow</option>
-				<option>Green</option>
-				<option>Aqua</option>
-				<option>Blue</option>
-				<option>Purple</option>
-			</options>
-		</field>
 		<field name="IRProtocol" units="function" type="enum" elements="1" defaultvalue="Disabled">
 			<options>
 				<option>Disabled</option>


### PR DESCRIPTION
Makes BrainRE1 use the fancy LED stuff introduced in #1449. Removes the LED configuration from the hardware config in the GCS and the OSD. We should find a more general / better way to add this to the OSD / GCS.

Status: bench tested, works.

Fixes #1485