### PR TITLE
python: support hid on (at least) Linux

### DIFF
--- a/python/dronin/telemetry.py
+++ b/python/dronin/telemetry.py
@@ -499,18 +499,25 @@ class HIDTelemetry(BidirTelemetry):
             try:
                 raw = str.split(vidpid, ':')
 
-                if len(raw) != 2:
+                if len(raw) > 2:
                     raise
 
                 vid = int(raw[0], base=16)
-                pid = int(raw[1], base=16)
+
+                if len(raw) == 2:
+                    if raw[1] != '':
+                        pid = int(raw[1], base=16)
+
             except Exception:
                 raise ValueError("Invalid value of vidpid")
 
         import usb.core
         import usb.util
 
-        dev = usb.core.find(idVendor = vid, idProduct = pid)
+        if pid is None:
+            dev = usb.core.find(idVendor = vid)
+        else:
+            dev = usb.core.find(idVendor = vid, idProduct = pid)
 
         if dev is None:
             raise RuntimeError("No fc found")
@@ -542,7 +549,7 @@ class HIDTelemetry(BidirTelemetry):
             raise RuntimeError("no output endpoint found")
 
         if self.ep_in is None:
-            raise RuntimeError("no output endpoint found")
+            raise RuntimeError("no input endpoint found")
 
         BidirTelemetry.__init__(self, *args, **kwargs)
 

--- a/python/dronin/uavtalk.py
+++ b/python/dronin/uavtalk.py
@@ -236,7 +236,7 @@ def process_stream(uavo_defs, use_walltime=False, gcs_timestamps=None,
         recv_cs = indexbytes(buf, buf_offset + calc_size)
 
         if recv_cs != cs:
-            print("Bad crc. Got", recv_cs, "but predicted", cs)
+            print("Bad crc. Got %d but wanted %d"%(recv_cs, cs))
 
             buf_offset += 1
 


### PR DESCRIPTION
use like: `sudo python dronin-getconfig -u 20a0:4250`

Tested lightly with python2 and python3 on Linux.  Part of the manufacturing support for Seppuku FC.

Not perfect (especially performance) / likely to be an area of further work but is useful for basic things now.