### PR TITLE
gcs: osd: teach "page" layout to expand horiz

### DIFF
--- a/ground/gcs/src/plugins/config/osdpage.ui
+++ b/ground/gcs/src/plugins/config/osdpage.ui
@@ -10,9 +10,15 @@
     <height>1014</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="maximumSize">
    <size>
-    <width>950</width>
+    <width>16777215</width>
     <height>16777215</height>
    </size>
   </property>
@@ -59,8 +65,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>932</width>
-        <height>966</height>
+        <width>914</width>
+        <height>1170</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">


### PR DESCRIPTION
On some machines, widgets get hidden in awkward scrolliness even when
you have the horizontal width for them.  This fixes that and gets the
osd page widget to consume whatever horiz width you have available.