### PR TITLE
Simplify connection polling

### DIFF
--- a/ground/gcs/src/plugins/serialconnection/serialplugin.h
+++ b/ground/gcs/src/plugins/serialconnection/serialplugin.h
@@ -35,34 +35,11 @@
 #include <extensionsystem/iplugin.h>
 #include "serialpluginconfiguration.h"
 #include "serialpluginoptionspage.h"
-#include <QThread>
+#include <QTimer>
 
 class IConnection;
 class QSerialPortInfo;
 class SerialConnection;
-
-/**
-*   Helper thread to check on new serial port connection/disconnection
-*   Some operating systems do not send device insertion events so
-*   for those we have to poll
-*/
-class SerialEnumerationThread : public QThread
-{
-    Q_OBJECT
-public:
-    SerialEnumerationThread(SerialConnection *serial);
-    virtual ~SerialEnumerationThread();
-
-    virtual void run();
-
-signals:
-    void enumerationChanged();
-
-protected:
-    SerialConnection *m_serial;
-    bool m_running;
-};
-
 
 /**
 *   Define a connection via the IConnection interface
@@ -90,22 +67,23 @@ public:
     SerialPluginConfiguration * Config() const { return m_config; }
     SerialPluginOptionsPage * Optionspage() const { return m_optionspage; }
 
-
 private:
     QSerialPort*  serialHandle;
     bool enablePolling;
     SerialPluginConfiguration *m_config;
     SerialPluginOptionsPage *m_optionspage;
 
+private slots:
+    void periodic();
+
 protected slots:
     void onEnumerationChanged();
 
 protected:
-    SerialEnumerationThread m_enumerateThread;
     bool m_deviceOpened;
+
+    QTimer periodicTimer;
 };
-
-
 
 //class SERIAL_EXPORT SerialPlugin
 class SerialPlugin

--- a/ground/gcs/src/plugins/uavtalk/telemetrymanager.cpp
+++ b/ground/gcs/src/plugins/uavtalk/telemetrymanager.cpp
@@ -37,9 +37,6 @@ TelemetryManager::TelemetryManager() :
     ExtensionSystem::PluginManager* pm = ExtensionSystem::PluginManager::instance();
     objMngr = pm->getObject<UAVObjectManager>();
 
-    // connect to start stop signals
-    connect(this, SIGNAL(myStart()), this, SLOT(onStart()),Qt::QueuedConnection);
-    connect(this, SIGNAL(myStop()), this, SLOT(onStop()),Qt::QueuedConnection);
     settings = pm->getObject<Core::Internal::GeneralSettings>();
     connect(settings, SIGNAL(generalSettingsChanged()), this, SLOT(onGeneralSettingsChanged()));
     connect(pm, SIGNAL(pluginsLoadEnded()), this, SLOT(onGeneralSettingsChanged()));
@@ -56,26 +53,14 @@ bool TelemetryManager::isConnected()
 
 void TelemetryManager::start(QIODevice *dev)
 {
-    device=dev;
-    emit myStart();
-}
-
-void TelemetryManager::onStart()
-{
-    utalk = new UAVTalk(device, objMngr);
+    utalk = new UAVTalk(dev, objMngr);
     telemetry = new Telemetry(utalk, objMngr);
     telemetryMon = new TelemetryMonitor(objMngr, telemetry, sessions);
     connect(telemetryMon, SIGNAL(connected()), this, SLOT(onConnect()));
     connect(telemetryMon, SIGNAL(disconnected()), this, SLOT(onDisconnect()));
 }
 
-
 void TelemetryManager::stop()
-{
-    emit myStop();
-}
-
-void TelemetryManager::onStop()
 {
     telemetryMon->disconnect(this);
     sessions = telemetryMon->savedSessions();

--- a/ground/gcs/src/plugins/uavtalk/telemetrymanager.h
+++ b/ground/gcs/src/plugins/uavtalk/telemetrymanager.h
@@ -54,21 +54,18 @@ public:
 signals:
     void connected();
     void disconnected();
-    void myStart();
-    void myStop();
 
 private slots:
     void onConnect();
     void onDisconnect();
-    void onStart();
-    void onStop();
     void onGeneralSettingsChanged();
+
 private:
     UAVObjectManager* objMngr;
     UAVTalk* utalk;
     Telemetry* telemetry;
     TelemetryMonitor* telemetryMon;
-    QIODevice *device;
+
     bool autopilotConnected;
     QHash<quint16, QList<TelemetryMonitor::objStruc> > sessions;
     Core::Internal::GeneralSettings *settings;


### PR DESCRIPTION
* Simplify serial polling, which was the last model that was using a separate thread.
* While we're at it, greatly reduce overhead and eliminate synchronization problems (static variable touched by multiple threads) in the serialplugin.
* Don't defer through queue the telemetrymanager stuff, as this could be a frequent cause of Windows crashes.
* Remove a lot of code :dagger:

Requires review and test.  Tested on Linux so far-- seems very snappy :D