### PR TITLE
PiOS:Actuator: Fix crash/bootloop when camerastab disabled

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -772,7 +772,7 @@ static float mix_channel(int ct, ActuatorDesiredData *desired,
 		(void) 0;
 
 		CameraDesiredData cameraDesired;
-		if (CameraDesiredGet(&cameraDesired) == 0) {
+		if (CameraDesiredHandle() && CameraDesiredGet(&cameraDesired) == 0) {
 			switch (type) {
 			case MIXERSETTINGS_MIXER1TYPE_CAMERAROLL:
 				return cameraDesired.Roll;


### PR DESCRIPTION
With an output channel configured in it's UAVO. Confirmed it fixed.