### PR TITLE
gcs: output: improve output calibration

### DIFF
--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -413,17 +413,12 @@ void ConfigOutputWidget::startESCCalibration()
             if (!channelsToCalibrate[i])
                 continue;
 
-            if (actuatorSettingsData.ChannelMax[i] >
-                    (actuatorSettingsData.ChannelMin[i] + 40)) {
-                // If it is reasonable to do it, calibrate the minimum of the range
-                // to be a little off what we send at idle.  Blheli takes the value
-                // we give verbatim as the minimum, and small amounts of jitter
-                // can cause the motor to tick over.
-                actuatorCommandFields.Channel[i] =
-                    actuatorSettingsData.ChannelMin[i] + 3;
-            } else {
-                actuatorCommandFields.Channel[i] = actuatorSettingsData.ChannelMin[i];
-            }
+            // calibrate the minimum of the range
+            // to be a little off what we send at idle.  Blheli takes the value
+            // we give verbatim as the minimum, and small amounts of jitter
+            // can cause the motor to tick over.
+            double range = actuatorSettingsData.ChannelMax[i] - actuatorSettingsData.ChannelMin[i];
+            actuatorCommandFields.Channel[i] = actuatorSettingsData.ChannelMin[i] + std::copysign(std::min(5.0, std::abs(range) / 40.0 + 0.5), range);
         }
         actuatorCommand->setData(actuatorCommandFields);
 

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -413,7 +413,17 @@ void ConfigOutputWidget::startESCCalibration()
             if (!channelsToCalibrate[i])
                 continue;
 
-            actuatorCommandFields.Channel[i] = actuatorSettingsData.ChannelMin[i];
+            if (actuatorSettingsData.ChannelMax[i] >
+                    (actuatorSettingsData.ChannelMin[i] + 40)) {
+                // If it is reasonable to do it, calibrate the minimum of the range
+                // to be a little off what we send at idle.  Blheli takes the value
+                // we give verbatim as the minimum, and small amounts of jitter
+                // can cause the motor to tick over.
+                actuatorCommandFields.Channel[i] =
+                    actuatorSettingsData.ChannelMin[i] + 3;
+            } else {
+                actuatorCommandFields.Channel[i] = actuatorSettingsData.ChannelMin[i];
+            }
         }
         actuatorCommand->setData(actuatorCommandFields);
 


### PR DESCRIPTION
Offset the minimum of the calibration range up a little bit from what we
send disarmed.