### PR TITLE
gcs: input wizard: improve arming switch sense

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -660,7 +660,7 @@ void ConfigInputWidget::wizardSetUpStep(enum wizardSteps step)
     }
         break;
     case wizardIdentifyInverted:
-        dimOtherControls(true);
+        dimOtherControls(false);
         setTxMovement(nothing);
         extraWidgets.clear();
 

--- a/ground/gcs/src/plugins/config/images/TX2.svg
+++ b/ground/gcs/src/plugins/config/images/TX2.svg
@@ -1741,7 +1741,7 @@
        id="armedswitchright"
        stroke-miterlimit="10"
        points="753.906,169.896 756.508,232.512 747.441,232.833 739.945,170.941 "
-       style="display:inline;fill:url(#linearGradient3697);stroke:#6d6e70;stroke-miterlimit:10"
+       style="display:inline;fill:url(#linearGradient3697);stroke:#ff3030;stroke-miterlimit:10"
        transform="matrix(-1,0,0,1,805.34281,-10.30399)"
        inkscape:label="#armedswitch" /><polygon
        id="armedswitchleft"


### PR DESCRIPTION
1. Don't dim the flight mode switches when we're asking user what
controls to invert.
2. Put a subtle red fringe on the outside of the arming switch in the
armed position.

Fixes #519