### PR TITLE
GCS:Config: Re-enable compiler warnings disabled for #664

### DIFF
--- a/ground/gcs/src/plugins/config/config.pro
+++ b/ground/gcs/src/plugins/config/config.pro
@@ -103,9 +103,3 @@ FORMS += airframe.ui \
     autotunefinalpage.ui
 
 RESOURCES += configgadget.qrc
-
-linux-g++* {
-    # Hax to stop eigen failing to compile, workaround for #664
-    QMAKE_CXXFLAGS_WARN_ON += -Wno-deprecated-declarations
-}
-


### PR DESCRIPTION
If build passes, good to go.