### PR TITLE
seppuku: drive mask low in bootloader

### DIFF
--- a/flight/targets/seppuku/bl/pios_board.c
+++ b/flight/targets/seppuku/bl/pios_board.c
@@ -52,6 +52,11 @@
 uintptr_t pios_com_telem_usb_id;
 
 void PIOS_Board_Init() {
+	/* Absolute first thing-- drive the video mask pin low */
+	GPIO_Init(video_mask_pin.gpio, (GPIO_InitTypeDef *)&video_mask_pin.init);
+	GPIO_WriteBit(video_mask_pin.gpio,
+			video_mask_pin.init.GPIO_Pin, Bit_RESET);
+
 	/* Delay system */
 	PIOS_DELAY_Init();
 

--- a/flight/targets/seppuku/board-info/board_hw_defs.c
+++ b/flight/targets/seppuku/board-info/board_hw_defs.c
@@ -1160,6 +1160,17 @@ void PIOS_ADC_DMA_irq_handler(void)
 
 #endif /* PIOS_INCLUDE_ADC */
 
+const struct stm32_gpio video_mask_pin = {
+	.gpio = GPIOA,
+	.init = {
+		.GPIO_Pin   = GPIO_Pin_6,
+		.GPIO_Speed = GPIO_Speed_25MHz,
+		.GPIO_Mode  = GPIO_Mode_AF,
+		.GPIO_OType = GPIO_OType_PP,
+		.GPIO_PuPd  = GPIO_PuPd_NOPULL
+	}
+};
+
 #if defined(PIOS_INCLUDE_VIDEO)
 #include <pios_video.h>
 


### PR DESCRIPTION
fixes #1510