### PR TITLE
gcs: autotune: used queued conn to check for flag

### DIFF
--- a/ground/gcs/src/plugins/config/configautotunewidget.cpp
+++ b/ground/gcs/src/plugins/config/configautotunewidget.cpp
@@ -81,8 +81,8 @@ ConfigAutotuneWidget::ConfigAutotuneWidget(ConfigGadgetWidget *parent) :
     ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
     utilMngr = pm->getObject<UAVObjectUtilManager>();
 
-    connect(this, SIGNAL(autoPilotConnected()), this, SLOT(atConnected()));
-    connect(this, SIGNAL(autoPilotDisconnected()), this, SLOT(atDisconnected()));
+    connect(this, SIGNAL(autoPilotConnected()), this, SLOT(atConnected()), Qt::QueuedConnection);
+    connect(this, SIGNAL(autoPilotDisconnected()), this, SLOT(atDisconnected()), Qt::QueuedConnection);
     connect(m_autotune->adjustTune, SIGNAL(pressed()), this, SLOT(openAutotuneDialog()));
 
     m_autotune->adjustTune->setEnabled(isAutopilotConnected());


### PR DESCRIPTION
Otherwise, we can start doing modal stuff while processing connected
state with bad results.

Fixes #1533 

So far this is the only regression I've spotted in GCS on OSX.