### PR TITLE
linux/udev: allow raw USB access in addition to HID

### DIFF
--- a/package/linux/deb/_package.udev
+++ b/package/linux/deb/_package.udev
@@ -89,9 +89,10 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="d7fc", MODE="0664
 #
 
 # IDs provided by @tracernz
-
 # Generic ID for dRonin firmware
+SUBSYSTEM=="usb", ATTR{idVendor}=="20a0", ATTR{idProduct}=="4250", MODE="0664", GROUP="plugdev"
 KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4250", MODE="0664", GROUP="plugdev"
 
 # Generic (multitarget) ID for dRonin bootloader
+SUBSYSTEM=="usb", ATTR{idVendor}=="20a0", ATTR{idProduct}=="427a", MODE="0664", GROUP="plugdev"
 KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="427a", MODE="0664", GROUP="plugdev"


### PR DESCRIPTION
Just for 2 main ids (not existing legacy ones).  Main use right now is
Seppuku mfg, but may broaden (allows using python API without root).