### PR TITLE
python-api: handle disconnection better

### DIFF
--- a/python/dronin-halt
+++ b/python/dronin-halt
@@ -1,34 +1,33 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import sys, time
 from dronin import telemetry
 
 def main():
-    t = telemetry.get_telemetry_by_args(service_in_iter=False, iter_blocks=False)
+    t = telemetry.get_telemetry_by_args(service_in_iter=False)
     t.start_thread()
-
-    magic_value=1122
 
     from dronin.uavo import UAVO_FirmwareIAPObj
 
-    t.request_object(UAVO_FirmwareIAPObj)
+    t.wait_connection()
 
-    time.sleep(0.9)
-
-    for i in range(3):
-        print(magic_value)
-        f=UAVO_FirmwareIAPObj._make_to_send(Command=magic_value,
-                Description=(0,)*100,
-                CPUSerial=(0,)*12,
-                BoardRevision=0, 
-                BoardType=0,
-                ArmReset=0,
-                crc=0)
-
-        magic_value += 1111
+    for i in (1122,2233,3344):
+        time.sleep(0.9)
+        # XXX ideally would wait for ack here / retry
+        f=UAVO_FirmwareIAPObj._make_to_send(Command=i)
 
         t.send_object(f)
-        time.sleep(0.9)
+
+#    expire = time.time() + 3
+
+#    for i in t:
+#        if time.time() > expire:
+#            raise Exception("Didn't reset in time")
+#
+#    print("Flight controller successfully reset")
+
 
 #-------------------------------------------------------------------------------
 if __name__ == "__main__":

--- a/python/dronin-reconntest
+++ b/python/dronin-reconntest
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+if __name__ == "__main__":
+    from dronin import telemetry
+    import time
+
+while True:
+    try:
+        uavo_list = telemetry.get_telemetry_by_args(service_in_iter=False)
+        uavo_list.start_thread()
+    except Exception:
+        time.sleep(0.5)
+        continue
+
+    for o in uavo_list: print(o)


### PR DESCRIPTION
Properly get EOF on many drivers.

Will be one more PR in this area-- need to add a "close" mechanism to clean up resources as appropriate.

The sum effect of these changes is that python stuff gets "stuck" less and it will be ultimately possible to connect to a FC several times in a session.