### PR TITLE
NOT FOR MERGE: Remove GLC_Lib

### DIFF
--- a/ground/gcs/src/libs/libs.pro
+++ b/ground/gcs/src/libs/libs.pro
@@ -19,8 +19,8 @@ SDL {
 SUBDIRS += sdlgamepad
 }
 
-!LIGHTWEIGHT_GCS {
-    SUBDIRS += glc_lib
-}
+#!LIGHTWEIGHT_GCS {
+#    SUBDIRS += glc_lib
+#}
 
 SUBDIRS +=

--- a/ground/gcs/src/plugins/plugins.pro
+++ b/ground/gcs/src/plugins/plugins.pro
@@ -75,12 +75,12 @@ plugin_uavobjectbrowser.depends += plugin_uavobjects
 SUBDIRS += plugin_uavobjectbrowser
 
 # ModelView UAVGadget
-!LIGHTWEIGHT_GCS {
-plugin_modelview.subdir = modelview
-plugin_modelview.depends = plugin_coreplugin
-plugin_modelview.depends += plugin_uavobjects
-SUBDIRS += plugin_modelview
-}
+#!LIGHTWEIGHT_GCS {
+#plugin_modelview.subdir = modelview
+#plugin_modelview.depends = plugin_coreplugin
+#plugin_modelview.depends += plugin_uavobjects
+#SUBDIRS += plugin_modelview
+#}
 
 !disable_notify_plugin {
     plugin_notify.subdir = notify

--- a/ground/gcs/src/plugins/uploader/uploader.pro
+++ b/ground/gcs/src/plugins/uploader/uploader.pro
@@ -6,11 +6,9 @@ QT += testlib
 QT += network
 include(../../gcsplugin.pri)
 include(uploader_dependencies.pri)
-include(../../libs/glc_lib/glc_lib.pri)
 
 CONFIG(release, debug|release):DEFINES += FIRMWARE_RELEASE_CONFIG
 
-INCLUDEPATH *= ../../libs/glc_lib
 HEADERS += uploadergadget.h \
     uploadergadgetfactory.h \
     uploadergadgetwidget.h \

--- a/package/Makefile.winx86
+++ b/package/Makefile.winx86
@@ -31,7 +31,7 @@ ifeq ($(USE_MSVC), YES)
 	$(V1)cp -v -f "$(VCREDIST)/vcruntime140.dll" $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME)/bin
 	$(V1)cp -v -f "$(VCREDIST)/vccorlib140.dll" $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME)/bin
 endif
-	$(V1)mv "$(PACKAGE_DIR)/$(GCS_PACKAGE_NAME)/bin/opengl32sw.dll" "$(PACKAGE_DIR)/$(GCS_PACKAGE_NAME)/bin/opengl32.dll" 
+#	$(V1)mv "$(PACKAGE_DIR)/$(GCS_PACKAGE_NAME)/bin/opengl32sw.dll" "$(PACKAGE_DIR)/$(GCS_PACKAGE_NAME)/bin/opengl32.dll" 
 	$(V1)find $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME) -type f -name "*.sym" -exec rm -f {} \;
 	$(V1)find $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME) -type f -name "*.lib" -exec rm -f {} \;
 	$(V1)find $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME) -type f -name "*.exp" -exec rm -f {} \;


### PR DESCRIPTION
jenkins, build artifacts please

This works under RDP (ANGLE backend is auto-selected), and natively (NVIDIA backend is auto-selected) on my machine. For @jhitesma to test.

Things to test:
```
drgcs.exe (and if that works, QSG_INFO=1 could be interesting too, the debug gadget will then tell you which backend it's using and some details about it's features)
QT_OPENGL=desktop drgcs.exe
QT_OPENGL=angle drgcs.exe
QT_OPENGL=software drgcs.exe
```