### PR TITLE
Attitude improvements

### DIFF
--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -534,9 +534,9 @@ static int32_t updateAttitudeComplementary(float dT, bool first_run, bool second
 		// Use a rapidly decrease accelKp to force the attitude to snap back
 		// to level and then converge more smoothly
 		if (complementary_filter_state.arming_count < 20)
-			attitudeSettings.AccKp = 1.0f;
-		else if (attitudeSettings.AccKp > 0.1f)
-			attitudeSettings.AccKp -= 0.01f;
+			attitudeSettings.AccKp = 50.0f;
+		else if (attitudeSettings.AccKp > 30.0f)
+			attitudeSettings.AccKp -= 1.0f;
 		complementary_filter_state.arming_count++;
 
 		// Set the other parameters to drive faster convergence

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -308,6 +308,10 @@ static void stabilizationTask(void* parameters)
 		} else if (iteration == 2100) {
 			dT_measured /= 2000;
 
+			/* Other modules-- attitude, etc, -- rely on us having
+			 * done this test and set an alarm here.  Do not remove
+			 * without verifying those places
+			 */
 			if ((dT_measured > dT_expected * 1.15f) || 
 					(dT_measured < dT_expected * 0.85f)) {
 				frequency_wrong = true;

--- a/ground/gcs/src/plugins/config/attitude.ui
+++ b/ground/gcs/src/plugins/config/attitude.ui
@@ -623,15 +623,15 @@ new home location unless it is in indoor mode.</string>
              <number>6</number>
             </property>
             <property name="maximum">
-             <double>0.010000000000000</double>
+             <double>1.0000000000000</double>
             </property>
             <property name="singleStep">
-             <double>0.000001000000000</double>
+             <double>0.001000000000</double>
             </property>
             <property name="objrelation" stdset="0">
              <stringlist>
               <string>objname:AttitudeSettings</string>
-              <string>fieldname:AccelKi</string>
+              <string>fieldname:AccKi</string>
               <string>buttongroup:1</string>
              </stringlist>
             </property>
@@ -649,15 +649,15 @@ new home location unless it is in indoor mode.</string>
              <number>3</number>
             </property>
             <property name="maximum">
-             <double>0.200000000000000</double>
+             <double>50.0000000000000</double>
             </property>
             <property name="singleStep">
-             <double>0.001000000000000</double>
+             <double>0.1000000000000</double>
             </property>
             <property name="objrelation" stdset="0">
              <stringlist>
               <string>objname:AttitudeSettings</string>
-              <string>fieldname:AccelKp</string>
+              <string>fieldname:AccKp</string>
               <string>buttongroup:1</string>
              </stringlist>
             </property>

--- a/ground/gcs/src/plugins/hitl/simulator.cpp
+++ b/ground/gcs/src/plugins/hitl/simulator.cpp
@@ -511,7 +511,7 @@ void Simulator::updateUAVOs(Output2Hardware out){
         float dT = out.delT;
 
         AttitudeSettings::DataFields attitudeSettingsData = attitudeSettings->getData();
-        float accelKp = attitudeSettingsData.AccelKp * 0.1666666666666667;
+        float accelKp = attitudeSettingsData.AccKp * 0.0001666666666666667;
 
         // calibrate sensors on arming
         if (flightStatus->getData().Armed == FlightStatus::ARMED_ARMING) {

--- a/shared/uavobjectdefinition/attitudesettings.xml
+++ b/shared/uavobjectdefinition/attitudesettings.xml
@@ -5,16 +5,16 @@
 		<field name="BoardRotation" units="deg*100" type="int16" elementnames="Roll,Pitch,Yaw" defaultvalue="0,0,0">
 			<description>Board rotation angles.</description>
 		</field>
-		<field name="MagKp" units="channel" type="float" elements="1" defaultvalue="0.05">
+		<field name="MgKp" units="channel" type="float" elements="1" defaultvalue="20.0">
 			<description>Magnetometer proportional gain for the attitude filter.</description>
 		</field>
-		<field name="MagKi" units="channel" type="float" elements="1" defaultvalue="0.0001">
+		<field name="MgKi" units="channel" type="float" elements="1" defaultvalue="0.05">
 			<description>Magnetometer integral gain for the attitude filter.</description>
 		</field>
-		<field name="AccelKp" units="channel" type="float" elements="1" defaultvalue="0.05">
+		<field name="AccKp" units="channel" type="float" elements="1" defaultvalue="20.0">
 			<description>Accelerometer proportional gain for the attitude filter.</description>
 		</field>
-		<field name="AccelKi" units="channel" type="float" elements="1" defaultvalue="0.0001">
+		<field name="AccKi" units="channel" type="float" elements="1" defaultvalue="0.05">
 			<description>Accelerometer integral gain for the attitude filter.</description>
 		</field>
 		<field name="AccelTau" units="" type="float" elements="1" defaultvalue="0.1">


### PR DESCRIPTION
Connects to #863.

* Calculate in a way that behaves the same no matter the sampling rate.
* Similarly, filter acceleration data in a sample-rate invariant way
* Adjust the default values to be a "compromise value" that behaves
something between how F1 and F3 do it currently.
* Rename accelkp/accelki to acckp/accki, and magkp/magki to mgkp/mgki
because the values have changed.

This is not sufficient to be without anomaly, but a good starting point of discussion.  Unclear if this should make it into Artifice.