### PR TITLE
Stabilization: Change default deriv gamma to 0.6

### DIFF
--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -28,7 +28,7 @@
 		<field name="YawPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
 		<field name="GyroCutoff" units="Hz" type="float" elements="1" defaultvalue="55.0"/>
 		<field name="DerivativeCutoff" units="Hz" type="uint8" elements="1" defaultvalue="20"/>
-		<field name="DerivativeGamma" units="" type="float" elements="1" defaultvalue="1"/>
+		<field name="DerivativeGamma" units="" type="float" elements="1" defaultvalue="0.6"/>
 		<field name="MaxAxisLock" units="deg" type="uint8" elements="1" defaultvalue="15"/>
 		<field name="MaxAxisLockRate" units="deg/s" type="uint8" elements="1" defaultvalue="2"/>
 		<field name="WeakLevelingKp" units="(deg/s)/deg" type="float" elements="1" defaultvalue="0.33"/>


### PR DESCRIPTION
When there's step inputs to rates-- (easy to generate in attitude
mode)-- there can easily be a big overshoot in achieved rate even
with an otherwise good tune.  This in turn tends to ring a couple
of times and look a little underdamped.

Setting derivative gamma to 0.6 turns down the derivative for the
setpoint portion by 40%-- which significantly limits the chaos.

Many PID systems choose to not apply D to setpoint at all, but IMO
the setpoint D is helpful in quick response to big commands.  This
is a compromise value to maintain familiar characteristics but
avoid the worst case ringing on big moves.