### PR TITLE
Flight: Work around arm errata 752770

### DIFF
--- a/flight/PiOS/Common/Libraries/ChibiOS/os/ports/GCC/ARMCMx/chcore_v7m.c
+++ b/flight/PiOS/Common/Libraries/ChibiOS/os/ports/GCC/ARMCMx/chcore_v7m.c
@@ -235,7 +235,8 @@ void _port_switch(Thread *ntp, Thread *otp) {
 #endif
 
   asm volatile ("str     sp, [%1, #12]                          \n\t"
-                "ldr     sp, [%0, #12]" : : "r" (ntp), "r" (otp));
+                "ldr     r4, [%0, #12]                          \n\t"
+                "mov     sp, r4" : : "r" (ntp), "r" (otp));
 
 #if CORTEX_USE_FPU
   asm volatile ("vpop    {s16-s31}" : : : "memory");

--- a/flight/UAVObjects/uavobjectmanager.c
+++ b/flight/UAVObjects/uavobjectmanager.c
@@ -1690,7 +1690,9 @@ static void invokeCallback(struct ObjectEventEntry *event, UAVObjEvent *msg,
 
 	asm volatile (
 		"mov	r4, sp\n\t"		// r4 = old stack pointer
-		"mov	sp, %0\n\t"		// set up the new stack
+		"mov	r5, %0\n\t"		// Get the new stack
+		// Happens in two steps because of Cortex-M4 errata 752770
+		"mov	sp, r5\n\t"		// set up the new stack
 		"bl	realInvokeCallback\n\t"	// run realInvokeCallback--
 						// with same args
 		"mov	sp, r4\n\t"		// Put back the stack frame
@@ -1706,7 +1708,7 @@ static void invokeCallback(struct ObjectEventEntry *event, UAVObjEvent *msg,
 		: // no pure read-only registers
 		: "memory",		// callback may clobber memory,
 		"cc",			// condition codes,
-		"r4", "ip", "lr"	// we clobber r4, ip, and lr
+		"r4", "r5", "ip", "lr"	// we clobber r4, r5, ip, and lr
 		// And call-clobbered floating point registers
 		, "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7",
 		"s8", "s9", "s10", "s11", "s12", "s13", "s14", "s15"


### PR DESCRIPTION
chcore_v7m is broken.  uavobjectmanager's task switch isn't with current code generation, but could become so in the future without this change.

> An interrupt occurring during the data-phase of a single word load to the stack pointer
(SP/R13) can cause an erroneous behavior of the device. In addition, returning from the
interrupt results in the load instruction being executed an additional time.

> The instructions affected by this limitation are the following:

...

> • LDR SP, [Rn]
> • LDR SP, [Rn,#imm]