### PR TITLE
GCS: Basic RGB LED UI

### DIFF
--- a/ground/gcs/src/plugins/config/configmodulewidget.h
+++ b/ground/gcs/src/plugins/config/configmodulewidget.h
@@ -58,8 +58,11 @@ private slots:
     void objectUpdated(UAVObject * obj, bool success);
     void autoCellDetectionToggled(bool checked);
     void maxCellVoltageChanged(double value);
+    void ledTabUpdate(UAVObject *obj);
+    void ledTabSetColor();
 
 private:
+    void setupLedTab();
     /* To activate the appropriate tabs */
     void enableBatteryTab(bool enabled);
     void enableAirspeedTab(bool enabled);

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -20,7 +20,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <property name="tabsClosable">
       <bool>false</bool>
@@ -468,7 +468,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>0</height>
           </size>
          </property>
         </spacer>
@@ -1322,6 +1322,335 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tabLED">
+      <attribute name="title">
+       <string>RGB LEDs</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_10">
+       <item>
+        <widget class="QGroupBox" name="gbxLEDBasic">
+         <property name="title">
+          <string>Basic Settings</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_8">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Total LEDs:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="sbLEDTotal">
+            <property name="objrelation" stdset="0">
+             <stringlist notr="true">
+              <string>objname:RGBLEDSettings</string>
+              <string>fieldname:NumLeds</string>
+              <string>haslimits:yes</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_15">
+            <property name="text">
+             <string>Alarm Group Begin:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_17">
+            <property name="text">
+             <string>Alarm Group End:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="sbLEDAlarmsBegin">
+            <property name="objrelation" stdset="0">
+             <stringlist notr="true">
+              <string>objname:RGBLEDSettings</string>
+              <string>fieldname:AnnunciateRangeBegin</string>
+              <string>haslimits:yes</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="sbLEDAlarmsEnd">
+            <property name="objrelation" stdset="0">
+             <stringlist notr="true">
+              <string>objname:RGBLEDSettings</string>
+              <string>fieldname:AnnunciateRangeEnd</string>
+              <string>haslimits:yes</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_27">
+            <property name="text">
+             <string>Default Color:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_22">
+            <item>
+             <widget class="QLabel" name="lblLEDDefaultColor">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>25</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::Box</enum>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="btnLEDDefaultColor">
+              <property name="text">
+               <string>Pick</string>
+              </property>
+              <property name="fieldname" stdset="0">
+               <string notr="true">DefaultColor</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="gbxLEDGroup1">
+         <property name="title">
+          <string>LED Group 1</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Range Begin:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="sbLEDRange1Begin">
+            <property name="objrelation" stdset="0">
+             <stringlist notr="true">
+              <string>objname:RGBLEDSettings</string>
+              <string>fieldname:RangeBegin</string>
+              <string>haslimits:yes</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Range End:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="sbLEDRange1End">
+            <property name="objrelation" stdset="0">
+             <stringlist notr="true">
+              <string>objname:RGBLEDSettings</string>
+              <string>fieldname:RangeEnd</string>
+              <string>haslimits:yes</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_18">
+            <property name="text">
+             <string>Color Begin:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
+             <widget class="QLabel" name="lblLEDRange1Begin">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>25</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::Box</enum>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="btnLEDRange1Begin">
+              <property name="text">
+               <string>Pick</string>
+              </property>
+              <property name="fieldname" stdset="0">
+               <string notr="true">RangeBaseColor</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_19">
+            <property name="text">
+             <string>Color End:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <item>
+             <widget class="QLabel" name="lblLEDRange1End">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>25</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::Box</enum>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="btnLEDRange1End">
+              <property name="text">
+               <string>Pick</string>
+              </property>
+              <property name="fieldname" stdset="0">
+               <string notr="true">RangeEndColor</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_20">
+            <property name="text">
+             <string>Blend Source:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QComboBox" name="cbLEDRange1Source">
+            <property name="objrelation" stdset="0">
+             <stringlist notr="true">
+              <string>objname:RGBLEDSettings</string>
+              <string>fieldname:RangeColorBlendSource</string>
+              <string>haslimits:yes</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_21">
+            <property name="text">
+             <string>Disarmed Source:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QComboBox" name="cbLEDRange1SourceDisarmed">
+            <property name="objrelation" stdset="0">
+             <stringlist notr="true">
+              <string>objname:RGBLEDSettings</string>
+              <string>fieldname:RangeColorBlendUnarmedSource</string>
+              <string>haslimits:yes</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_22">
+            <property name="text">
+             <string>Blend Type:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QComboBox" name="cbLEDRange1BlendType">
+            <property name="objrelation" stdset="0">
+             <stringlist notr="true">
+              <string>objname:RGBLEDSettings</string>
+              <string>fieldname:RangeColorBlendType</string>
+              <string>haslimits:yes</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_26">
+            <property name="text">
+             <string>Blend Mode:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QComboBox" name="cbLEDRange1BlendMode">
+            <property name="objrelation" stdset="0">
+             <stringlist notr="true">
+              <string>objname:RGBLEDSettings</string>
+              <string>fieldname:RangeColorBlendMode</string>
+              <string>haslimits:yes</string>
+             </stringlist>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="tabAirspeed">
       <attribute name="title">
        <string>Airspeed</string>
@@ -1577,8 +1906,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>353</width>
-            <height>864</height>
+            <width>1059</width>
+            <height>920</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout">

--- a/ground/gcs/src/plugins/uavobjects/uavobjectfield.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectfield.cpp
@@ -35,6 +35,7 @@
 #include "uavobjectfield.h"
 #include <QtEndian>
 #include <QDebug>
+#include <cfloat>
 
 UAVObjectField::UAVObjectField(const QString& name, const QString& units, FieldType type, quint32 numElements,
                                const QStringList& options, const QList<int>& indices, const QString &limits,
@@ -436,8 +437,31 @@ bool UAVObjectField::isWithinLimits(QVariant var,quint32 index, int board)
 
 QVariant UAVObjectField::getMaxLimit(quint32 index,int board)
 {
-    if(!elementLimits.keys().contains(index))
+    if (!elementLimits.keys().contains(index)) {
+        // if nothing explicitly specified, assume max possible value
+        switch (type) {
+        case INT8:
+            return INT8_MAX;
+        case INT16:
+            return INT16_MAX;
+        case INT32:
+            return INT32_MAX;
+        case UINT8:
+            return UINT8_MAX;
+        case UINT16:
+            return UINT16_MAX;
+        case UINT32:
+            return UINT32_MAX;
+        case FLOAT32:
+            return FLT_MAX;
+        case ENUM: // TODO: could do better for this one
+        case BITFIELD:
+        case STRING:
+            break;
+        }
         return QVariant();
+    }
+
     foreach(const LimitStruct &struc,elementLimits.value(index))
     {
         if((struc.board!=board) && board!=0 && struc.board!=0)
@@ -465,8 +489,29 @@ QVariant UAVObjectField::getMaxLimit(quint32 index,int board)
 }
 QVariant UAVObjectField::getMinLimit(quint32 index, int board)
 {
-    if(!elementLimits.keys().contains(index))
+    if (!elementLimits.keys().contains(index)) {
+        // if nothing explicitly specified, assume min possible value
+        switch (type) {
+        case INT8:
+            return INT8_MIN;
+        case INT16:
+            return INT16_MIN;
+        case INT32:
+            return INT32_MIN;
+        case UINT8:
+        case UINT16:
+        case UINT32:
+            return 0;
+        case FLOAT32:
+            return FLT_MIN;
+        case ENUM: // TODO: could do better for this one
+        case BITFIELD:
+        case STRING:
+            break;
+        }
         return QVariant();
+    }
+
     foreach(LimitStruct struc,elementLimits.value(index))
     {
         if((struc.board!=board) && board!=0 && struc.board!=0)


### PR DESCRIPTION
Very basic, no frills.
![image](https://cloud.githubusercontent.com/assets/9995998/22616981/55223444-eb1e-11e6-83be-57ea27e88014.png)

First commit (UAVO field limits derived from datatype) may want additional test as it affects other parts of GCS. It will only be harmful if limits are set for UAVO relation widgets in the widget properties rather than the UAVO relation (which we should not be doing anyway) AND the UAVO relation specifies `haslimits:yes`.