### PR TITLE
GCS:Config: Fix black buttons on multirotor throttle curve

### DIFF
--- a/ground/gcs/src/plugins/config/airframe.ui
+++ b/ground/gcs/src/plugins/config/airframe.ui
@@ -960,9 +960,6 @@ margin:1px;</string>
                       <height>50</height>
                      </size>
                     </property>
-                    <property name="styleSheet">
-                     <string notr="true">background:transparent</string>
-                    </property>
                    </widget>
                   </item>
                  </layout>

--- a/ground/gcs/src/plugins/config/mixercurve.ui
+++ b/ground/gcs/src/plugins/config/mixercurve.ui
@@ -38,7 +38,7 @@
    <string>MixerCurve</string>
   </property>
   <property name="frameShape">
-   <enum>QFrame::StyledPanel</enum>
+   <enum>QFrame::NoFrame</enum>
   </property>
   <property name="frameShadow">
    <enum>QFrame::Raised</enum>


### PR DESCRIPTION
Also removed frame on MixerCurve widget to resolve another small rendering issue