### PR TITLE
GCS: Use git log for authors dialog

### DIFF
--- a/ground/gcs/gcsversioninfo.pri
+++ b/ground/gcs/gcsversioninfo.pri
@@ -12,6 +12,11 @@ VERSION_INFO_SCRIPT   = $$ROOT_DIR/make/scripts/version-info.py
 VERSION_INFO_TEMPLATE = $$ROOT_DIR/make/templates/gcsversioninfotemplate.h
 VERSION_INFO_COMMAND  = $$PYTHON_LOCAL \"$$VERSION_INFO_SCRIPT\"
 UAVO_DEF_PATH         = $$ROOT_DIR/shared/uavobjectdefinition
+AUTHORS_TEMPLATE      = $$ROOT_DIR/make/templates/gcsauthorstemplate.html
+REL_AUTHORS_TEMPLATE  = $$ROOT_DIR/make/templates/gcsrelauthorstemplate.html
+AUTHORS_PATH          = $$system_path($$targetPath(\"$$GCS_DATA_PATH\"))
+AUTHORS_DEST          = $$system_path($$AUTHORS_PATH/gcsauthors.html)
+REL_AUTHORS_DEST      = $$system_path($$AUTHORS_PATH/gcsrelauthors.html)
 
 # this runs once while Qmake is reading pro files rather than later during the actual build
 !build_pass:system($$VERSION_INFO_COMMAND \
@@ -19,7 +24,19 @@ UAVO_DEF_PATH         = $$ROOT_DIR/shared/uavobjectdefinition
                                 --template=\"$$VERSION_INFO_TEMPLATE\" \
                                 --uavodir=\"$$UAVO_DEF_PATH\" \
                                 --outfile=\"$$VERSION_INFO_HEADER\")
+# this runs once while Qmake is reading pro files rather than later during the actual build
+!build_pass:system($$VERSION_INFO_COMMAND \
+                                --path=\"$$GCS_SOURCE_TREE\" \
+                                --template=\"$$AUTHORS_TEMPLATE\" \
+                                --outfile=\"$$AUTHORS_DEST\")
+# this runs once while Qmake is reading pro files rather than later during the actual build
+!build_pass:system($$VERSION_INFO_COMMAND \
+                                --path=\"$$GCS_SOURCE_TREE\" \
+                                --template=\"$$REL_AUTHORS_TEMPLATE\" \
+                                --outfile=\"$$REL_AUTHORS_DEST\")
 
 DEPENDPATH *= $$VERSION_INFO_PATH
 HEADERS *= $$VERSION_INFO_HEADER
 DEFINES += 'GCS_VERSION_INFO_FILE=\\\"$$VERSION_INFO_HEADER\\\"'
+DEFINES += 'GCS_AUTHORS_FILE=\\\"$$AUTHORS_DEST\\\"'
+DEFINES += 'GCS_REL_AUTHORS_FILE=\\\"$$REL_AUTHORS_DEST\\\"'

--- a/ground/gcs/src/libs/utils/pathutils.h
+++ b/ground/gcs/src/libs/utils/pathutils.h
@@ -41,9 +41,9 @@ class QTCREATOR_UTILS_EXPORT PathUtils
 {
 public:
     PathUtils();
-    QString GetDataPath();
-    QString RemoveDataPath(QString path);
-    QString InsertDataPath(QString path);
+    static QString GetDataPath();
+    static QString RemoveDataPath(QString path);
+    static QString InsertDataPath(QString path);
 
     QString GetStoragePath();
     QString RemoveStoragePath(QString path);

--- a/ground/gcs/src/plugins/coreplugin/authorsdialog.cpp
+++ b/ground/gcs/src/plugins/coreplugin/authorsdialog.cpp
@@ -32,6 +32,7 @@
 #include "icore.h"
 
 #include <utils/qtcassert.h>
+#include <utils/pathutils.h>
 
 #include <QtCore/QDate>
 #include <QtCore/QFile>
@@ -56,23 +57,23 @@ AuthorsDialog::AuthorsDialog(QWidget *parent)
 
     setWindowTitle(tr("About GCS Authors"));
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-    QGridLayout *layout = new QGridLayout(this);
+    auto layout = new QGridLayout(this);
     layout->setSizeConstraint(QLayout::SetFixedSize);
 
     QString version = QLatin1String(GCS_VERSION_LONG);
     version += QDate(2007, 25, 10).toString(Qt::SystemLocaleDate);
 
-    const QString description = tr(
-            "Proudly brought to you by this fine team:<br/>"
-            );
+    QLabel *mainLabel = new QLabel(tr("%0 proudly brought to you by this fine team:").arg(GCS_PROJECT_BRANDING_PRETTY));
 
-    QLabel *copyRightLabel = new QLabel(description);
-    copyRightLabel->setWordWrap(true);
-    copyRightLabel->setOpenExternalLinks(true);
-    copyRightLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
+    QLabel *relCreditsLabel = new QLabel(tr("Current release:"));
+    relCreditsLabel->setWordWrap(true);
+    QTextBrowser *relCreditsArea = new QTextBrowser(this);
+    relCreditsArea->setSource(QUrl(Utils::PathUtils::InsertDataPath("%%DATAPATH%%/gcsrelauthors.html")));
 
+    QLabel *creditsLabel = new QLabel(tr("All time (including previous contributions under OpenPilot and Tau Labs):"));
+    creditsLabel->setWordWrap(true);
     QTextBrowser *creditsArea = new QTextBrowser(this);
-    creditsArea->setSource(QUrl("qrc:core/CREDITS.html"));
+    creditsArea->setSource(QUrl(Utils::PathUtils::InsertDataPath("%%DATAPATH%%/gcsauthors.html")));
 
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close);
     QPushButton *closeButton = buttonBox->button(QDialogButtonBox::Close);
@@ -82,8 +83,12 @@ AuthorsDialog::AuthorsDialog(QWidget *parent)
 
     QLabel *logoLabel = new QLabel;
     logoLabel->setPixmap(QPixmap(QLatin1String(":/core/gcs_logo_128")));
-    layout->addWidget(logoLabel ,     0, 0, 1, 1);
-    layout->addWidget(copyRightLabel, 0, 1, 2, 4);
-    layout->addWidget(creditsArea,    3, 0, 2, 5);
-    layout->addWidget(buttonBox,      6, 0, 1, 5);
+
+    layout->addWidget(logoLabel, 0, 0, 1, 2, Qt::AlignHCenter);
+    layout->addWidget(mainLabel, 1, 0, 1, 2, Qt::AlignHCenter);
+    layout->addWidget(relCreditsLabel, 2, 0, 1, 1, Qt::AlignBottom);
+    layout->addWidget(relCreditsArea, 3, 0, 1, 1, Qt::AlignTop);
+    layout->addWidget(creditsLabel, 2, 1, 1, 1, Qt::AlignBottom);
+    layout->addWidget(creditsArea, 3, 1, 1, 1, Qt::AlignTop);
+    layout->addWidget(buttonBox, 4, 0, 1, 2);
 }

--- a/make/templates/gcsauthorstemplate.html
+++ b/make/templates/gcsauthorstemplate.html
@@ -1,0 +1,7 @@
+<html>
+	<body>
+		<pre>
+${AUTHORS}
+		</pre>
+	</body>
+</html>

--- a/make/templates/gcsrelauthorstemplate.html
+++ b/make/templates/gcsrelauthorstemplate.html
@@ -1,0 +1,7 @@
+<html>
+	<body>
+		<pre>
+${AUTHORS_SINCE_LAST_REL}
+		</pre>
+	</body>
+</html>


### PR DESCRIPTION
Not sure if this should make current cycle or not (@mlyle to add milestone). Needs some agreement on the approach (described in https://github.com/d-ronin/dRonin/pull/336#issuecomment-231619949). `git-shortlog` is not a plumbing command so really should fix this up to use a plumbing command instead (although plenty of porcelain commands are used in version-info.py already). mailmap could also do with some help.

<img width="676" alt="credits" src="https://cloud.githubusercontent.com/assets/9995998/22641070/1c904d58-ecba-11e6-85cb-e06ad04aaf69.png">

Fixes #271 
