### PR TITLE
GCS: Disable LED tab when RGBLEDSettings not present

### DIFF
--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -48,6 +48,9 @@ ConfigModuleWidget::ConfigModuleWidget(QWidget *parent) : ConfigTaskWidget(paren
     ui = new Ui::Modules();
     ui->setupUi(this);
 
+    // override anything set in .ui file by Qt Designer
+    ui->moduleTab->setCurrentIndex(0);
+
     connect(this, SIGNAL(autoPilotConnected()), this, SLOT(recheckTabs()));
 
     // Populate UAVO strings

--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -395,7 +395,7 @@ void ConfigModuleWidget::setupLedTab()
     if (!objMgr) // hope it can only be destructed in this thread
         return;
 
-    auto obj = objMgr->getObject("RGBLEDSettings");
+    auto obj = qobject_cast<UAVDataObject *>(objMgr->getObject("RGBLEDSettings"));
     if (!obj)
         return;
 
@@ -403,6 +403,10 @@ void ConfigModuleWidget::setupLedTab()
     connect(ui->btnLEDDefaultColor, &QPushButton::clicked, this, &ConfigModuleWidget::ledTabSetColor);
     connect(ui->btnLEDRange1Begin, &QPushButton::clicked, this, &ConfigModuleWidget::ledTabSetColor);
     connect(ui->btnLEDRange1End, &QPushButton::clicked, this, &ConfigModuleWidget::ledTabSetColor);
+    connect(obj, static_cast<void (UAVDataObject::*)(bool)>(&UAVDataObject::presentOnHardwareChanged), [=](bool enable) {
+        tabEnable(ui->tabLED, enable);
+    });
+    tabEnable(ui->tabLED, obj->getIsPresentOnHardware());
 }
 
 void ConfigModuleWidget::ledTabUpdate(UAVObject *obj)
@@ -453,6 +457,15 @@ void ConfigModuleWidget::ledTabSetColor()
         return;
 
     lbl->setStyleSheet(QString("background: rgb(%0, %1, %2);").arg(col.red()).arg(col.green()).arg(col.blue()));
+}
+
+void ConfigModuleWidget::tabEnable(QWidget *tab, bool enable)
+{
+    int idx = ui->moduleTab->indexOf(tab);
+    if (ui->moduleTab->currentIndex() == idx)
+        ui->moduleTab->setCurrentIndex(0);
+    if (idx >= 0)
+        ui->moduleTab->setTabEnabled(idx, enable);
 }
 
 /**

--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -447,6 +447,7 @@ void ConfigModuleWidget::ledTabSetColor()
 
     const QColor initial(field->getValue(0).toInt(), field->getValue(1).toInt(), field->getValue(2).toInt());
     QColorDialog picker(initial, this);
+    picker.raise();
     if (picker.exec() != QDialog::Accepted)
         return;
 

--- a/ground/gcs/src/plugins/config/configmodulewidget.h
+++ b/ground/gcs/src/plugins/config/configmodulewidget.h
@@ -71,6 +71,7 @@ private:
     void enableGeofenceTab(bool enabled);
     void enableGpsTab(bool enabled);
     void enableLoggingTab(bool enabled);
+    void tabEnable(QWidget *tab, bool enable);
 
     void refreshAdcNames(void);
 

--- a/ground/gcs/src/plugins/uavobjects/uavdataobject.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavdataobject.cpp
@@ -113,8 +113,10 @@ void UAVDataObject::setIsPresentOnHardware(bool value)
 {
     bool temp = isPresentOnHardware;
     isPresentOnHardware = value;
-    if(temp != isPresentOnHardware)
+    if(temp != isPresentOnHardware) {
         emit presentOnHardwareChanged(this);
+        emit presentOnHardwareChanged(isPresentOnHardware);
+    }
 }
 
 

--- a/ground/gcs/src/plugins/uavobjects/uavdataobject.h
+++ b/ground/gcs/src/plugins/uavobjects/uavdataobject.h
@@ -54,6 +54,7 @@ public:
 
 signals:
     void presentOnHardwareChanged(UAVDataObject*);
+    void presentOnHardwareChanged(bool present);
 
 private:
     UAVMetaObject* mobj;


### PR DESCRIPTION
Missed this in #1548. Also set default tab in C++, prevents recurrence of #1567.