### PR TITLE
posix/logfs: fflush after writes

### DIFF
--- a/flight/tests/logfs/pios_flash_posix.c
+++ b/flight/tests/logfs/pios_flash_posix.c
@@ -116,6 +116,8 @@ static int32_t PIOS_Flash_Posix_EraseSector(uintptr_t chip_id, uint32_t chip_sec
 
 	assert (s == flash_dev->cfg->size_of_sector);
 
+	fflush(flash_dev->flash_file);
+
 	return 0;
 }
 
@@ -136,6 +138,8 @@ static int32_t PIOS_Flash_Posix_WriteData(uintptr_t chip_id, uint32_t chip_offse
 	s = fwrite (data, 1, len, flash_dev->flash_file);
 
 	assert (s == len);
+
+	fflush(flash_dev->flash_file);
 
 	return 0;
 }


### PR DESCRIPTION
If we fully order write operations, things are safe and we won't ever
lose data.  Otherwise, with buffers, if the simulator exits config
changes can be lost.