### PR TITLE
Tools:Breakpad: Upgrade, remove accidental duplicate git command

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -562,7 +562,7 @@ zip_clean:
 
 
 # Google breakpad
-BREAKPAD_REV := 20170129
+BREAKPAD_REV := 20170224
 BREAKPAD_REPO := https://github.com/d-ronin/breakpad.git
 BREAKPAD_DIR := $(TOOLS_DIR)/breakpad/$(BREAKPAD_REV)
 BREAKPAD_BUILD_DIR := $(DL_DIR)/breakpad

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -575,12 +575,11 @@ breakpad_install: | breakpad_clean
 	$(V0) @echo " DOWNLOAD     $(BREAKPAD_REPO) @ $(BREAKPAD_REV)"
 	$(V1) [ ! -d "$(BREAKPAD_BUILD_DIR)" ] || $(RM) -rf "$(BREAKPAD_BUILD_DIR)"
 	$(V1) mkdir -p "$(BREAKPAD_BUILD_DIR)"
-	$(V1) git clone -q --no-checkout $(BREAKPAD_REPO) "$(BREAKPAD_BUILD_DIR)"
 	$(V1) ( \
 	  cd $(BREAKPAD_BUILD_DIR) ; \
 	  git init -q ; \
 	  git remote add upstream "$(BREAKPAD_REPO)" ; \
-	  git fetch -q --depth=1 --recurse-submodules upstream $(BREAKPAD_REV) ; \
+	  git fetch -q --tags --depth=1 --recurse-submodules upstream $(BREAKPAD_REV) ; \
 	  git checkout -q $(BREAKPAD_REV) ; \
 	  git submodule -q update --init ; \
 	)


### PR DESCRIPTION
Remove accidental clone and fix the error it was hiding in the fetch call (not fetching tags).

Upgrade breakpad version:
- Picks up some upstream bugfixes
- Use github mirror for LSS rather than googlesource.com since it's blocked in China (for IRC user bi4wms)