### PR TITLE
actuators: some small simplifications and code cleanups

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -457,23 +457,13 @@ static void actuator_task(void* parameters)
 #if defined(MIXERSTATUS_DIAGNOSTICS)
 		MixerStatusSet(&mixerStatus);
 #endif
-
-		// Update servo outputs
-		bool success = true;
-
 		for (int n = 0; n < ACTUATORCOMMAND_CHANNEL_NUMELEM; ++n) {
 			PIOS_Servo_Set(n, command.Channel[n]);
 		}
 
 		PIOS_Servo_Update();
 
-		if (!success) {
-			command.NumFailedUpdates++;
-			ActuatorCommandSet(&command);
-			AlarmsSet(SYSTEMALARMS_ALARM_ACTUATOR, SYSTEMALARMS_ALARM_CRITICAL);
-		} else {
-			AlarmsClear(SYSTEMALARMS_ALARM_ACTUATOR);
-		}
+		AlarmsClear(SYSTEMALARMS_ALARM_ACTUATOR);
 	}
 }
 

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -95,7 +95,6 @@ static float scale_channel(float value, int idx);
 static void set_failsafe();
 static float throt_curve(const float input, const float* curve, uint8_t num_points);
 static float collective_curve(const float input, const float* curve, uint8_t num_points);
-static bool set_channel(uint8_t mixer_channel, float value);
 static void actuator_set_servo_mode(void);
 float process_mixer(const int index, const float curve1, const float curve2,
 		ActuatorDesiredData *desired);
@@ -303,8 +302,9 @@ static void actuator_task(void* parameters)
 				nMixers++;
 			}
 		}
-		if ((nMixers < 2) && !ActuatorCommandReadOnly()) { //Nothing can fly with less than two mixers.
-			set_failsafe(); // So that channels like PWM buzzer keep working
+		if ((nMixers < 2) && !ActuatorCommandReadOnly()) {
+			// Nothing can fly with less than two mixers.
+			set_failsafe();
 			continue;
 		}
 
@@ -312,9 +312,9 @@ static void actuator_task(void* parameters)
 		bool spin_while_armed = actuatorSettings.MotorsSpinWhileArmed == ACTUATORSETTINGS_MOTORSSPINWHILEARMED_TRUE;
 
 		float throttle_source = -1;
-		// as long as we're not a heli in failsafe mode, we should set throttle from the manual throttle value
-		// if we're not a heli, set it from the thrust value
 		if (airframe_type == SYSTEMSETTINGS_AIRFRAMETYPE_HELICP) {
+			// Helis set throttle from manual control's throttle value,
+			// unless in failsafe.
 			if (flightStatus.FlightMode != FLIGHTSTATUS_FLIGHTMODE_FAILSAFE) {
 				throttle_source = manual_control_command.Throttle;
 			}
@@ -462,7 +462,7 @@ static void actuator_task(void* parameters)
 		bool success = true;
 
 		for (int n = 0; n < ACTUATORCOMMAND_CHANNEL_NUMELEM; ++n) {
-			success &= set_channel(n, command.Channel[n]);
+			PIOS_Servo_Set(n, command.Channel[n]);
 		}
 
 		PIOS_Servo_Update();
@@ -575,141 +575,24 @@ static float channel_failsafe_value(int idx)
  */
 static void set_failsafe()
 {
-	/* grab only the parts that we are going to use */
 	float Channel[ACTUATORCOMMAND_CHANNEL_NUMELEM];
-	ActuatorCommandChannelGet(Channel);
 
-	// Reset ActuatorCommand to safe values
-	for (int n = 0; n < ACTUATORCOMMAND_CHANNEL_NUMELEM; ++n) {
-		Channel[n] = channel_failsafe_value(n);
-	}
+	ActuatorCommandChannelGet(Channel);
 
 	// Set alarm
 	AlarmsSet(SYSTEMALARMS_ALARM_ACTUATOR, SYSTEMALARMS_ALARM_CRITICAL);
 
 	// Update servo outputs
 	for (int n = 0; n < ACTUATORCOMMAND_CHANNEL_NUMELEM; ++n) {
-		set_channel(n, Channel[n]);
+		float fs_val = channel_failsafe_value(n);
+
+		PIOS_Servo_Set(n, fs_val);
 	}
 	
 	PIOS_Servo_Update();
 
 	// Update output object's parts that we changed
 	ActuatorCommandChannelSet(Channel);
-}
-
-static bool set_channel(uint8_t mixer_channel, float value)
-{
-	switch (actuatorSettings.ChannelType[mixer_channel]) {
-	case ACTUATORSETTINGS_CHANNELTYPE_PWMALARM:
-	case ACTUATORSETTINGS_CHANNELTYPE_ARMINGLED:
-	case ACTUATORSETTINGS_CHANNELTYPE_INFOLED:
-	{
-		// This is for buzzers that take a PWM input
-
-		static uint32_t currBuzzTune = 0;
-		static uint32_t currBuzzTuneState;
-
-		static uint32_t currArmingTune = 0;
-		static uint32_t currArmingTuneState;
-
-		static uint32_t currInfoTune = 0;
-		static uint32_t currInfoTuneState;
-
-		uint32_t newTune = 0;
-		if (actuatorSettings.ChannelType[mixer_channel] == ACTUATORSETTINGS_CHANNELTYPE_PWMALARM) {
-
-			// Decide what tune to play
-			if (AlarmsGet(SYSTEMALARMS_ALARM_BATTERY) > SYSTEMALARMS_ALARM_WARNING) {
-				newTune = 0b11110110110000;     // pause, short, short, short, long
-			} else if (AlarmsGet(SYSTEMALARMS_ALARM_GPS) >= SYSTEMALARMS_ALARM_WARNING) {
-				newTune = 0x80000000;                           // pause, short
-			} else {
-				newTune = 0;
-			}
-
-			// Do we need to change tune?
-			if (newTune != currBuzzTune) {
-				currBuzzTune = newTune;
-				currBuzzTuneState = currBuzzTune;
-			}
-		} else {     // ACTUATORSETTINGS_CHANNELTYPE_ARMINGLED || ACTUATORSETTINGS_CHANNELTYPE_INFOLED
-			uint8_t arming;
-			FlightStatusArmedGet(&arming);
-			//base idle tune
-			newTune =  0x80000000;          // 0b1000...
-
-			// Merge the error pattern for InfoLed
-			if (actuatorSettings.ChannelType[mixer_channel] == ACTUATORSETTINGS_CHANNELTYPE_INFOLED) {
-				if (AlarmsGet(SYSTEMALARMS_ALARM_BATTERY) > SYSTEMALARMS_ALARM_WARNING) {
-					newTune |= 0b00000000001111111011111110000000;
-				} else if (AlarmsGet(SYSTEMALARMS_ALARM_GPS) >= SYSTEMALARMS_ALARM_WARNING) {
-					newTune |= 0b00000000000000110110110000000000;
-				}
-			}
-			// fast double blink pattern if armed
-			if (arming == FLIGHTSTATUS_ARMED_ARMED)
-				newTune |= 0xA0000000;  // 0b101000...
-
-			// Do we need to change tune?
-			if (actuatorSettings.ChannelType[mixer_channel] == ACTUATORSETTINGS_CHANNELTYPE_ARMINGLED) {
-				if (newTune != currArmingTune) {
-					currArmingTune = newTune;
-					// note: those are both updated so that Info and Arming are in sync if used simultaneously
-					currArmingTuneState = currArmingTune;
-					currInfoTuneState = currInfoTune;
-				}
-			} else {
-				if (newTune != currInfoTune) {
-					currInfoTune = newTune;
-					currArmingTuneState = currArmingTune;
-					currInfoTuneState = currInfoTune;
-				}
-			}
-		}
-
-		// Play tune
-		bool buzzOn = false;
-		static uint32_t lastSysTime = 0;
-		uint32_t thisSysTime = PIOS_Thread_Systime();
-		uint32_t dT = 0;
-
-		// For now, only look at the battery alarm, because functions like AlarmsHasCritical() can block for some time; to be discussed
-		if (currBuzzTune||currArmingTune||currInfoTune) {
-			if (thisSysTime > lastSysTime)
-				dT = thisSysTime - lastSysTime;
-			if (actuatorSettings.ChannelType[mixer_channel] == ACTUATORSETTINGS_CHANNELTYPE_PWMALARM)
-				buzzOn = (currBuzzTuneState&1);  // Buzz when the LS bit is 1
-			else if (actuatorSettings.ChannelType[mixer_channel] == ACTUATORSETTINGS_CHANNELTYPE_ARMINGLED)
-				buzzOn = (currArmingTuneState&1);
-			else if (actuatorSettings.ChannelType[mixer_channel] == ACTUATORSETTINGS_CHANNELTYPE_INFOLED)
-				buzzOn = (currInfoTuneState&1);
-
-			if (dT > 80) {
-				// Go to next bit in alarm_seq_state
-				currArmingTuneState >>= 1;
-				currInfoTuneState >>= 1;
-				currBuzzTuneState >>= 1;
-
-				if (currBuzzTuneState == 0)
-					currBuzzTuneState = currBuzzTune;       // All done, re-start the tune
-				if (currArmingTuneState == 0)
-					currArmingTuneState = currArmingTune;
-				if (currInfoTuneState == 0)
-					currInfoTuneState = currInfoTune;
-				lastSysTime = thisSysTime;
-			}
-		}
-		PIOS_Servo_Set(mixer_channel,
-					buzzOn ? actuatorSettings.ChannelMax[mixer_channel] : actuatorSettings.ChannelMin[mixer_channel]);
-		return true;
-	}
-	case ACTUATORSETTINGS_CHANNELTYPE_PWM:
-		PIOS_Servo_Set(mixer_channel, value);
-		return true;
-	}
-
-	return false;
 }
 
 /**

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -256,10 +256,6 @@ void ConfigOutputWidget::assignOutputChannels(UAVObject *obj)
 
         quint32 neutral = actuatorSettingsData.ChannelNeutral[outputChannelForm->index()];
         outputChannelForm->setNeutral(neutral);
-
-        // init type
-        quint16 type = actuatorSettingsData.ChannelType[outputChannelForm->index()];
-        outputChannelForm->setType(type);
     }
 
     refreshWidgetRanges();
@@ -590,7 +586,6 @@ void ConfigOutputWidget::updateObjectsFromWidgets()
             actuatorSettingsData.ChannelMax[outputChannelForm->index()] = outputChannelForm->max();
             actuatorSettingsData.ChannelMin[outputChannelForm->index()] = outputChannelForm->min();
             actuatorSettingsData.ChannelNeutral[outputChannelForm->index()] = outputChannelForm->neutral();
-            actuatorSettingsData.ChannelType[outputChannelForm->index()] = outputChannelForm->type();
         }
 
         // Set update rates

--- a/ground/gcs/src/plugins/config/configvehicletypewidget.cpp
+++ b/ground/gcs/src/plugins/config/configvehicletypewidget.cpp
@@ -118,7 +118,7 @@ ConfigVehicleTypeWidget::ConfigVehicleTypeWidget(QWidget *parent) : ConfigTaskWi
 
     //Generate lists of mixerTypeNames, mixerVectorNames, channelNames
     channelNames << "None";
-    for (int i = 0; i < (int)ActuatorSettings::CHANNELTYPE_NUMELEM; i++) {
+    for (int i = 0; i < (int)ActuatorSettings::CHANNELMIN_NUMELEM; i++) {
 
         mixerTypes << QString("Mixer%1Type").arg(i+1);
         mixerVectors << QString("Mixer%1Vector").arg(i+1);

--- a/ground/gcs/src/plugins/config/outputchannelform.cpp
+++ b/ground/gcs/src/plugins/config/outputchannelform.cpp
@@ -45,10 +45,6 @@ OutputChannelForm::OutputChannelForm(const int index, QWidget *parent, const boo
 
     ActuatorSettings *actuatorSettings = ActuatorSettings::GetInstance(getObjectManager());
     Q_ASSERT(actuatorSettings);
-    UAVObjectField *types = actuatorSettings->getField("ChannelType");
-    Q_ASSERT(types);
-    ui.actuatorType->clear();
-    ui.actuatorType->addItems(types->getOptions());
 
     if(!showLegend)
     {
@@ -83,8 +79,6 @@ OutputChannelForm::OutputChannelForm(const int index, QWidget *parent, const boo
     connect(ui.actuatorMin, SIGNAL(valueChanged(int)), this, SLOT(notifyFormChanged()));
     connect(ui.actuatorMax, SIGNAL(valueChanged(int)), this, SLOT(notifyFormChanged()));
     connect(ui.actuatorNeutral, SIGNAL(sliderReleased()), this, SLOT(notifyFormChanged()));
-    connect(ui.actuatorType, SIGNAL(currentIndexChanged(int)), this, SLOT(notifyFormChanged()));
-
     ui.actuatorLink->setChecked(false);
     connect(ui.actuatorLink, SIGNAL(toggled(bool)), this, SLOT(linkToggled(bool)));
 
@@ -112,14 +106,12 @@ void OutputChannelForm::enableChannelTest(bool state)
         ui.actuatorMin->setEnabled(false);
         ui.actuatorMax->setEnabled(false);
         ui.pb_reverseActuator->setEnabled(false);
-        ui.actuatorType->setEnabled(false);
     }
     else
     {
         ui.actuatorMin->setEnabled(!minMaxFixed);
         ui.actuatorMax->setEnabled(!minMaxFixed);
         ui.pb_reverseActuator->setEnabled(!minMaxFixed);
-        ui.actuatorType->setEnabled(true);
     }
 }
 
@@ -200,19 +192,6 @@ void OutputChannelForm::setMinmax(int minimum, int maximum)
 void OutputChannelForm::setNeutral(int value)
 {
     ui.actuatorNeutral->setValue(value);
-}
-
-/**
- * Set type of channel.
- */
-void OutputChannelForm::setType(int value)
-{
-    ui.actuatorType->setCurrentIndex(value);
-}
-
-int OutputChannelForm::type() const
-{
-    return ui.actuatorType->currentIndex();
 }
 
 void OutputChannelForm::alignFields()

--- a/ground/gcs/src/plugins/config/outputchannelform.h
+++ b/ground/gcs/src/plugins/config/outputchannelform.h
@@ -51,8 +51,6 @@ public slots:
     void setNeutral(int value);
     int neutral() const;
     void enableChannelTest(bool state);
-    void setType(int type);
-    int type() const;
     void updateChannelLimits(int minPulse, int maxPulse, bool digitalProtocol = false);
 
 signals:

--- a/ground/gcs/src/plugins/config/outputchannelform.ui
+++ b/ground/gcs/src/plugins/config/outputchannelform.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>825</width>
-    <height>68</height>
+    <width>846</width>
+    <height>72</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -45,46 +45,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
-    <widget class="QComboBox" name="actuatorType">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>Set &quot;PWM&quot; simple pulse generation.</string>
-     </property>
-     <property name="autoFillBackground">
-      <bool>false</bool>
-     </property>
-     <item>
-      <property name="text">
-       <string>PWM</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>PWM Alarm</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Arming LED</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Info LED</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="1" column="8">
+   <item row="1" column="7">
     <widget class="QPushButton" name="pb_reverseActuator">
      <property name="minimumSize">
       <size>
@@ -101,7 +62,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="7">
+   <item row="1" column="6">
     <widget class="QSpinBox" name="actuatorMax">
      <property name="minimumSize">
       <size>
@@ -123,7 +84,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="5">
+   <item row="0" column="4">
     <widget class="QLabel" name="legend2">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -158,6 +119,22 @@ margin:1px;</string>
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
+   </item>
+   <item row="1" column="3">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Minimum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>5</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="legend6">
@@ -201,7 +178,7 @@ margin:1px;</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="9">
+   <item row="1" column="8">
     <widget class="QCheckBox" name="actuatorLink">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -223,7 +200,7 @@ margin:1px;</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="3">
+   <item row="0" column="2">
     <widget class="QLabel" name="legend1">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -259,7 +236,7 @@ margin:1px;</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="5">
+   <item row="1" column="4">
     <widget class="TextBubbleSlider" name="actuatorNeutral">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -296,7 +273,7 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
-   <item row="1" column="6">
+   <item row="1" column="5">
     <spacer name="horizontalSpacer_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -312,7 +289,7 @@ p, li { white-space: pre-wrap; }
      </property>
     </spacer>
    </item>
-   <item row="1" column="3">
+   <item row="1" column="2">
     <widget class="QSpinBox" name="actuatorMin">
      <property name="minimumSize">
       <size>
@@ -398,23 +375,7 @@ margin:1px;</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="4">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Minimum</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>5</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="7">
+   <item row="0" column="6">
     <widget class="QLabel" name="legend3">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -450,7 +411,7 @@ margin:1px;</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="8">
+   <item row="0" column="7">
     <widget class="QLabel" name="legend3_2">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -489,7 +450,7 @@ margin:1px;</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="9">
+   <item row="0" column="8">
     <widget class="QLabel" name="legend5">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -519,42 +480,6 @@ margin:1px;</string>
      </property>
      <property name="text">
       <string>Link</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QLabel" name="legend7">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <italic>false</italic>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">background-color: qlineargradient(spread:reflect, x1:0.507, y1:0, x2:0.507, y2:0.772, stop:0.208955 rgba(74, 74, 74, 255), stop:0.78607 rgba(36, 36, 36, 255));
-color: rgb(255, 255, 255);
-border-radius: 5;
-font:bold;
-margin:1px;</string>
-     </property>
-     <property name="text">
-      <string>Type</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/ground/gcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
+++ b/ground/gcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
@@ -254,8 +254,6 @@ void VehicleConfigurationHelper::applyActuatorConfiguration()
         }
 
         for (quint16 i = 0; i < ActuatorSettings::CHANNELMAX_NUMELEM; i++) {
-            data.ChannelType[i]    = ActuatorSettings::CHANNELTYPE_PWM;
-
             if (i < max_motors) {
                 data.ChannelMin[i]     = actuatorSettings[i].channelMin;
                 data.ChannelNeutral[i] = actuatorSettings[i].channelNeutral;

--- a/shared/uavobjectdefinition/actuatorcommand.xml
+++ b/shared/uavobjectdefinition/actuatorcommand.xml
@@ -5,7 +5,6 @@
 		<field name="Channel" units="us" type="float" elements="10"/>
 		<field name="UpdateTime" units="ms" type="uint8" elements="1"/>
 		<field name="MaxUpdateTime" units="ms" type="uint16" elements="1"/>
-		<field name="NumFailedUpdates" units="" type="uint8" elements="1"/>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="false" updatemode="manual" period="0"/>
 		<telemetryflight acked="false" updatemode="throttled" period="1000"/>

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -14,9 +14,6 @@
 		<field name="ChannelMin" units="us" type="uint16" elements="10" defaultvalue="0">
 			<description>Minimum output pulse length. Actuator commands will be scaled from [-1,1] to [ChannelMin,ChannelMax].</description>
 		</field>
-		<field name="ChannelType" units="" type="enum" elements="10" options="PWM,PWM Alarm,Arming LED,Info LED" defaultvalue="PWM">
-			<description>The type of output signal. Use PWM for motors.</description>
-		</field>
 		<field name="MotorsSpinWhileArmed" units="" type="enum" elements="1" options="FALSE,TRUE" defaultvalue="FALSE">
 			<description>When enabled, the motors will spin at the ChannelNeutral command when armed with zero throttle.</description>
 		</field>


### PR DESCRIPTION
- Existing code for LEDs and buzzer is not useful.  Redirecting output
from existing annunciator subsystem up at the mixer level could
eventually be worthwhile and cleaner.
- Reclaim horizontal space from that pulldown on the output pane / make
things less busy.
- Clarify some comments.