### PR TITLE
Udev rules updated to support udev tags for permissions

### DIFF
--- a/package/linux/deb/_package.udev
+++ b/package/linux/deb/_package.udev
@@ -3,86 +3,86 @@
 #
 
 # OpenPilot Flight Control board
-KERNEL=="hidraw*"KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4117", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*"KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4117", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 # OpenPilot OP board
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="415a", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="415a", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 # OpenPilot CopterControl flight control board
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="415b", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="415b", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 # OpenPilot Pipx radio modem board
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="415c", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="415c", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 # OpenPilot CopterControl3D flight control board
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="415d", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="415d", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 # OpenPilot Revolution flight control board
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="415e", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="415e", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 # OpenPilot osd
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4194", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4194", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 # OpenPilot spare
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4195", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4195", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 #
 # Quantec Networks GmbH
 #
 
 # Quantec Networks GmbH - quanton flight control rev. 1
-KERNEL=="hidraw*", ATTRS{idVendor}=="0fda", ATTRS{idProduct}=="0100", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="0fda", ATTRS{idProduct}=="0100", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 #
 # BrainFPV
 #
 # BrainFPV - Brain FPV Flight Controller rev. 1
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4242", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4242", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 # Team Black Sheep
 #
 
 # Team Black Sheep - colibri flight control rev. 1
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4235", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4235", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 #
 # Tau Labs
 #
 
 # TauLabs Freedom flight controller board
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="41d0", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="41d0", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 # TauLabs Sparky flight controller board
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="41d0", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="41d0", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 #
 # ST Micro
 #
 
 # DFU (Internal bootloader for STM32 MCUs)
-KERNEL=="hidraw*", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 #
 # JTAG adapters
 #
 
 # FTDI FT2232C Dual USB-UART/FIFO IC
-KERNEL=="hidraw*", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 # Olimex Ltd. OpenOCD JTAG TINY
-KERNEL=="hidraw*", ATTRS{idVendor}=="15ba", ATTRS{idProduct}=="0004", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="15ba", ATTRS{idProduct}=="0004", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 #
 # AeroQuad
 #
 
 # AeroQuad AQ32 flight controller board
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4284", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4284", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 #
 # Lumenier
 # 
 
 # Lumenier LUX flight controller
-KERNEL=="hidraw*", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="f3fc", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="f3fc", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 #
 # DTFUHF
 #
 
 # DTFUHF DTFc flight controller
-KERNEL=="hidraw*", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="d7fc", MODE="0664", GROUP="plugdev"
+KERNEL=="hidraw*", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="d7fc", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 #
 # dRonin
@@ -90,9 +90,9 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="d7fc", MODE="0664
 
 # IDs provided by @tracernz
 # Generic ID for dRonin firmware
-SUBSYSTEM=="usb", ATTR{idVendor}=="20a0", ATTR{idProduct}=="4250", MODE="0664", GROUP="plugdev"
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4250", MODE="0664", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTR{idVendor}=="20a0", ATTR{idProduct}=="4250", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="4250", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
 
 # Generic (multitarget) ID for dRonin bootloader
-SUBSYSTEM=="usb", ATTR{idVendor}=="20a0", ATTR{idProduct}=="427a", MODE="0664", GROUP="plugdev"
-KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="427a", MODE="0664", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTR{idVendor}=="20a0", ATTR{idProduct}=="427a", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
+KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="427a", MODE="0664", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"


### PR DESCRIPTION
Debian 6+, Ubuntu 13.04+ and Arch Linux do not rely on the 'plugdev' group and have been switching to a convention of using udev tags for device permissions instead.

This should avoid users having to create a group, add themseves to it, and logout/login. Plugdev group method still in place for backwards compat. Won't hurt anything.

I have been modifying this by hand for Arch and finally decided to PR it.