### PR TITLE
sim: cross-compile improvements and sample rate hack

### DIFF
--- a/flight/PiOS/Common/pios_bmx055.c
+++ b/flight/PiOS/Common/pios_bmx055.c
@@ -288,8 +288,12 @@ int32_t PIOS_BMX055_SPI_Init(pios_bmx055_dev_t *dev, uint32_t spi_id, uint32_t s
 	TaskMonitorAdd(TASKINFO_RUNNING_IMU, bmx_dev->task_handle);
 
 	PIOS_SENSORS_SetMaxGyro(2000);
-	PIOS_SENSORS_SetSampleRate(PIOS_SENSOR_GYRO, 800);
-	PIOS_SENSORS_SetSampleRate(PIOS_SENSOR_ACCEL, 800);
+
+	/* XXX These should be 800, but until we wait on interrupt line properly
+	 * pretend it's 1KHz as that's the rate we emit.
+	 */
+	PIOS_SENSORS_SetSampleRate(PIOS_SENSOR_GYRO, 1000);
+	PIOS_SENSORS_SetSampleRate(PIOS_SENSOR_ACCEL, 1000);
 
 	PIOS_SENSORS_Register(PIOS_SENSOR_ACCEL, bmx_dev->accel_queue);
 	PIOS_SENSORS_Register(PIOS_SENSOR_GYRO, bmx_dev->gyro_queue);

--- a/flight/targets/simulation/fw/Makefile
+++ b/flight/targets/simulation/fw/Makefile
@@ -246,7 +246,13 @@ CFLAGS += -O2 -g3
 endif
 
 ifneq ($(PI_CROSS_SIM)x,x)
-CC=arm-linux-gnueabihf-gcc
+ARMGCC:=$(shell command -v arm-linux-gnueabihf-gcc-6 2>/dev/null)
+
+ifeq ($(ARMGCC),)
+ARMGCC:=arm-linux-gnueabihf-gcc
+endif
+
+CC=$(ARMGCC)
 LDFLAGS += -static
 endif
 


### PR DESCRIPTION
If you install gcc6, on some distributions the compiler name is
arm-linux-gnueabihf-gcc-6 ... probe for this and use gcc6 if possible,
else fall back to arm-linux-gnueabihf-gcc.