### PR TITLE
attitude: cope when no baro is present (neuter cfvert)

### DIFF
--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -728,6 +728,8 @@ static int32_t updateAttitudeComplementary(float dT, bool first_run, bool second
 	}
 
 	if (!secondary) {
+		static bool got_baro_pt = false;
+
 		// Calculate the NED acceleration and get the z-component
 		float z_accel = calc_ned_accel(cf_q, &accelsData.x);
 
@@ -739,7 +741,10 @@ static int32_t updateAttitudeComplementary(float dT, bool first_run, bool second
 
 			cfvert_predict_pos(&cfvert, z_accel, dT);
 			cfvert_update_baro(&cfvert, baro, dT);
-		} else if (PIOS_SENSORS_GetMissing(PIOS_SENSOR_BARO)) {
+
+			got_baro_pt = true;
+		} else if (!got_baro_pt) {
+			/* If we've never heard from the baro hold alt at 0 */
 			cfvert.position_z = 0;
 			cfvert.velocity_z = 0;
 		} else {

--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -728,20 +728,25 @@ static int32_t updateAttitudeComplementary(float dT, bool first_run, bool second
 	}
 
 	if (!secondary) {
-
 		// Calculate the NED acceleration and get the z-component
 		float z_accel = calc_ned_accel(cf_q, &accelsData.x);
 
 		// When this is the only filter compute th vertical state from baro data
 		// Reset the filter for barometric data
-		cfvert_predict_pos(&cfvert, z_accel, dT);
 		if (PIOS_Queue_Receive(baroQueue, &ev, 0) == true) {
 			float baro;
 			BaroAltitudeAltitudeGet(&baro);
-			cfvert_update_baro(&cfvert, baro, dT);
-		}
 
+			cfvert_predict_pos(&cfvert, z_accel, dT);
+			cfvert_update_baro(&cfvert, baro, dT);
+		} else if (PIOS_SENSORS_GetMissing(PIOS_SENSOR_BARO)) {
+			cfvert.position_z = 0;
+			cfvert.velocity_z = 0;
+		} else {
+			cfvert_predict_pos(&cfvert, z_accel, dT);
+		}
 	}
+
 	if (!secondary && !raw_gps) {
 		// When in raw GPS mode, it will set the error to none if
 		// reception is good
@@ -1044,7 +1049,7 @@ static int32_t updateAttitudeINSGPS(bool first_run, bool outdoor_mode)
 		BaroAltitudeGet(&baroData);
 
 	if (mag_updated)
-       MagnetometerGet(&magData);
+		MagnetometerGet(&magData);
 
 	if (gps_updated)
 		GPSPositionGet(&gpsData);


### PR DESCRIPTION
Corrects the issue where if you're using a board without a baro, that altitude can run up to infinity (or down to negative infinity) just following the accelerometer.

Now if things are missing, don't even try to run cfvert.  Just peg the altitude at 0.