### PR TITLE
python-api: bump py version for pypi/pip

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -26,7 +26,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='20160825',
+    version='20170305',
 
     description='dRonin Python API',
     long_description=long_description,


### PR DESCRIPTION
Going to push a release to pypi at minimum today.