### PR TITLE
GCS:Reporter: Fix trailing ^0 (distance from ref)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@
 /tools
 /build
 
+# Ignore jenkins stuff
+/Nodes
+
 #flight/Project/Xcode.OSX
 flight/Project/Xcode.OSX/build
 flight/Project/Xcode.OSX/firmware.xcodeproj/*.mode1v3

--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,7 @@ androidgcs/google-play-services_lib/build.xml
 androidgcs/google-play-services_lib/gen/
 androidgcs/google-play-services_lib/local.properties
 androidgcs/google-play-services_lib/proguard-project.txt
-
+androidgcs/build
 
 # Ignore build output from Eclipse android builds
 androidgcs/bin/

--- a/ground/gcs/src/crashreporterapp/crashreporterapp.pro
+++ b/ground/gcs/src/crashreporterapp/crashreporterapp.pro
@@ -27,7 +27,7 @@ RESOURCES += \
 GIT_COMMIT = $$system(git rev-parse -q --short HEAD)
 GIT_BRANCH = $$system(git for-each-ref --count=1 --format=$$system_quote(%(refname:strip=2)) --contains HEAD refs/heads)
 GIT_TAG    = $$system(git for-each-ref --count=1 --format=$$system_quote(%(refname:strip=2)) --points-at HEAD refs/tags)
-GIT_DIFF   = $$system(git diff-index --shortstat HEAD)
+GIT_DIFF   = $$system(git status --porcelain)
 GIT_DIRTY  = true
 isEmpty(GIT_DIFF): GIT_DIRTY = false
 

--- a/ground/gcs/src/crashreporterapp/crashreporterapp.pro
+++ b/ground/gcs/src/crashreporterapp/crashreporterapp.pro
@@ -22,13 +22,14 @@ FORMS    += mainwindow.ui
 RESOURCES += \
     resources.qrc
 
+# TODO: should really use the GCS revision rather than crashreporterapp
+# (it is possible to build it seperately, then the results are misleading)
 GIT_COMMIT = $$system(git rev-parse -q --short HEAD)
-GIT_BRANCH = $$system(git symbolic-ref -q --short HEAD)
-GIT_TAG    = $$system(git name-rev --tags --name-only HEAD)
+GIT_BRANCH = $$system(git for-each-ref --count=1 --format=$$system_quote(%(refname:strip=2)) --contains HEAD refs/heads)
+GIT_TAG    = $$system(git for-each-ref --count=1 --format=$$system_quote(%(refname:strip=2)) --points-at HEAD refs/tags)
+GIT_DIFF   = $$system(git diff-index --shortstat HEAD)
 GIT_DIRTY  = true
-isEmpty($$system(git diff-files --shortstat)) {
-	GIT_DIRTY = false
-}
+isEmpty(GIT_DIFF): GIT_DIRTY = false
 
 DEFINES += GIT_COMMIT=\\\"$$GIT_COMMIT\\\" \
            GIT_BRANCH=\\\"$$GIT_BRANCH\\\" \


### PR DESCRIPTION
- GIT_TAG had the distance from the ref on the end, we already have a coarser version of this ("dirty") and it makes using the tag name more difficult. This will also now result in a blank string rather than "undefined" when HEAD isn't tagged.
- Funnily enough GIT_DIRTY was broken and always returned false as the qmake function isEmpty takes a variable __name__, not a value, and of course the variable named "" is empty, as is "4 files changed, 8 insertions(+), 6 deletions(-)" if we're actually dirty.
- Additionally, use plumbing commands rather than porcelain.