### PR TITLE
GCS: Fix USB header compilation

### DIFF
--- a/ground/gcs/src/plugins/boards_aeroquad/boards_aeroquad.pro
+++ b/ground/gcs/src/plugins/boards_aeroquad/boards_aeroquad.pro
@@ -9,8 +9,7 @@ OTHER_FILES += AeroQuad.json
 
 HEADERS += \
     aeroquadplugin.h \
-    aq32.h \
-    $$USB_ID_HEADER
+    aq32.h
 
 SOURCES += \
     aeroquadplugin.cpp \

--- a/ground/gcs/src/plugins/boards_brainfpv/boards_brainfpv.pro
+++ b/ground/gcs/src/plugins/boards_brainfpv/boards_brainfpv.pro
@@ -14,8 +14,7 @@ HEADERS += \
     brain.h \
     brainconfiguration.h \
     brainre1.h \
-    brainre1configuration.h \
-    $$USB_ID_HEADER
+    brainre1configuration.h
 
 SOURCES += \
     brainfpvplugin.cpp \

--- a/ground/gcs/src/plugins/boards_brotronics/boards_brotronics.pro
+++ b/ground/gcs/src/plugins/boards_brotronics/boards_brotronics.pro
@@ -12,8 +12,7 @@ OTHER_FILES += Brotronics.pluginspec
 HEADERS += \
     brotronicsplugin.h \
     lux.h \
-    luxconfiguration.h \
-    $$USB_ID_HEADER
+    luxconfiguration.h
 
 SOURCES += \
     brotronicsplugin.cpp \

--- a/ground/gcs/src/plugins/boards_dronin/boards_dronin.pro
+++ b/ground/gcs/src/plugins/boards_dronin/boards_dronin.pro
@@ -17,8 +17,7 @@ HEADERS += \
     simulationconfiguration.h \
     playuavosd.h \
     seppuku.h \
-    seppukuconfiguration.h \
-    $$USB_ID_HEADER
+    seppukuconfiguration.h
 
 SOURCES += \
     droninplugin.cpp \

--- a/ground/gcs/src/plugins/boards_dtf/boards_dtf.pro
+++ b/ground/gcs/src/plugins/boards_dtf/boards_dtf.pro
@@ -12,8 +12,7 @@ OTHER_FILES += dtfuhf.pluginspec
 HEADERS += \
     dtfplugin.h \
     dtfc.h \
-    dtfcconfiguration.h \
-    $$USB_ID_HEADER
+    dtfcconfiguration.h
 
 SOURCES += \
     dtfplugin.cpp \

--- a/ground/gcs/src/plugins/boards_openpilot/boards_openpilot.pro
+++ b/ground/gcs/src/plugins/boards_openpilot/boards_openpilot.pro
@@ -12,8 +12,7 @@ OTHER_FILES += OpenPilot.pluginspec \
 
 HEADERS += \
     openpilotplugin.h \
-    revolution.h \
-    $$USB_ID_HEADER
+    revolution.h
 
 SOURCES += \
     openpilotplugin.cpp \

--- a/ground/gcs/src/plugins/boards_quantec/boards_quantec.pro
+++ b/ground/gcs/src/plugins/boards_quantec/boards_quantec.pro
@@ -9,8 +9,7 @@ OTHER_FILES += Quantec.pluginspec
 
 HEADERS += \
     quantecplugin.h \
-    quanton.h \
-    $$USB_ID_HEADER
+    quanton.h
 
 SOURCES += \
     quantecplugin.cpp \

--- a/ground/gcs/src/plugins/boards_taulabs/boards_taulabs.pro
+++ b/ground/gcs/src/plugins/boards_taulabs/boards_taulabs.pro
@@ -13,8 +13,7 @@ HEADERS += \
     taulabsplugin.h \
     sparky.h \
     sparky2.h \
-    taulink.h \
-    $$USB_ID_HEADER
+    taulink.h
 
 SOURCES += \
     taulabsplugin.cpp \

--- a/ground/gcs/usbids.pri
+++ b/ground/gcs/usbids.pri
@@ -1,13 +1,17 @@
+include(gcs.pri)
+
 USB_ID_SOURCE_DIR = $$clean_path($$GCS_SOURCE_TREE/../../shared/usb_ids)
 USB_ID_JSON = $$USB_ID_SOURCE_DIR/usb_ids.json
 
 USB_ID_OUT_DIR = $$clean_path($$GCS_BUILD_TREE/../../shared/usb_ids)
 USB_ID_HEADER = $$USB_ID_OUT_DIR/board_usb_ids.h
 
-usbidjson.target = $$USB_ID_JSON
-
-usbids.target = $$USB_ID_HEADER
-usbids.depends = usbidjson
-usbids.command = $$PYTHON $$USB_ID_SOURCE_DIR/generate_usb_files.py -i "$$usbidjson.target" -c "$$usbids.target"
+# Behold the USB Header Compiler
+uhc.output  = $$USB_ID_HEADER
+uhc.commands = $$PYTHON $$USB_ID_SOURCE_DIR/generate_usb_files.py -i ${QMAKE_FILE_NAME} -c ${QMAKE_FILE_OUT}
+uhc.depends = $$USB_ID_JSON
+uhc.input = USB_ID_JSON
+uhc.CONFIG = explicit_dependencies no_link
+QMAKE_EXTRA_COMPILERS += uhc
 
 INCLUDEPATH *= $$USB_ID_OUT_DIR


### PR DESCRIPTION
Fixes #notyetreported. :wink: Luckily the flight targets ran first on all the builders so the header was always generated by the time GCS got built.