### PR TITLE
Flight: AQ32 - Remove PWM RX support, add WS2811 and DAC features

### DIFF
--- a/flight/targets/aq32/board-info/board_hw_defs.c
+++ b/flight/targets/aq32/board-info/board_hw_defs.c
@@ -63,6 +63,19 @@ static const struct pios_annunc pios_annuncs[] = {
 		.remap = 0,
 		.active_high = true,
 	},
+	[PIOS_ANNUNCIATOR_BUZZER] = {
+		.pin = {
+			.gpio = GPIOD,
+			.init = {
+				.GPIO_Pin   = GPIO_Pin_7,
+				.GPIO_Speed = GPIO_Speed_50MHz,
+				.GPIO_Mode  = GPIO_Mode_OUT,
+				.GPIO_OType = GPIO_OType_PP,
+				.GPIO_PuPd = GPIO_PuPd_NOPULL
+			},
+		},
+		.active_high = true,
+	},
 };
 
 static const struct pios_annunc_cfg pios_annunc_cfg = {
@@ -803,10 +816,10 @@ void PIOS_RTC_IRQ_Handler (void)
 
 #include "pios_tim_priv.h"
 
-//Timers used for inputs (4)
+//Timers used for inputs (5)
 
 // Set up timers that only have outputs on APB1
-static const TIM_TimeBaseInitTypeDef tim_4_time_base = {
+static const TIM_TimeBaseInitTypeDef tim_5_time_base = {
 	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
@@ -814,12 +827,12 @@ static const TIM_TimeBaseInitTypeDef tim_4_time_base = {
 	.TIM_RepetitionCounter = 0x0000,
 };
 
-static const struct pios_tim_clock_cfg tim_4_cfg = {
-	.timer = TIM4,
-	.time_base_init = &tim_4_time_base,
+static const struct pios_tim_clock_cfg tim_5_cfg = {
+	.timer = TIM5,
+	.time_base_init = &tim_5_time_base,
 	.irq = {
 		.init = {
-			.NVIC_IRQChannel                   = TIM4_IRQn,
+			.NVIC_IRQChannel                   = TIM5_IRQn,
 			.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_MID,
 			.NVIC_IRQChannelSubPriority        = 0,
 			.NVIC_IRQChannelCmd                = ENABLE,
@@ -827,10 +840,10 @@ static const struct pios_tim_clock_cfg tim_4_cfg = {
 	},
 };
 
-// Timers used for outputs (1,2,3,8)
+// Timers used for outputs (1,2,3,4,8)
 
 // Set up timers that only have outputs on APB1
-static const TIM_TimeBaseInitTypeDef tim_2_3_time_base = {
+static const TIM_TimeBaseInitTypeDef tim_2_3_4_time_base = {
 	.TIM_Prescaler         = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision     = TIM_CKD_DIV1,
 	.TIM_CounterMode       = TIM_CounterMode_Up,
@@ -849,7 +862,7 @@ static const TIM_TimeBaseInitTypeDef tim_1_8_time_base = {
 
 static const struct pios_tim_clock_cfg tim_2_cfg = {
 	.timer = TIM2,
-	.time_base_init = &tim_2_3_time_base,
+	.time_base_init = &tim_2_3_4_time_base,
 	.irq = {
 		.init = {
 			.NVIC_IRQChannel                   = TIM2_IRQn,
@@ -862,10 +875,23 @@ static const struct pios_tim_clock_cfg tim_2_cfg = {
 
 static const struct pios_tim_clock_cfg tim_3_cfg = {
 	.timer = TIM3,
-	.time_base_init = &tim_2_3_time_base,
+	.time_base_init = &tim_2_3_4_time_base,
 	.irq = {
 		.init = {
 			.NVIC_IRQChannel                   = TIM3_IRQn,
+			.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_MID,
+			.NVIC_IRQChannelSubPriority        = 0,
+			.NVIC_IRQChannelCmd                = ENABLE,
+		},
+	},
+};
+
+static const struct pios_tim_clock_cfg tim_4_cfg = {
+	.timer = TIM4,
+	.time_base_init = &tim_2_3_4_time_base,
+	.irq = {
+		.init = {
+			.NVIC_IRQChannel                   = TIM4_IRQn,
 			.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_MID,
 			.NVIC_IRQChannelSubPriority        = 0,
 			.NVIC_IRQChannelCmd                = ENABLE,
@@ -886,39 +912,24 @@ static const struct pios_tim_clock_cfg tim_8_cfg = {
 	},
 };
 
-// Timers used for inputs or outputs (1)
-
-static const struct pios_tim_clock_cfg tim_1_cfg = {
-	.timer = TIM1,
-	.time_base_init = &tim_1_8_time_base,
-	.irq = {
-		.init = {
-			.NVIC_IRQChannel                   = TIM1_CC_IRQn,
-			.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_MID,
-			.NVIC_IRQChannelSubPriority        = 0,
-			.NVIC_IRQChannelCmd                = ENABLE,
-		},
-	},
-};
-
 /**
  * Pios servo configuration structures
  */
 
 /*
- * Available outputs with PPM RX
+ * Outputs
 	1:  TIM8_CH4 (PC9)
 	2:  TIM8_CH3 (PC8)
 	3:  TIM2_CH1 (PA15)
 	4:  TIM2_CH2 (PB3)
 	5:  TIM3_CH1 (PB4)
 	6:  TIM3_CH2 (PB5)
-	7:  TIM1_CH1 (PE9)
-	8:  TIM1_CH2 (PE11)
-	9:  TIM1_CH3 (PE13)
-	10: TIM1_CH4 (PE14)
+	7:  TIM4_CH1 (PD12)  RX1
+	8:  TIM4_CH2 (PD13)  RX2
+	9:  TIM4_CH3 (PD14)  RX3
+	10: TIM4_CH4 (PD15)  RX4
  */
-static const struct pios_tim_channel pios_tim_outputs_pins_ppm_rx[] = {
+static const struct pios_tim_channel pios_tim_outputs_pins[] = {
 	{
 		.timer = TIM8,
 		.timer_chan = TIM_Channel_4,
@@ -1015,229 +1026,6 @@ static const struct pios_tim_channel pios_tim_outputs_pins_ppm_rx[] = {
 			.pin_source = GPIO_PinSource5,
 		},
 	},
-	{
-		.timer = TIM1,
-		.timer_chan = TIM_Channel_1,
-		.remap = GPIO_AF_TIM1,
-		.pin = {
-			.gpio = GPIOE,
-			.init = {
-				.GPIO_Pin   = GPIO_Pin_9,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_NOPULL
-			},
-			.pin_source = GPIO_PinSource9,
-		},
-	},
-	{
-		.timer = TIM1,
-		.timer_chan = TIM_Channel_2,
-		.remap = GPIO_AF_TIM1,
-		.pin = {
-			.gpio = GPIOE,
-			.init = {
-				.GPIO_Pin   = GPIO_Pin_11,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_NOPULL
-			},
-			.pin_source = GPIO_PinSource11,
-		},
-	},
-	{
-		.timer = TIM1,
-		.timer_chan = TIM_Channel_3,
-		.remap = GPIO_AF_TIM1,
-		.pin = {
-			.gpio = GPIOE,
-			.init = {
-				.GPIO_Pin   = GPIO_Pin_13,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_NOPULL
-			},
-			.pin_source = GPIO_PinSource13,
-		},
-	},
-	{
-		.timer = TIM1,
-		.timer_chan = TIM_Channel_4,
-		.remap = GPIO_AF_TIM1,
-		.pin = {
-			.gpio = GPIOE,
-			.init = {
-				.GPIO_Pin   = GPIO_Pin_14,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_NOPULL
-			},
-			.pin_source = GPIO_PinSource14,
-		},
-	},
-};
-
-/*
- * Available outputs with PWM RX
-	1:  TIM8_CH4 (PC9)
-	2:  TIM8_CH3 (PC8)
-	3:  TIM2_CH1 (PA15)
-	4:  TIM2_CH2 (PB3)
-	5:  TIM3_CH1 (PB4)
-	6:  TIM3_CH2 (PB5)
- */
-static const struct pios_tim_channel pios_tim_outputs_pins_pwm_rx[] = {
-	{
-		.timer = TIM8,
-		.timer_chan = TIM_Channel_4,
-		.remap = GPIO_AF_TIM8,
-		.pin = {
-			.gpio = GPIOC,
-			.init = {
-				.GPIO_Pin   = GPIO_Pin_9,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_NOPULL
-			},
-			.pin_source = GPIO_PinSource9,
-		},
-	},
-	{
-		.timer = TIM8,
-		.timer_chan = TIM_Channel_3,
-		.remap = GPIO_AF_TIM8,
-		.pin = {
-			.gpio = GPIOC,
-			.init = {
-				.GPIO_Pin   = GPIO_Pin_8,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_NOPULL
-			},
-			.pin_source = GPIO_PinSource8,
-		},
-	},
-	{
-		.timer = TIM2,
-		.timer_chan = TIM_Channel_1,
-		.remap = GPIO_AF_TIM2,
-		.pin = {
-			.gpio = GPIOA,
-			.init = {
-				.GPIO_Pin   = GPIO_Pin_15,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_NOPULL
-			},
-			.pin_source = GPIO_PinSource15,
-		},
-	},
-	{
-		.timer = TIM2,
-		.timer_chan = TIM_Channel_2,
-		.remap = GPIO_AF_TIM2,
-		.pin = {
-			.gpio = GPIOB,
-			.init = {
-				.GPIO_Pin   = GPIO_Pin_3,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_NOPULL
-			},
-			.pin_source = GPIO_PinSource3,
-		},
-	},
-	{
-		.timer = TIM3,
-		.timer_chan = TIM_Channel_1,
-		.remap = GPIO_AF_TIM3,
-		.pin = {
-			.gpio = GPIOB,
-			.init = {
-				.GPIO_Pin   = GPIO_Pin_4,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_NOPULL
-			},
-			.pin_source = GPIO_PinSource4,
-		},
-	},
-	{
-		.timer = TIM3,
-		.timer_chan = TIM_Channel_2,
-		.remap = GPIO_AF_TIM3,
-		.pin = {
-			.gpio = GPIOB,
-			.init = {
-				.GPIO_Pin   = GPIO_Pin_5,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_NOPULL
-			},
-			.pin_source = GPIO_PinSource5,
-		},
-	},
-};
-
-#if defined(PIOS_INCLUDE_SERVO) && defined(PIOS_INCLUDE_TIM)
-/*
- * Servo outputs
- */
-#include <pios_servo_priv.h>
-
-const struct pios_servo_cfg pios_servo_cfg_ppm_rx = {
-	.tim_oc_init = {
-		.TIM_OCMode       = TIM_OCMode_PWM1,
-		.TIM_OutputState  = TIM_OutputState_Enable,
-		.TIM_OutputNState = TIM_OutputNState_Disable,
-		.TIM_Pulse        = PIOS_SERVOS_INITIAL_POSITION,
-		.TIM_OCPolarity   = TIM_OCPolarity_High,
-		.TIM_OCNPolarity  = TIM_OCPolarity_High,
-		.TIM_OCIdleState  = TIM_OCIdleState_Reset,
-		.TIM_OCNIdleState = TIM_OCNIdleState_Reset,
-	},
-	.channels = pios_tim_outputs_pins_ppm_rx,
-	.num_channels = NELEMENTS(pios_tim_outputs_pins_ppm_rx),
-};
-
-const struct pios_servo_cfg pios_servo_cfg_pwm_rx = {
-	.tim_oc_init = {
-		.TIM_OCMode       = TIM_OCMode_PWM1,
-		.TIM_OutputState  = TIM_OutputState_Enable,
-		.TIM_OutputNState = TIM_OutputNState_Disable,
-		.TIM_Pulse        = PIOS_SERVOS_INITIAL_POSITION,
-		.TIM_OCPolarity   = TIM_OCPolarity_High,
-		.TIM_OCNPolarity  = TIM_OCPolarity_High,
-		.TIM_OCIdleState  = TIM_OCIdleState_Reset,
-		.TIM_OCNIdleState = TIM_OCNIdleState_Reset,
-	},
-	.channels = pios_tim_outputs_pins_pwm_rx,
-	.num_channels = NELEMENTS(pios_tim_outputs_pins_pwm_rx),
-};
-#endif	/* PIOS_INCLUDE_SERVO && PIOS_INCLUDE_TIM */
-
-/*
- * 	PWM INPUTS
-	1: TIM4_CH1 (PD12)
-	2: TIM4_CH2 (PD13)
-	3: TIM4_CH3 (PD14)
-	4: TIM4_CH4 (PD15)
-	5: TIM1_CH1 (PE9)
-	6: TIM1_CH2 (PE11)
-	7: TIM1_CH3 (PE13)
-	8: TIM1_CH4 (PE14)
- */
-static const struct pios_tim_channel pios_tim_rcvrport_pwm[] = {
 	{
 		.timer = TIM4,
 		.timer_chan = TIM_Channel_1,
@@ -1245,11 +1033,11 @@ static const struct pios_tim_channel pios_tim_rcvrport_pwm[] = {
 		.pin = {
 			.gpio = GPIOD,
 			.init = {
-				.GPIO_Pin = GPIO_Pin_12,
+				.GPIO_Pin   = GPIO_Pin_12,
 				.GPIO_Speed = GPIO_Speed_2MHz,
 				.GPIO_Mode  = GPIO_Mode_AF,
 				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_UP
+				.GPIO_PuPd  = GPIO_PuPd_NOPULL
 			},
 			.pin_source = GPIO_PinSource12,
 		},
@@ -1261,11 +1049,11 @@ static const struct pios_tim_channel pios_tim_rcvrport_pwm[] = {
 		.pin = {
 			.gpio = GPIOD,
 			.init = {
-				.GPIO_Pin = GPIO_Pin_13,
+				.GPIO_Pin   = GPIO_Pin_13,
 				.GPIO_Speed = GPIO_Speed_2MHz,
 				.GPIO_Mode  = GPIO_Mode_AF,
 				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_UP
+				.GPIO_PuPd  = GPIO_PuPd_NOPULL
 			},
 			.pin_source = GPIO_PinSource13,
 		},
@@ -1277,11 +1065,11 @@ static const struct pios_tim_channel pios_tim_rcvrport_pwm[] = {
 		.pin = {
 			.gpio = GPIOD,
 			.init = {
-				.GPIO_Pin = GPIO_Pin_14,
+				.GPIO_Pin   = GPIO_Pin_14,
 				.GPIO_Speed = GPIO_Speed_2MHz,
 				.GPIO_Mode  = GPIO_Mode_AF,
 				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_UP
+				.GPIO_PuPd  = GPIO_PuPd_NOPULL
 			},
 			.pin_source = GPIO_PinSource14,
 		},
@@ -1293,101 +1081,68 @@ static const struct pios_tim_channel pios_tim_rcvrport_pwm[] = {
 		.pin = {
 			.gpio = GPIOD,
 			.init = {
-				.GPIO_Pin = GPIO_Pin_15,
+				.GPIO_Pin   = GPIO_Pin_15,
 				.GPIO_Speed = GPIO_Speed_2MHz,
 				.GPIO_Mode  = GPIO_Mode_AF,
 				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_UP
+				.GPIO_PuPd  = GPIO_PuPd_NOPULL
 			},
 			.pin_source = GPIO_PinSource15,
 		},
 	},
-	{
-		.timer = TIM1,
-		.timer_chan = TIM_Channel_1,
-		.remap = GPIO_AF_TIM1,
-		.pin = {
-			.gpio = GPIOE,
-			.init = {
-				.GPIO_Pin = GPIO_Pin_9,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_UP
-			},
-			.pin_source = GPIO_PinSource9,
-		},
+};
+
+#if defined(PIOS_INCLUDE_SERVO) && defined(PIOS_INCLUDE_TIM)
+/*
+ * Servo outputs
+ */
+#include <pios_servo_priv.h>
+
+const struct pios_servo_cfg pios_servo_cfg = {
+	.tim_oc_init = {
+		.TIM_OCMode       = TIM_OCMode_PWM1,
+		.TIM_OutputState  = TIM_OutputState_Enable,
+		.TIM_OutputNState = TIM_OutputNState_Disable,
+		.TIM_Pulse        = PIOS_SERVOS_INITIAL_POSITION,
+		.TIM_OCPolarity   = TIM_OCPolarity_High,
+		.TIM_OCNPolarity  = TIM_OCPolarity_High,
+		.TIM_OCIdleState  = TIM_OCIdleState_Reset,
+		.TIM_OCNIdleState = TIM_OCNIdleState_Reset,
 	},
+	.channels = pios_tim_outputs_pins,
+	.num_channels = NELEMENTS(pios_tim_outputs_pins),
+};
+
+#endif	/* PIOS_INCLUDE_SERVO && PIOS_INCLUDE_TIM */
+
+/*
+ * 	PPM INPUT
+	1: TIM5_CH3 (PA2)
+ */
+static const struct pios_tim_channel pios_tim_rcvrport_ppm[] = {
 	{
-		.timer = TIM1,
-		.timer_chan = TIM_Channel_2,
-		.remap = GPIO_AF_TIM1,
-		.pin = {
-			.gpio = GPIOE,
-			.init = {
-				.GPIO_Pin = GPIO_Pin_11,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_UP
-			},
-			.pin_source = GPIO_PinSource11,
-		},
-	},
-	{
-		.timer = TIM1,
+		.timer = TIM5,
 		.timer_chan = TIM_Channel_3,
-		.remap = GPIO_AF_TIM1,
+		.remap = GPIO_AF_TIM5,
 		.pin = {
-			.gpio = GPIOE,
+			.gpio = GPIOA,
 			.init = {
-				.GPIO_Pin = GPIO_Pin_13,
+				.GPIO_Pin = GPIO_Pin_2,
 				.GPIO_Speed = GPIO_Speed_2MHz,
 				.GPIO_Mode  = GPIO_Mode_AF,
 				.GPIO_OType = GPIO_OType_PP,
 				.GPIO_PuPd  = GPIO_PuPd_UP
 			},
-			.pin_source = GPIO_PinSource13,
-		},
-	},
-	{
-		.timer = TIM1,
-		.timer_chan = TIM_Channel_4,
-		.remap = GPIO_AF_TIM1,
-		.pin = {
-			.gpio = GPIOE,
-			.init = {
-				.GPIO_Pin = GPIO_Pin_14,
-				.GPIO_Speed = GPIO_Speed_2MHz,
-				.GPIO_Mode  = GPIO_Mode_AF,
-				.GPIO_OType = GPIO_OType_PP,
-				.GPIO_PuPd  = GPIO_PuPd_UP
-			},
-			.pin_source = GPIO_PinSource14,
+			.pin_source = GPIO_PinSource2,
 		},
 	},
 };
 
 /*
- * PWM Inputs
+ * PPM Input
  */
-#if defined(PIOS_INCLUDE_PWM) || defined(PIOS_INCLUDE_PPM)
-#include <pios_pwm_priv.h>
+#if defined(PIOS_INCLUDE_PPM)
 #include <pios_ppm_priv.h>
-
-/*
- * PWM Inputs
- */
-const struct pios_pwm_cfg pios_pwm_cfg = {
-	.tim_ic_init = {
-		.TIM_ICPolarity = TIM_ICPolarity_Rising,
-		.TIM_ICSelection = TIM_ICSelection_DirectTI,
-		.TIM_ICPrescaler = TIM_ICPSC_DIV1,
-		.TIM_ICFilter = 0x0,
-	},
-	.channels = pios_tim_rcvrport_pwm,
-	.num_channels = NELEMENTS(pios_tim_rcvrport_pwm),
-};
 
 /*
  * PPM Input
@@ -1398,10 +1153,10 @@ const struct pios_ppm_cfg pios_ppm_cfg = {
 		.TIM_ICSelection = TIM_ICSelection_DirectTI,
 		.TIM_ICPrescaler = TIM_ICPSC_DIV1,
 		.TIM_ICFilter = 0x0,
-		.TIM_Channel = TIM_Channel_4,
+		.TIM_Channel = TIM_Channel_3,
 	},
-	/* Channel 4 for PPM use */
-	.channels = &pios_tim_rcvrport_pwm[3],
+	/* Servo Out 3 for PPM Input */
+	.channels = &pios_tim_rcvrport_ppm[0],
 	.num_channels = 1,
 };
 
@@ -1496,31 +1251,29 @@ const struct pios_usb_hid_cfg pios_usb_hid_cfg = {
 #include "pios_internal_adc_priv.h"
 
 void PIOS_ADC_DMA_irq_handler(void);
-void DMA2_Stream4_IRQHandler(void) __attribute__((alias("PIOS_ADC_DMA_irq_handler")));
-
+void DMA2_Stream0_IRQHandler(void) __attribute__((alias("PIOS_ADC_DMA_irq_handler")));
 struct pios_internal_adc_cfg pios_adc_cfg = {
+	.adc_dev_master = ADC1,
 	.dma = {
 		.irq = {
-			.flags = (DMA_FLAG_TCIF4 | DMA_FLAG_TEIF4 | DMA_FLAG_HTIF4),
+			.flags = (DMA_FLAG_TCIF0 | DMA_FLAG_TEIF0 | DMA_FLAG_HTIF0),
 			.init = {
-				.NVIC_IRQChannel = DMA2_Stream4_IRQn,
+				.NVIC_IRQChannel = DMA2_Stream0_IRQn,
 				.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_LOW,
 				.NVIC_IRQChannelSubPriority = 0,
 				.NVIC_IRQChannelCmd = ENABLE,
 			},
 		},
 		.rx = {
-			.channel = DMA2_Stream4,
+			.channel = DMA2_Stream0,
 			.init = {
 				.DMA_Channel = DMA_Channel_0,
 				.DMA_PeripheralBaseAddr = (uint32_t)&ADC1->DR
 			},
 		}
 	},
-	.half_flag = DMA_IT_HTIF4,
-	.full_flag = DMA_IT_TCIF4,
-
-	.adc_dev_master = ADC1,
+	.half_flag = DMA_IT_HTIF0,
+	.full_flag = DMA_IT_TCIF0,
 	.adc_pins =  {                                                              \
 		{ GPIOC, GPIO_Pin_4, ADC_Channel_14 },  /* AI2                      */  \
 		{ GPIOC, GPIO_Pin_0, ADC_Channel_10 },  /* Internal Voltage Monitor */  \
@@ -1538,6 +1291,84 @@ void PIOS_ADC_DMA_irq_handler(void)
 }
 
 #endif /* PIOS_INCLUDE_ADC */
+
+/**
+ * Configuration for driving a WS2811 LED out RX8
+ */
+
+#if defined(PIOS_INCLUDE_WS2811)
+#include "pios_ws2811.h"
+
+ws2811_dev_t pios_ws2811;
+
+void DMA2_Stream6_IRQHandler() {
+	PIOS_WS2811_dma_interrupt_handler(pios_ws2811);
+}
+
+static const struct pios_ws2811_cfg pios_ws2811_cfg = {
+	.timer = TIM1,
+	.clock_cfg = {
+		.TIM_Prescaler = (PIOS_PERIPHERAL_APB2_COUNTER_CLOCK / 12000000) - 1,
+		.TIM_ClockDivision = TIM_CKD_DIV1,
+		.TIM_CounterMode = TIM_CounterMode_Up,
+		.TIM_Period = 25,	/* 2.083us/bit */
+	},
+	.interrupt = {
+		.NVIC_IRQChannel = DMA2_Stream6_IRQn,
+		.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_LOW,
+		.NVIC_IRQChannelSubPriority = 0,
+		.NVIC_IRQChannelCmd = ENABLE,
+	},
+	.bit_clear_dma_tcif = DMA_IT_TCIF6,
+	.fall_time_l = 5,                       /* 333ns */
+	.fall_time_h = 11,                      /* 833ns */
+	.led_gpio = GPIOB,
+	.gpio_pin = GPIO_Pin_0,                 /* PB0 / RNG */
+	.bit_set_dma_stream = DMA2_Stream4,
+	.bit_set_dma_channel = DMA_Channel_6,   /* 2/S4/C6: TIM1 CH4|TRIG|COM */
+	.bit_clear_dma_stream = DMA2_Stream6,
+	.bit_clear_dma_channel = DMA_Channel_0, /* 0/S6/C0: TIM1 CH1|CH2|CH3 */
+};
+#endif
+
+#if defined(PIOS_INCLUDE_DAC)
+#include "pios_dac.h"
+
+dac_dev_t pios_dac;
+
+/* DAC 1 is the DAC output on AQ32; DMA1 Stream 5 Ch7 */
+
+void DMA1_Stream5_IRQHandler() {
+	PIOS_DAC_dma_interrupt_handler(pios_dac);
+}
+
+typedef struct dac_dev_s *dac_dev_t;
+
+struct pios_dac_cfg pios_dac_cfg = {
+	.timer = TIM6,
+	.clock_cfg = {
+		.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 600000) - 1,
+		.TIM_ClockDivision = TIM_CKD_DIV1,
+		.TIM_CounterMode = TIM_CounterMode_Up,
+		.TIM_Period = 25-1,	/* 600000 / 25 = 24000 samples per sec */
+	},
+	.interrupt = {
+		.NVIC_IRQChannel = DMA1_Stream5_IRQn,
+		.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_LOW,
+		.NVIC_IRQChannelSubPriority = 0,
+		.NVIC_IRQChannelCmd = ENABLE,
+	},
+	.gpio = GPIOA,
+	.gpio_pin = GPIO_Pin_4,
+	.dma_stream = DMA1_Stream5,
+	.dma_channel = DMA_Channel_7,
+	.dac_channel = DAC_Channel_1,
+	.dac_trigger = DAC_Trigger_T6_TRGO,
+	.dac_outreg = (uintptr_t) (&DAC->DHR12L1),
+	.dma_tcif = DMA_IT_TCIF5,
+};
+
+#endif /* PIOS_INCLUDE_DAC */
 
 /**
  * Configuration for the MPU6000 chip

--- a/flight/targets/aq32/board-info/pios_board.h
+++ b/flight/targets/aq32/board-info/pios_board.h
@@ -84,6 +84,7 @@ TIM8  |           |           |           |
 //------------------------
 #define PIOS_LED_HEARTBEAT				0
 #define PIOS_LED_ALARM					1
+#define PIOS_ANNUNCIATOR_BUZZER			2
 
 //------------------------
 // PIOS_WDG
@@ -142,6 +143,11 @@ extern uintptr_t pios_com_debug_id;
 extern max7456_dev_t pios_max7456_id;
 #endif
 
+#if defined(PIOS_INCLUDE_WS2811)
+#include <pios_ws2811.h>
+
+extern ws2811_dev_t pios_ws2811;
+#endif
 
 //------------------------
 // TELEMETRY

--- a/flight/targets/aq32/fw/Makefile
+++ b/flight/targets/aq32/fw/Makefile
@@ -36,6 +36,7 @@ DEBUG ?= NO
 
 # List of modules to include
 MODULES = Sensors
+MODULES += System
 MODULES += Attitude 
 MODULES += Actuator
 MODULES += ManualControl
@@ -66,6 +67,7 @@ OPTMODULES += Geofence
 OPTMODULES += Logging
 OPTMODULES += Storm32Bgc
 OPTMODULES += CharacterOSD
+OPTMODULES += OpenAeroVtol
 
 # Paths
 OPUAVTALKINC = $(OPUAVTALK)/inc
@@ -74,8 +76,6 @@ PIOSINC = $(PIOS)/inc
 FLIGHTLIBINC = $(FLIGHTLIB)/inc
 MATHLIB = $(FLIGHTLIB)/math
 MATHLIBINC = $(FLIGHTLIB)/math
-RSCODE = $(FLIGHTLIB)/rscode
-RSCODEINC = $(FLIGHTLIB)/rscode
 PIOSSTM32F4XX = $(PIOS)/STM32F4xx
 PIOSCOMMON = $(PIOS)/Common
 PIOSCOMMONLIB = $(PIOSCOMMON)/Libraries
@@ -98,7 +98,6 @@ include $(APPLIBDIR)/ChibiOS/library.mk
 ## MODULES
 SRC += ${foreach MOD, ${MODULES} ${OPTMODULES}, ${wildcard ${OPMODULEDIR}/${MOD}/*.c}}
 ## OPENPILOT CORE:
-SRC += ${OPMODULEDIR}/System/systemmod.c
 SRC += main.c
 SRC += board.c
 SRC += pios_board.c
@@ -136,7 +135,8 @@ SRC += pios_gcsrcvr.c
 SRC += pios_hmc5883.c
 SRC += pios_hmc5983_i2c.c
 SRC += pios_ms5611.c
-
+SRC += pios_fskdac.c
+SRC += pios_annuncdac.c
 SRC += pios_crc.c
 SRC += pios_com.c
 SRC += pios_dsm.c
@@ -147,6 +147,7 @@ SRC += pios_sensors.c
 SRC += pios_flash.c
 SRC += pios_flash_jedec.c
 SRC += pios_flashfs_logfs.c
+SRC += printf-stdarg.c
 SRC += pios_usb_desc_hid_cdc.c
 SRC += pios_usb_desc_hid_only.c
 SRC += pios_usb_util.c
@@ -199,6 +200,20 @@ EXTRAINCDIRS += $(DEBUG_CM3_DIR_INC)
 EXTRAINCDIRS += $(MAVLINKINC)
 
 EXTRAINCDIRS += ${foreach MOD, ${MODULES} ${OPTMODULES}, $(OPMODULEDIR)/${MOD}/inc} ${OPMODULEDIR}/System/inc
+
+# List any extra directories to look for library files here.
+# Also add directories where the linker should search for
+# includes from linker-script to the list
+#     Each directory must be seperated by a space.
+EXTRA_LIBDIRS =
+
+# Extra Libraries
+#    Each library-name must be seperated by a space.
+#    i.e. to link with libxyz.a, libabc.a and libefsl.a:
+#    EXTRA_LIBS = xyz abc efsl
+# for newlib-lpc (file: libnewlibc-lpc.a):
+#    EXTRA_LIBS = newlib-lpc
+EXTRA_LIBS =
 
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F4XX)
@@ -311,10 +326,11 @@ LIBS += $(UAVOBJLIB)
 #    -Map:      create map file
 #    --cref:    add cross reference to  map file
 LDFLAGS = -nostartfiles -Wl,-Map=$(OUTDIR)/$(TARGET).map,--cref,--gc-sections
+LDFLAGS += $(patsubst %,-L%,$(EXTRA_LIBDIRS))
+LDFLAGS += $(patsubst %,-l%,$(EXTRA_LIBS))
 LDFLAGS += -lc -lgcc -lm
 LDFLAGS += -Wl,--warn-common
 LDFLAGS += -Wl,--fatal-warnings
-LDFLAGS += -u _printf_float
 
 # Linker scripts
 LDFLAGS += -T memory.ld $(addprefix -T,$(LINKER_SCRIPTS_APP))

--- a/flight/targets/aq32/fw/Makefile
+++ b/flight/targets/aq32/fw/Makefile
@@ -330,6 +330,7 @@ LDFLAGS += $(patsubst %,-l%,$(EXTRA_LIBS))
 LDFLAGS += -lc -lgcc -lm
 LDFLAGS += -Wl,--warn-common
 LDFLAGS += -Wl,--fatal-warnings
+LDFLAGS += -u _printf_float
 
 # Linker scripts
 LDFLAGS += -T memory.ld $(addprefix -T,$(LINKER_SCRIPTS_APP))

--- a/flight/targets/aq32/fw/Makefile
+++ b/flight/targets/aq32/fw/Makefile
@@ -67,7 +67,6 @@ OPTMODULES += Geofence
 OPTMODULES += Logging
 OPTMODULES += Storm32Bgc
 OPTMODULES += CharacterOSD
-OPTMODULES += OpenAeroVtol
 
 # Paths
 OPUAVTALKINC = $(OPUAVTALK)/inc

--- a/flight/targets/aq32/fw/pios_board.c
+++ b/flight/targets/aq32/fw/pios_board.c
@@ -186,7 +186,7 @@ void PIOS_Board_Init(void) {
     // Timers used for outputs (2, 3, 4, 8)
     PIOS_TIM_InitClock(&tim_2_cfg);
     PIOS_TIM_InitClock(&tim_3_cfg);
-	PIOS_TIM_InitClock(&tim_4_cfg);
+    PIOS_TIM_InitClock(&tim_4_cfg);
     PIOS_TIM_InitClock(&tim_8_cfg);
 
 #ifdef PIOS_INCLUDE_SPI

--- a/flight/targets/aq32/fw/pios_config.h
+++ b/flight/targets/aq32/fw/pios_config.h
@@ -33,8 +33,6 @@
 #define PIOS_INCLUDE_CHIBIOS
 #define PIOS_INCLUDE_BL_HELPER
 
-#define OPENAEROVTOL
-
 /* Enable/Disable PiOS Modules */
 #define PIOS_INCLUDE_ADC
 #define PIOS_INCLUDE_I2C

--- a/flight/targets/aq32/fw/pios_config.h
+++ b/flight/targets/aq32/fw/pios_config.h
@@ -33,6 +33,8 @@
 #define PIOS_INCLUDE_CHIBIOS
 #define PIOS_INCLUDE_BL_HELPER
 
+#define OPENAEROVTOL
+
 /* Enable/Disable PiOS Modules */
 #define PIOS_INCLUDE_ADC
 #define PIOS_INCLUDE_I2C
@@ -55,13 +57,15 @@
 #define PIOS_INCLUDE_OPENLOG
 #define PIOS_INCLUDE_STORM32BGC
 #define PIOS_INCLUDE_MAX7456
+#define PIOS_INCLUDE_WS2811
+#define PIOS_INCLUDE_DAC
+#define PIOS_INCLUDE_DAC_FSK
+#define PIOS_INCLUDE_DAC_ANNUNCIATOR
 
 /* Select the sensors to include */
 #define PIOS_INCLUDE_HMC5883
 #define PIOS_INCLUDE_HMC5983_I2C
 #define PIOS_INCLUDE_MPU
-//#define PIOS_MPU6000_ACCEL
-//#define PIOS_MPU6000_SIMPLE_INIT_SEQUENCE
 #define PIOS_INCLUDE_MS5611
 #define PIOS_TOLERATE_MISSING_SENSORS
 
@@ -88,7 +92,6 @@
 #define PIOS_INCLUDE_HSUM
 #define PIOS_INCLUDE_SBUS
 #define PIOS_INCLUDE_PPM
-#define PIOS_INCLUDE_PWM
 #define PIOS_INCLUDE_GCSRCVR
 #define PIOS_INCLUDE_SRXL
 #define PIOS_INCLUDE_IBUS
@@ -100,6 +103,8 @@
 /* Flags that alter behaviours - mostly to lower resources for CC */
 #define PIOS_INCLUDE_INITCALL           /* Include init call structures */
 #define PIOS_TELEM_PRIORITY_QUEUE       /* Enable a priority queue in telemetry */
+
+#define SYSTEMMOD_RGBLED_SUPPORT
 
 #define CAMERASTAB_POI_MODE
 

--- a/ground/gcs/src/plugins/boards_aeroquad/aq32.cpp
+++ b/ground/gcs/src/plugins/boards_aeroquad/aq32.cpp
@@ -132,9 +132,6 @@ bool AQ32::setInputType(Core::IBoardType::InputType type)
     case INPUT_TYPE_PPM:
         settings.RcvrPort = HwAQ32::RCVRPORT_PPM;
         break;
-    case INPUT_TYPE_PWM:
-        settings.RcvrPort = HwAQ32::RCVRPORT_PWM;
-        break;
     case INPUT_TYPE_HOTTSUMD:
         settings.Uart3 = HwAQ32::UART3_HOTTSUMD;
         break;
@@ -184,8 +181,6 @@ Core::IBoardType::InputType AQ32::getInputType()
     switch(settings.RcvrPort) {
     case HwAQ32::RCVRPORT_PPM:
         return INPUT_TYPE_PPM;
-    case HwAQ32::RCVRPORT_PWM:
-        return INPUT_TYPE_PWM;
     default:
         break;
     }

--- a/ground/gcs/src/plugins/boards_aeroquad/aq32.cpp
+++ b/ground/gcs/src/plugins/boards_aeroquad/aq32.cpp
@@ -98,6 +98,7 @@ QPixmap AQ32::getBoardPicture()
 bool AQ32::isInputConfigurationSupported(Core::IBoardType::InputType type)
 {
     switch(type) {
+    case INPUT_TYPE_PWM:
     case INPUT_TYPE_UNKNOWN:
         return false;
     default:

--- a/shared/uavobjectdefinition/hwaq32.xml
+++ b/shared/uavobjectdefinition/hwaq32.xml
@@ -3,11 +3,10 @@
 	<object name="HwAQ32" singleinstance="true" settings="true" category="HardwareSettings">
 		<description>Selection of optional hardware configurations.</description>
 		<field name="RcvrPort" units="function" type="enum" elements="1" parent="HwShared.PortTypes" defaultvalue="Disabled">
-			<description>The pins next to the "Z" arrow</description>
+			<description>The pin labelled Servo3</description>
 			<options>
 				<option>Disabled</option>
 				<option>PPM</option>
-				<option>PWM</option>
 			</options>
 		</field>
 		<field name="Uart1" units="function" type="enum" elements="1" parent="HwShared.PortTypes" defaultvalue="Disabled">


### PR DESCRIPTION
This PR adds WS2811 LED and DAC support, at the expense of removing PWM receiver support.  It also shuffled some pin definitions, but since the AQ32 silkscreen never match Dronin use anyway, this isn't a deal killer in my opinion.  I'll update the pin definition spreadsheet in the hardware repo after this PR is merged.  Pin use is:

Function         Silkscreen            Resource Use
PPM RX          Servo 3 Output    (TIM5 CH3 configured for PPM Input)
PWM 7 Out    PWM 1 Input       (TIM4 CH1 configured as PWM output)
PWM 8 Out    PWM 2 Input       (TIM4 CH2 configured as PWM output)
PWM 9 Out    PWM 3 Input       (TIM4 CH3 configured as PWM output)
PWM 10 Out  PWM 4 Input       (TIM4 CH4 configured as PWM output)
WS2811          RNG Input           (TIM1, identical to Quanton with exception of GPIO pin)
DAC Out         Modem Output   (TIM6, identical to Seppuku with exception of GPIO pin)

All outputs have been checked on a logic analyzer and work correctly.  A PPM receiver was connected and I was able to set it up properly.  I have not flown the code yet, but the CPU load looks reasonable I think it's safe to merge as is.