### PR TITLE
lux: eliminate MPU9250Rate on board config pane.

### DIFF
--- a/ground/gcs/src/plugins/boards_brotronics/luxconfiguration.ui
+++ b/ground/gcs/src/plugins/boards_brotronics/luxconfiguration.ui
@@ -399,7 +399,7 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="0">
+          <item row="7" column="0">
            <widget class="QLabel" name="label_12">
             <property name="font">
              <font>
@@ -443,7 +443,7 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="1">
+          <item row="7" column="1">
            <widget class="QComboBox" name="cmbDsmxMode">
             <property name="objrelation" stdset="0">
              <stringlist>
@@ -511,39 +511,6 @@
             </property>
             <property name="text">
              <string>Accel LPF</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="label_14">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>MPU Rate</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1">
-           <widget class="QComboBox" name="cmbMpuRate">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sampling frequency for the gyros and accelerometers in Hz. A higher frequency is better, but will increase the CPU utilization. When SyncPWM is used, this is the frequency with which the ESCs are updated.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="objrelation" stdset="0">
-             <stringlist>
-              <string>objname:HwLux</string>
-              <string>fieldname:MPU9250Rate</string>
-              <string>buttongroup:1</string>
-             </stringlist>
             </property>
            </widget>
           </item>
@@ -760,7 +727,6 @@
   <tabstop>cmbAccelRange</tabstop>
   <tabstop>cmbGyroLpf</tabstop>
   <tabstop>cmbAccelLpf</tabstop>
-  <tabstop>cmbMpuRate</tabstop>
   <tabstop>cmbDsmxMode</tabstop>
   <tabstop>help</tabstop>
   <tabstop>reloadSettings</tabstop>


### PR DESCRIPTION
egrep -r 'MPU[0-9]' ground | grep -i rate   now comes up clean, so
hopefully this is the last of these...