### PR TITLE
vtolpathfollower: use altitude hold maximums

### DIFF
--- a/shared/uavobjectdefinition/vtolpathfollowersettings.xml
+++ b/shared/uavobjectdefinition/vtolpathfollowersettings.xml
@@ -5,9 +5,6 @@
 		<field name="HorizontalVelMax" units="m/s" type="uint16" elements="1" defaultvalue="10">
 			<description>Maximum Horizontal Velocity</description>
 		</field>
-		<field name="VerticalVelMax" units="m/s" type="uint16" elements="1" defaultvalue="2">
-			<description>Maximum Vertical Velocity</description>
-		</field>
 		<field name="HorizontalPosPI" units="(m/s)/m" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="1,0,2">
 			<description/>
 		</field>


### PR DESCRIPTION
For climb rate / descent rate.  Also do appropriate math in loiter-er.

Fixes #174.