### PR TITLE
attitude: raise AccKI, both during startup and at baseline

### DIFF
--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -530,7 +530,7 @@ static int32_t updateAttitudeComplementary(float dT, bool first_run, bool second
 
 		// For first 7 seconds use accels to get gyro bias
 		accKp = MIN(accKp, 20 + 20 * (PIOS_Thread_Systime() < 4000));
-		accKi = 1;
+		accKi = 15;
 		mgKp = 1;
 
 	} else if ((attitudeSettings.ZeroDuringArming == ATTITUDESETTINGS_ZERODURINGARMING_TRUE) && 

--- a/shared/uavobjectdefinition/attitudesettings.xml
+++ b/shared/uavobjectdefinition/attitudesettings.xml
@@ -14,7 +14,7 @@
 		<field name="AccKp" units="channel" type="float" elements="1" defaultvalue="20.0">
 			<description>Accelerometer proportional gain for the attitude filter.</description>
 		</field>
-		<field name="AccKi" units="channel" type="float" elements="1" defaultvalue="0.05">
+		<field name="AccKi" units="channel" type="float" elements="1" defaultvalue="0.4">
 			<description>Accelerometer integral gain for the attitude filter.</description>
 		</field>
 		<field name="AccelTau" units="" type="float" elements="1" defaultvalue="0.1">


### PR DESCRIPTION
This is based on eyeballing actual behavior in plots from gooch/irc.  He
has a quad with a severe gyro bias issue.  The initial transient at
startup isn't fixing it, and the further trimming would take
approximately forever to correct it.

The arming value is chosen to be 15; a value of 6 would deliver a time
constant of approximately the startup interval (6 seconds); 15 is about
2/5 of the arming interval or we should expect about 92% of the error to
get trimmed out.

Since that's raising by 15x, raise the "normal" value by a factor of 8x
to 0.4.  By the above rationale that's a time constant of about 90
seconds-- enough that slow, very small drift is coped with, but small
attitude errors don't do much at all