### PR TITLE
stabilization: Introduce control input smoothing

### DIFF
--- a/flight/Libraries/math/smoothcontrol.c
+++ b/flight/Libraries/math/smoothcontrol.c
@@ -102,7 +102,7 @@ void smoothcontrol_run(smoothcontrol_state state, uint8_t axis_num, float *new_s
 		smoothcontrol_update(state, axis, *new_signal);
 	}
 
-	if(state->tick_counter <= axis->integrator_timeout && state->tick_counter < state->time_bomb) {
+	if(state->tick_counter < axis->integrator_timeout && state->tick_counter < state->time_bomb) {
 		// Don't fiddle with first value after update.
 		if(state->tick_counter > 0)
 			axis->current += axis->differential;

--- a/flight/Libraries/math/smoothcontrol.c
+++ b/flight/Libraries/math/smoothcontrol.c
@@ -1,0 +1,178 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+
+#include "openpilot.h"
+#include "pios.h"
+#include "misc_math.h"
+#include "smoothcontrol.h"
+
+struct smoothcontrol_axis_state {
+	// Last known signal value. Needed to detect change.
+	float signal;
+
+	// Current state of axis.
+	float current;
+
+	// Amount of differential per step of integration.
+	float differential;
+
+	// Stores a time-out when to stop predicting. Unit is integrator ticks.
+	uint8_t integrator_timeout;
+
+	// Which conditioning algorithm.
+	uint8_t mode;
+};
+
+struct smoothcontrol_state_internal {
+
+	// Maximum ticks to integrate. Calculate value from dT and constant. Unit is ticks.
+	uint8_t time_bomb;
+
+	// Semaphore for cheapskates.
+	bool ringer;
+
+	// Whole state tick counter
+	uint8_t tick_counter;
+
+	// Control interval determined by the ringer.
+	uint8_t control_interval;
+
+	// RPY+Thrust.
+	struct smoothcontrol_axis_state axis[4];
+};
+
+// Ran on signal change, recalculates the diffs and timeouts for the specific mode.
+static void smoothcontrol_update(smoothcontrol_state state, struct smoothcontrol_axis_state *axis, const float new_signal)
+{
+	float signal_diff = new_signal - axis->signal;
+
+	switch(axis->mode) {
+		default:
+			// Override any crap values.
+			axis->mode = SMOOTHCONTROL_NONE;
+		case SMOOTHCONTROL_NONE:
+			// Doesn't do anything in the integrator.
+			break;
+
+		// icee's proposal, creates chamfered steps with signal prediction
+		case SMOOTHCONTROL_NORMAL:
+		case SMOOTHCONTROL_EXTENDED:
+			axis->differential = signal_diff * SMOOTHCONTROL_PREDICTOR_SLOPE / (float)state->control_interval;
+			axis->current = axis->signal + signal_diff * SMOOTHCONTROL_CHAMFER_START;
+			axis->integrator_timeout = (uint8_t)MAX((float)state->control_interval*
+				(axis->mode == SMOOTHCONTROL_NORMAL ? SMOOTHCONTROL_DUTY_CYCLE : SMOOTHCONTROL_EXTENDED_DUTY_CYCLE), 255);
+			break;
+	}
+
+	axis->signal = new_signal;
+}
+
+// Resets the axis state.
+void smoothcontrol_reinit(smoothcontrol_state state, uint8_t axis_num, float new_signal)
+{
+	PIOS_Assert(state);
+
+	// Prevent integrating when stick scale changes.
+	state->axis[axis_num].differential = 0;
+	state->axis[axis_num].signal = new_signal;
+	state->axis[axis_num].current = new_signal;
+}
+
+// Sets mode for an axis.
+void smoothcontrol_set_mode(smoothcontrol_state state, uint8_t axis_num, uint8_t mode)
+{
+	PIOS_Assert(state && axis_num <= 3);
+	state->axis[axis_num].mode = mode;
+	smoothcontrol_reinit(state, axis_num, state->axis[axis_num].signal);
+}
+
+// Processes the signal, if internal state allows it.
+void smoothcontrol_run(smoothcontrol_state state, uint8_t axis_num, float *new_signal, float limit)
+{
+	PIOS_Assert(state && axis_num <= 3);
+
+	struct smoothcontrol_axis_state *axis = &state->axis[axis_num];
+
+	// No mode, bypass.
+	if(axis->mode == SMOOTHCONTROL_NONE) return;
+
+	if(!state->tick_counter) {
+		// Manual control updated, do stuff
+		smoothcontrol_update(state, axis, *new_signal);
+	}
+
+	if(state->tick_counter <= axis->integrator_timeout && state->tick_counter < state->time_bomb) {
+		// Don't fiddle with first value after update.
+		if(state->tick_counter > 0)
+			axis->current += axis->differential;
+	} else {
+		// If we passed the timebomb, force the receiver signal, too.
+		if(state->tick_counter >= state->time_bomb) axis->current = *new_signal;
+	}
+
+	*new_signal = axis->current;
+}
+
+// Separate handling of thrust.
+void smoothcontrol_run_thrust(smoothcontrol_state state, float *new_signal)
+{
+	// The -1 on zero throttle causes a huge blip when throttling up, so we need to
+	// handle it separately.
+	if(*new_signal < 0)
+	{
+		smoothcontrol_reinit(state, 3, 0);
+	}
+	else
+	{
+		smoothcontrol_run(state, 3, new_signal, 1.0f);
+
+		// If prediction undershoots while original signal is positive
+		// bound it to zero.
+		if(*new_signal < 0)
+			*new_signal = 0;
+	}
+}
+
+// Advances the tick counters.
+void smoothcontrol_next(smoothcontrol_state state)
+{
+	PIOS_Assert(state);
+
+	if(state->tick_counter < 255) state->tick_counter++;
+
+	// This function is supposed to get called at the end of the stabilization loop.
+	// If MCC rang the ringer meanwhile, ticks will be at zero next loop, as expected.
+	if(state->ringer) {
+		int x = ((int)state->control_interval + (int)state->tick_counter) >> 1;
+		state->control_interval = (uint8_t)MAX(x, 255);
+		state->tick_counter = 0;
+
+		state->ringer = false;
+	}
+}
+
+// To tell us the dT, to calculate the time bomb for the integrator.
+void smoothcontrol_update_dT(smoothcontrol_state state, float dT)
+{
+	PIOS_Assert(state);
+	state->time_bomb = (uint8_t)(SMOOTHCONTROL_TIMEBOMB / 1000.0f / dT);
+}
+
+// Duh.
+void smoothcontrol_initialize(smoothcontrol_state *state)
+{
+	PIOS_Assert(state);
+
+	if(!*state) {
+		*state = PIOS_malloc_no_dma(sizeof(struct smoothcontrol_state_internal));
+		PIOS_Assert(*state);
+		memset(*state, 0, sizeof(struct smoothcontrol_state_internal));
+	}
+}
+
+bool* smoothcontrol_get_ringer(smoothcontrol_state state)
+{
+	PIOS_Assert(state);
+	return &state->ringer;
+}

--- a/flight/Libraries/math/smoothcontrol.c
+++ b/flight/Libraries/math/smoothcontrol.c
@@ -60,7 +60,7 @@ static void smoothcontrol_update(smoothcontrol_state state, struct smoothcontrol
 		case SMOOTHCONTROL_EXTENDED:
 			axis->differential = signal_diff * SMOOTHCONTROL_PREDICTOR_SLOPE / (float)state->control_interval;
 			axis->current = axis->signal + signal_diff * SMOOTHCONTROL_CHAMFER_START;
-			axis->integrator_timeout = (uint8_t)MAX((float)state->control_interval*
+			axis->integrator_timeout = (uint8_t)MAX((float)state->control_interval *
 				(axis->mode == SMOOTHCONTROL_NORMAL ? SMOOTHCONTROL_DUTY_CYCLE : SMOOTHCONTROL_EXTENDED_DUTY_CYCLE), 255);
 			break;
 	}
@@ -165,9 +165,9 @@ void smoothcontrol_initialize(smoothcontrol_state *state)
 	PIOS_Assert(state);
 
 	if(!*state) {
-		*state = PIOS_malloc_no_dma(sizeof(struct smoothcontrol_state_internal));
+		*state = PIOS_malloc_no_dma(sizeof(**state));
 		PIOS_Assert(*state);
-		memset(*state, 0, sizeof(struct smoothcontrol_state_internal));
+		memset(*state, 0, sizeof(**state));
 	}
 }
 

--- a/flight/Libraries/math/smoothcontrol.h
+++ b/flight/Libraries/math/smoothcontrol.h
@@ -1,0 +1,44 @@
+#ifndef SMOOTHCONTROL_H
+#define SMOOTHCONTROL_H
+
+// Defines the predictor time-limit so it doesn't go haywire.
+// Chosem PPM frame timing for now.
+#define SMOOTHCONTROL_TIMEBOMB						20.0f
+
+// Defines ratio of inter-signal timing to run a prediction algorithm for.
+#define SMOOTHCONTROL_DUTY_CYCLE					0.5f
+
+// Same for extended mode.
+#define SMOOTHCONTROL_EXTENDED_DUTY_CYCLE			0.75f
+
+// Controls steepness of prediction slope.
+#define SMOOTHCONTROL_PREDICTOR_SLOPE				0.8f
+
+// At which ratio to start the chamfer.
+#define SMOOTHCONTROL_CHAMFER_START					0.75f
+
+enum {
+	// Bypass.
+	SMOOTHCONTROL_NONE,
+
+	// Chamfers the corners of the stairstepped control signal.
+	// icee's idea.
+	SMOOTHCONTROL_NORMAL,
+
+	// Same but with extended duty cycle.
+	SMOOTHCONTROL_EXTENDED,
+};
+
+typedef struct smoothcontrol_state_internal* smoothcontrol_state;
+
+
+void smoothcontrol_initialize(smoothcontrol_state *state);
+void smoothcontrol_update_dT(smoothcontrol_state state, float dT);
+void smoothcontrol_next(smoothcontrol_state state);
+void smoothcontrol_run(smoothcontrol_state state, uint8_t axis_num, float *new_signal, float limit);
+void smoothcontrol_run_thrust(smoothcontrol_state state, float *new_signal);
+void smoothcontrol_reinit(smoothcontrol_state state, uint8_t axis_num, float new_signal);
+void smoothcontrol_set_mode(smoothcontrol_state state, uint8_t axis_num, uint8_t mode);
+bool* smoothcontrol_get_ringer(smoothcontrol_state state);
+
+#endif // SMOOTHCONTROL_H

--- a/flight/targets/simulation/fw/Makefile
+++ b/flight/targets/simulation/fw/Makefile
@@ -151,6 +151,7 @@ SRC += $(MATHLIB)/coordinate_conversions.c
 SRC += $(MATHLIB)/misc_math.c
 SRC += $(MATHLIB)/pid.c
 SRC += $(MATHLIB)/lpfilter.c
+SRC += $(MATHLIB)/smoothcontrol.c
 
 include $(PIOS)/posix/library.mk
 

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -52,6 +52,9 @@
 		<field name="DeadbandSlope" units="%" type="uint8" elementnames="Roll,Pitch,Yaw" defaultvalue="60,60,50" limits="%BE:0:100,%BE:0:100,%BE:0:100">
 			<description>Sets the slope of the deadband area in the PID controller.</description>
 		</field>
+		<field name="RCControlSmoothing" units="" type="enum" elementnames="Axes,Thrust" options="None,Normal,Extended" defaultvalue="None">
+			<description>Enables different ways of input signal smoothing, to reduce excessive P- and D-term excitation in the PID controller. Normal and Extended modes chamfer the leading edges in combination with some amount of prediction, to avoid delay.</description>
+		</field>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
@mlyle and I discussed this a few months ago (I did some work, however a lot of procrastrination happened). The idea is to take the stair stepped RC input signal and smooth the corners out a bit, by using some amount of prediction to prevent delay. The output signal of it would have the leading edges chamfered. This is supposed reduce the P- and D-term kicks on large control input changes, and in consequence reduce actuator saturation.

This early implementation has four modes. The chamfered steps with two different prediction duty cycles, simple linear interpolation (for whoever wants it, maybe planes for servo smoothness), and interpolation by using predicted values similar to the first two modes (same as previous, but with reduced delay).

In normal operation, it should maximally only predict as long as it detects the frame timing to be (which is per-axis, for the very rare multi-RX setup). There's a hard limit of 20ms, since that's the PPM timing, in case something goes wrong with detection of the timing (it stores the smallest number it encounters).

The final implementation would have modes selectable per axis for RPY+T at least via UAVO browser.

Right now only smoothcontrol.c/h in this PR are of interest, the rest is just barebones integration for Seppuku.

Here's what the generated signals look in the simulator code (the green stuff is FFT, forgot why I added that the last time).

Chamfered steps with 50% of the signal time predicted.
![icee50](https://cloud.githubusercontent.com/assets/4010813/24062402/b85c8200-0b5b-11e7-82d9-4d1f0c5433e6.png)

Same but with 75% duty cycle.
![icee75](https://cloud.githubusercontent.com/assets/4010813/24062425/cfb4f66c-0b5b-11e7-981c-c6d754bebd9d.png)

Linear interpolation, well, result as expected.
![interpol](https://cloud.githubusercontent.com/assets/4010813/24062434/d9b04d38-0b5b-11e7-8abf-7a171761fe83.png)

Interpolation using predicts. With current parameters, the overshoots are pretty tame.
![predictive](https://cloud.githubusercontent.com/assets/4010813/24062449/e2b446be-0b5b-11e7-8aed-862025c83b1e.png)

In my opinion, the 75% one seems to be a nice approach, with the interpolated version for least delay maximum smoothness. The overshoots in the former are very very tame compared to plain extrapolation. And they look unspectacular in latter, too. (If you switch between 75% and interpolated predicts, the curve looks similar enough.)