### PR TITLE
pios_rcvr: Update rcvr_last_wake on semaphore timeout.

### DIFF
--- a/flight/PiOS/Common/pios_rcvr.c
+++ b/flight/PiOS/Common/pios_rcvr.c
@@ -107,7 +107,14 @@ int32_t PIOS_RCVR_Read(uintptr_t rcvr_id, uint8_t channel)
 
 bool PIOS_RCVR_WaitActivity(uint32_t timeout_ms) {
   if (rcvr_activity) {
-    return PIOS_Semaphore_Take(rcvr_activity, timeout_ms);
+    bool result = PIOS_Semaphore_Take(rcvr_activity, timeout_ms);
+    if(!result) {
+      // If the semaphore times out, update last wake, to try to avoid
+      // resonance due to jitter, when the update rate of the receiver
+      // matches the timeout.
+      rcvr_last_wake = PIOS_DELAY_GetRaw();
+    }
+    return result;
   } else {
     PIOS_Thread_Sleep(timeout_ms);
 


### PR DESCRIPTION
Most serial receiver drivers call PIOS_RCVR_ActiveFromISR(), to trigger ManualControl as early as possible. The current semaphore timeout used in ManualControl is 20ms (PPM period).

The Crossfire system drops its update rate from 150hz to 50hz under weak RF conditions. With timing jitter, this however makes ManualControl do double time, because ActiveFromISR can/will get called very shortly after the semaphore in pios_rcvr timed out and gets released again immediately, because ActiveFromISR thinks the minimum wake interval has been passed due to insufficient time keeping. Other receivers with serial protocols might possibly get affected, too, if they decide to run 50hz for whatever reason, but it's hard to find information about actual update rates.

The result of 50hz ISR vs. 20ms timeout is this:

![mcc_bad](https://cloud.githubusercontent.com/assets/4010813/24087863/6756f0e6-0d24-11e7-8a22-e5589dcda77d.png)

The graph is tracking the control interval in the control smoothing patch. This was recorded on a Seppuku with its 1600hz loop. When I force the receiver to output 50hz, ManualControl fires at 32 ticks (x1.6 = ~51hz) as expected, and very often immediately after (1 tick).

After updating rcvr_last_wake whenever the semaphore times out, the minimum wake interval (currently 4ms) steps in properly and improves the situation a lot:

![mcc_fixed](https://cloud.githubusercontent.com/assets/4010813/24087906/d77e2d9e-0d24-11e7-875c-978a5adc34d2.png)
