### PR TITLE
GCS: Clear up some references to F1

### DIFF
--- a/ground/gcs/src/plugins/config/configattitudewidget.cpp
+++ b/ground/gcs/src/plugins/config/configattitudewidget.cpp
@@ -177,9 +177,6 @@ ConfigAttitudeWidget::ConfigAttitudeWidget(QWidget *parent) :
     m_ui->levelingStart->setEnabled(true);
     m_ui->levelingAndBiasStart->setEnabled(true);
 
-    // F1 boards don't have this object
-    setNotMandatory("StateEstimation");
-
     refreshWidgetsValues();
 }
 

--- a/ground/gcs/src/plugins/config/configmodulewidget.cpp
+++ b/ground/gcs/src/plugins/config/configmodulewidget.cpp
@@ -197,12 +197,6 @@ void ConfigModuleWidget::objectUpdated(UAVObject * obj, bool success)
     } else if (objName.compare(LoggingSettings::NAME) == 0) {
         enableLoggingTab(success && moduleSettings->getAdminState_Logging() == ModuleSettings::ADMINSTATE_ENABLED);
     }
-
-    // indicate that we can't tell which modules are running when taskinfo isn't available
-    const bool haveTaskInfo = taskInfo->getIsPresentOnHardware();
-    ui->lblAutoHaveTaskInfo->setVisible(haveTaskInfo);
-    ui->lblAutoNoTaskInfo->setVisible(!haveTaskInfo);
-    ui->gbAutoModules->setEnabled(haveTaskInfo);
 }
 
 /**

--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -311,23 +311,6 @@
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="lblAutoHaveTaskInfo">
-            <property name="text">
-             <string>The checkboxes here indicate which modules are currently running on your board.</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="lblAutoNoTaskInfo">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Unfortunately it is not possible to determine which modules are running on your board (likely due to resource constraints). These checkboxes are &lt;span style=&quot; font-weight:600;&quot;&gt;non-functional&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QReadOnlyCheckBox" name="cbComBridge">
             <property name="toolTip">
              <string>Select to enable USB serial relay to a serial port (select the board on the board options)</string>

--- a/ground/gcs/src/plugins/coreplugin/telemetrymonitorwidget.h
+++ b/ground/gcs/src/plugins/coreplugin/telemetrymonitorwidget.h
@@ -55,6 +55,9 @@ signals:
     
 public slots:
     void connected();
+    /**
+     * @todo Shadows QObject::disconnect!!
+     */
     void disconnect();
 
     void updateTelemetry(double txRate, double rxRate);

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -1226,7 +1226,7 @@ void UploaderGadgetWidget::onExportButtonClick()
         QMessageBox msgBox;
 
         msgBox.setText(tr("No settings partition accessible; can't export."));
-        msgBox.setInformativeText(tr("If you're using a F3 or F4 flight controller, please upgrade your bootloader. F1 does not support export configuration in the main loader."));
+        msgBox.setInformativeText(tr("Please upgrade your bootloader."));
         msgBox.setStandardButtons(QMessageBox::Ok);
         msgBox.setDefaultButton(QMessageBox::Ok);
 


### PR DESCRIPTION
Follow-up #1608. Should reduce confusion on modules tab. PipX is the only remaining F1 target, and this stuff doesn't apply to it.

I left F1 related stuff in TL-DFU as it explains why some things are the way they are.