### PR TITLE
pios_rcvr: handle very early updates OK

### DIFF
--- a/flight/PiOS/Common/pios_rcvr.c
+++ b/flight/PiOS/Common/pios_rcvr.c
@@ -117,8 +117,10 @@ bool PIOS_RCVR_WaitActivity(uint32_t timeout_ms) {
 
 void PIOS_RCVR_Active() {
   if (PIOS_DELAY_DiffuS(rcvr_last_wake) >= MIN_WAKE_INTERVAL_uS) {
-    rcvr_last_wake = PIOS_DELAY_GetRaw();
-    PIOS_Semaphore_Give(rcvr_activity);
+    if (rcvr_activity) {
+      rcvr_last_wake = PIOS_DELAY_GetRaw();
+      PIOS_Semaphore_Give(rcvr_activity);
+    }
   }
 }
 
@@ -126,8 +128,10 @@ void PIOS_RCVR_ActiveFromISR() {
   if (PIOS_DELAY_DiffuS(rcvr_last_wake) >= MIN_WAKE_INTERVAL_uS) {
     bool dont_care;
 
-    rcvr_last_wake = PIOS_DELAY_GetRaw();
-    PIOS_Semaphore_Give_FromISR(rcvr_activity, &dont_care);
+    if (rcvr_activity) {
+      rcvr_last_wake = PIOS_DELAY_GetRaw();
+      PIOS_Semaphore_Give_FromISR(rcvr_activity, &dont_care);
+    }
   }
 }
 


### PR DESCRIPTION
RX protocol inits before first PIOS_RCVR_Init, which in turn can cause
hangs/badness.  Possible this is what @ufodziner was experiencing, but
unlikely.  But in any event this is good to fix.