### PR TITLE
androidgcs: changes to number parsing

### DIFF
--- a/androidgcs/src/org/dronin/androidgcs/util/ObjectFieldMappable.java
+++ b/androidgcs/src/org/dronin/androidgcs/util/ObjectFieldMappable.java
@@ -25,6 +25,7 @@ package org.dronin.androidgcs.util;
 
 public interface ObjectFieldMappable {
 	public double getValue();
-	public void setValue(double val);
+	public void setValue(Number val);
 	public void setOnChangedListener(Runnable run);
+	public void setValue(String val);
 }

--- a/androidgcs/src/org/dronin/androidgcs/views/EnumFieldView.java
+++ b/androidgcs/src/org/dronin/androidgcs/views/EnumFieldView.java
@@ -23,6 +23,7 @@ package org.dronin.androidgcs.views;
  */
 
 import java.util.List;
+import java.text.NumberFormat;
 
 import org.dronin.androidgcs.util.ObjectFieldMappable;
 import org.dronin.uavtalk.UAVObjectField;
@@ -110,12 +111,21 @@ public class EnumFieldView extends LinearLayout implements ObjectFieldMappable {
 	}
 
 	@Override
-	public void setValue(double val) {
+	public void setValue(Number val) {
 		localUpdate = true;
 		Log.d(TAG, "Value set to: " + val);
-		value = val;
-		spin.setSelection((int) val);
+		value = val.doubleValue();
+		spin.setSelection(val.intValue());
 		localUpdate = false;
+	}
+
+	@Override
+	public void setValue(String val) {
+		try {
+			setValue(NumberFormat.getInstance().parse(val));
+		} catch (Exception e) {
+			setValue(0);
+		}
 	}
 
 	@Override

--- a/androidgcs/src/org/dronin/androidgcs/views/NumericalFieldView.java
+++ b/androidgcs/src/org/dronin/androidgcs/views/NumericalFieldView.java
@@ -23,6 +23,7 @@ package org.dronin.androidgcs.views;
  */
 
 import java.util.List;
+import java.text.NumberFormat;
 
 import org.dronin.androidgcs.util.ObjectFieldMappable;
 import org.dronin.uavtalk.UAVObjectField;
@@ -67,15 +68,17 @@ public class NumericalFieldView extends LinearLayout implements ObjectFieldMappa
 
 			@Override
 			public void afterTextChanged(Editable s) {
-				try {
-					value = Double.parseDouble(s.toString());
-				} catch (NumberFormatException e) {
-					// This is a numerical field so this only happens when they
-					// backspace through all the characters
-					value = 0;
+				if (localUpdate == false) {
+					try {
+						value = NumberFormat.getInstance().parse(s.toString()).doubleValue();
+					} catch (Exception e) {
+						// This is a numerical field so this only happens when they
+						// backspace through all the characters
+						setValue(0);
+					}
+					if (changeListener != null)
+						changeListener.run();
 				}
-				if (changeListener != null && localUpdate == false)
-					changeListener.run();
 			}
 
 			@Override
@@ -120,11 +123,20 @@ public class NumericalFieldView extends LinearLayout implements ObjectFieldMappa
 	}
 
 	@Override
-	public void setValue(double val) {
+	public void setValue(Number val) {
 		localUpdate = true;
-		value = val;
+		value = val.doubleValue();
 		edit.setText(Double.toString(value));
 		localUpdate = false;
+	}
+
+	@Override
+	public void setValue(String val) {
+		try {
+			setValue(NumberFormat.getInstance().parse(val));
+		} catch (Exception e) {
+			setValue(0);
+		}
 	}
 
 	@Override

--- a/androidgcs/src/org/dronin/androidgcs/views/ObjectEditView.java
+++ b/androidgcs/src/org/dronin/androidgcs/views/ObjectEditView.java
@@ -82,7 +82,7 @@ public class ObjectEditView extends LinearLayout {
 		{
 		case FLOAT32:
 			fieldValue = new NumericalFieldView(context, null, field, idx);
-			((NumericalFieldView)fieldValue).setValue(Double.parseDouble(field.getValue(idx).toString()));
+			((NumericalFieldView)fieldValue).setValue(field.getValue(idx).toString());
 			((NumericalFieldView)fieldValue).setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL);
 			if (smartSave != null)
 				smartSave.addControlMapping((NumericalFieldView)fieldValue, field.getName(), idx);
@@ -91,7 +91,7 @@ public class ObjectEditView extends LinearLayout {
 		case INT16:
 		case INT32:
 			fieldValue = new NumericalFieldView(context, null, field, idx);
-			((NumericalFieldView)fieldValue).setValue(Double.parseDouble(field.getValue(idx).toString()));
+			((NumericalFieldView)fieldValue).setValue(field.getValue(idx).toString());
 			((NumericalFieldView)fieldValue).setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED);
 			if (smartSave != null)
 				smartSave.addControlMapping((NumericalFieldView)fieldValue, field.getName(), idx);
@@ -100,7 +100,7 @@ public class ObjectEditView extends LinearLayout {
 		case UINT16:
 		case UINT32:
 			fieldValue = new NumericalFieldView(context, null, field, idx);
-			((NumericalFieldView)fieldValue).setValue(Double.parseDouble(field.getValue(idx).toString()));
+			((NumericalFieldView)fieldValue).setValue(field.getValue(idx).toString());
 			((NumericalFieldView)fieldValue).setInputType(InputType.TYPE_CLASS_NUMBER);
 			if (smartSave != null)
 				smartSave.addControlMapping((NumericalFieldView)fieldValue, field.getName(), idx);

--- a/androidgcs/src/org/dronin/androidgcs/views/ScrollBarView.java
+++ b/androidgcs/src/org/dronin/androidgcs/views/ScrollBarView.java
@@ -25,6 +25,8 @@ package org.dronin.androidgcs.views;
 import org.dronin.androidgcs.R;
 import org.dronin.androidgcs.util.ObjectFieldMappable;
 
+import java.text.NumberFormat;
+
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.text.Editable;
@@ -98,7 +100,12 @@ public class ScrollBarView extends GridLayout implements ObjectFieldMappable {
 
 			@Override
 			public void afterTextChanged(Editable s) {
-				value = Float.parseFloat(s.toString());
+				try {
+				value = NumberFormat.getInstance().parse(s.toString()).doubleValue();
+				} catch (Exception e) {
+					setValue(0);
+				}
+
 				bar.setProgress((int) (SCALE * value));
 				if (changeListener != null && localUpdate == false)
 					changeListener.run();
@@ -147,12 +154,21 @@ public class ScrollBarView extends GridLayout implements ObjectFieldMappable {
 	}
 
 	@Override
-	public void setValue(double val) {
+	public void setValue(Number val) {
 		localUpdate = true;
-		value = val;
+		value = val.doubleValue();
 		edit.setText(String.format("%.7f", value));
 		bar.setProgress((int) (SCALE * value));
 		localUpdate = false;
+	}
+
+	@Override
+	public void setValue(String val) {
+		try {
+			setValue(NumberFormat.getInstance().parse(val));
+		} catch (Exception e) {
+			setValue(0);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Don't crash when a letter shows up, do locale-specific parsing, blah
blah.  The way this is written is still **not good**.  But this is
minimal fix.

Fixes #1631

Would be **much** cleaner with Java 8 features like default methods in interfaces.