### PR TITLE
GCS:IPConnection: Allow configuring multiple hosts

### DIFF
--- a/ground/gcs/src/plugins/ipconnection/ipconnectionconfiguration.h
+++ b/ground/gcs/src/plugins/ipconnection/ipconnectionconfiguration.h
@@ -28,46 +28,49 @@
 #define IPconnectionCONFIGURATION_H
 
 #include <coreplugin/iuavgadgetconfiguration.h>
-#include <QtCore/QString>
-#include <QtCore/QSettings>
+#include <QString>
+#include <QSettings>
+#include <QVector>
+#include <QMetaType>
 
 using namespace Core;
 
-class IPconnectionConfiguration : public IUAVGadgetConfiguration
+class IPConnectionConfiguration : public IUAVGadgetConfiguration
 {
 Q_OBJECT
-Q_PROPERTY(QString HostName READ HostName WRITE setHostName)
-Q_PROPERTY(int Port READ Port WRITE setPort)
-Q_PROPERTY(int UseTCP READ UseTCP WRITE setUseTCP)
 
 public:
-    explicit IPconnectionConfiguration(QString classId, QSettings* qSettings = 0, QObject *parent = 0);
+    explicit IPConnectionConfiguration(QString classId, QSettings* qSettings = 0, QObject *parent = 0);
 
-    virtual ~IPconnectionConfiguration();
-    void saveConfig(QSettings* settings) const;
-    //void savesettings(QSettings* settings) const;
-    //void restoresettings(QSettings* settings);
-    void savesettings() const;
-    void restoresettings();
-     IUAVGadgetConfiguration *clone();
+    virtual ~IPConnectionConfiguration();
+    void saveConfig() const;
+    void readConfig();
+    IUAVGadgetConfiguration *clone();
 
-    QString HostName() const { return m_HostName; }
-    int Port() const { return m_Port; }
-    int UseTCP() const { return m_UseTCP; }
+    enum Protocol {
+        ProtocolTcp,
+        ProtocolUdp,
+    };
 
+    struct Host {
+        Protocol protocol = ProtocolTcp;
+        QString hostname = "localhost";
+        int port = 9000;
 
-public slots:
-    void setHostName(QString HostName) { m_HostName = HostName; }
-    void setPort(int Port) { m_Port = Port; }
-    void setUseTCP(int UseTCP) { m_UseTCP = UseTCP; }
+        inline bool operator==(const Host& rhs) const {
+            return protocol == rhs.protocol
+                    && port == rhs.port
+                    && hostname == rhs.hostname;
+        }
+    };
+
+    QVector<Host> &hosts() { return m_hosts; }
+    void setHosts(QVector<Host> &hosts) { m_hosts = hosts; }
 
 private:
-    QString m_HostName;
-    int m_Port;
-    int m_UseTCP;
-    QSettings* settings;
-
-
+    QVector<Host> m_hosts;
 };
+
+Q_DECLARE_METATYPE(IPConnectionConfiguration::Protocol)
 
 #endif // IPconnectionCONFIGURATION_H

--- a/ground/gcs/src/plugins/ipconnection/ipconnectionoptionspage.cpp
+++ b/ground/gcs/src/plugins/ipconnection/ipconnectionoptionspage.cpp
@@ -3,6 +3,7 @@
  *
  * @file       IPconnectionoptionspage.cpp
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2017
  * @addtogroup GCSPlugins GCS Plugins
  * @{
  * @addtogroup IPConnPlugin IP Telemetry Plugin
@@ -26,56 +27,298 @@
 
 #include "ipconnectionoptionspage.h"
 #include "ipconnectionconfiguration.h"
-#include <QLabel>
 #include <QComboBox>
+#include <QLineEdit>
 #include <QSpinBox>
-#include <QDoubleSpinBox>
-#include <QRadioButton>
-#include <QHBoxLayout>
-#include <QVBoxLayout>
 
 #include "ui_ipconnectionoptionspage.h"
 
 
-IPconnectionOptionsPage::IPconnectionOptionsPage(IPconnectionConfiguration *config, QObject *parent) :
+IPConnectionOptionsPage::IPConnectionOptionsPage(IPConnectionConfiguration *config, QObject *parent) :
     IOptionsPage(parent),
     m_config(config)
 {
-
 }
-IPconnectionOptionsPage::~IPconnectionOptionsPage()
+
+IPConnectionOptionsPage::~IPConnectionOptionsPage()
 {
 }
-QWidget *IPconnectionOptionsPage::createPage(QWidget *parent)
+
+QWidget *IPConnectionOptionsPage::createPage(QWidget *parent)
 {
 
     m_page = new Ui::IPconnectionOptionsPage();
     QWidget *w = new QWidget(parent);
     m_page->setupUi(w);
 
-    m_page->Port->setValue(m_config->Port());
-    m_page->HostName->setText(m_config->HostName());
-    m_page->UseTCP->setChecked(m_config->UseTCP()?true:false);
-    m_page->UseUDP->setChecked(m_config->UseTCP()?false:true);
+    m_model = new IPConnectionOptionsModel(this);
+
+    for (const auto &host : m_config->hosts()) {
+        m_model->insertRow(m_model->rowCount());
+        int row = m_model->rowCount() - 1;
+        m_model->setData(m_model->index(row, ColumnProtocol), QVariant::fromValue(host.protocol));
+        m_model->setData(m_model->index(row, ColumnHostname), host.hostname);
+        m_model->setData(m_model->index(row, ColumnPort), host.port);
+    }
+
+    // make the columns take up full width
+    m_page->tblHosts->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    m_page->tblHosts->setItemDelegate(new IPConnectionOptionsDelegate(m_page->tblHosts));
+    m_page->tblHosts->setModel(m_model);
+
+    connect(m_page->btnAdd, &QPushButton::clicked, this, [this]() {
+        m_model->insertRow(m_model->rowCount());
+    });
+
+    connect(m_page->btnRemove, &QPushButton::clicked, this, [this]() {
+        const auto selection = m_page->tblHosts->selectionModel()->selectedIndexes();
+        if (selection.count() && selection.at(0).isValid())
+            m_page->tblHosts->model()->removeRow(selection.at(0).row());
+    });
 
     return w;
 }
 
-void IPconnectionOptionsPage::apply()
+void IPConnectionOptionsPage::apply()
 {
-    m_config->setPort(m_page->Port->value());
-    m_config->setHostName(m_page->HostName->text());
-    m_config->setUseTCP(m_page->UseTCP->isChecked()?1:0);
-    m_config->savesettings();
-
+    // discard invalid rows
+    for (int row = 0; row < m_model->rowCount();) {
+        auto hostname = m_model->data(m_model->index(row, ColumnHostname)).toString();
+        auto port = m_model->data(m_model->index(row, ColumnPort)).toInt();
+        if (!hostname.length() || port < 1 || port > 65535)
+            m_model->removeRow(row);
+        else
+            row++;
+    }
+    m_config->setHosts(m_model->hosts());
+    m_config->saveConfig();
     emit availableDevChanged();
-
-
-
 }
 
-void IPconnectionOptionsPage::finish()
+void IPConnectionOptionsPage::finish()
 {
     delete m_page;
 }
 
+
+QWidget *IPConnectionOptionsDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option,
+                                                   const QModelIndex &index) const
+{
+    Q_UNUSED(option)
+
+    switch (index.column()) {
+    case IPConnectionOptionsPage::ColumnProtocol:
+    {
+        auto editor = new QComboBox(parent);
+        editor->addItem("TCP", IPConnectionConfiguration::ProtocolTcp);
+        editor->addItem("UDP", IPConnectionConfiguration::ProtocolUdp);
+        editor->setFrame(false);
+        return editor;
+    }
+    case IPConnectionOptionsPage::ColumnHostname:
+    {
+        auto editor = new QLineEdit(parent);
+        editor->setFrame(false);
+        return editor;
+    }
+    case IPConnectionOptionsPage::ColumnPort:
+    {
+        auto editor = new QSpinBox(parent);
+        editor->setMinimum(1);
+        editor->setMaximum(65535);
+        editor->setFrame(false);
+        return editor;
+    }
+    default:
+        Q_ASSERT(false);
+    }
+    return nullptr;
+}
+
+void IPConnectionOptionsDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
+{
+    QVariant val = index.model()->data(index, Qt::EditRole);
+
+    switch (index.column()) {
+    case IPConnectionOptionsPage::ColumnProtocol:
+    {
+        auto comboBox = static_cast<QComboBox *>(editor);
+        for (int i = 0; i < comboBox->count(); i++) {
+            if (comboBox->itemData(i) == val.value<IPConnectionConfiguration::Protocol>())
+                comboBox->setCurrentIndex(i);
+        }
+        break;
+    }
+    case IPConnectionOptionsPage::ColumnHostname:
+    {
+        auto lineEdit = static_cast<QLineEdit *>(editor);
+        lineEdit->setText(val.toString());
+        break;
+    }
+    case IPConnectionOptionsPage::ColumnPort:
+    {
+        auto spinBox = static_cast<QSpinBox *>(editor);
+        spinBox->setValue(val.toInt());
+        break;
+    }
+    default:
+        Q_ASSERT(false);
+    }
+}
+
+void IPConnectionOptionsDelegate::setModelData(QWidget *editor, QAbstractItemModel *model,
+                                               const QModelIndex &index) const
+{
+    QVariant val;
+
+    switch (index.column()) {
+    case IPConnectionOptionsPage::ColumnProtocol:
+    {
+        auto comboBox = static_cast<QComboBox *>(editor);
+        val.setValue(QVariant::fromValue(comboBox->currentData()));
+        break;
+    }
+    case IPConnectionOptionsPage::ColumnHostname:
+    {
+        auto lineEdit = static_cast<QLineEdit *>(editor);
+        val.setValue(lineEdit->text());
+        break;
+    }
+    case IPConnectionOptionsPage::ColumnPort:
+    {
+        auto spinBox = static_cast<QSpinBox *>(editor);
+        spinBox->interpretText();
+        val.setValue(spinBox->value());
+        break;
+    }
+    default:
+        Q_ASSERT(false);
+        return;
+    }
+
+    model->setData(index, val, Qt::EditRole);
+}
+
+void IPConnectionOptionsDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option,
+                                                       const QModelIndex &index) const
+{
+    Q_UNUSED(index)
+    editor->setGeometry(option.rect);
+}
+
+int IPConnectionOptionsModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return m_hosts.count();
+}
+
+int IPConnectionOptionsModel::columnCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return IPConnectionOptionsPage::ColumnCount;
+}
+
+QVariant IPConnectionOptionsModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() >= m_hosts.count())
+        return QVariant();
+
+    const IPConnectionConfiguration::Host host = m_hosts.at(index.row());
+
+    if (index.column() == IPConnectionOptionsPage::ColumnProtocol && role == Qt::DisplayRole)
+        return host.protocol == IPConnectionConfiguration::ProtocolTcp ? "TCP" : "UDP";
+
+    if (role == Qt::DisplayRole || role == Qt::EditRole) {
+        switch (index.column()) {
+        case IPConnectionOptionsPage::ColumnProtocol:
+            return QVariant::fromValue(host.protocol);
+        case IPConnectionOptionsPage::ColumnHostname:
+            return host.hostname;
+        case IPConnectionOptionsPage::ColumnPort:
+            return host.port;
+        default:
+            Q_ASSERT(false);
+        }
+    }
+
+    return QVariant();
+}
+
+QVariant IPConnectionOptionsModel::headerData(int section, Qt::Orientation orientation,
+                                              int role) const
+{
+    if (role != Qt::DisplayRole)
+        return QVariant();
+
+    if (orientation == Qt::Horizontal) {
+        switch (section) {
+        case IPConnectionOptionsPage::ColumnProtocol:
+            return tr("Protocol");
+        case IPConnectionOptionsPage::ColumnHostname:
+            return tr("IP/Hostname");
+        case IPConnectionOptionsPage::ColumnPort:
+            return tr("Port");
+        default:
+            return QVariant();
+        }
+    }
+    return QString::number(section + 1);
+}
+
+Qt::ItemFlags IPConnectionOptionsModel::flags(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return Qt::ItemIsEnabled;
+    return QAbstractTableModel::flags(index) | Qt::ItemIsEditable;
+}
+
+bool IPConnectionOptionsModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    if (index.isValid() && role == Qt::EditRole) {
+        auto &host = m_hosts[index.row()];
+        switch (index.column()) {
+        case IPConnectionOptionsPage::ColumnProtocol:
+            host.protocol = value.value<IPConnectionConfiguration::Protocol>();
+            break;
+        case IPConnectionOptionsPage::ColumnHostname:
+            host.hostname = value.toString();
+            break;
+        case IPConnectionOptionsPage::ColumnPort:
+            host.port = value.toInt();
+            break;
+        default:
+            return false;
+        }
+        emit dataChanged(index, index);
+        return true;
+    }
+    return false;
+}
+
+bool IPConnectionOptionsModel::insertRows(int position, int rows, const QModelIndex &index)
+{
+    Q_UNUSED(index)
+
+    beginInsertRows(QModelIndex(), position, position + rows - 1);
+
+    for (int row = 0; row < rows; row++)
+        m_hosts.insert(position, IPConnectionConfiguration::Host());
+
+    endInsertRows();
+    return true;
+}
+
+bool IPConnectionOptionsModel::removeRows(int position, int rows, const QModelIndex &index)
+{
+    Q_UNUSED(index)
+
+    beginRemoveRows(QModelIndex(), position, position + rows - 1);
+
+    for (int row = 0; row < rows; row++)
+        m_hosts.removeAt(position);
+
+    endRemoveRows();
+    return true;
+}

--- a/ground/gcs/src/plugins/ipconnection/ipconnectionoptionspage.ui
+++ b/ground/gcs/src/plugins/ipconnection/ipconnectionoptionspage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>429</width>
-    <height>291</height>
+    <width>517</width>
+    <height>555</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -42,12 +42,21 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>390</width>
-        <height>154</height>
+        <width>493</width>
+        <height>555</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item row="0" column="0">
@@ -57,58 +66,21 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
           <item row="0" column="0">
-           <widget class="QLabel" name="label_2">
+           <widget class="QPushButton" name="btnAdd">
             <property name="text">
-             <string>Host Name/Number</string>
+             <string>Add</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="HostName"/>
-          </item>
-          <item row="0" column="2">
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="1" column="1">
-           <widget class="QRadioButton" name="UseTCP">
+           <widget class="QPushButton" name="btnRemove">
             <property name="text">
-             <string>TCP connection</string>
+             <string>Remove</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QRadioButton" name="UseUDP">
-            <property name="text">
-             <string>UDP connection</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Port</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QSpinBox" name="Port">
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>999999</number>
-            </property>
-           </widget>
+          <item row="1" column="0" colspan="2">
+           <widget class="QTableView" name="tblHosts"/>
           </item>
          </layout>
         </widget>
@@ -116,19 +88,6 @@
       </layout>
      </widget>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/ground/gcs/src/plugins/ipconnection/ipconnectionplugin.h
+++ b/ground/gcs/src/plugins/ipconnection/ipconnectionplugin.h
@@ -66,10 +66,7 @@ public:
     virtual QString connectionName();
     virtual QString shortName();
 
-    IPconnectionConfiguration * Config() const { return m_config; }
-    IPconnectionOptionsPage * Optionspage() const { return m_optionspage; }
-
-
+    IPConnectionOptionsPage *optionsPage() const { return m_optionspage; }
 
 protected slots:
     void onEnumerationChanged();
@@ -77,21 +74,21 @@ protected slots:
 private:
     void openDevice(QString HostName, int Port, bool UseTCP);
     QAbstractSocket *ipSocket;
-    IPconnectionConfiguration *m_config;
-    IPconnectionOptionsPage *m_optionspage;
-    IPDevice dev;
+    IPConnectionConfiguration *m_config;
+    IPConnectionOptionsPage *m_optionspage;
+    QList<Core::IDevice *> devices;
     QString errorMsg;
 };
 
 
-class IPconnection_EXPORT IPconnectionPlugin
+class IPconnection_EXPORT IPConnectionPlugin
     : public ExtensionSystem::IPlugin
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "org.dronin.plugins.IPconnection")
+    Q_PLUGIN_METADATA(IID "org.dronin.plugins.IPConnection")
 public:
-    IPconnectionPlugin();
-    ~IPconnectionPlugin();
+    IPConnectionPlugin();
+    ~IPConnectionPlugin();
 
     virtual bool initialize(const QStringList &arguments, QString *error_message);
     virtual void extensionsInitialized();

--- a/ground/gcs/src/plugins/ipconnection/ipdevice.h
+++ b/ground/gcs/src/plugins/ipconnection/ipdevice.h
@@ -27,6 +27,7 @@
 #define IPDEVICE_H
 
 #include <coreplugin/idevice.h>
+#include "ipconnectionconfiguration.h"
 
 
 /**
@@ -36,8 +37,16 @@
 
 class IPDevice : public Core::IDevice
 {
+Q_OBJECT
+
 public:
     IPDevice();
+
+    IPConnectionConfiguration::Host host() const { return m_host; }
+    void setHost(IPConnectionConfiguration::Host host) { m_host = host; }
+
+private:
+    IPConnectionConfiguration::Host m_host;
 };
 
 #endif // IPDEVICE_H


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/9995998/24321718/85ed2302-11b8-11e7-89e2-c8c4f382fc48.png)

@glowtape done :wink:

~~~Note: I'm not 100% sure the settings actually save properly or not because (at least on my dev branch?) GCS doesn't save __any__ settings! I can't think how this would have regressed... will try a release build from this PR.~~~

Also note: The default configuration is now 1 device, `tcp://localhost:9000`, which also happens to be the default for the POSIX simulator :grin: .