### PR TITLE
GCS:Wizard: Correct connection dropdown and button state

### DIFF
--- a/ground/gcs/src/plugins/coreplugin/connectionmanager.cpp
+++ b/ground/gcs/src/plugins/coreplugin/connectionmanager.cpp
@@ -157,7 +157,7 @@ bool ConnectionManager::connectDevice(DevListItem device)
     connect(m_connectionDevice.connection, SIGNAL(destroyed(QObject *)), this, SLOT(onConnectionDestroyed(QObject *)), Qt::QueuedConnection);
 
     // signal interested plugins that we connected to the device
-    emit deviceConnected(io_dev);
+    emit connectionStatusChanged(true);
     m_connectBtn->setText("Disconnect");
     m_availableDevList->setEnabled(false);
 
@@ -191,9 +191,6 @@ bool ConnectionManager::disconnectDevice()
     if(reconnectCheck->isActive())
         reconnectCheck->stop();
 
-    // signal interested plugins that user is disconnecting his device
-    emit deviceAboutToDisconnect();
-
     try {
         if (m_connectionDevice.connection) {
             m_connectionDevice.connection->closeDevice(m_connectionDevice.getConName());
@@ -205,7 +202,7 @@ bool ConnectionManager::disconnectDevice()
     m_connectionDevice.connection = NULL;
     m_ioDev = NULL;
 
-    emit deviceDisconnected();
+    emit connectionStatusChanged(false);
     m_connectBtn->setText("Connect");
     m_availableDevList->setEnabled(true);
 

--- a/ground/gcs/src/plugins/coreplugin/connectionmanager.h
+++ b/ground/gcs/src/plugins/coreplugin/connectionmanager.h
@@ -71,7 +71,7 @@ public:
 
     DevListItem() : connection(NULL) { }
 
-    QString getConName() {
+    QString getConName() const {
         if (connection == NULL || device.isNull())
             return "";
         return connection->shortName() + ": " + device->getDisplayName();
@@ -116,10 +116,8 @@ protected:
     void updateConnectionDropdown();
 
 signals:
-    void deviceConnected(QIODevice *device);
-    void deviceAboutToDisconnect();
-    void deviceDisconnected();
     void availableDevicesChanged(const QLinkedList<Core::DevListItem> devices);
+    void connectionStatusChanged(bool connected);
 
 public slots:
     void telemetryConnected();

--- a/ground/gcs/src/plugins/coreplugin/iconnection.h
+++ b/ground/gcs/src/plugins/coreplugin/iconnection.h
@@ -63,12 +63,12 @@ public:
     /**
     *   Connection type name "USB HID"
     */
-    virtual QString connectionName() = 0;
+    virtual QString connectionName() const = 0;
 
     /**
     *   Short name to display in a combo box
     */
-    virtual QString shortName() {return connectionName();}
+    virtual QString shortName() const {return connectionName();}
 
     /**
      * Manage whether the plugin is allowed to poll for devices

--- a/ground/gcs/src/plugins/ipconnection/ipconnectionplugin.cpp
+++ b/ground/gcs/src/plugins/ipconnection/ipconnectionplugin.cpp
@@ -173,12 +173,12 @@ void IPConnection::closeDevice(const QString &)
 }
 
 
-QString IPConnection::connectionName()
+QString IPConnection::connectionName() const
 {
     return QString("Network telemetry port");
 }
 
-QString IPConnection::shortName()
+QString IPConnection::shortName() const
 {
     return tr("IP");
 }

--- a/ground/gcs/src/plugins/ipconnection/ipconnectionplugin.h
+++ b/ground/gcs/src/plugins/ipconnection/ipconnectionplugin.h
@@ -63,8 +63,8 @@ public:
     virtual QIODevice *openDevice(Core::IDevice *deviceName);
     virtual void closeDevice(const QString &deviceName);
 
-    virtual QString connectionName();
-    virtual QString shortName();
+    virtual QString connectionName() const;
+    virtual QString shortName() const;
 
     IPConnectionOptionsPage *optionsPage() const { return m_optionspage; }
 

--- a/ground/gcs/src/plugins/logging/loggingplugin.cpp
+++ b/ground/gcs/src/plugins/logging/loggingplugin.cpp
@@ -109,12 +109,12 @@ void LoggingConnection::closeDevice(const QString &deviceName)
 }
 
 
-QString LoggingConnection::connectionName()
+QString LoggingConnection::connectionName() const
 {
     return QString("Logfile replay");
 }
 
-QString LoggingConnection::shortName()
+QString LoggingConnection::shortName() const
 {
     return QString("Logfile");
 }

--- a/ground/gcs/src/plugins/logging/loggingplugin.h
+++ b/ground/gcs/src/plugins/logging/loggingplugin.h
@@ -61,8 +61,8 @@ public:
     virtual QIODevice *openDevice(Core::IDevice* deviceName);
     virtual void closeDevice(const QString &deviceName);
 
-    virtual QString connectionName();
-    virtual QString shortName();
+    virtual QString connectionName() const;
+    virtual QString shortName() const;
 
     bool deviceOpened() {return m_deviceOpened;}
     LogFile* getLogfile() { return &logFile;}

--- a/ground/gcs/src/plugins/rawhid/rawhidplugin.cpp
+++ b/ground/gcs/src/plugins/rawhid/rawhidplugin.cpp
@@ -133,12 +133,12 @@ void RawHIDConnection::closeDevice(const QString &deviceName)
     }
 }
 
-QString RawHIDConnection::connectionName()
+QString RawHIDConnection::connectionName() const
 {
     return QString("Raw HID USB");
 }
 
-QString RawHIDConnection::shortName()
+QString RawHIDConnection::shortName() const
 {
     return QString("USB");
 }

--- a/ground/gcs/src/plugins/rawhid/rawhidplugin.h
+++ b/ground/gcs/src/plugins/rawhid/rawhidplugin.h
@@ -60,8 +60,8 @@ public:
     virtual QIODevice *openDevice(Core::IDevice *deviceName);
     virtual void closeDevice(const QString &deviceName);
 
-    virtual QString connectionName();
-    virtual QString shortName();
+    virtual QString connectionName() const;
+    virtual QString shortName() const;
     virtual void suspendPolling();
     virtual void resumePolling();
 

--- a/ground/gcs/src/plugins/serialconnection/serialplugin.cpp
+++ b/ground/gcs/src/plugins/serialconnection/serialplugin.cpp
@@ -169,12 +169,12 @@ void SerialConnection::closeDevice(const QString &deviceName)
 }
 
 
-QString SerialConnection::connectionName()
+QString SerialConnection::connectionName() const
 {
     return QString("Serial port");
 }
 
-QString SerialConnection::shortName()
+QString SerialConnection::shortName() const
 {
     return QString("Serial");
 }

--- a/ground/gcs/src/plugins/serialconnection/serialplugin.h
+++ b/ground/gcs/src/plugins/serialconnection/serialplugin.h
@@ -57,8 +57,8 @@ public:
     virtual QIODevice *openDevice(Core::IDevice *deviceName);
     virtual void closeDevice(const QString &deviceName);
 
-    virtual QString connectionName();
-    virtual QString shortName();
+    virtual QString connectionName() const;
+    virtual QString shortName() const;
     virtual void suspendPolling();
     virtual void resumePolling();
     virtual bool reconnect() { return m_config->reconnect(); }

--- a/ground/gcs/src/plugins/setupwizard/pages/controllerpage.h
+++ b/ground/gcs/src/plugins/setupwizard/pages/controllerpage.h
@@ -60,7 +60,7 @@ private:
 
 private slots:
     void devicesChanged(QLinkedList<Core::DevListItem> devices);
-    void connectionStatusChanged();
+    void connectionStatusChanged(bool connected);
     void connectDisconnect();
 };
 


### PR DESCRIPTION
Before auto-connected devices would leave the connect button in the wrong state, wrong device would be selected etc.

Also don't show devices that can't be setup through wizard (because that would require a bunch more pointless code to decide if the connect button should be enabled depending on selected device). Before they were shown disabled in the list using __undocumented API__, but they could still be selected (probably why the API is undocumented, because it's incomplete/unintended) due to no valid devices being available.

Made some APIs a bit nicer in the process.