### PR TITLE
aq32/sparky: include JEDEC flash

### DIFF
--- a/flight/targets/aq32/fw/pios_config.h
+++ b/flight/targets/aq32/fw/pios_config.h
@@ -32,6 +32,7 @@
 #include <pios_flight_config.h>
 
 /* Major features */
+#define PIOS_INCLUDE_FLASH_JEDEC
 
 /* Enable/Disable PiOS Modules */
 #define PIOS_INCLUDE_I2C

--- a/flight/targets/sparky2/fw/pios_config.h
+++ b/flight/targets/sparky2/fw/pios_config.h
@@ -33,6 +33,7 @@
 #include <pios_flight_config.h>
 
 /* Major features */
+#define PIOS_INCLUDE_FLASH_JEDEC
 
 /* Enable/Disable PiOS Modules */
 #define PIOS_INCLUDE_I2C


### PR DESCRIPTION
Was omitted by mistake.