### PR TITLE
pios_hal: frsky sport in noninverted, single wire mode

### DIFF
--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -644,6 +644,16 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 #endif /* PIOS_INCLUDE_FRSKY_SENSOR_HUB */
 		break;
 
+	case HWSHARED_PORTTYPES_FRSKYSPORTNONINVERTED:
+#if defined(PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY)
+		usart_port_params.single_wire = true;
+
+		PIOS_HAL_ConfigureCom(usart_port_cfg, &usart_port_params, PIOS_COM_FRSKYSPORT_RX_BUF_LEN, PIOS_COM_FRSKYSPORT_TX_BUF_LEN, com_driver, &port_driver_id);
+		target = &pios_com_frsky_sport_id;
+		PIOS_Modules_Enable(PIOS_MODULE_UAVOFRSKYSPORTBRIDGE);
+#endif /* PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY */
+		break;
+
 	case HWSHARED_PORTTYPES_FRSKYSPORTTELEMETRY:
 #if defined(PIOS_INCLUDE_FRSKY_SPORT_TELEMETRY)
 #if defined(STM32F30X) || defined(STM32F0XX)

--- a/shared/uavobjectdefinition/hwaq32.xml
+++ b/shared/uavobjectdefinition/hwaq32.xml
@@ -16,6 +16,7 @@
 				<option>DebugConsole</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>HoTT Telemetry</option>
 				<option>LighttelemetryTx</option>
 				<option>MavLinkTX</option>
@@ -40,6 +41,7 @@
 				<option>DebugConsole</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -66,6 +68,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -91,6 +94,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>

--- a/shared/uavobjectdefinition/hwbrain.xml
+++ b/shared/uavobjectdefinition/hwbrain.xml
@@ -27,6 +27,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -53,6 +54,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -79,6 +81,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>

--- a/shared/uavobjectdefinition/hwdtfc.xml
+++ b/shared/uavobjectdefinition/hwdtfc.xml
@@ -22,6 +22,7 @@
 				<option>FrSKY Sensor Hub</option>
 				<option>LighttelemetryTx</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>OpenLog</option>
 				<option>HoTT SUMD</option>
 				<option>HoTT SUMH</option>
@@ -47,6 +48,7 @@
 				<option>FrSKY Sensor Hub</option>
 				<option>LighttelemetryTx</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>OpenLog</option>
 				<option>HoTT SUMD</option>
 				<option>HoTT SUMH</option>
@@ -72,6 +74,7 @@
 				<option>FrSKY Sensor Hub</option>
 				<option>LighttelemetryTx</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>OpenLog</option>
 				<option>HoTT SUMD</option>
 				<option>HoTT SUMH</option>

--- a/shared/uavobjectdefinition/hwlux.xml
+++ b/shared/uavobjectdefinition/hwlux.xml
@@ -17,6 +17,7 @@
 				<option>DebugConsole</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>HoTT Telemetry</option>
 				<option>I2C</option>
@@ -39,6 +40,7 @@
 				<option>SRXL</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>HoTT Telemetry</option>
 				<option>I2C</option>
@@ -64,6 +66,7 @@
 				<option>SRXL</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>HoTT Telemetry</option>
 				<option>LighttelemetryTx</option>

--- a/shared/uavobjectdefinition/hwpikoblx.xml
+++ b/shared/uavobjectdefinition/hwpikoblx.xml
@@ -11,6 +11,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>HoTT Telemetry</option>
 				<option>I2C</option>
@@ -38,6 +39,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>HoTT Telemetry</option>
 				<option>LighttelemetryTx</option>

--- a/shared/uavobjectdefinition/hwquanton.xml
+++ b/shared/uavobjectdefinition/hwquanton.xml
@@ -31,6 +31,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -56,6 +57,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -82,6 +84,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -108,6 +111,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -134,6 +138,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -159,6 +164,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>

--- a/shared/uavobjectdefinition/hwrevolution.xml
+++ b/shared/uavobjectdefinition/hwrevolution.xml
@@ -36,6 +36,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -62,6 +63,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -88,6 +90,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>

--- a/shared/uavobjectdefinition/hwseppuku.xml
+++ b/shared/uavobjectdefinition/hwseppuku.xml
@@ -25,6 +25,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -51,6 +52,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -77,6 +79,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -110,6 +113,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>

--- a/shared/uavobjectdefinition/hwshared.xml
+++ b/shared/uavobjectdefinition/hwshared.xml
@@ -23,6 +23,7 @@
 				<option>HoTT Telemetry</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>LighttelemetryTx</option>
 				<option>OpenLog</option>
 				<option>Storm32Bgc</option>

--- a/shared/uavobjectdefinition/hwsparky.xml
+++ b/shared/uavobjectdefinition/hwsparky.xml
@@ -25,6 +25,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>HoTT Telemetry</option>
 				<option>I2C</option>
@@ -50,6 +51,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>HoTT Telemetry</option>
 				<option>LighttelemetryTx</option>

--- a/shared/uavobjectdefinition/hwsparky2.xml
+++ b/shared/uavobjectdefinition/hwsparky2.xml
@@ -26,6 +26,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>SRXL</option>
 				<option>HoTT SUMD</option>
@@ -51,6 +52,7 @@
 				<option>DSM</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
+				<option>FrSKY SPort Non Inverted</option>
 				<option>GPS</option>
 				<option>I2C</option>
 				<option>SRXL</option>


### PR DESCRIPTION
re: discussion in https://forum.dronin.org/forum/d/214-frsky-s-port-in-revo-hardware-tab/6

Needs verification.  Have only confirmed that this compiles-- no more.