### PR TITLE
linux: put simulator (both x86 and pi) in packages

### DIFF
--- a/package/Makefile.linux
+++ b/package/Makefile.linux
@@ -63,9 +63,9 @@ gcs:
 
 ground_package_os_specific: ground_package_common usb_id_udev
 	$(V1) cp -v $(BUILD_DIR)/shared/usb_ids/dronin.udev $(PACKAGE_DIR)/rules.udev
-	$(V1) mkdir -p $(PACKAGE_DIR)/sim
-	-$(V1) cp -v $(BUILD_DIR)/sim-pi/sim.elf $(PACKAGE_DIR)/sim/sim-pi.elf
-	$(V1) cp -v $(BUILD_DIR)/sim/sim.elf $(PACKAGE_DIR)/sim/sim.elf
+	$(V1) mkdir -p $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME)/sim
+	-$(V1) cp -v $(BUILD_DIR)/sim-pi/sim.elf $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME)/sim/sim-pi.elf
+	$(V1) cp -v $(BUILD_DIR)/sim/sim.elf $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME)/sim/sim.elf
 	$(V1) cp -v $(ROOT_DIR)/package/linux/assets/exec $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME)/drgcs
 	$(V1) sed -i -e "$(SED_SUBSTITUTE)" $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME)/drgcs
 

--- a/package/Makefile.linux
+++ b/package/Makefile.linux
@@ -63,6 +63,9 @@ gcs:
 
 ground_package_os_specific: ground_package_common usb_id_udev
 	$(V1) cp -v $(BUILD_DIR)/shared/usb_ids/dronin.udev $(PACKAGE_DIR)/rules.udev
+	$(V1) mkdir -p $(PACKAGE_DIR)/sim
+	-$(V1) cp -v $(BUILD_DIR)/sim-pi/sim.elf $(PACKAGE_DIR)/sim/sim-pi.elf
+	$(V1) cp -v $(BUILD_DIR)/sim/sim.elf $(PACKAGE_DIR)/sim/sim.elf
 	$(V1) cp -v $(ROOT_DIR)/package/linux/assets/exec $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME)/drgcs
 	$(V1) sed -i -e "$(SED_SUBSTITUTE)" $(PACKAGE_DIR)/$(GCS_PACKAGE_NAME)/drgcs
 


### PR DESCRIPTION
Requires a jenkins change (already made) to run `PI_CROSS_SIM=yes make -j3 sim` on master.