### PR TITLE
small sim refinements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -606,7 +606,6 @@ sim: uavobjects
 		BOARD_NAME=$(1) \
 		BOARD_SHORT_NAME=$(3) \
 		BUILD_TYPE=fw \
-		TCHAIN_PREFIX="" \
 		REMOVE_CMD="$(RM)" \
 		\
 		ROOT_DIR=$(ROOT_DIR) \

--- a/flight/targets/flyingpio/flyingpi.cfg
+++ b/flight/targets/flyingpio/flyingpi.cfg
@@ -20,7 +20,7 @@ reset_config connect_assert_srst
 init
 reset init
 halt
-flash write_image erase fw_flyingpio.bin 0x08000000
+flash write_image erase fw_flyingpio.hex
 
 reset run
 

--- a/flight/targets/simulation/fw/Makefile
+++ b/flight/targets/simulation/fw/Makefile
@@ -32,7 +32,27 @@
 all: elf
 
 override THUMB :=
+
+ifneq ($(PI_CROSS_SIM)x,x)
+TCHAIN_PREFIX = arm-linux-gnueabihf-
+
+LDFLAGS += -static
+else
+TCHAIN_PREFIX =
+endif
+
 include $(MAKE_INC_DIR)/firmware-defs.mk
+
+ifneq ($(PI_CROSS_SIM)x,x)
+
+ARMGCC:=$(shell command -v arm-linux-gnueabihf-gcc-6 2>/dev/null)
+
+ifneq ($(ARMGCC),)
+CC = $(CCACHE) $(ARMGCC)
+BARECC = $(ARMGCC)
+endif
+
+endif
 
 # Set developer code and compile options
 # Set to YES to compile for debugging
@@ -236,17 +256,6 @@ LDFLAGS += -fprofile-arcs
 
 else
 CFLAGS += -O2 -g3
-endif
-
-ifneq ($(PI_CROSS_SIM)x,x)
-ARMGCC:=$(shell command -v arm-linux-gnueabihf-gcc-6 2>/dev/null)
-
-ifeq ($(ARMGCC),)
-ARMGCC:=arm-linux-gnueabihf-gcc
-endif
-
-CC=$(ARMGCC)
-LDFLAGS += -static
 endif
 
 # common architecture-specific flags from the device-specific library makefile


### PR DESCRIPTION
1. improve / fix the build process to build properly in all cases and to use ccache.
2. adjust the flyingpi.cfg openocd script to use ef_flyingpio.hex instead of fw_flyingpio.bin