### PR TITLE
Stronger filtering, and accounting for this in OG autotune.

### DIFF
--- a/flight/Modules/Autotune/autotune.c
+++ b/flight/Modules/Autotune/autotune.c
@@ -612,7 +612,7 @@ __attribute__((always_inline)) static inline void af_predict(float X[AF_NUMX], f
 	const float q_B = 1e-6f;
 	const float q_tau = 1e-6f;
 	const float q_bias = 1e-19f;
-	const float s_a = 150.0f; // expected gyro measurement noise
+	const float s_a = 50.0f; // expected gyro measurement noise
 
 	const float Q[AF_NUMX] = {q_w, q_w, q_w, q_ud, q_ud, q_ud, q_B, q_B, q_B, q_tau, q_bias, q_bias, q_bias};
 

--- a/shared/uavobjectdefinition/sensorsettings.xml
+++ b/shared/uavobjectdefinition/sensorsettings.xml
@@ -36,10 +36,10 @@
 				<option>TRUE</option>
 			</options>
 		</field>
-		<field name="LowpassCutoff" units="Hz" type="float" elements="1" defaultvalue="55">
+		<field name="LowpassCutoff" units="Hz" type="float" elements="1" defaultvalue="85">
 			<description>Cutoff frequency for the lowpass on both the gyroscopes and accelerometers.</description>
 		</field>
-		<field name="LowpassOrder" units="" type="uint8" elements="1" defaultvalue="1">
+		<field name="LowpassOrder" units="" type="uint8" elements="1" defaultvalue="2">
 			<description>Order of the lowpass filter. Maximum 8, a value of zero bypasses the filter.</description>
 		</field>
 		<access gcs="readwrite" flight="readwrite"/>


### PR DESCRIPTION
This a proposed patch, in case autotune-ng doesn't make it to Neat. I've seen @mlyle ask on IRC whether to focus on it or actuator improvements (didn't these rely on the new data anyway?), so if former is pushed up, this might be worth a consideration.

Before, the gyro input to autotune were raw samples, and therefore the EKF filter did some modicum of filtering to account for that. Now the gyro samples are filtered globally before they go anywhere, so you can in principle turn down the filtering, this is what I did in this patch. It looks like without this reduction, OG autotune overestimates gains and underestimates tau, resulting in some weak PIDs.

The default filtering was also bumped to second order and 85hz cutoff. That should match the group delay in the important frequency range to before.

In the past, my quad in this combination tuned to roughly 16ms on the old code, with these changes it's ~18ms (versus ~22ms without the tweak to autotune.c), altho I've used 80hz cutoff not 85hz. The resulting PIDs are reasonable.

This is still out for proper flying, and I guess testing on other quads, however my backyard antics were successful. Interestingly, my ever present prop oscillations during hangtime seem to have finally completely gone away (--edit: hrm, still show up for my quad blade props, probably this problem on top of it https://www.youtube.com/watch?v=LMeJ7AUCJcY ).

Tune used outside:
http://dronin-autotown.appspot.com/at/tune/ahFzfmRyb25pbi1hdXRvdG93bnIYCxILVHVuZVJlc3VsdHMYgICAkLel_QsM