### PR TITLE
seppuku: increase OSD video levels

### DIFF
--- a/flight/targets/seppuku/board-info/board_hw_defs.c
+++ b/flight/targets/seppuku/board-info/board_hw_defs.c
@@ -1175,13 +1175,13 @@ const struct stm32_gpio video_mask_pin = {
 
 void set_bw_levels(uint8_t black, uint8_t white)
 {
-	uint16_t black_calc = black + 70;
+	uint16_t black_calc = black + 82;
 
 	if (black_calc > 191) {
 		black_calc = 191;
 	}
 
-	uint16_t white_calc = white + 70;
+	uint16_t white_calc = white + 82;
 
 	if (white_calc > 191) {
 		white_calc = 191;


### PR DESCRIPTION
Suggested by @litterbugs--- I think this amount can be done safely
without losing too much authority on the lower end.  I also get black
ghosting at defaults.