### PR TITLE
picoblx: Enable neotune support on picoblx

### DIFF
--- a/flight/targets/pikoblx/fw/pios_config.h
+++ b/flight/targets/pikoblx/fw/pios_config.h
@@ -56,7 +56,8 @@
 
 /* Flags that alter behaviors - mostly to lower resources for CC */
 //#define PIOS_TELEM_PRIORITY_QUEUE       /* Enable a priority queue in telemetry */
-//#define AUTOTUNE_AVERAGING_MODE
+#define AUTOTUNE_AVERAGING_MODE
+#define AUTOTUNE_AVERAGING_DECIMATION 2
 
 /* Alarm Thresholds */
 


### PR DESCRIPTION
As per @mlyle  in irc this should enable picoblx as the "first 500Hz-averaged-autotune target"