### PR TITLE
gcs: Prettify expo widget a little.

### DIFF
--- a/ground/gcs/src/plugins/config/expocurve.cpp
+++ b/ground/gcs/src/plugins/config/expocurve.cpp
@@ -26,17 +26,30 @@
 #include "qwt/src/qwt_painter.h"
 #include "expocurve.h"
 
+#include <QFrame>
+
 ExpoCurve::ExpoCurve(QWidget *parent) :
     QwtPlot(parent)
 {
+    QPalette palette = parent->palette();
+
+    palette.setColor(QPalette::Foreground, palette.color(QPalette::Dark));
+    palette.setColor(QPalette::Background, palette.color(QPalette::Light));
+
     QwtPainter::setPolylineSplitting(false);
     QwtPainter::setRoundingAlignment(false);
     setMouseTracking(true);
 
     setMinimumSize(64, 64);
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
+    setContentsMargins(6, 0, 0, 0);
 
-    //setCanvasBackground(QColor(64, 64, 64));
+    QFrame *f = qobject_cast<QFrame *>(canvas());
+    if (f) {
+        f->setFrameStyle(QFrame::Box | QFrame::Plain);
+        f->setLineWidth(1);
+        f->setPalette(palette);
+    }
 
     //Add grid lines
     QwtPlotGrid *grid = new QwtPlotGrid;
@@ -47,17 +60,17 @@ ExpoCurve::ExpoCurve(QWidget *parent) :
 
 
     roll_elements.Curve.setRenderHint(QwtPlotCurve::RenderAntialiased);
-    roll_elements.Curve.setPen(QPen(QColor(Qt::blue), 1.0, Qt::SolidLine,
+    roll_elements.Curve.setPen(QPen(QColor(41, 128, 185), 1.25, Qt::SolidLine,
                 Qt::FlatCap));
     roll_elements.Curve.attach(this);
 
     pitch_elements.Curve.setRenderHint(QwtPlotCurve::RenderAntialiased);
-    pitch_elements.Curve.setPen(QPen(QColor(Qt::red), 1.0, Qt::SolidLine,
+    pitch_elements.Curve.setPen(QPen(QColor(192, 57, 43), 1.25, Qt::SolidLine,
                 Qt::FlatCap));
     pitch_elements.Curve.attach(this);
 
     yaw_elements.Curve.setRenderHint(QwtPlotCurve::RenderAntialiased);
-    yaw_elements.Curve.setPen(QPen(QColor(Qt::green), 1.0, Qt::SolidLine,
+    yaw_elements.Curve.setPen(QPen(QColor(39, 174, 96), 1.25, Qt::SolidLine,
                 Qt::FlatCap));
     yaw_elements.Curve.attach(this);
 
@@ -108,6 +121,9 @@ ExpoCurve::ExpoCurve(QWidget *parent) :
 
     axis_title.setText(tr("rate (deg/s)"));
     this->setAxisTitle(QwtPlot::yLeft, axis_title);
+
+    this->axisWidget(QwtPlot::xBottom)->setPalette(palette);
+    this->axisWidget(QwtPlot::yLeft)->setPalette(palette);
 
     plotDataRoll(50, 720, 50);
     plotDataPitch(50, 720, 50);


### PR DESCRIPTION
Shuffles colors around a little programmatically in a QPalette, so it should adapt with system colors fine. Uses slightly prettier colors for the curves. Fixes the terrible sunken canvas.

Old vs. new in Windows:

![expo_w_old](https://cloud.githubusercontent.com/assets/4010813/24804688/8e6d4330-1baf-11e7-848f-c716633ef764.png)

![expo_w_new](https://cloud.githubusercontent.com/assets/4010813/24804691/92ada6e2-1baf-11e7-846d-f3a99b963bb0.png)

Old vs. new in Ubuntu:

![expo_u_old](https://cloud.githubusercontent.com/assets/4010813/24804696/9af37908-1baf-11e7-957b-a56581f9af86.png)

![expo_u_new](https://cloud.githubusercontent.com/assets/4010813/24804702/a010f9a6-1baf-11e7-895c-d42b160172ad.png)

Old vs. new in OSX:

I don't have a Mac :[