### PR TITLE
gcs: Use system-style groupboxes (RFC)

### DIFF
--- a/ground/gcs/share/stylesheets/linux.qss
+++ b/ground/gcs/share/stylesheets/linux.qss
@@ -2,18 +2,7 @@ QListWidget {font-size: 11px;}
 MixerCurveWidget {font-size: 12px;}
 
 	QGroupBox 	{
-		border: 1px solid gray;
-		border-radius: 5px;
-		margin-top: 1ex; /* leave space at the top for the title */
-		font-size: 11px;
 		font-weight: bold;
-		}
-
-	QGroupBox::title {
-		subcontrol-origin: margin;
-		subcontrol-position: top left; /* position at the top center */
-		padding: 0 3px;
-		
 		}
 
 	QSlider::groove:horizontal {

--- a/ground/gcs/share/stylesheets/windows.qss
+++ b/ground/gcs/share/stylesheets/windows.qss
@@ -1,18 +1,7 @@
 QListWidget {font-size: 11px;}
 
 	QGroupBox 	{
-		border: 1px solid gray;
-		border-radius: 5px;
-		margin-top: 1ex; /* leave space at the top for the title */
-		font-size: 11px;
 		font-weight: bold;
-		}
-
-	QGroupBox::title {
-		subcontrol-origin: margin;
-		subcontrol-position: top left; /* position at the top center */
-		padding: 0 3px;
-		
 		}
 
 	QSlider::groove:horizontal {

--- a/ground/gcs/src/plugins/config/input.ui
+++ b/ground/gcs/src/plugins/config/input.ui
@@ -90,7 +90,7 @@
               <string/>
              </property>
              <property name="flat">
-              <bool>true</bool>
+              <bool>false</bool>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_6">
               <property name="leftMargin">

--- a/ground/gcs/src/plugins/config/stabilization.ui
+++ b/ground/gcs/src/plugins/config/stabilization.ui
@@ -705,7 +705,7 @@
                  <string/>
                 </property>
                 <property name="flat">
-                 <bool>true</bool>
+                 <bool>false</bool>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_6">
                  <item row="0" column="1">
@@ -2227,18 +2227,6 @@ border-radius: 5;</string>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>195</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>16777215</height>
-              </size>
-             </property>
              <property name="title">
               <string>Rate Stabilization (Inner Loop)</string>
              </property>
@@ -2328,12 +2316,6 @@ border-radius: 5;</string>
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>0</width>
-                  <height>140</height>
-                 </size>
-                </property>
                 <property name="font">
                  <font>
                   <weight>50</weight>
@@ -2352,7 +2334,7 @@ border-radius: 5;</string>
                  <string/>
                 </property>
                 <property name="flat">
-                 <bool>true</bool>
+                 <bool>false</bool>
                 </property>
                 <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0,1,0,1,0">
                  <item row="1" column="3">
@@ -3954,18 +3936,6 @@ value as the Kp.</string>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>195</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>195</height>
-              </size>
-             </property>
              <property name="autoFillBackground">
               <bool>false</bool>
              </property>
@@ -4060,7 +4030,7 @@ value as the Kp.</string>
               <item row="1" column="0" colspan="3">
                <widget class="QGroupBox" name="RateStabilizationGroup_18">
                 <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
@@ -4068,7 +4038,7 @@ value as the Kp.</string>
                 <property name="minimumSize">
                  <size>
                   <width>0</width>
-                  <height>131</height>
+                  <height>0</height>
                  </size>
                 </property>
                 <property name="autoFillBackground">
@@ -4081,7 +4051,7 @@ value as the Kp.</string>
                  <string/>
                 </property>
                 <property name="flat">
-                 <bool>true</bool>
+                 <bool>false</bool>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_12" columnstretch="0,1,0,1,0,1,0">
                  <item row="0" column="1">
@@ -5213,7 +5183,7 @@ border-radius: 5;</string>
                  <string/>
                 </property>
                 <property name="flat">
-                 <bool>true</bool>
+                 <bool>false</bool>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0,0,0,0,0,0">
                  <property name="leftMargin">
@@ -6153,7 +6123,7 @@ Then lower the value by 20% or so.</string>
                         <string/>
                        </property>
                        <property name="flat">
-                        <bool>true</bool>
+                        <bool>false</bool>
                        </property>
                        <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0,0,0,0">
                         <property name="leftMargin">
@@ -6795,7 +6765,7 @@ border-radius: 5;</string>
                         <string/>
                        </property>
                        <property name="flat">
-                        <bool>true</bool>
+                        <bool>false</bool>
                        </property>
                        <layout class="QGridLayout" name="gridLayout_10" rowstretch="0,0" columnstretch="0,0,0,0,0,0,0">
                         <property name="leftMargin">
@@ -7413,7 +7383,7 @@ border-radius: 5;</string>
                 <item row="1" column="0" colspan="2">
                  <widget class="QGroupBox" name="groupBox_1">
                   <property name="flat">
-                   <bool>true</bool>
+                   <bool>false</bool>
                   </property>
                   <layout class="QGridLayout" name="gridLayout_4">
                    <property name="leftMargin">
@@ -8034,7 +8004,7 @@ border-radius: 5;</string>
                    <string/>
                   </property>
                   <property name="flat">
-                   <bool>true</bool>
+                   <bool>false</bool>
                   </property>
                   <layout class="QGridLayout" name="gridLayout_13">
                    <item row="0" column="2">
@@ -8518,7 +8488,7 @@ border-radius: 5;</string>
                    <string/>
                   </property>
                   <property name="flat">
-                   <bool>true</bool>
+                   <bool>false</bool>
                   </property>
                   <layout class="QGridLayout" name="gridLayout_8" columnstretch="0,0,0,0,0,0,0">
                    <property name="leftMargin">


### PR DESCRIPTION
OSX builds don't use a custom style, so I removed it for the others to see how it looks. Personally I prefer the system ones, altho they're less contrasty.

As far as trying to make them more contrasty... Same story as always, that's been my bane with anything QT. Look the wrong way at attributes like border or anything, and it suddenly falls onto an apparently entirely different control renderer.

![groupbox_w_old](https://cloud.githubusercontent.com/assets/4010813/24808808/95789892-1bbd-11e7-8a81-137d42c7cc11.png)

![groupbox_w_new](https://cloud.githubusercontent.com/assets/4010813/24808809/998ab190-1bbd-11e7-89a5-143e03d792bc.png)

![groupbox_u_old](https://cloud.githubusercontent.com/assets/4010813/24808819/a2296792-1bbd-11e7-8c97-cf954e5219ad.png)

![groupbox_u_new](https://cloud.githubusercontent.com/assets/4010813/24808826/a866670e-1bbd-11e7-858f-ffa9136cea46.png)

