### PR TITLE
pios_servo,gcs: DShot900 timing added.

### DIFF
--- a/flight/PiOS/STM32/pios_servo.c
+++ b/flight/PiOS/STM32/pios_servo.c
@@ -64,6 +64,7 @@ enum channel_mode {
 	SYNC_PWM,
 	SYNC_DSHOT_300,
 	SYNC_DSHOT_600,
+	SYNC_DSHOT_900,
 	SYNC_DSHOT_1200
 } __attribute__((packed));
 
@@ -162,6 +163,9 @@ static void ChannelSetup_DShot(int j, uint16_t rate)
 			break;
 		case SHOT_DSHOT600:
 			output_channels[j].mode = SYNC_DSHOT_600;
+			break;
+		case SHOT_DSHOT900:
+			output_channels[j].mode = SYNC_DSHOT_900;
 			break;
 		case SHOT_DSHOT1200:
 			output_channels[j].mode = SYNC_DSHOT_1200;
@@ -374,6 +378,7 @@ int PIOS_Servo_SetMode(const uint16_t *out_rate, const int banks, const uint16_t
 
 		case SHOT_DSHOT300:
 		case SHOT_DSHOT600:
+		case SHOT_DSHOT900:
 		case SHOT_DSHOT1200:
 			dshot_in_use = true;
 
@@ -390,6 +395,7 @@ int PIOS_Servo_SetMode(const uint16_t *out_rate, const int banks, const uint16_t
 				switch (rate) {
 				case SHOT_DSHOT300:
 				case SHOT_DSHOT600:
+				case SHOT_DSHOT900:
 				case SHOT_DSHOT1200:
 					ChannelSetup_DShot(j, rate);
 					break;
@@ -454,6 +460,7 @@ void PIOS_Servo_SetFraction(uint8_t servo, uint16_t fraction,
 	switch (output_channels[servo].mode) {
 		case SYNC_DSHOT_300:
 		case SYNC_DSHOT_600:
+		case SYNC_DSHOT_900:
 		case SYNC_DSHOT_1200:
 			/* Expect a 0 to 2047 range!
 			 * Don't bother with min/max tomfoolery here.
@@ -510,6 +517,7 @@ void PIOS_Servo_Set(uint8_t servo, float position)
 	switch (output_channels[servo].mode) {
 		case SYNC_DSHOT_300:
 		case SYNC_DSHOT_600:
+		case SYNC_DSHOT_900:
 		case SYNC_DSHOT_1200:
 			/* Expect a 0 to 2047 range! */
 			if (position > 2047) {
@@ -560,6 +568,7 @@ static int DSHOT_Update()
 		switch (chan->mode) {
 			case SYNC_DSHOT_300:
 			case SYNC_DSHOT_600:
+			case SYNC_DSHOT_900:
 			case SYNC_DSHOT_1200:
 				break;
 			default:
@@ -627,6 +636,11 @@ static int DSHOT_Update()
 			time_0   = PIOS_INLINEDELAY_NsToCycles(500);
 			time_1   = PIOS_INLINEDELAY_NsToCycles(1083);
 			time_tot = PIOS_INLINEDELAY_NsToCycles(1667);
+			break;
+		case SYNC_DSHOT_900:
+			time_0   = PIOS_INLINEDELAY_NsToCycles(333);
+			time_1   = PIOS_INLINEDELAY_NsToCycles(722);
+			time_tot = PIOS_INLINEDELAY_NsToCycles(1111);
 			break;
 		case SYNC_DSHOT_1200:
 			time_0   = PIOS_INLINEDELAY_NsToCycles(250);

--- a/flight/PiOS/inc/pios_servo.h
+++ b/flight/PiOS/inc/pios_servo.h
@@ -39,7 +39,8 @@ enum pios_servo_shot_type {
 	SHOT_ONESHOT = 0,
 	SHOT_DSHOT300 = 65532,
 	SHOT_DSHOT600 = 65533,
-	SHOT_DSHOT1200 = 65534
+	SHOT_DSHOT1200 = 65534,
+	SHOT_DSHOT900 = 65531,
 };
 
 struct pios_servo_callbacks {

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -535,6 +535,7 @@ void ConfigOutputWidget::refreshWidgetRanges()
                     break;
                 case RATE_DSHOT300:
                 case RATE_DSHOT600:
+                case RATE_DSHOT900:
                 case RATE_DSHOT1200:
                     // 1-47 reserved for commands
                     minPulseWidth = 48;
@@ -615,6 +616,7 @@ QString ConfigOutputWidget::timerFreqToString(quint32 freq) const {
         {RATE_SYNCPWM, tr("SyncPWM")},
         {RATE_DSHOT300, tr("Dshot300")},
         {RATE_DSHOT600, tr("Dshot600")},
+        {RATE_DSHOT900, tr("Dshot900")},
         {RATE_DSHOT1200, tr("Dshot1200")},
     };
     return mapping.value(freq, QString::number(freq));
@@ -625,6 +627,7 @@ quint32 ConfigOutputWidget::timerStringToFreq(QString str) const {
         {tr("SyncPWM"), RATE_SYNCPWM},
         {tr("Dshot300"), RATE_DSHOT300},
         {tr("Dshot600"), RATE_DSHOT600},
+        {tr("Dshot900"), RATE_DSHOT900},
         {tr("Dshot1200"), RATE_DSHOT1200},
     };
     return mapping.value(str, str.toUInt());

--- a/ground/gcs/src/plugins/config/configoutputwidget.h
+++ b/ground/gcs/src/plugins/config/configoutputwidget.h
@@ -52,6 +52,7 @@ private:
         RATE_SYNCPWM = 0,
         RATE_DSHOT300 = 65532,
         RATE_DSHOT600 = 65533,
+        RATE_DSHOT900 = 65531,
         RATE_DSHOT1200 = 65534,
     };
 

--- a/ground/gcs/src/plugins/config/output.ui
+++ b/ground/gcs/src/plugins/config/output.ui
@@ -267,6 +267,11 @@ Leave at 50Hz for fixed wing.</string>
                 </item>
                 <item>
                  <property name="text">
+                  <string>Dshot900</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
                   <string>Dshot1200</string>
                  </property>
                 </item>
@@ -377,6 +382,11 @@ Leave at 50Hz for fixed wing.</string>
                 <item>
                  <property name="text">
                   <string>Dshot600</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Dshot900</string>
                  </property>
                 </item>
                 <item>
@@ -495,6 +505,11 @@ Leave at 50Hz for fixed wing.</string>
                 </item>
                 <item>
                  <property name="text">
+                  <string>Dshot900</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
                   <string>Dshot1200</string>
                  </property>
                 </item>
@@ -605,6 +620,11 @@ Leave at 50Hz for fixed wing.</string>
                 <item>
                  <property name="text">
                   <string>Dshot600</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Dshot900</string>
                  </property>
                 </item>
                 <item>
@@ -729,6 +749,11 @@ Leave at 50Hz for fixed wing.</string>
                 </item>
                 <item>
                  <property name="text">
+                  <string>Dshot900</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
                   <string>Dshot1200</string>
                  </property>
                 </item>
@@ -842,6 +867,11 @@ Leave at 50Hz for fixed wing.</string>
                 <item>
                  <property name="text">
                   <string>Dshot600</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Dshot900</string>
                  </property>
                 </item>
                 <item>


### PR DESCRIPTION
It exists apparently. Add it for something something signal integrity? Works on KISS 24A RE.

Seppuku OSD wobbles with that, too, still requires DShot1200 to be stable.