### PR TITLE
DO NOT MERGE Temporarily disable crash reporting

### DIFF
--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -65,7 +65,8 @@
 
 #include GCS_VERSION_INFO_FILE
 
-#define USE_CRASHREPORTING
+//#define USE_CRASHREPORTING
+
 #ifdef Q_OS_WIN
 #ifndef _MSC_VER
 #undef USE_CRASHREPORTING


### PR DESCRIPTION
To help determine why builds from the Linux builder are not working
post-update to 16.04