### PR TITLE
pios_dmashot: Initial implementation.

### DIFF
--- a/flight/PiOS/STM32/pios_servo.c
+++ b/flight/PiOS/STM32/pios_servo.c
@@ -389,7 +389,19 @@ int PIOS_Servo_SetMode(const uint16_t *out_rate, const int banks, const uint16_t
 			ret = 1;
 #if defined(PIOS_INCLUDE_DMASHOT)
 			if (PIOS_DMAShot_IsConfigured()) {
-				uint32_t freq = rate == SHOT_DSHOT1200 ? DMASHOT_1200 : rate == SHOT_DSHOT600 ? DMASHOT_600 : DMASHOT_300;
+				uint32_t freq;
+				switch(rate) {
+					default:
+					case SHOT_DSHOT300:
+						freq = DMASHOT_300;
+						break;
+					case SHOT_DSHOT600:
+						freq = DMASHOT_600;
+						break;
+					case SHOT_DSHOT1200:
+						freq = DMASHOT_1200;
+						break;
+				}
 				ret = PIOS_DMAShot_RegisterTimer(timer_banks[i].timer, max_tim_clock, freq) ? 0 : 1;
 			}
 #endif

--- a/flight/PiOS/STM32/pios_servo.c
+++ b/flight/PiOS/STM32/pios_servo.c
@@ -568,6 +568,11 @@ void PIOS_Servo_Set(uint8_t servo, float position)
 		case SYNC_DSHOT_DMA:
 #if defined(PIOS_INCLUDE_DMASHOT)
 			if (PIOS_DMAShot_IsConfigured()) {
+				if (position > 2047)
+					position = 2047;
+				else if (position < 0)
+					position = 0;
+
 				PIOS_DMAShot_WriteValue(&servo_cfg->channels[servo], position);
 			}
 #endif

--- a/flight/PiOS/STM32/pios_servo.c
+++ b/flight/PiOS/STM32/pios_servo.c
@@ -444,8 +444,8 @@ int PIOS_Servo_SetMode(const uint16_t *out_rate, const int banks, const uint16_t
 #if defined (PIOS_INCLUDE_DMASHOT)
 	if (PIOS_DMAShot_IsConfigured()) {
 		PIOS_DMAShot_Validate();
-		PIOS_DMAShot_InitializeGPIOs();
 		PIOS_DMAShot_InitializeTimers((TIM_OCInitTypeDef *)&servo_cfg->tim_oc_init);
+		PIOS_DMAShot_InitializeGPIOs();
 		PIOS_DMAShot_InitializeDMAs();
 	}
 #endif

--- a/flight/PiOS/STM32/pios_servo.c
+++ b/flight/PiOS/STM32/pios_servo.c
@@ -392,6 +392,9 @@ int PIOS_Servo_SetMode(const uint16_t *out_rate, const int banks, const uint16_t
 				uint32_t freq;
 				switch(rate) {
 					default:
+						// If for whatever reason new frequencies show up in the GPIO version,
+						// we oughta know about it. So fail if that happens.
+						PIOS_Assert(0);
 					case SHOT_DSHOT300:
 						freq = DMASHOT_300;
 						break;

--- a/flight/PiOS/STM32/pios_servo.c
+++ b/flight/PiOS/STM32/pios_servo.c
@@ -418,10 +418,13 @@ int PIOS_Servo_SetMode(const uint16_t *out_rate, const int banks, const uint16_t
 					if (PIOS_DMAShot_IsConfigured() && PIOS_DMAShot_RegisterServo(chan)) {
 						output_channels[j].mode = SYNC_DSHOT_DMA;
 					} else {
+						// If RegisterServo fails, the relevant timer wasn't registered, or DMAShot
+						// isn't configured, so we expect the bank to be set up already higher up in this
+						// section.
 						ChannelSetup_DShot(j, rate);
 					}
 #else
-						ChannelSetup_DShot(j, rate);
+					ChannelSetup_DShot(j, rate);
 #endif
 					break;
 				case SHOT_ONESHOT:

--- a/flight/PiOS/STM32F4xx/inc/pios_dmashot.h
+++ b/flight/PiOS/STM32F4xx/inc/pios_dmashot.h
@@ -83,7 +83,7 @@ void PIOS_DMAShot_InitializeTimers(TIM_OCInitTypeDef *ocinit);
 void PIOS_DMAShot_InitializeDMAs();
 void PIOS_DMAShot_Validate();
 
-bool PIOS_DMAShot_WriteValue(const struct pios_tim_channel *servo_channel, uint16_t throttle);
+void PIOS_DMAShot_WriteValue(const struct pios_tim_channel *servo_channel, uint16_t throttle);
 
 void PIOS_DMAShot_TriggerUpdate();
 

--- a/flight/PiOS/STM32F4xx/inc/pios_dmashot.h
+++ b/flight/PiOS/STM32F4xx/inc/pios_dmashot.h
@@ -43,20 +43,6 @@
 #define DMASHOT_600                                             600000
 #define DMASHOT_1200                                            1200000
 
-// Which register to target in master-slave mode.
-#define DMASHOT_REG_CCR1                                        0x01
-#define DMASHOT_REG_CCR2                                        0x02
-#define DMASHOT_REG_CCR3                                        0x03
-#define DMASHOT_REG_CCR4                                        0x04
-
-// Which DMA event source to use in master-slave mode. Make sure the proper
-// DMA channel and stream are selected, too.
-#define DMASHOT_EVENTSOURCE_UP                                  0x10
-#define DMASHOT_EVENTSOURCE_CCR1                                0x20
-#define DMASHOT_EVENTSOURCE_CCR2                                0x30
-#define DMASHOT_EVENTSOURCE_CCR3                                0x40
-#define DMASHOT_EVENTSOURCE_CCR4                                0x50
-
 /**
  * @brief Configuration struct to assign a DMA channel and stream to a timer, and
                         optionally specify a master timer to update single timer registers of
@@ -70,7 +56,7 @@ struct pios_dmashot_timer_cfg {
 	uint32_t tcif;
 
 	TIM_TypeDef *master_timer;
-	uint8_t master_config;
+	uint16_t master_config;
 
 };
 

--- a/flight/PiOS/STM32F4xx/inc/pios_dmashot.h
+++ b/flight/PiOS/STM32F4xx/inc/pios_dmashot.h
@@ -70,21 +70,78 @@ struct pios_dmashot_cfg {
 
 };
 
+/**
+ * @brief Initializes the DMAShot driver by loading the configuration.
+ * @param[in] config Configuration struct.
+ */
 void PIOS_DMAShot_Init(const struct pios_dmashot_cfg *config);
+
+/**
+ * @brief Makes sure the DMAShot driver has allocated all internal structs.
+ */
 void PIOS_DMAShot_Prepare();
+
+/**
+ * @brief Checks whether DMAShot has been configured.
+ * @retval TRUE on success, FALSE when there's no configuration.
+ */
 bool PIOS_DMAShot_IsConfigured();
+
+/**
+ * @brief Checks whether DMAShot is ready for use (i.e. at least one DMA configured timer).
+ * @retval TRUE on success, FALSE when there's no configuration or DMA capable timers.
+ */
 bool PIOS_DMAShot_IsReady();
 
+/**
+ * @brief Tells the DMAShot driver about a timer that needs to be set up.
+ * @param[in] timer The STM32 timer in question.
+ * @param[in] clockrate The frequency the timer's set up to run.
+ * @param[in] dshot_freq The desired DShot signal frequency (in KHz).
+ * @retval TRUE on success, FALSE when there's no configuration for the specific timer,
+                        or DMAShot isn't set up correctly.
+ */
 bool PIOS_DMAShot_RegisterTimer(TIM_TypeDef *timer, uint32_t clockrate, uint32_t dshot_freq);
+
+/**
+ * @brief Tells the DMAShot driver about a servo that needs to be set up.
+ * @param[in] servo_channel The servo in question.
+ * @retval TRUE on success, FALSE when the related timer isn't set up, or DMAShot
+                        isn't set up correctly.
+ */
 bool PIOS_DMAShot_RegisterServo(const struct pios_tim_channel *servo_channel);
 
+/**
+ * @brief Initializes the GPIO on the registered servos for DMAShot operation.
+ */
 void PIOS_DMAShot_InitializeGPIOs();
+
+/**
+ * @brief Initializes and configures the registered timers for DMAShot operation.
+ */
 void PIOS_DMAShot_InitializeTimers(TIM_OCInitTypeDef *ocinit);
+
+/**
+ * @brief Initializes and configures the known DMA channels for DMAShot operation.
+ */
 void PIOS_DMAShot_InitializeDMAs();
+
+/**
+ * @brief Validates any timer and servo registrations.
+ */
 void PIOS_DMAShot_Validate();
 
+/**
+ * @brief Sets the throttle value of a specific servo.
+ * @param[in] servo_channel The servo to update.
+ * @param[in] throttle The desired throttle value (0-2047).
+ * @retval TRUE on success, FALSE if the channel's not set up for DMA.
+ */
 void PIOS_DMAShot_WriteValue(const struct pios_tim_channel *servo_channel, uint16_t throttle);
 
+/**
+ * @brief Triggers the configured DMA channels to fire and send throttle values to the timer DMAR and optional CCRx registers.
+ */
 void PIOS_DMAShot_TriggerUpdate();
 
 #endif // PIOS_DMASHOT_H

--- a/flight/PiOS/STM32F4xx/inc/pios_dmashot.h
+++ b/flight/PiOS/STM32F4xx/inc/pios_dmashot.h
@@ -1,0 +1,104 @@
+/**
+ ******************************************************************************
+ * @file       pios_dmashot.h
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2017
+ * @addtogroup PIOS PIOS Core hardware abstraction layer
+ * @{
+ * @addtogroup PIOS_DMAShot PiOS DMA-driven DShot driver
+ * @{
+ * @brief Generates DShot signal by updating timer CC registers via DMA bursts.
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
+ */
+
+#ifndef PIOS_DMASHOT_H
+#define PIOS_DMASHOT_H
+
+#include <stdint.h>
+
+#include <pios_stm32.h>
+#include "stm32f4xx_tim.h"
+
+#include "pios_tim_priv.h"
+
+// Frequencies.
+#define DMASHOT_150                                             150000
+#define DMASHOT_300                                             300000
+#define DMASHOT_600                                             600000
+#define DMASHOT_1200                                            1200000
+
+// Which register to target in master-slave mode.
+#define DMASHOT_REG_CCR1                                        0x01
+#define DMASHOT_REG_CCR2                                        0x02
+#define DMASHOT_REG_CCR3                                        0x03
+#define DMASHOT_REG_CCR4                                        0x04
+
+// Which DMA event source to use in master-slave mode. Make sure the proper
+// DMA channel and stream are selected, too.
+#define DMASHOT_EVENTSOURCE_UP                                  0x10
+#define DMASHOT_EVENTSOURCE_CCR1                                0x20
+#define DMASHOT_EVENTSOURCE_CCR2                                0x30
+#define DMASHOT_EVENTSOURCE_CCR3                                0x40
+#define DMASHOT_EVENTSOURCE_CCR4                                0x50
+
+/**
+ * @brief Configuration struct to assign a DMA channel and stream to a timer, and
+                        optionally specify a master timer to update single timer registers of
+                        timers without DMA channel.
+ */
+struct pios_dmashot_timer_cfg {
+
+	TIM_TypeDef *timer;
+	DMA_Stream_TypeDef *stream;
+	uint32_t channel;
+	uint32_t tcif;
+
+	TIM_TypeDef *master_timer;
+	uint8_t master_config;
+
+};
+
+/**
+ * @brief Configuration struct holding all timer configurations.
+ */
+struct pios_dmashot_cfg {
+
+	const struct pios_dmashot_timer_cfg *timer_cfg;
+	uint8_t num_timers;
+
+};
+
+void PIOS_DMAShot_Init(const struct pios_dmashot_cfg *config);
+void PIOS_DMAShot_Prepare();
+bool PIOS_DMAShot_IsConfigured();
+bool PIOS_DMAShot_IsReady();
+
+bool PIOS_DMAShot_RegisterTimer(TIM_TypeDef *timer, uint32_t clockrate, uint32_t dshot_freq);
+bool PIOS_DMAShot_RegisterServo(const struct pios_tim_channel *servo_channel);
+
+void PIOS_DMAShot_InitializeGPIOs();
+void PIOS_DMAShot_InitializeTimers(TIM_OCInitTypeDef *ocinit);
+void PIOS_DMAShot_InitializeDMAs();
+void PIOS_DMAShot_Validate();
+
+bool PIOS_DMAShot_WriteValue(const struct pios_tim_channel *servo_channel, uint16_t throttle);
+
+void PIOS_DMAShot_TriggerUpdate();
+
+#endif // PIOS_DMASHOT_H

--- a/flight/PiOS/STM32F4xx/pios_dmashot.c
+++ b/flight/PiOS/STM32F4xx/pios_dmashot.c
@@ -180,6 +180,7 @@ bool PIOS_DMAShot_WriteValue(const struct pios_tim_channel *servo_channel, uint1
 	// Wriiiiiiiiiiiiiiiite!
 
 	int shift = (servo_channel->timer_chan - s_timer->low_channel) >> 2;
+	int channels = PIOS_DMAShot_GetNumChannels(s_timer);
 
 	if (throttle > 2047)
 		throttle = 2047;
@@ -192,7 +193,7 @@ bool PIOS_DMAShot_WriteValue(const struct pios_tim_channel *servo_channel, uint1
 
 	// Leading zero, trailing zero.
 	for (int i = DMASHOT_MESSAGE_PAUSE; i < DMASHOT_MESSAGE_WIDTH+DMASHOT_MESSAGE_PAUSE; i++) {
-		int addr = i * PIOS_DMAShot_GetNumChannels(s_timer) + shift;
+		int addr = i * channels + shift;
 		if (PIOS_DMAShot_HalfWord(s_timer)) {
 			s_timer->buffer.hw[addr] = throttle & 0x8000 ? s_timer->duty_cycle_1 : s_timer->duty_cycle_0;
 		} else {

--- a/flight/PiOS/STM32F4xx/pios_dmashot.c
+++ b/flight/PiOS/STM32F4xx/pios_dmashot.c
@@ -165,7 +165,7 @@ void PIOS_DMAShot_Prepare()
 			servo_timers = PIOS_malloc_no_dma(sizeof(struct servo_timer*) * MAX_TIMERS);
 			PIOS_Assert(servo_timers);
 
-			memset(servo_timers, 0, sizeof(struct servo_timer) * MAX_TIMERS);
+			memset(servo_timers, 0, sizeof(struct servo_timer*) * MAX_TIMERS);
 		}
 		for (int i = 0; i < MAX_TIMERS; i++) {
 			if (servo_timers[i]) {

--- a/flight/PiOS/STM32F4xx/pios_dmashot.c
+++ b/flight/PiOS/STM32F4xx/pios_dmashot.c
@@ -417,6 +417,13 @@ void PIOS_DMAShot_InitializeTimers(TIM_OCInitTypeDef *ocinit)
 		if (!s_timer || !s_timer->sysclock)
 			continue;
 
+		if(PIOS_DMAShot_GetNumChannels(s_timer) == 0) {
+			// Servo's should have been registered before InitializeTimers. If there's none,
+			// disable the timer.
+			s_timer->sysclock = 0;
+			continue;
+		}
+
 		PIOS_DMAShot_TimerSetup(s_timer, s_timer->sysclock, s_timer->dshot_freq, ocinit, false);
 
 		int f = s_timer->sysclock / s_timer->dshot_freq;

--- a/flight/PiOS/STM32F4xx/pios_dmashot.c
+++ b/flight/PiOS/STM32F4xx/pios_dmashot.c
@@ -412,6 +412,8 @@ void PIOS_DMAShot_InitializeTimers(TIM_OCInitTypeDef *ocinit)
 
 		if (s_timer->dma->master_timer)
 			PIOS_DMAShot_TimerSetup(s_timer, s_timer->sysclock, s_timer->dshot_freq, ocinit, true);
+
+		s_timer->dma_started = 0;
 	}
 }
 

--- a/flight/PiOS/STM32F4xx/pios_dmashot.c
+++ b/flight/PiOS/STM32F4xx/pios_dmashot.c
@@ -76,22 +76,6 @@ struct servo_timer {
 const struct pios_dmashot_cfg *dmashot_cfg;
 struct servo_timer **servo_timers;
 
-static inline int PIOS_DMAShot_GetFIFOCadence(int num_chan)
-{
-	switch (num_chan)
-	{
-	default:
-	case 1:
-		return DMA_FIFOThreshold_1QuarterFull;
-	case 2:
-		return DMA_FIFOThreshold_HalfFull;
-	case 3:
-		return DMA_FIFOThreshold_3QuartersFull;
-	case 4:
-		return DMA_FIFOThreshold_Full;
-	}
-}
-
 // Whether a timer is 16- or 32-bit wide.
 static inline bool PIOS_DMAShot_HalfWord(struct servo_timer *s_timer)
 {
@@ -469,8 +453,7 @@ static void PIOS_DMAShot_DMASetup(struct servo_timer *s_timer)
 	dma.DMA_MemoryBurst = DMA_MemoryBurst_Single;
 	dma.DMA_PeripheralBurst = DMA_PeripheralBurst_Single;
 
-	dma.DMA_FIFOMode = DMA_FIFOMode_Enable;
-	dma.DMA_FIFOThreshold = PIOS_DMAShot_GetFIFOCadence(PIOS_DMAShot_GetNumChannels(s_timer));
+	dma.DMA_FIFOMode = DMA_FIFOMode_Disable;
 
 	DMA_Init(s_timer->dma->stream, &dma);
 

--- a/flight/PiOS/STM32F4xx/pios_dmashot.c
+++ b/flight/PiOS/STM32F4xx/pios_dmashot.c
@@ -405,8 +405,8 @@ void PIOS_DMAShot_InitializeTimers(TIM_OCInitTypeDef *ocinit)
 
 		int f = s_timer->sysclock / s_timer->dshot_freq;
 
-		s_timer->duty_cycle_0 = f * DSHOT_DUTY_CYCLE_0 / 100;
-		s_timer->duty_cycle_1 = f * DSHOT_DUTY_CYCLE_1 / 100;
+		s_timer->duty_cycle_0 = (f * DSHOT_DUTY_CYCLE_0 + 50) / 100;
+		s_timer->duty_cycle_1 = (f * DSHOT_DUTY_CYCLE_1 + 50) / 100;
 
 		if (s_timer->dma->master_timer)
 			PIOS_DMAShot_TimerSetup(s_timer, s_timer->sysclock, s_timer->dshot_freq, ocinit, true);

--- a/flight/PiOS/STM32F4xx/pios_dmashot.c
+++ b/flight/PiOS/STM32F4xx/pios_dmashot.c
@@ -529,13 +529,14 @@ void PIOS_DMAShot_TriggerUpdate()
 					s_timer->dma->master_config & 0xFF00,
 					DISABLE);
 			TIM_Cmd(s_timer->dma->master_timer, DISABLE);
+			TIM_SetCounter(s_timer->dma->master_timer, 0);
 		} else {
 			TIM_DMACmd(s_timer->dma->timer, TIM_DMA_Update, DISABLE);
 		}
 
 		TIM_Cmd(s_timer->dma->timer, DISABLE);
-
 		TIM_SetCounter(s_timer->dma->timer, 0);
+
 		DMA_ClearFlag(s_timer->dma->stream, s_timer->dma->tcif);
 		DMA_SetCurrDataCounter(s_timer->dma->stream, PIOS_DMAShot_GetNumChannels(s_timer) * DMASHOT_STM32_BUFFER);
 	}
@@ -551,6 +552,7 @@ void PIOS_DMAShot_TriggerUpdate()
 					// This results in a typical event source value
 					s_timer->dma->master_config & 0xFF00,
 					ENABLE);
+			TIM_Cmd(s_timer->dma->timer, ENABLE);
 			TIM_Cmd(s_timer->dma->master_timer, ENABLE);
 		} else {
 			int offset = s_timer->low_channel >> 2;
@@ -558,9 +560,9 @@ void PIOS_DMAShot_TriggerUpdate()
 			TIM_DMAConfig(s_timer->dma->timer, TIM_DMABase_CCR1 + offset, transfers << 8);
 
 			TIM_DMACmd(s_timer->dma->timer, TIM_DMA_Update, ENABLE);
+			TIM_Cmd(s_timer->dma->timer, ENABLE);
 		}
 
-		TIM_Cmd(s_timer->dma->timer, ENABLE);
 		DMA_Cmd(s_timer->dma->stream, ENABLE);
 	}
 }

--- a/flight/PiOS/STM32F4xx/pios_dmashot.c
+++ b/flight/PiOS/STM32F4xx/pios_dmashot.c
@@ -163,16 +163,16 @@ static struct servo_timer *PIOS_DMAShot_GetServoTimer(const struct pios_tim_chan
  * @param[in] throttle The desired throttle value (0-2047).
  * @retval TRUE on success, FALSE if the channel's not set up for DMA.
  */
-bool PIOS_DMAShot_WriteValue(const struct pios_tim_channel *servo_channel, uint16_t throttle)
+void PIOS_DMAShot_WriteValue(const struct pios_tim_channel *servo_channel, uint16_t throttle)
 {
 	// Fail hard if trying to write values without configured DMAShot. We shouldn't be getting to
 	// this point in that case.
 	PIOS_Assert(dmashot_cfg);
 
-	// Can't find a matching timer, tell upstream to use GPIO.
+	// If we can't find a timer for this, something's wrong. We shouldn't be getting to this point.
+	// Fail hard.
 	struct servo_timer *s_timer = PIOS_DMAShot_GetServoTimer(servo_channel);
-	if (!s_timer)
-		return false;
+	PIOS_Assert(s_timer);
 
 	int shift = (servo_channel->timer_chan - s_timer->low_channel) >> 2;
 	int channels = PIOS_DMAShot_GetNumChannels(s_timer);
@@ -196,8 +196,6 @@ bool PIOS_DMAShot_WriteValue(const struct pios_tim_channel *servo_channel, uint1
 		}
 		throttle <<= 1;
 	}
-
-	return true;
 }
 
 /**

--- a/flight/PiOS/STM32F4xx/pios_dmashot.c
+++ b/flight/PiOS/STM32F4xx/pios_dmashot.c
@@ -325,7 +325,8 @@ bool PIOS_DMAShot_RegisterServo(const struct pios_tim_channel *servo_channel)
 	if (!s_timer)
 		return false;
 
-	if (s_timer->dma->master_timer && PIOS_DMAShot_GetNumChannels(s_timer) > 0) {
+	if (s_timer->dma->master_timer && (PIOS_DMAShot_GetNumChannels(s_timer) > 0) &&
+		(s_timer->low_channel != servo_channel->timer_chan)) {
 		// I'm sorry, Dave, I'm afraid I cannot do that!
 
 		// If DMA'ing to CCR, can only do one channel per timer.

--- a/flight/PiOS/STM32F4xx/pios_dmashot.c
+++ b/flight/PiOS/STM32F4xx/pios_dmashot.c
@@ -162,7 +162,7 @@ void PIOS_DMAShot_Prepare()
 	if (dmashot_cfg) {
 		if (!servo_timers) {
 			// Allocate memory
-			servo_timers = PIOS_malloc_no_dma(sizeof(struct servo_timer) * MAX_TIMERS);
+			servo_timers = PIOS_malloc_no_dma(sizeof(struct servo_timer*) * MAX_TIMERS);
 			PIOS_Assert(servo_timers);
 
 			memset(servo_timers, 0, sizeof(struct servo_timer) * MAX_TIMERS);

--- a/flight/PiOS/STM32F4xx/pios_dmashot.c
+++ b/flight/PiOS/STM32F4xx/pios_dmashot.c
@@ -110,10 +110,10 @@ void PIOS_DMAShot_Prepare()
 	if (dmashot_cfg) {
 		if (!servo_timers) {
 			// Allocate memory
-			servo_timers = PIOS_malloc_no_dma(sizeof(struct servo_timer*) * MAX_TIMERS);
+			servo_timers = PIOS_malloc_no_dma(sizeof(servo_timers) * MAX_TIMERS);
 			PIOS_Assert(servo_timers);
 
-			memset(servo_timers, 0, sizeof(struct servo_timer*) * MAX_TIMERS);
+			memset(servo_timers, 0, sizeof(servo_timers) * MAX_TIMERS);
 		}
 		for (int i = 0; i < MAX_TIMERS; i++) {
 			if (servo_timers[i]) {
@@ -230,11 +230,11 @@ bool PIOS_DMAShot_RegisterTimer(TIM_TypeDef *timer, uint32_t clockrate, uint32_t
 	if (!found) {
 		for (int i = 0; i < MAX_TIMERS; i++) {
 			if (!servo_timers[i]) {
-				s_timer = PIOS_malloc_no_dma(sizeof(struct servo_timer));
+				s_timer = PIOS_malloc_no_dma(sizeof(*s_timer));
 				// No point in returning false and falling back to GPIO, because that
 				// also needs to allocate stuff later on, so we might just fail here.
 				PIOS_Assert(s_timer);
-				memset(s_timer, 0, sizeof(struct servo_timer));
+				memset(s_timer, 0, sizeof(*s_timer));
 				s_timer->low_channel = TIM_Channel_4;
 				s_timer->high_channel = TIM_Channel_1;
 				servo_timers[i] = s_timer;

--- a/flight/PiOS/STM32F4xx/pios_dmashot.c
+++ b/flight/PiOS/STM32F4xx/pios_dmashot.c
@@ -93,10 +93,6 @@ static int PIOS_DMAShot_GetNumChannels(struct servo_timer *timer)
 	return (channels >> 2) + 1;
 }
 
-/**
- * @brief Initializes the DMAShot driver by loading the configuration.
- * @param[in] config Configuration struct.
- */
 void PIOS_DMAShot_Init(const struct pios_dmashot_cfg *config)
 {
 	dmashot_cfg = config;
@@ -144,12 +140,6 @@ static struct servo_timer *PIOS_DMAShot_GetServoTimer(const struct pios_tim_chan
 	return NULL;
 }
 
-/**
- * @brief Sets the throttle value of a specific servo.
- * @param[in] servo_channel The servo to update.
- * @param[in] throttle The desired throttle value (0-2047).
- * @retval TRUE on success, FALSE if the channel's not set up for DMA.
- */
 void PIOS_DMAShot_WriteValue(const struct pios_tim_channel *servo_channel, uint16_t throttle)
 {
 	// Fail hard if trying to write values without configured DMAShot. We shouldn't be getting to
@@ -185,14 +175,6 @@ void PIOS_DMAShot_WriteValue(const struct pios_tim_channel *servo_channel, uint1
 	}
 }
 
-/**
- * @brief Tells the DMAShot driver about a timer that needs to be set up.
- * @param[in] timer The STM32 timer in question.
- * @param[in] clockrate The frequency the timer's set up to run.
- * @param[in] dshot_freq The desired DShot signal frequency (in KHz).
- * @retval TRUE on success, FALSE when there's no configuration for the specific timer,
-                        or DMAShot isn't set up correctly.
- */
 bool PIOS_DMAShot_RegisterTimer(TIM_TypeDef *timer, uint32_t clockrate, uint32_t dshot_freq)
 {
 	// No configuration, push for GPIO in upstream.
@@ -253,12 +235,6 @@ bool PIOS_DMAShot_RegisterTimer(TIM_TypeDef *timer, uint32_t clockrate, uint32_t
 	return true;
 }
 
-/**
- * @brief Tells the DMAShot driver about a servo that needs to be set up.
- * @param[in] servo_channel The servo in question.
- * @retval TRUE on success, FALSE when the related timer isn't set up, or DMAShot
-                        isn't set up correctly.
- */
 bool PIOS_DMAShot_RegisterServo(const struct pios_tim_channel *servo_channel)
 {
 	// No configuration? kthxbye!
@@ -288,9 +264,6 @@ bool PIOS_DMAShot_RegisterServo(const struct pios_tim_channel *servo_channel)
 	return true;
 }
 
-/**
- * @brief Validates any timer and servo registrations.
- */
 void PIOS_DMAShot_Validate()
 {
 	if (!dmashot_cfg || !servo_timers)
@@ -309,9 +282,6 @@ void PIOS_DMAShot_Validate()
 	}
 }
 
-/**
- * @brief Initializes the GPIO on the registered servos for DMAShot operation.
- */
 void PIOS_DMAShot_InitializeGPIOs()
 {
 	// If there's nothing setup, fail hard. We shouldn't be getting here.
@@ -382,9 +352,6 @@ static void PIOS_DMAShot_TimerSetup(struct servo_timer *s_timer, uint32_t sysclo
 	TIM_SelectOnePulseMode(timer, TIM_OPMode_Repetitive);
 }
 
-/**
- * @brief Initializes and configures the registered timers for DMAShot operation.
- */
 void PIOS_DMAShot_InitializeTimers(TIM_OCInitTypeDef *ocinit)
 {
 	// If there's nothing setup, fail hard. We shouldn't be getting here.
@@ -485,9 +452,6 @@ static uint32_t PIOS_DMAShot_AllocateBuffer(uint16_t size)
 	return ptr;
 }
 
-/**
- * @brief Initializes and configures the known DMA channels for DMAShot operation.
- */
 void PIOS_DMAShot_InitializeDMAs()
 {
 	// If there's nothing setup, fail hard. We shouldn't be getting here.
@@ -510,9 +474,6 @@ void PIOS_DMAShot_InitializeDMAs()
 	}
 }
 
-/**
- * @brief Triggers the configured DMA channels to fire and send throttle values to the timer DMAR and optional CCRx registers.
- */
 void PIOS_DMAShot_TriggerUpdate()
 {
 	// If there's nothing setup, fail hard. We shouldn't be getting here.
@@ -576,10 +537,6 @@ void PIOS_DMAShot_TriggerUpdate()
 	}
 }
 
-/**
- * @brief Checks whether DMAShot is ready for use (i.e. at least one DMA configured timer).
- * @retval TRUE on success, FALSE when there's no configuration or DMA capable timers.
- */
 bool PIOS_DMAShot_IsReady()
 {
 	if (!dmashot_cfg || !servo_timers)
@@ -593,10 +550,6 @@ bool PIOS_DMAShot_IsReady()
 	return false;
 }
 
-/**
- * @brief Checks whether DMAShot has been configured.
- * @retval TRUE on success, FALSE when there's no configuration.
- */
 bool PIOS_DMAShot_IsConfigured()
 {
 	return dmashot_cfg != NULL;

--- a/flight/targets/brain/board-info/board_hw_defs.c
+++ b/flight/targets/brain/board-info/board_hw_defs.c
@@ -1056,6 +1056,36 @@ const struct pios_servo_cfg pios_servo_rcvr_all_cfg = {
 	.num_channels = NELEMENTS(pios_tim_servoport_rcvrport_pins),
 };
 
+#if defined(PIOS_INCLUDE_DMASHOT)
+
+#include <pios_dmashot.h>
+
+// Enable pins 1-8 for DMA.
+// Pins 9 & 10 on TIM12 should fall back onto GPIO DShot.
+// Unlikely that these find use configured as such.
+
+static const struct pios_dmashot_timer_cfg dmashot_tim_cfg[] = {
+	{
+		.timer = TIM5,
+		.stream = DMA1_Stream6,
+		.channel = DMA_Channel_6,
+		.tcif = DMA_FLAG_TCIF6
+	},
+	{
+		.timer = TIM8,
+		.stream = DMA2_Stream1,
+		.channel = DMA_Channel_7,
+		.tcif = DMA_FLAG_TCIF1
+	}
+};
+
+static const struct pios_dmashot_cfg dmashot_config = {
+	.timer_cfg = &dmashot_tim_cfg[0],
+	.num_timers = NELEMENTS(dmashot_tim_cfg)
+};
+
+#endif // defined(PIOS_INCLUDE_DMASHOT)
+
 #endif	/* PIOS_INCLUDE_SERVO && PIOS_INCLUDE_TIM */
 
 /*

--- a/flight/targets/brain/fw/pios_board.c
+++ b/flight/targets/brain/fw/pios_board.c
@@ -436,6 +436,10 @@ void PIOS_Board_Init(void) {
 	pios_rcvr_group_map[MANUALCONTROLSETTINGS_CHANNELGROUPS_GCS] = pios_gcsrcvr_rcvr_id;
 #endif	/* PIOS_INCLUDE_GCSRCVR */
 
+#if defined(PIOS_INCLUDE_SERVO) & defined(PIOS_INCLUDE_DMASHOT)
+	PIOS_DMAShot_Init(&dmashot_config);
+#endif // defined(PIOS_INCLUDE_DMASHOT)
+
 #ifndef PIOS_DEBUG_ENABLE_DEBUG_PINS
 	switch (hw_rxport) {
 	case HWBRAIN_RXPORT_DISABLED:

--- a/flight/targets/brain/fw/pios_config.h
+++ b/flight/targets/brain/fw/pios_config.h
@@ -64,6 +64,7 @@
 /* Supported receiver interfaces */
 #define PIOS_INCLUDE_PWM
 
+#define PIOS_INCLUDE_DMASHOT
 
 /* OSD stuff */
 #define PIOS_VIDEO_TIM4_COUNTER

--- a/flight/targets/brainre1/board-info/board_hw_defs.c
+++ b/flight/targets/brainre1/board-info/board_hw_defs.c
@@ -1042,6 +1042,44 @@ static const struct pios_tim_channel pios_tim_servoport_all_pins[] = {
 	}
 };
 
+#if defined(PIOS_INCLUDE_DMASHOT)
+
+#include <pios_dmashot.h>
+
+static const struct pios_dmashot_timer_cfg dmashot_tim_cfg[] = {
+	{
+		.timer = TIM5,
+		.stream = DMA1_Stream6,
+		.channel = DMA_Channel_6,
+		.tcif = DMA_FLAG_TCIF6
+	},
+	{
+		.timer = TIM1,
+		.stream = DMA2_Stream5,
+		.channel = DMA_Channel_6,
+		.tcif = DMA_FLAG_TCIF5
+	},
+	{
+		.timer = TIM2,
+		.stream = DMA1_Stream7,
+		.channel = DMA_Channel_3,
+		.tcif = DMA_FLAG_TCIF7
+	},
+	{
+		.timer = TIM8,
+		.stream = DMA2_Stream1,
+		.channel = DMA_Channel_7,
+		.tcif = DMA_FLAG_TCIF1
+	}
+};
+
+static const struct pios_dmashot_cfg dmashot_config = {
+	.timer_cfg = &dmashot_tim_cfg[0],
+	.num_timers = NELEMENTS(dmashot_tim_cfg)
+};
+
+#endif /* defined(PIOS_INCLUDE_DMASHOT) */
+
 /*
  * Servo outputs
  */

--- a/flight/targets/brainre1/fw/pios_board.c
+++ b/flight/targets/brainre1/fw/pios_board.c
@@ -354,6 +354,11 @@ void PIOS_Board_Init(void) {
 
 	/* Configure PWM Outputs */
 #if defined(PIOS_INCLUDE_SERVO) && defined(PIOS_INCLUDE_TIM)
+
+#if defined(PIOS_INCLUDE_DMASHOT)
+	PIOS_DMAShot_Init(&dmashot_config);
+#endif // defined(PIOS_INCLUDE_DMASHOT)
+
 	switch (hw_mp_mode) {
 		case HWBRAINRE1_MULTIPORTMODE_NORMAL:
 			if (hw_mp_serial == HWBRAINRE1_MULTIPORTSERIAL_PWM) {

--- a/flight/targets/brainre1/fw/pios_config.h
+++ b/flight/targets/brainre1/fw/pios_config.h
@@ -62,6 +62,8 @@
 
 #define PIOS_GPS_SETS_HOMELOCATION
 
+#define PIOS_INCLUDE_DMASHOT
+
 /* Supported receiver interfaces */
 
 

--- a/flight/targets/seppuku/board-info/board_hw_defs.c
+++ b/flight/targets/seppuku/board-info/board_hw_defs.c
@@ -727,7 +727,7 @@ void PIOS_RTC_IRQ_Handler (void)
 /* Timers used for outputs (8, 14, 3, 5) */
 
 // Set up timers that only have inputs on APB1 - 3, 5, 14
-static const TIM_TimeBaseInitTypeDef tim_3_5_14_time_base = {
+static const TIM_TimeBaseInitTypeDef tim_3_4_5_14_time_base = {
 	.TIM_Prescaler = (PIOS_PERIPHERAL_APB1_COUNTER_CLOCK / 1000000) - 1,
 	.TIM_ClockDivision = TIM_CKD_DIV1,
 	.TIM_CounterMode = TIM_CounterMode_Up,
@@ -746,7 +746,7 @@ static const TIM_TimeBaseInitTypeDef tim_8_time_base = {
 
 static const struct pios_tim_clock_cfg tim_3_cfg = {
 	.timer = TIM3,
-	.time_base_init = &tim_3_5_14_time_base,
+	.time_base_init = &tim_3_4_5_14_time_base,
 	.irq = {
 		.init = {
 			.NVIC_IRQChannel                   = TIM3_IRQn,
@@ -757,9 +757,22 @@ static const struct pios_tim_clock_cfg tim_3_cfg = {
 	},
 };
 
+static const struct pios_tim_clock_cfg tim_4_cfg = {
+	.timer = TIM4,
+	.time_base_init = &tim_3_4_5_14_time_base,
+	.irq = {
+		.init = {
+			.NVIC_IRQChannel                   = TIM4_IRQn,
+			.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_MID,
+			.NVIC_IRQChannelSubPriority        = 0,
+			.NVIC_IRQChannelCmd                = ENABLE,
+		},
+	},
+};
+
 static const struct pios_tim_clock_cfg tim_5_cfg = {
 	.timer = TIM5,
-	.time_base_init = &tim_3_5_14_time_base,
+	.time_base_init = &tim_3_4_5_14_time_base,
 	.irq = {
 		.init = {
 			.NVIC_IRQChannel                   = TIM5_IRQn,
@@ -772,7 +785,7 @@ static const struct pios_tim_clock_cfg tim_5_cfg = {
 
 static const struct pios_tim_clock_cfg tim_14_cfg = {
 	.timer = TIM14,
-	.time_base_init = &tim_3_5_14_time_base,
+	.time_base_init = &tim_3_4_5_14_time_base,
 	.irq = {
 		.init = {
 			.NVIC_IRQChannel                   = TIM8_TRG_COM_TIM14_IRQn,
@@ -947,6 +960,56 @@ static const struct pios_tim_channel pios_tim_servoport_all_pins[] = {
 };
 
 #if defined(PIOS_INCLUDE_SERVO) && defined(PIOS_INCLUDE_TIM)
+
+#if defined(PIOS_INCLUDE_DMASHOT)
+
+#include <pios_dmashot.h>
+
+/*
+TIM8 C4, C3
+TIM14 C1
+TIM3 C1, C3, C4
+TIM5 C1, C2
+*/
+
+static const struct pios_dmashot_timer_cfg dmashot_tim_cfg[] = {
+	{
+		.timer = TIM8,
+		.stream = DMA2_Stream1,
+		.channel = DMA_Channel_7,
+		.tcif = DMA_FLAG_TCIF1,
+	},
+	{
+		.timer = TIM14,
+		.master_timer = TIM4,
+		.master_config = DMASHOT_EVENTSOURCE_UP | DMASHOT_REG_CCR1,
+
+		.stream = DMA1_Stream6,
+		.channel = DMA_Channel_2,
+		.tcif = DMA_FLAG_TCIF6,
+	},
+	{
+		.timer = TIM3,
+		.stream = DMA1_Stream2,
+		.channel = DMA_Channel_5,
+		.tcif = DMA_FLAG_TCIF2,
+	},
+	{
+		.timer = TIM5,
+		.stream = DMA1_Stream0,
+		.channel = DMA_Channel_6,
+		.tcif = DMA_FLAG_TCIF0,
+	}
+};
+
+static const struct pios_dmashot_cfg dmashot_config = {
+	.timer_cfg = &dmashot_tim_cfg[0],
+	.num_timers = NELEMENTS(dmashot_tim_cfg)
+};
+
+#endif /* defined(PIOS_INCLUDE_DMASHOT) */
+
+
 /*
  * Servo outputs
  */

--- a/flight/targets/seppuku/board-info/board_hw_defs.c
+++ b/flight/targets/seppuku/board-info/board_hw_defs.c
@@ -982,7 +982,7 @@ static const struct pios_dmashot_timer_cfg dmashot_tim_cfg[] = {
 	{
 		.timer = TIM14,
 		.master_timer = TIM4,
-		.master_config = DMASHOT_EVENTSOURCE_UP | DMASHOT_REG_CCR1,
+		.master_config = TIM_DMA_Update | TIM_DMABase_CCR1,
 
 		.stream = DMA1_Stream6,
 		.channel = DMA_Channel_2,

--- a/flight/targets/seppuku/fw/pios_board.c
+++ b/flight/targets/seppuku/fw/pios_board.c
@@ -222,6 +222,7 @@ void PIOS_Board_Init(void) {
 	PIOS_TIM_InitClock(&tim_8_cfg);
 	PIOS_TIM_InitClock(&tim_14_cfg);
 	PIOS_TIM_InitClock(&tim_3_cfg);
+	PIOS_TIM_InitClock(&tim_4_cfg);
 	PIOS_TIM_InitClock(&tim_5_cfg);
 
 	/* IAP System Setup */
@@ -394,6 +395,10 @@ void PIOS_Board_Init(void) {
 #endif
 			break;
 	}
+
+#if defined(PIOS_INCLUDE_DMASHOT)
+	PIOS_DMAShot_Init(&dmashot_config);
+#endif
 
 #if defined(PIOS_INCLUDE_GCSRCVR)
 	GCSReceiverInitialize();

--- a/flight/targets/seppuku/fw/pios_config.h
+++ b/flight/targets/seppuku/fw/pios_config.h
@@ -90,6 +90,9 @@
 
 #define CAMERASTAB_POI_MODE
 
+/* DMA DShot */
+#define PIOS_INCLUDE_DMASHOT
+
 /* Alarm Thresholds */
 
 /*


### PR DESCRIPTION
This is the DMA implementation of DShot. It is implemented in a self-contained module that hooks into pios_servo via #ifdefs on F4 targets.

You set up a configuration struct in board_hw_defs.c that specifies which timers can use what DMA channel and stream combination (among other things), which then gets fed to PIOS_DMAShot_Init(). Timers that don't have a DMA configuration will fall back to GPIO DShot within pios_servo. Optionally you can slave DMA writes to a single CC register onto another timer, to deal with things like Seppuku's TIM14.

Each timer can run on its own DShot frequency, so you can mix DShot300 - DShot1200, if you want to, for whatever reason.

As per @mlyle's suggestion, it doesn't use the prescaler and calculates the period and duty cycles during initialization. The duty cycles chosen are the out-of-spec ones BF/BLHeli uses. They work with KISS though.

As far as memory use goes, if DMAShot is compiled in (data, not code), it uses statically:
- 4 bytes to store a pointer to the DMA configuration.
- 4 bytes to allocate an array to.

If DMAShot gets initialized with a configuration, it'll eventually allocate 32 bytes to aforementioned array, should an user configure DShot on any timer, to hold up to 8 pointers to the internal timer configuration allocations.

For each timer configured, it'll allocate 42 bytes on a struct to store a variety of data to look up.

For DMA buffers, it'll allocate at word (32-bit) or half-word (16-bit) where appropriate. 18 "bits" will be allocated, a leading and trailing one that silences the timer, and 16 actual "bits". So the buffer would be at least 36 or 72 bytes (multiplied by amount of channels per timer).

Due to the nature of DMAR writes, there might be some overallocation. If there's only two pins on a timer, but they're spaced apart as much as possible (one pin on channel 1 and another on channel 4), it has to allocate a DMA buffer for four channels (up to 288 bytes on a 32-bit timer) to fill in for in-between. If two pins are only separated by one or when pins are adjacent, memory is allocated accordingly, i.e. always the minimum.

Best situation would be four motors on a single 16-bit timer, that'd use 226 bytes of RAM (excluding code). The RE1 would use 370 bytes, because it has the first four pins on a single but 32-bit timer. The Seppuku would use 418 bytes, due four pins being spread across three but 16-bit timers. (If I got my math correctly.)

I could successfully drive DShot on all eight pins of the RE1 and Seppuku, at mixed frequencies. OG Brain was only tested on the first four, because I don't have any 8-pin JST cables anymore.

Still need to add other targets.

Old PR message:

> PR created for general appraisal and critique. Given how much I chased my tail over a bunch of stupid bugs, I'm going to leave it a day or two alone.
> 
> Everything is pretty much standalone with a bunch of hooks into pios_servo.
> 
> Tested on a BrainRE1, I can drive all eight pins with DMA DShot (specifically disabled bitbanging code to check).
> 
> Things I need to do:
> - Implement actual frequency selection. Maybe compute it per timer instead of a bunch of #ifdef'd defines (like currently for F446).
> - Test whether 16-bit timers can do away with half-word writes, to save memory in the DMA buffers. Full word writes to 16-bit timers (e.g. TIM1 and TIM8 on RE1) don't break anything, though.
> - Add code to deal with TIM14 for Seppuku (write to DMAR, if it has it, or direct write to CCR, slaved to other timer like second TIM3_UP).