### PR TITLE
PiOS: Change IMU drivers to common rotation convention

### DIFF
--- a/flight/PiOS/Common/pios_bmi160.c
+++ b/flight/PiOS/Common/pios_bmi160.c
@@ -546,7 +546,11 @@ static void PIOS_BMI160_Task(void *parameters)
 		float gyro_y = (int16_t)(bmi160_rec_buf[IDX_GYRO_YOUT_H] << 8 | bmi160_rec_buf[IDX_GYRO_YOUT_L]);
 		float gyro_z = (int16_t)(bmi160_rec_buf[IDX_GYRO_ZOUT_H] << 8 | bmi160_rec_buf[IDX_GYRO_ZOUT_L]);
 
-		// Convert from sensor frame (x: forward y: left z: up) to TL convention (x: forward y: right z: down)
+		/* 
+		 * Convert from sensor frame (x: forward y: left z: up) to
+		 * TL convention (x: forward y: right z: down).
+		 * See flight/Doc/imu_orientation.md for more detail
+		 */
 		switch (dev->cfg->orientation) {
 		case PIOS_BMI160_TOP_0DEG:
 			accel_data.x = accel_x;
@@ -585,31 +589,31 @@ static void PIOS_BMI160_Task(void *parameters)
 			accel_data.y = accel_y;
 			accel_data.z = accel_z;
 			gyro_data.x  = gyro_x;
-			gyro_data.y  = gyro_x;
-			gyro_data.z  = gyro_z;
-			break;
-		case PIOS_BMI160_BOTTOM_90DEG:
-			accel_data.x = accel_y;
-			accel_data.y = -accel_x;
-			accel_data.z = accel_z;
-			gyro_data.x  = gyro_y;
-			gyro_data.y  = -gyro_x;
-			gyro_data.z  = gyro_z;
-			break;
-		case PIOS_BMI160_BOTTOM_180DEG:
-			accel_data.x = -accel_x;
-			accel_data.y = accel_y;
-			accel_data.z = accel_z;
-			gyro_data.x  = -gyro_x;
 			gyro_data.y  = gyro_y;
 			gyro_data.z  = gyro_z;
 			break;
-		case PIOS_BMI160_BOTTOM_270DEG:
+		case PIOS_BMI160_BOTTOM_90DEG:
 			accel_data.x = -accel_y;
 			accel_data.y = accel_x;
 			accel_data.z = accel_z;
 			gyro_data.x  = -gyro_y;
 			gyro_data.y  = gyro_x;
+			gyro_data.z  = gyro_z;
+			break;
+		case PIOS_BMI160_BOTTOM_180DEG:
+			accel_data.x = -accel_x;
+			accel_data.y = -accel_y;
+			accel_data.z = accel_z;
+			gyro_data.x  = -gyro_x;
+			gyro_data.y  = -gyro_y;
+			gyro_data.z  = gyro_z;
+			break;
+		case PIOS_BMI160_BOTTOM_270DEG:
+			accel_data.x = accel_y;
+			accel_data.y = -accel_x;
+			accel_data.z = accel_z;
+			gyro_data.x  = gyro_y;
+			gyro_data.y  = -gyro_x;
 			gyro_data.z  = gyro_z;
 			break;
 		}

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -1419,16 +1419,19 @@ int PIOS_HAL_ConfigureExternalMag(HwSharedMagOptions mag,
 		if (PIOS_HMC5883_Test())
 			goto mag_fail;
 
-		// XXX: Lame.  Move driver to HwShared constants.
+		/* XXX: Lame.  Move driver to HwShared constants.
+		 * Note: drivers rotate around vehicle Z-axis, this rotates around ??
+		 * This is dubious because both the sensor and vehicle Z-axis point down
+		 * in bottom orientation, whereas this is rotating around an upwards vector. */
 		enum pios_hmc5883_orientation hmc5883_orientation = 
 			(orientation == HWSHARED_MAGORIENTATION_TOP0DEGCW)      ? PIOS_HMC5883_TOP_0DEG      : 
 			(orientation == HWSHARED_MAGORIENTATION_TOP90DEGCW)     ? PIOS_HMC5883_TOP_90DEG     : 
 			(orientation == HWSHARED_MAGORIENTATION_TOP180DEGCW)    ? PIOS_HMC5883_TOP_180DEG    : 
 			(orientation == HWSHARED_MAGORIENTATION_TOP270DEGCW)    ? PIOS_HMC5883_TOP_270DEG    : 
 			(orientation == HWSHARED_MAGORIENTATION_BOTTOM0DEGCW)   ? PIOS_HMC5883_BOTTOM_0DEG   : 
-			(orientation == HWSHARED_MAGORIENTATION_BOTTOM90DEGCW)  ? PIOS_HMC5883_BOTTOM_90DEG  : 
+			(orientation == HWSHARED_MAGORIENTATION_BOTTOM90DEGCW)  ? PIOS_HMC5883_BOTTOM_270DEG : 
 			(orientation == HWSHARED_MAGORIENTATION_BOTTOM180DEGCW) ? PIOS_HMC5883_BOTTOM_180DEG : 
-			(orientation == HWSHARED_MAGORIENTATION_BOTTOM270DEGCW) ? PIOS_HMC5883_BOTTOM_270DEG : 
+			(orientation == HWSHARED_MAGORIENTATION_BOTTOM270DEGCW) ? PIOS_HMC5883_BOTTOM_90DEG  : 
 			external_hmc5883_cfg.Default_Orientation;
 
 		PIOS_HMC5883_SetOrientation(hmc5883_orientation);
@@ -1443,16 +1446,19 @@ int PIOS_HAL_ConfigureExternalMag(HwSharedMagOptions mag,
 		if (PIOS_HMC5983_Test())
 			goto mag_fail;
 
-		/* Annoying to do this, but infecting low-level drivers with UAVO deps is yucky */
+		/* Annoying to do this, but infecting low-level drivers with UAVO deps is yucky
+		 * Note: drivers rotate around vehicle Z-axis, this rotates around ??
+		 * This is dubious because both the sensor and vehicle Z-axis point down
+		 * in bottom orientation, whereas this is rotating around an upwards vector. */
 		enum pios_hmc5983_orientation hmc5983_orientation = 
 			(orientation == HWSHARED_MAGORIENTATION_TOP0DEGCW)      ? PIOS_HMC5983_TOP_0DEG      : 
 			(orientation == HWSHARED_MAGORIENTATION_TOP90DEGCW)     ? PIOS_HMC5983_TOP_90DEG     : 
 			(orientation == HWSHARED_MAGORIENTATION_TOP180DEGCW)    ? PIOS_HMC5983_TOP_180DEG    : 
 			(orientation == HWSHARED_MAGORIENTATION_TOP270DEGCW)    ? PIOS_HMC5983_TOP_270DEG    : 
 			(orientation == HWSHARED_MAGORIENTATION_BOTTOM0DEGCW)   ? PIOS_HMC5983_BOTTOM_0DEG   : 
-			(orientation == HWSHARED_MAGORIENTATION_BOTTOM90DEGCW)  ? PIOS_HMC5983_BOTTOM_90DEG  : 
+			(orientation == HWSHARED_MAGORIENTATION_BOTTOM90DEGCW)  ? PIOS_HMC5983_BOTTOM_270DEG : 
 			(orientation == HWSHARED_MAGORIENTATION_BOTTOM180DEGCW) ? PIOS_HMC5983_BOTTOM_180DEG : 
-			(orientation == HWSHARED_MAGORIENTATION_BOTTOM270DEGCW) ? PIOS_HMC5983_BOTTOM_270DEG : 
+			(orientation == HWSHARED_MAGORIENTATION_BOTTOM270DEGCW) ? PIOS_HMC5983_BOTTOM_90DEG  : 
 			external_hmc5983_cfg.Orientation;
 
 		PIOS_HMC5983_SetOrientation(hmc5983_orientation);

--- a/flight/PiOS/Common/pios_hmc5883.c
+++ b/flight/PiOS/Common/pios_hmc5883.c
@@ -344,8 +344,8 @@ static int32_t PIOS_HMC5883_ReadMag(struct pios_sensor_mag_data *mag_data)
 			mag_data->z = mag_z;
 			break;
 		case PIOS_HMC5883_BOTTOM_90DEG:
-			mag_data->x = -mag_y;
-			mag_data->y = mag_x;
+			mag_data->x = mag_y;
+			mag_data->y = -mag_x;
 			mag_data->z = mag_z;
 			break;
 		case PIOS_HMC5883_BOTTOM_180DEG:
@@ -354,8 +354,8 @@ static int32_t PIOS_HMC5883_ReadMag(struct pios_sensor_mag_data *mag_data)
 			mag_data->z = mag_z;
 			break;
 		case PIOS_HMC5883_BOTTOM_270DEG:
-			mag_data->x = mag_y;
-			mag_data->y = -mag_x;
+			mag_data->x = -mag_y;
+			mag_data->y = mag_x;
 			mag_data->z = mag_z;
 			break;
 	}

--- a/flight/PiOS/Common/pios_hmc5983.c
+++ b/flight/PiOS/Common/pios_hmc5983.c
@@ -319,8 +319,8 @@ static int32_t PIOS_HMC5983_ReadMag(struct pios_sensor_mag_data *mag_data)
 		mag_data->z = mag_z;
 		break;
 	case PIOS_HMC5983_BOTTOM_90DEG:
-		mag_data->x = -mag_y;
-		mag_data->y = mag_x;
+		mag_data->x = mag_y;
+		mag_data->y = -mag_x;
 		mag_data->z = mag_z;
 		break;
 	case PIOS_HMC5983_BOTTOM_180DEG:
@@ -329,8 +329,8 @@ static int32_t PIOS_HMC5983_ReadMag(struct pios_sensor_mag_data *mag_data)
 		mag_data->z = mag_z;
 		break;
 	case PIOS_HMC5983_BOTTOM_270DEG:
-		mag_data->x = mag_y;
-		mag_data->y = -mag_x;
+		mag_data->x = -mag_y;
+		mag_data->y = mag_x;
 		mag_data->z = mag_z;
 		break;
 	}

--- a/flight/PiOS/Common/pios_hmc5983_i2c.c
+++ b/flight/PiOS/Common/pios_hmc5983_i2c.c
@@ -360,8 +360,8 @@ static int32_t PIOS_HMC5983_ReadMag(struct pios_sensor_mag_data *mag_data, float
 			mag_data->z = mag_z;
 			break;
 		case PIOS_HMC5983_BOTTOM_90DEG:
-			mag_data->x = -mag_y;
-			mag_data->y = mag_x;
+			mag_data->x = mag_y;
+			mag_data->y = -mag_x;
 			mag_data->z = mag_z;
 			break;
 		case PIOS_HMC5983_BOTTOM_180DEG:
@@ -370,8 +370,8 @@ static int32_t PIOS_HMC5983_ReadMag(struct pios_sensor_mag_data *mag_data, float
 			mag_data->z = mag_z;
 			break;
 		case PIOS_HMC5983_BOTTOM_270DEG:
-			mag_data->x = mag_y;
-			mag_data->y = -mag_x;
+			mag_data->x = -mag_y;
+			mag_data->y = mag_x;
 			mag_data->z = mag_z;
 			break;
 	}

--- a/flight/PiOS/Common/pios_lis3mdl.c
+++ b/flight/PiOS/Common/pios_lis3mdl.c
@@ -349,10 +349,15 @@ static void PIOS_LIS_Task(void *parameters)
 
 		struct pios_sensor_mag_data mag_data;
 
+		/*
+		 * Vehicle axes = x front, y right, z down
+		 * LIS3MDL axes = x left, y rear, z up
+		 * See flight/Doc/imu_orientation.md
+		 */
 		switch (lis_dev->cfg->orientation) {
 			case PIOS_LIS_TOP_0DEG:
-				mag_data.y  =  mag_x;
-				mag_data.x  =  mag_y;
+				mag_data.y  = -mag_x;
+				mag_data.x  = -mag_y;
 				mag_data.z  = -mag_z;
 				break;
 			case PIOS_LIS_TOP_90DEG:
@@ -361,8 +366,8 @@ static void PIOS_LIS_Task(void *parameters)
 				mag_data.z  = -mag_z;
 				break;
 			case PIOS_LIS_TOP_180DEG:
-				mag_data.y  = -mag_x;
-				mag_data.x  = -mag_y;
+				mag_data.y  =  mag_x;
+				mag_data.x  =  mag_y;
 				mag_data.z  = -mag_z;
 				break;
 			case PIOS_LIS_TOP_270DEG:
@@ -371,23 +376,23 @@ static void PIOS_LIS_Task(void *parameters)
 				mag_data.z  = -mag_z;
 				break;
 			case PIOS_LIS_BOTTOM_0DEG:
-				mag_data.y  = -mag_x;
-				mag_data.x  =  mag_y;
-				mag_data.z  =  mag_z;
-				break;
-			case PIOS_LIS_BOTTOM_90DEG:
-				mag_data.y  =  mag_y;
-				mag_data.x  =  mag_x;
-				mag_data.z  =  mag_z;
-				break;
-			case PIOS_LIS_BOTTOM_180DEG:
 				mag_data.y  =  mag_x;
 				mag_data.x  = -mag_y;
 				mag_data.z  =  mag_z;
 				break;
-			case PIOS_LIS_BOTTOM_270DEG:
+			case PIOS_LIS_BOTTOM_90DEG:
 				mag_data.y  = -mag_y;
 				mag_data.x  = -mag_x;
+				mag_data.z  =  mag_z;
+				break;
+			case PIOS_LIS_BOTTOM_180DEG:
+				mag_data.y  = -mag_x;
+				mag_data.x  =  mag_y;
+				mag_data.z  =  mag_z;
+				break;
+			case PIOS_LIS_BOTTOM_270DEG:
+				mag_data.y  =  mag_y;
+				mag_data.x  =  mag_x;
 				mag_data.z  =  mag_z;
 				break;
 		}

--- a/flight/PiOS/Common/pios_mpu.c
+++ b/flight/PiOS/Common/pios_mpu.c
@@ -993,11 +993,11 @@ static void PIOS_MPU_Task(void *parameters)
 		// to our convention. This is true for accels and gyros. Magnetometer corresponds our convention.
 		switch (mpu_dev->cfg->orientation) {
 		case PIOS_MPU_TOP_0DEG:
-			accel_data.y =  accel_x;
 			accel_data.x =  accel_y;
+			accel_data.y =  accel_x;
 			accel_data.z = -accel_z;
-			gyro_data.y  =  gyro_x;
 			gyro_data.x  =  gyro_y;
+			gyro_data.y  =  gyro_x;
 			gyro_data.z  = -gyro_z;
 #ifdef PIOS_INCLUDE_MPU_MAG
 			mag_data.x   =  mag_x;
@@ -1006,11 +1006,11 @@ static void PIOS_MPU_Task(void *parameters)
 #endif // PIOS_INCLUDE_MPU_MAG
 			break;
 		case PIOS_MPU_TOP_90DEG:
-			accel_data.y = -accel_y;
 			accel_data.x =  accel_x;
+			accel_data.y = -accel_y;
 			accel_data.z = -accel_z;
-			gyro_data.y  = -gyro_y;
 			gyro_data.x  =  gyro_x;
+			gyro_data.y  = -gyro_y;
 			gyro_data.z  = -gyro_z;
 #ifdef PIOS_INCLUDE_MPU_MAG
 			mag_data.x   = -mag_y;
@@ -1019,11 +1019,11 @@ static void PIOS_MPU_Task(void *parameters)
 #endif // PIOS_INCLUDE_MPU_MAG
 			break;
 		case PIOS_MPU_TOP_180DEG:
-			accel_data.y = -accel_x;
 			accel_data.x = -accel_y;
+			accel_data.y = -accel_x;
 			accel_data.z = -accel_z;
-			gyro_data.y  = -gyro_x;
 			gyro_data.x  = -gyro_y;
+			gyro_data.y  = -gyro_x;
 			gyro_data.z  = -gyro_z;
 #ifdef PIOS_INCLUDE_MPU_MAG
 			mag_data.x   = -mag_x;
@@ -1032,11 +1032,11 @@ static void PIOS_MPU_Task(void *parameters)
 #endif // PIOS_INCLUDE_MPU_MAG
 			break;
 		case PIOS_MPU_TOP_270DEG:
-			accel_data.y =  accel_y;
 			accel_data.x = -accel_x;
+			accel_data.y =  accel_y;
 			accel_data.z = -accel_z;
-			gyro_data.y  =  gyro_y;
 			gyro_data.x  = -gyro_x;
+			gyro_data.y  =  gyro_y;
 			gyro_data.z  = -gyro_z;
 #ifdef PIOS_INCLUDE_MPU_MAG
 			mag_data.x   =  mag_y;
@@ -1045,11 +1045,11 @@ static void PIOS_MPU_Task(void *parameters)
 #endif // PIOS_INCLUDE_MPU_MAG
 			break;
 		case PIOS_MPU_BOTTOM_0DEG:
-			accel_data.y = -accel_x;
 			accel_data.x =  accel_y;
+			accel_data.y = -accel_x;
 			accel_data.z =  accel_z;
-			gyro_data.y  = -gyro_x;
 			gyro_data.x  =  gyro_y;
+			gyro_data.y  = -gyro_x;
 			gyro_data.z  =  gyro_z;
 #ifdef PIOS_INCLUDE_MPU_MAG
 			mag_data.x   =  mag_x;
@@ -1059,11 +1059,11 @@ static void PIOS_MPU_Task(void *parameters)
 			break;
 
 		case PIOS_MPU_BOTTOM_90DEG:
-			accel_data.y =  accel_y;
 			accel_data.x =  accel_x;
+			accel_data.y =  accel_y;
 			accel_data.z =  accel_z;
-			gyro_data.y  =  gyro_y;
 			gyro_data.x  =  gyro_x;
+			gyro_data.y  =  gyro_y;
 			gyro_data.z  =  gyro_z;
 #ifdef PIOS_INCLUDE_MPU_MAG
 			mag_data.x   = -mag_y;
@@ -1073,11 +1073,11 @@ static void PIOS_MPU_Task(void *parameters)
 			break;
 
 		case PIOS_MPU_BOTTOM_180DEG:
-			accel_data.y =  accel_x;
 			accel_data.x = -accel_y;
+			accel_data.y =  accel_x;
 			accel_data.z =  accel_z;
-			gyro_data.y  =  gyro_x;
 			gyro_data.x  = -gyro_y;
+			gyro_data.y  =  gyro_x;
 			gyro_data.z  =  gyro_z;
 #ifdef PIOS_INCLUDE_MPU_MAG
 			mag_data.x   = -mag_x;
@@ -1087,11 +1087,11 @@ static void PIOS_MPU_Task(void *parameters)
 			break;
 
 		case PIOS_MPU_BOTTOM_270DEG:
-			accel_data.y = -accel_y;
 			accel_data.x = -accel_x;
+			accel_data.y = -accel_y;
 			accel_data.z =  accel_z;
-			gyro_data.y  = -gyro_y;
 			gyro_data.x  = -gyro_x;
+			gyro_data.y  = -gyro_y;
 			gyro_data.z  =  gyro_z;
 #ifdef PIOS_INCLUDE_MPU_MAG
 			mag_data.x   =  mag_y;

--- a/flight/PiOS/Common/pios_mpu.c
+++ b/flight/PiOS/Common/pios_mpu.c
@@ -988,9 +988,13 @@ static void PIOS_MPU_Task(void *parameters)
 		float mag_z = (int16_t)(mpu_rec_buf[IDX_MAG_ZOUT_H] << 8 | mpu_rec_buf[IDX_MAG_ZOUT_L]);
 #endif // PIOS_INCLUDE_MPU_MAG
 
-		// Rotate the sensor to our convention.  The datasheet defines X as towards the right
-		// and Y as forward. Our convention transposes this.  Also the Z is defined negatively
-		// to our convention. This is true for accels and gyros. Magnetometer corresponds our convention.
+		/* 
+		 * Rotate the sensor to our convention (x forward, y right, z down).
+		 * Sensor orientation for all supported Invensense variants is
+		 * x right, y forward, z up.
+		 * The embedded AK8xxx magnetometer in MPU9x50 variants matches our convention.
+		 * See flight/Doc/imu_orientation.md for further detail
+		 */
 		switch (mpu_dev->cfg->orientation) {
 		case PIOS_MPU_TOP_0DEG:
 			accel_data.x =  accel_y;
@@ -1006,11 +1010,11 @@ static void PIOS_MPU_Task(void *parameters)
 #endif // PIOS_INCLUDE_MPU_MAG
 			break;
 		case PIOS_MPU_TOP_90DEG:
-			accel_data.x =  accel_x;
-			accel_data.y = -accel_y;
+			accel_data.x = -accel_x;
+			accel_data.y =  accel_y;
 			accel_data.z = -accel_z;
-			gyro_data.x  =  gyro_x;
-			gyro_data.y  = -gyro_y;
+			gyro_data.x  = -gyro_x;
+			gyro_data.y  =  gyro_y;
 			gyro_data.z  = -gyro_z;
 #ifdef PIOS_INCLUDE_MPU_MAG
 			mag_data.x   = -mag_y;
@@ -1032,11 +1036,11 @@ static void PIOS_MPU_Task(void *parameters)
 #endif // PIOS_INCLUDE_MPU_MAG
 			break;
 		case PIOS_MPU_TOP_270DEG:
-			accel_data.x = -accel_x;
-			accel_data.y =  accel_y;
+			accel_data.x =  accel_x;
+			accel_data.y = -accel_y;
 			accel_data.z = -accel_z;
-			gyro_data.x  = -gyro_x;
-			gyro_data.y  =  gyro_y;
+			gyro_data.x  =  gyro_x;
+			gyro_data.y  = -gyro_y;
 			gyro_data.z  = -gyro_z;
 #ifdef PIOS_INCLUDE_MPU_MAG
 			mag_data.x   =  mag_y;
@@ -1066,8 +1070,8 @@ static void PIOS_MPU_Task(void *parameters)
 			gyro_data.y  =  gyro_y;
 			gyro_data.z  =  gyro_z;
 #ifdef PIOS_INCLUDE_MPU_MAG
-			mag_data.x   = -mag_y;
-			mag_data.y   = -mag_x;
+			mag_data.x   =  mag_y;
+			mag_data.y   =  mag_x;
 			mag_data.z   = -mag_z;
 #endif // PIOS_INCLUDE_MPU_MAG
 			break;
@@ -1094,8 +1098,8 @@ static void PIOS_MPU_Task(void *parameters)
 			gyro_data.y  = -gyro_y;
 			gyro_data.z  =  gyro_z;
 #ifdef PIOS_INCLUDE_MPU_MAG
-			mag_data.x   =  mag_y;
-			mag_data.y   =  mag_x;
+			mag_data.x   = -mag_y;
+			mag_data.y   = -mag_x;
 			mag_data.z   = -mag_z;
 #endif // PIOS_INCLUDE_MPU_MAG
 			break;

--- a/flight/PiOS/Common/pios_mpu9150.c
+++ b/flight/PiOS/Common/pios_mpu9150.c
@@ -691,10 +691,10 @@ static void PIOS_MPU9150_Task(void *parameters)
 			accel_data.z = - (int16_t)(mpu9150_rec_buf[IDX_ACCEL_ZOUT_H] << 8 | mpu9150_rec_buf[IDX_ACCEL_ZOUT_L]);
 			break;
 		case PIOS_MPU60X0_TOP_90DEG:
-			accel_data.y = - (int16_t)(mpu9150_rec_buf[IDX_ACCEL_YOUT_H] << 8 | mpu9150_rec_buf[IDX_ACCEL_YOUT_L]);
-			accel_data.x = (int16_t)(mpu9150_rec_buf[IDX_ACCEL_XOUT_H] << 8 | mpu9150_rec_buf[IDX_ACCEL_XOUT_L]);
-			gyro_data.y  = - (int16_t)(mpu9150_rec_buf[IDX_GYRO_YOUT_H] << 8 | mpu9150_rec_buf[IDX_GYRO_YOUT_L]);
-			gyro_data.x  = (int16_t)(mpu9150_rec_buf[IDX_GYRO_XOUT_H] << 8 | mpu9150_rec_buf[IDX_GYRO_XOUT_L]);
+			accel_data.y = (int16_t)(mpu9150_rec_buf[IDX_ACCEL_YOUT_H] << 8 | mpu9150_rec_buf[IDX_ACCEL_YOUT_L]);
+			accel_data.x = - (int16_t)(mpu9150_rec_buf[IDX_ACCEL_XOUT_H] << 8 | mpu9150_rec_buf[IDX_ACCEL_XOUT_L]);
+			gyro_data.y  = (int16_t)(mpu9150_rec_buf[IDX_GYRO_YOUT_H] << 8 | mpu9150_rec_buf[IDX_GYRO_YOUT_L]);
+			gyro_data.x  = - (int16_t)(mpu9150_rec_buf[IDX_GYRO_XOUT_H] << 8 | mpu9150_rec_buf[IDX_GYRO_XOUT_L]);
 			gyro_data.z  = - (int16_t)(mpu9150_rec_buf[IDX_GYRO_ZOUT_H] << 8 | mpu9150_rec_buf[IDX_GYRO_ZOUT_L]);
 			accel_data.z = - (int16_t)(mpu9150_rec_buf[IDX_ACCEL_ZOUT_H] << 8 | mpu9150_rec_buf[IDX_ACCEL_ZOUT_L]);
 			break;
@@ -707,10 +707,10 @@ static void PIOS_MPU9150_Task(void *parameters)
 			accel_data.z = - (int16_t)(mpu9150_rec_buf[IDX_ACCEL_ZOUT_H] << 8 | mpu9150_rec_buf[IDX_ACCEL_ZOUT_L]);
 			break;
 		case PIOS_MPU60X0_TOP_270DEG:
-			accel_data.y = (int16_t)(mpu9150_rec_buf[IDX_ACCEL_YOUT_H] << 8 | mpu9150_rec_buf[IDX_ACCEL_YOUT_L]);
-			accel_data.x = - (int16_t)(mpu9150_rec_buf[IDX_ACCEL_XOUT_H] << 8 | mpu9150_rec_buf[IDX_ACCEL_XOUT_L]);
-			gyro_data.y  = (int16_t)(mpu9150_rec_buf[IDX_GYRO_YOUT_H] << 8 | mpu9150_rec_buf[IDX_GYRO_YOUT_L]);
-			gyro_data.x  = - (int16_t)(mpu9150_rec_buf[IDX_GYRO_XOUT_H] << 8 | mpu9150_rec_buf[IDX_GYRO_XOUT_L]);
+			accel_data.y = - (int16_t)(mpu9150_rec_buf[IDX_ACCEL_YOUT_H] << 8 | mpu9150_rec_buf[IDX_ACCEL_YOUT_L]);
+			accel_data.x = (int16_t)(mpu9150_rec_buf[IDX_ACCEL_XOUT_H] << 8 | mpu9150_rec_buf[IDX_ACCEL_XOUT_L]);
+			gyro_data.y  = - (int16_t)(mpu9150_rec_buf[IDX_GYRO_YOUT_H] << 8 | mpu9150_rec_buf[IDX_GYRO_YOUT_L]);
+			gyro_data.x  = (int16_t)(mpu9150_rec_buf[IDX_GYRO_XOUT_H] << 8 | mpu9150_rec_buf[IDX_GYRO_XOUT_L]);
 			gyro_data.z  = - (int16_t)(mpu9150_rec_buf[IDX_GYRO_ZOUT_H] << 8 | mpu9150_rec_buf[IDX_GYRO_ZOUT_L]);
 			accel_data.z = - (int16_t)(mpu9150_rec_buf[IDX_ACCEL_ZOUT_H] << 8 | mpu9150_rec_buf[IDX_ACCEL_ZOUT_L]);
 			break;
@@ -747,7 +747,6 @@ static void PIOS_MPU9150_Task(void *parameters)
 			accel_data.z = (int16_t)(mpu9150_rec_buf[IDX_ACCEL_ZOUT_H] << 8 | mpu9150_rec_buf[IDX_ACCEL_ZOUT_L]);
 			break;
 		}
-
 
 		int16_t raw_temp = (int16_t)(mpu9150_rec_buf[IDX_TEMP_OUT_H] << 8 | mpu9150_rec_buf[IDX_TEMP_OUT_L]);
 		float temperature = 35.0f + ((float)raw_temp + 512.0f) / 340.0f;

--- a/flight/targets/aq32/board-info/board_hw_defs.c
+++ b/flight/targets/aq32/board-info/board_hw_defs.c
@@ -1409,7 +1409,7 @@ static const struct pios_exti_cfg pios_exti_mpu_cfg __exti_config = {
 static struct pios_mpu_cfg pios_mpu_cfg = {
 	.exti_cfg            = &pios_exti_mpu_cfg,
 	.default_samplerate  = 1000,
-	.orientation         = PIOS_MPU_TOP_90DEG
+	.orientation         = PIOS_MPU_TOP_270DEG
 };
 #endif /* PIOS_INCLUDE_MPU */
 

--- a/flight/targets/pikoblx/board-info/board_hw_defs.c
+++ b/flight/targets/pikoblx/board-info/board_hw_defs.c
@@ -985,7 +985,7 @@ static const struct pios_exti_cfg pios_exti_mpu_cfg __exti_config = {
 static struct pios_mpu_cfg pios_mpu_cfg = {
     .exti_cfg = &pios_exti_mpu_cfg,
     .default_samplerate = 1000,
-    .orientation = PIOS_MPU_TOP_270DEG
+    .orientation = PIOS_MPU_TOP_90DEG
 };
 #endif /* PIOS_INCLUDE_MPU */
 /**

--- a/flight/targets/seppuku/board-info/board_hw_defs.c
+++ b/flight/targets/seppuku/board-info/board_hw_defs.c
@@ -229,7 +229,7 @@ static const struct pios_bmi160_cfg pios_bmi160_cfg = {
 #include <pios_lis3mdl.h>
 
 static const struct pios_lis3mdl_cfg pios_lis3mdl_cfg = {
-	.orientation = PIOS_LIS_TOP_180DEG
+	.orientation = PIOS_LIS_TOP_0DEG
 };
 
 #endif /* PIOS_INCLUDE_LIS3MDL */


### PR DESCRIPTION
Documented in #1725. This should make no functional change. The variety of conventions in these drivers highlights why standardising is a great idea!

Note: HMC5*83 rotation convention in HwShared is wonky, but I have kept it to avoid breaking existing configurations.

TODO:
- BMX055/BMM150

~~~Depends on/needs rebased after #1724 (due to PIOS_MPU changes).~~~