### PR TITLE
f3: don't double-depend upon pios_dma.c

### DIFF
--- a/flight/targets/dtfc/fw/Makefile
+++ b/flight/targets/dtfc/fw/Makefile
@@ -126,7 +126,6 @@ SRC += pios_flashfs_logfs.c
 SRC += printf-stdarg.c
 SRC += pios_usb_desc_hid_cdc.c
 SRC += pios_usb_util.c
-SRC += pios_dma.c
 SRC += pios_adc.c
 SRC += pios_heap.c
 SRC += pios_semaphore.c

--- a/flight/targets/lux/fw/Makefile
+++ b/flight/targets/lux/fw/Makefile
@@ -126,7 +126,6 @@ SRC += pios_flashfs_logfs.c
 SRC += printf-stdarg.c
 SRC += pios_usb_desc_hid_cdc.c
 SRC += pios_usb_util.c
-SRC += pios_dma.c
 SRC += pios_adc.c
 SRC += pios_heap.c
 SRC += pios_semaphore.c

--- a/flight/targets/pikoblx/fw/Makefile
+++ b/flight/targets/pikoblx/fw/Makefile
@@ -130,7 +130,6 @@ SRC += pios_flashfs_logfs.c
 SRC += printf-stdarg.c
 SRC += pios_usb_desc_hid_cdc.c
 SRC += pios_usb_util.c
-SRC += pios_dma.c
 SRC += pios_adc.c
 SRC += pios_heap.c
 SRC += pios_semaphore.c

--- a/flight/targets/sparky/fw/Makefile
+++ b/flight/targets/sparky/fw/Makefile
@@ -131,7 +131,6 @@ SRC += pios_flashfs_logfs.c
 SRC += printf-stdarg.c
 SRC += pios_usb_desc_hid_cdc.c
 SRC += pios_usb_util.c
-SRC += pios_dma.c
 SRC += pios_adc.c
 SRC += pios_heap.c
 SRC += pios_semaphore.c


### PR DESCRIPTION
F3 PiOS stuff is brought in by wildcard, and pios_dma is newly factored
there but wasn't removed from their makefiles.  Eliminates an annoying
message about duplicate deps during build.