### PR TITLE
f3 targets: enable autotune decimation

### DIFF
--- a/flight/targets/dtfc/fw/pios_config.h
+++ b/flight/targets/dtfc/fw/pios_config.h
@@ -58,7 +58,7 @@
 
 /* Flags that alter behaviors - mostly to lower resources for CC */
 #define AUTOTUNE_AVERAGING_MODE
-
+#define AUTOTUNE_AVERAGING_DECIMATION 2
 
 /* Alarm Thresholds */
 

--- a/flight/targets/lux/fw/pios_config.h
+++ b/flight/targets/lux/fw/pios_config.h
@@ -53,6 +53,7 @@
 
 /* Flags that alter behaviors - mostly to lower resources for CC */
 #define AUTOTUNE_AVERAGING_MODE
+#define AUTOTUNE_AVERAGING_DECIMATION 2
 
 /* Alarm Thresholds */
 

--- a/flight/targets/sparky/fw/pios_config.h
+++ b/flight/targets/sparky/fw/pios_config.h
@@ -64,6 +64,7 @@
 
 /* Flags that alter behaviors - mostly to lower resources for CC */
 #define AUTOTUNE_AVERAGING_MODE
+#define AUTOTUNE_AVERAGING_DECIMATION 2
 
 /* Alarm Thresholds */
 


### PR DESCRIPTION
There's just too many configs that can hit low memory with autotune now
witout it.