### PR TITLE
GCS: Launch setup wizard when unconfigured board is connected

### DIFF
--- a/ground/gcs/src/plugins/config/configplugin.h
+++ b/ground/gcs/src/plugins/config/configplugin.h
@@ -32,12 +32,13 @@
 #include <coreplugin/actionmanager/actionmanager.h>
 #include "uavtalk/telemetrymanager.h"
 #include "objectpersistence.h"
+#include "config_global.h"
 
 #include <QMessageBox>
 
 class ConfigGadgetFactory;
 
-class ConfigPlugin : public ExtensionSystem::IPlugin
+class CONFIG_EXPORT ConfigPlugin : public ExtensionSystem::IPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "org.dronin.plugins.Config")
@@ -50,6 +51,9 @@ public:
     void extensionsInitialized();
     bool initialize(const QStringList &arguments, QString *errorString);
     void shutdown();
+
+signals:
+    void launchSetupWizard();
 
 private slots:
     void eraseAllSettings();

--- a/ground/gcs/src/plugins/setupwizard/setupwizard.cpp
+++ b/ground/gcs/src/plugins/setupwizard/setupwizard.cpp
@@ -374,9 +374,9 @@ void SetupWizard::boardIgnorePrompt()
     if (!m_autoLaunched)
         return;
 
-    QMessageBox prompt(QMessageBox::Question, tr("Ignore Board?"),
-                       tr("Would you like to ignore the setup wizard for this board?"),
-                       QMessageBox::Yes | QMessageBox::No);
+    QMessageBox prompt(QMessageBox::Question, tr("Setup Wizard Cancelled"),
+                       tr("Would you like to prevent the setup wizard from automatically opening"
+                       " for the remainder of this session?"), QMessageBox::Yes | QMessageBox::No);
     if (prompt.exec() == QMessageBox::No)
         return;
 

--- a/ground/gcs/src/plugins/setupwizard/setupwizard.h
+++ b/ground/gcs/src/plugins/setupwizard/setupwizard.h
@@ -49,7 +49,7 @@ class SetupWizard : public QWizard, public VehicleConfigurationSource
     Q_OBJECT
 
 public:
-    SetupWizard(QWidget *parent = 0);
+    explicit SetupWizard(bool autoLaunched = false, QWidget *parent = Q_NULLPTR);
     int nextId() const;
 
     void setControllerType(Core::IBoardType *type) { m_controllerType = type; }
@@ -114,9 +114,13 @@ public:
         return m_connectionManager;
     }
 
+signals:
+    void boardIgnored(QByteArray uuid);
+
 private slots:
     void customBackClicked();
     void pageChanged(int currId);
+    void boardIgnorePrompt();
 
 private:
     enum {
@@ -159,7 +163,7 @@ private:
     QList<actuatorChannelSettings> m_actuatorSettings;
 
     bool m_restartNeeded;
-
+    bool m_autoLaunched;
     bool m_back;
 
     Core::ConnectionManager *m_connectionManager;

--- a/ground/gcs/src/plugins/setupwizard/setupwizard.pro
+++ b/ground/gcs/src/plugins/setupwizard/setupwizard.pro
@@ -12,6 +12,7 @@ include(../../plugins/uavobjects/uavobjects.pri)
 include(../../plugins/uavobjectutil/uavobjectutil.pri)
 include(../../plugins/uavobjectwidgetutils/uavobjectwidgetutils.pri)
 include(../../plugins/uavtalk/uavtalk.pri)
+include(../../plugins/uploader/uploader.pri)
 
 HEADERS += setupwizardplugin.h \ 
     setupwizard.h \

--- a/ground/gcs/src/plugins/setupwizard/setupwizardplugin.cpp
+++ b/ground/gcs/src/plugins/setupwizard/setupwizardplugin.cpp
@@ -39,6 +39,7 @@
 #include <QKeySequence>
 #include <coreplugin/modemanager.h>
 #include <extensionsystem/pluginmanager.h>
+#include <uploader/uploadergadgetwidget.h>
 
 SetupWizardPlugin::SetupWizardPlugin()
     : wizardRunning(false)
@@ -92,6 +93,15 @@ void SetupWizardPlugin::showSetupWizard(bool autoLaunched)
 
     if (autoLaunched) {
         ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+
+        // check if uploader is working with this board
+        auto uploaders = pm->getObjects<uploader::UploaderGadgetWidget>();
+        for (const auto uploader : uploaders) {
+            if (uploader->active())
+                return;
+        }
+
+        // check if it's been ignored already
         UAVObjectUtilManager *utilMngr = pm->getObject<UAVObjectUtilManager>();
         if (!utilMngr) {
             qWarning() << "Could not get UAVObjectUtilManager";

--- a/ground/gcs/src/plugins/setupwizard/setupwizardplugin.h
+++ b/ground/gcs/src/plugins/setupwizard/setupwizardplugin.h
@@ -45,11 +45,13 @@ public:
     void shutdown();
 
 private slots:
-    void showSetupWizard();
+    void showSetupWizard(bool autoLaunched);
     void wizardTerminated();
+    void ignoreBoard(QByteArray uuid);
 
 private:
     bool wizardRunning;
+    QSet<QByteArray> ignoredBoards;
 };
 
 #endif // SETUPWIZARDPLUGIN_H

--- a/ground/gcs/src/plugins/uavobjectutil/uavobjectutilmanager.h
+++ b/ground/gcs/src/plugins/uavobjectutil/uavobjectutilmanager.h
@@ -77,6 +77,8 @@ public:
     int getBoardRevision();
     QString getFirmwareHash();
     QString getGcsHash();
+    bool boardConfigured();
+    bool firmwareHashMatchesGcs();
 
 protected:
     FirmwareIAPObj::DataFields getFirmwareIap();

--- a/ground/gcs/src/plugins/uploader/uploadergadgetfactory.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetfactory.cpp
@@ -28,6 +28,7 @@
 #include "uploadergadget.h"
 #include <coreplugin/iuavgadget.h>
 #include "uploadergadgetwidget.h"
+#include <extensionsystem/pluginmanager.h>
 
 using namespace uploader;
 
@@ -44,6 +45,8 @@ UploaderGadgetFactory::~UploaderGadgetFactory()
 Core::IUAVGadget *UploaderGadgetFactory::createGadget(QWidget *parent)
 {
     UploaderGadgetWidget *gadgetWidget = new UploaderGadgetWidget(parent);
+    // TODO remove this when upgrader + backend factored out of widget
+    ExtensionSystem::PluginManager::instance()->addObject(gadgetWidget);
     connect(gadgetWidget, &UploaderGadgetWidget::newBoardSeen, this,
             &UploaderGadgetFactory::newBoardSeen);
     return new UploaderGadget(QString("Uploader"), gadgetWidget, parent);

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -34,6 +34,7 @@
 #include <QDesktopServices>
 #include <QHttpPart>
 #include <QHttpMultiPart>
+#include <QNetworkAccessManager>
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QUrl>
@@ -44,6 +45,8 @@
 #include <coreplugin/modemanager.h>
 #include <coreplugin/actionmanager/actionmanager.h>
 #include "rawhid/rawhidplugin.h"
+#include "ui_uploader.h"
+#include <extensionsystem/pluginmanager.h>
 
 using namespace uploader;
 
@@ -165,6 +168,8 @@ UploaderGadgetWidget::UploaderGadgetWidget(QWidget *parent)
  */
 UploaderGadgetWidget::~UploaderGadgetWidget()
 {
+    // TODO remove this when addObject removed from factory
+    ExtensionSystem::PluginManager::instance()->removeObject(this);
 }
 
 /**
@@ -813,6 +818,8 @@ bool UploaderGadgetWidget::tradeSettingsWithCloud(QString srcRelease, QString an
 
 void UploaderGadgetWidget::upgradeError(QString why)
 {
+    upgraderActive = false;
+
     Q_UNUSED(why);
 
     m_dialog.hide();
@@ -849,6 +856,8 @@ void UploaderGadgetWidget::stepChangeAndDelay(QEventLoop &loop, int delayMs,
 
 void UploaderGadgetWidget::doUpgradeOperation(bool blankFC, tl_dfu::device &dev)
 {
+    upgraderActive = true;
+
     Core::ModeManager::instance()->activateModeByWorkspaceName("Firmware");
 
     m_dialog.onStepChanged(UpgradeAssistantDialog::STEP_ENTERLOADER);
@@ -1213,6 +1222,8 @@ void UploaderGadgetWidget::doUpgradeOperation(bool blankFC, tl_dfu::device &dev)
     while (!aborted) {
         loop.exec();
     }
+
+    upgraderActive = false;
 }
 
 /**
@@ -1979,4 +1990,20 @@ bool UploaderGadgetWidget::FirmwareCheckForUpdate(deviceDescriptorStruct device)
         }
     }
     return false;
+}
+
+bool UploaderGadgetWidget::active() const
+{
+    switch (uploaderStatus) {
+    case DISCONNECTED:
+    case CONNECTED_TO_TELEMETRY:
+        return upgraderActive;
+    case ENTERING_LOADER:
+    case BL_SITTING:
+    case BL_BUSY:
+    case UPGRADING:
+    case UPGRADING_CATCHLOADER:
+        break;
+    }
+    return true;
 }

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.h
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.h
@@ -33,8 +33,6 @@
 #define UPLOADERGADGETWIDGET_H
 
 #include <QPointer>
-#include <QNetworkAccessManager>
-#include "ui_uploader.h"
 #include "tl_dfu.h"
 #include <coreplugin/iboardtype.h>
 #include "uploader_global.h"
@@ -44,6 +42,9 @@
 #include "coreplugin/connectionmanager.h"
 #include "uavsettingsimportexport/uavsettingsimportexportmanager.h"
 #include "upgradeassistantdialog.h"
+
+class QNetworkAccessManager;
+class Ui_UploaderWidget;
 
 using namespace tl_dfu;
 
@@ -58,7 +59,13 @@ class UPLOADER_EXPORT UploaderGadgetWidget : public QWidget
 public:
     UploaderGadgetWidget(QWidget *parent = 0);
     ~UploaderGadgetWidget();
-public slots:
+
+    /**
+     * @brief active
+     * @return true if the uploader is currently doing something (e.g. upgrader)
+     */
+    bool active() const;
+
 signals:
     void newBoardSeen(deviceInfo board, deviceDescriptorStruct device);
     void enteredLoader();
@@ -145,6 +152,7 @@ private:
     uploader::UploaderStatus uploaderStatus;
     QByteArray tempArray;
     QTimer rescueTimer;
+    bool upgraderActive = false;
 
     const QString exportUrl = QString("http://dronin-autotown.appspot.com/convert");
     const QString hasRevUrl = QString("http://dronin-autotown.appspot.com/uavos/%1");


### PR DESCRIPTION
Got bored, wrote a little bit of code. This __always__ pops the setup wizard when a board without actuators configured is connected. Thoughts?

"unconfigured" means no non-zero channels in ActuatorSettings.

Fixes #1737.