### PR TITLE
stabilizationdesired: ensure reprojection always driven

### DIFF
--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -262,6 +262,8 @@ static void altitudeHoldTask(void *parameters)
 
 			stabilizationDesired.Thrust = bound_min_max(throttle_desired, min_throttle, 1.0f);
 
+			stabilizationDesired.ReprojectionMode = STABILIZATIONDESIRED_REPROJECTIONMODE_NONE;
+
 			if (landing) {
 				stabilizationDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;
 				stabilizationDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;

--- a/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
+++ b/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
@@ -659,6 +659,7 @@ static uint8_t updateFixedDesiredAttitude()
 	// TODO implement raw control mode for yaw and base on Accels.Y
 	stabDesired.Yaw = 0;
 
+	stabDesired.ReprojectionMode = STABILIZATIONDESIRED_REPROJECTIONMODE_NONE;
 
 	stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;
 	stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;

--- a/flight/Modules/ManualControl/failsafe_control.c
+++ b/flight/Modules/ManualControl/failsafe_control.c
@@ -82,6 +82,8 @@ int32_t failsafe_control_select(bool reset_controller)
 	stabilization_desired.Pitch = 0;
 	stabilization_desired.Yaw   = 0;
 
+	stabilization_desired.ReprojectionMode = STABILIZATIONDESIRED_REPROJECTIONMODE_NONE;
+
 	if (!armed_when_enabled) {
 		/* disable stabilization so outputs do not move when system was not armed */
 		stabilization_desired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_DISABLED;

--- a/flight/Modules/ManualControl/geofence_control.c
+++ b/flight/Modules/ManualControl/geofence_control.c
@@ -83,9 +83,10 @@ int32_t geofence_control_select(bool reset_controller)
 	StabilizationDesiredGet(&stabilization_desired);
 	StabilizationDesiredGet(&stabilization_desired);
 	stabilization_desired.Thrust = (airframe_type == SYSTEMSETTINGS_AIRFRAMETYPE_HELICP) ? 0 : -1;
-	stabilization_desired.Roll = 0;
+	stabilization_desired.Roll  = 0;
 	stabilization_desired.Pitch = 0;
 	stabilization_desired.Yaw   = 0;
+	stabilization_desired.ReprojectionMode = STABILIZATIONDESIRED_REPROJECTIONMODE_NONE;
 
 	if (!geofence_armed_when_enabled) {
 		/* disable stabilization so outputs do not move when system was not armed */

--- a/flight/Modules/VtolPathFollower/vtol_follower_control.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_control.c
@@ -494,6 +494,8 @@ int32_t vtol_follower_control_attitude(float dT, const float *att_adj)
 	stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;
 	stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;
 
+	stabDesired.ReprojectionMode = STABILIZATIONDESIRED_REPROJECTIONMODE_NONE;
+
 	// Calculate the throttle setting or use pass through from transmitter
 	if (guidanceSettings.ThrottleControl == VTOLPATHFOLLOWERSETTINGS_THROTTLECONTROL_FALSE) {
 		stabDesired.Thrust = (system_settings.AirframeType == SYSTEMSETTINGS_AIRFRAMETYPE_HELICP) ? manual_control_command.Collective : manual_control_command.Throttle;


### PR DESCRIPTION
Various non-mainline things often **did not** drive the reprojection
mode, which could be bad.