### PR TITLE
Stabilization: Add optional integral decay to rate mode.

### DIFF
--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -583,6 +583,9 @@ static void stabilizationTask(void* parameters)
 					actuatorDesiredAxis[i] = pid_apply_setpoint(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], dT_expected);
 					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 
+					// apply integral decay to roll and pitch if integral decay is non-zero
+					if((i == ROLL || i == PITCH) && settings.IntegralDecay[i] > 0.001f) pids[PID_GROUP_RATE + i].iAccumulator *= powf(0.01f,dT_expected/settings.IntegralDecay[i]);
+
 					break;
 
 				case STABILIZATIONDESIRED_STABILIZATIONMODE_ACRODYNE:

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -26,6 +26,7 @@
 		<field name="RollPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
 		<field name="PitchPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
 		<field name="YawPI" units="" type="float" elementnames="Kp,Ki,ILimit" defaultvalue="2.5,0,50" limits="%BE:0:20,%BE:0:20,"/>
+		<field name="IntegralDecay" units="seconds" type="float" elementnames="Roll,Pitch" defaultvalue="0,0" limits="%BE:0:10,%BE:0:10"/>
 		<field name="DerivativeCutoff" units="Hz" type="uint8" elements="1" defaultvalue="20"/>
 		<field name="DerivativeGamma" units="" type="float" elements="1" defaultvalue="0.6"/>
 		<field name="MaxAxisLock" units="deg" type="uint8" elements="1" defaultvalue="15"/>


### PR DESCRIPTION
This PR adds a tweak to optimize rate mode for HeliCP. It allows the user to configure an IntegralDecay for Pitch and Roll that causes the iAccumulator to smoothly settle to zero over time. The decay value defines how long it will take for the accumulator to drop to 1% of its starting value (assuming no extra error is accumulated). I'm currently using a value of 4 seconds.

Some background: I've struggled for a while to get my helis flying nice and "locked in" with any open-source software despite hours of tuning, trying different flight modes, etc. Recently, I bought a mini iKon2, and couldn't believe how well it flew with minimal setup/tuning, so I decided to take a simple pass at reverse engineering its control algorithms.

My main realization is that the swashplate on a CP heli appears to function more like a steering wheel on a car than the steering flaps on an airboat or hovercraft; the swashplate is almost like a mechanical rate control which must be held at a fixed displacement to attain a fixed rate, and when centered it actually abruptly stops the motion of the axis you're controlling. So trying to apply a negative angle to slow down is like overcorrecting when steering a car.

With this realization, I looked at the open-loop response of the iKon2 for roll and pitch (I focused on the P and the I terms) and found that the P-term only contributes ~2 degrees of tilt to the main rotor blades (whether from user input or vehicle motion), while the I-term contributes ~13 degrees. It also clearly has some kind of settling behavior that causes the swashplate to slowly re-center over about 4 seconds (regardless of initial displacement), as well as some small feed-forward component which I chose to ignore.

Starting with just the P-term, and then just I-term (for roll and pitch), I found that in dRonin-scaled values, for pitch:
* P-term is about 0.001 (10)
* I-term is about 0.03 (300!)
* I-limit is about 0.9 (I think default is 0.3)
* Somewhat arbitrarily chose 5e-6 for the D-term

And for roll:
* P-term is about 0.0005 (5)
* I-term is about 0.03 (300)
* I-limit is about 0.9 (I think default is 0.3)
* Somewhat arbitrarily chose 1e-6 for the D-term

Combined with the integral decay from this PR, the open-loop behavior for both FCs was very similar (both via transmitter control and from physically rotating the aircraft with the control sticks centered). I went out and flew and the heli was very nimble and very stable, almost on par with the iKon2. I also tried attitude mode (with this modified rate mode as the inner loop, and with very low attitude gains) and althold mode, and I've never seen it fly so well with any open-source hardware/software.

The iKon also has an attitude mode, and it's definitely doing something different than just passing the attitude error to the rate loop; I think it's just passing the attitude error straight to the actuators, since the swash is effectively already a rate control. But this mode also has a similar swashplate displacement decay, so maybe it's running and I-controller. I need to look into it a bit more. Regardless, our attitude mode worked great with this modified rate mode, but I used very low attitude p-gains since I wasn't sure how everything would behave.