### PR TITLE
GCS:CrashReporter: Include Qt version info

### DIFF
--- a/ground/gcs/src/crashreporterapp/mainwindow.cpp
+++ b/ground/gcs/src/crashreporterapp/mainwindow.cpp
@@ -112,6 +112,9 @@ void MainWindow::onSendReport()
     json["currentArch"] = QSysInfo::currentCpuArchitecture();
     json["buildInfo"] = QSysInfo::buildAbi();
 
+    json["qtRuntimeVersion"] = qVersion();
+    json["qtBuildVersion"] = QT_VERSION_STR;
+
     QUrl url(postUrl);
     QNetworkRequest request(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json; charset=utf-8");


### PR DESCRIPTION
I could infer this from dRonin rev but this way is simpler.