### PR TITLE
AQ32: Add ComBridge to UART 1 and UART 2

### DIFF
--- a/shared/uavobjectdefinition/hwaq32.xml
+++ b/shared/uavobjectdefinition/hwaq32.xml
@@ -13,6 +13,7 @@
 			<description>The port labelled "SER"</description>
 			<options>
 				<option>Disabled</option>
+				<option>ComBridge</option>
 				<option>DebugConsole</option>
 				<option>FrSKY Sensor Hub</option>
 				<option>FrSKY SPort Telemetry</option>
@@ -28,6 +29,7 @@
 			<description>The port labelled "GPS"</description>
 			<options>
 				<option>Disabled</option>
+				<option>ComBridge</option>
 				<option>GPS</option>
 				<option>MavLinkTX_GPS_RX</option>
 			</options>


### PR DESCRIPTION
Don't know why it was omitted, but my MinimOSD is connected to UART1...

Tested and works @ UART1.
No issues expected at UART2.