### PR TITLE
Uncrustify: Explictly specify C, Fix pointer spacing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1099,7 +1099,7 @@ ifneq ($(strip $(filter uncrustify_flight,$(MAKECMDGOALS))),)
 endif
 
 .PHONY: uncrustify_flight
-uncrustify_flight: UNCRUSTIFY_OPTIONS := -c make/uncrustify.cfg --replace
+uncrustify_flight: UNCRUSTIFY_OPTIONS := -c make/uncrustify.cfg --replace -l C
 uncrustify_flight:
 	$(V1) $(UNCRUSTIFY) $(UNCRUSTIFY_OPTIONS) $(FILE)
 

--- a/make/uncrustify.cfg
+++ b/make/uncrustify.cfg
@@ -145,3 +145,8 @@ nl_for_brace=remove
 nl_while_brace=remove
 nl_brace_brace=add
 nl_fdef_brace=add
+
+# convention is space before pointer star and none after
+sp_before_ptr_star=force
+sp_between_ptr_star=remove
+sp_after_ptr_star=remove


### PR DESCRIPTION
Uncrustify defaults to C++ for headers which doesn't make sense for `uncrustify_flight`. Default pointer/star config doesn't match our coding standard, add it to our config.