### PR TITLE
UAVTalk: Fix bug with calculation of timestamp length

### DIFF
--- a/flight/UAVTalk/uavtalk.c
+++ b/flight/UAVTalk/uavtalk.c
@@ -368,6 +368,7 @@ UAVTalkRxState UAVTalkProcessInputStreamQuiet(UAVTalkConnection connectionHandle
 		iproc->obj = UAVObjGetByID(iproc->objId);
 
 		// Determine data length
+		iproc->timestampLength = (iproc->type & UAVTALK_TIMESTAMPED) ? 2 : 0;
 		if (iproc->type == UAVTALK_TYPE_OBJ_REQ || iproc->type == UAVTALK_TYPE_ACK || iproc->type == UAVTALK_TYPE_NACK) {
 			iproc->length = 0;
 			iproc->instanceLength = 0;
@@ -375,7 +376,6 @@ UAVTalkRxState UAVTalkProcessInputStreamQuiet(UAVTalkConnection connectionHandle
 			if (iproc->obj) {
 				iproc->length = UAVObjGetNumBytes(iproc->obj);
 				iproc->instanceLength = (UAVObjIsSingleInstance(iproc->obj) ? 0 : 2);
-				iproc->timestampLength = (iproc->type & UAVTALK_TIMESTAMPED) ? 2 : 0;
 			} else {
 				// We don't know if it's a multi-instance object, so just assume it's 0.
 				iproc->instanceLength = 0;


### PR DESCRIPTION
timestampLength was uninitialised and only written when receiving certain packet types. This prevented PipX from properly receiving requests for HwTauLink thus breaking the RFM bind wizard (unlikely to affect other targets much as they will almost certainly process a packet that results in timestampLength being set to 0 early on). It would also break the next untimestamped packet if any timestamped packets were received (would be from a 3rd party impl. since GCS doesn't AFAIK).

Confirmed to make RFM bind wizard work again for PipX (see comment https://github.com/d-ronin/dRonin/issues/1602#issuecomment-292793646).

Amazing that this hasn't been caught since it was introduced in 2012! https://github.com/d-ronin/dRonin/commit/4809d569c028d3a75950c889cf6ddc6e332a1ac5