### PR TITLE
Packaging: deb package only works on Ubuntu, tag it as such

### DIFF
--- a/package/release-asset-info.py
+++ b/package/release-asset-info.py
@@ -77,7 +77,7 @@ def main():
         elif name.endswith('.tar.xz'):
             label = "Linux 64-bit portable"
         elif name.endswith('.deb'):
-            label = "Linux 64-bit Debian-style package"
+            label = "Ubuntu 64-bit package"
         elif name.endswith('.zip'):
             label = "Windows (portable)"
         elif name.endswith('-install.exe'):

--- a/package/release-asset-info.py
+++ b/package/release-asset-info.py
@@ -83,7 +83,7 @@ def main():
         elif name.endswith('-install.exe'):
             label = "Windows (installer)"
         elif name.endswith('.dmg'):
-            label = "Mac OS X"
+            label = "macOS"
         else:
             label = name
         asset['new_label'] = label


### PR DESCRIPTION
Due to pulseaudio package being named differently between Debian and Ubuntu repos or some such (reported by IRC user OneSplot).
Also update the mac package name while there.

@mlyle Might want to run this on the current release because it's already caused people problems.