### PR TITLE
sprf3e: cut down target modules

### DIFF
--- a/flight/targets/sprf3e/fw/Makefile
+++ b/flight/targets/sprf3e/fw/Makefile
@@ -46,12 +46,10 @@ OPTMODULES += GPS
 OPTMODULES += CameraStab
 OPTMODULES += Autotune
 OPTMODULES += TxPID
-#OPTMODULES += GenericI2CSensor
 OPTMODULES += AltitudeHold
 OPTMODULES += PathPlanner
 OPTMODULES += VtolPathFollower
 OPTMODULES += FixedWingPathFollower
-OPTMODULES += VibrationAnalysis
 OPTMODULES += UAVOMavlinkBridge
 OPTMODULES += UAVOMSPBridge
 OPTMODULES += UAVOLighttelemetryBridge
@@ -61,9 +59,7 @@ OPTMODULES += Airspeed
 OPTMODULES += UAVOHoTTBridge
 OPTMODULES += UAVOFrSKYSensorHubBridge
 OPTMODULES += UAVOFrSKYSPortBridge
-OPTMODULES += Geofence
 OPTMODULES += Logging
-OPTMODULES += Storm32Bgc
 OPTMODULES += UAVOCrossfireTelemetry
 
 # Paths


### PR DESCRIPTION
Because we overflow in the blheli-passthrough branch.