### PR TITLE
pios_spi: Optional DMA transfers on F4 (WIP).

### DIFF
--- a/flight/PiOS/STM32/inc/pios_quickdma.h
+++ b/flight/PiOS/STM32/inc/pios_quickdma.h
@@ -1,0 +1,46 @@
+#ifndef PIOS_QUICKDMA_H
+#define PIOS_QUICKDMA_H
+
+#include <pios.h>
+
+typedef struct quickdma_transfer* quickdma_transfer_t;
+
+#define QUICKDMA_SIZE_BYTE				1
+#define QUICKDMA_SIZE_HALFWORD			2
+#define QUICKDMA_SIZE_WORD				4
+
+#define QUICKDMA_PRIORITY_LOW			0
+#define QUICKDMA_PRIORITY_MEDIUM		1
+#define QUICKDMA_PRIORITY_HIGH			2
+#define QUICKDMA_PRIORITY_VERYHIGH		3
+
+#if defined(STM32F4XX)
+
+#include "stm32f4xx.h"
+
+quickdma_transfer_t quickdma_initialize(DMA_Stream_TypeDef *stream, uint32_t channel, bool fifo);
+
+#elif defined(STM32F30X)
+
+#include "stm32f30x.h"
+
+/* quickdma_transfer_t quickdma_initialize(DMA_Channel_TypeDef *stream, bool fifo); */
+#error MCU not supported.
+
+#else
+#error MCU not supported.
+#endif
+
+void quickdma_mem_to_peripheral(quickdma_transfer_t tr, uint32_t memaddr, uint32_t phaddr, uint16_t len, uint8_t datasize);
+void quickdma_peripheral_to_mem(quickdma_transfer_t tr, uint32_t phaddr, uint32_t memaddr, uint16_t len, uint8_t datasize);
+
+void quickdma_set_meminc(quickdma_transfer_t tr, bool enabled);
+
+void quickdma_set_priority(quickdma_transfer_t tr, uint8_t priority);
+
+bool quickdma_start_transfer(quickdma_transfer_t tr);
+void quickdma_wait_for_transfer(quickdma_transfer_t tr);
+bool quickdma_is_transferring(quickdma_transfer_t tr);
+void quickdma_stop_transfer(quickdma_transfer_t tr);
+
+#endif // PIOS_QUICKDMA_H

--- a/flight/PiOS/STM32/inc/pios_quickdma.h
+++ b/flight/PiOS/STM32/inc/pios_quickdma.h
@@ -35,7 +35,9 @@ struct quickdma_config {
 #endif
 
 	/* Common settings */
-	uint8_t fifo;
+	uint8_t fifo;				/* Whether to configure FIFO. */
+
+	uint8_t irq;				/* IRQ channel for DMA interrupts. */
 };
 
 quickdma_transfer_t quickdma_initialize(const struct quickdma_config *cfg);
@@ -44,12 +46,14 @@ void quickdma_mem_to_peripheral(quickdma_transfer_t tr, uint32_t memaddr, uint32
 void quickdma_peripheral_to_mem(quickdma_transfer_t tr, uint32_t phaddr, uint32_t memaddr, uint16_t len, uint8_t datasize);
 
 void quickdma_set_meminc(quickdma_transfer_t tr, bool enabled);
-
 void quickdma_set_priority(quickdma_transfer_t tr, uint8_t priority);
 
 bool quickdma_start_transfer(quickdma_transfer_t tr);
 void quickdma_wait_for_transfer(quickdma_transfer_t tr);
 bool quickdma_is_transferring(quickdma_transfer_t tr);
 void quickdma_stop_transfer(quickdma_transfer_t tr);
+
+void quickdma_enable_yielding(quickdma_transfer_t tr);
+void quickdma_irq_trigger(const struct quickdma_config *cfg);
 
 #endif // PIOS_QUICKDMA_H

--- a/flight/PiOS/STM32/inc/pios_quickdma.h
+++ b/flight/PiOS/STM32/inc/pios_quickdma.h
@@ -18,18 +18,27 @@ typedef struct quickdma_transfer* quickdma_transfer_t;
 
 #include "stm32f4xx.h"
 
-quickdma_transfer_t quickdma_initialize(DMA_Stream_TypeDef *stream, uint32_t channel, bool fifo);
+struct quickdma_config {
+	DMA_Stream_TypeDef *stream;
+	uint32_t channel;
 
 #elif defined(STM32F30X)
+#error MCU not supported.
 
 #include "stm32f30x.h"
 
-/* quickdma_transfer_t quickdma_initialize(DMA_Channel_TypeDef *stream, bool fifo); */
-#error MCU not supported.
+struct quickdma_config {
+	DMA_Channel_TypeDef *channel;
 
 #else
 #error MCU not supported.
 #endif
+
+	/* Common settings */
+	uint8_t fifo;
+};
+
+quickdma_transfer_t quickdma_initialize(const struct quickdma_config *cfg);
 
 void quickdma_mem_to_peripheral(quickdma_transfer_t tr, uint32_t memaddr, uint32_t phaddr, uint16_t len, uint8_t datasize);
 void quickdma_peripheral_to_mem(quickdma_transfer_t tr, uint32_t phaddr, uint32_t memaddr, uint16_t len, uint8_t datasize);

--- a/flight/PiOS/STM32F4xx/pios_quickdma.c
+++ b/flight/PiOS/STM32F4xx/pios_quickdma.c
@@ -1,0 +1,458 @@
+#include <pios.h>
+#include <pios_thread.h>
+
+#include "pios_quickdma.h"
+
+struct quickdma_transfer {
+	DMA_Stream_TypeDef *stream;
+	uint32_t channel;
+
+	/*
+		ISR and IFCR flags are all the same on F4. Use one set for both checking
+		interrupt status and clearing them.
+	*/
+	uint32_t tcflag;
+
+	uint32_t memaddr;
+	uint32_t phaddr;
+
+	uint16_t transfer_length;
+
+	uint8_t fifo;
+};
+
+#define HIFCR_FLAG 0x80000000
+
+/**
+ * @brief Generates interrupt flag clearing masks for (de)initialization.
+ */
+uint32_t quickdma_ifcflag_mask(DMA_Stream_TypeDef *stream)
+{
+	/*
+		Ugly as hell.
+
+		Probably should do the sketchy bitshifting stuff like in StdPeriph.
+	*/
+	switch ((uint32_t)stream) {
+	case (uint32_t)DMA1_Stream0:
+	case (uint32_t)DMA2_Stream0:
+		return DMA_LIFCR_CTCIF0 | DMA_LIFCR_CHTIF0 | DMA_LIFCR_CTEIF0 | DMA_LIFCR_CDMEIF0 | DMA_LIFCR_CFEIF0;
+
+	case (uint32_t)DMA1_Stream1:
+	case (uint32_t)DMA2_Stream1:
+		return DMA_LIFCR_CTCIF1 | DMA_LIFCR_CHTIF1 | DMA_LIFCR_CTEIF1 | DMA_LIFCR_CDMEIF1 | DMA_LIFCR_CFEIF1;
+
+	case (uint32_t)DMA1_Stream2:
+	case (uint32_t)DMA2_Stream2:
+		return DMA_LIFCR_CTCIF2 | DMA_LIFCR_CHTIF2 | DMA_LIFCR_CTEIF2 | DMA_LIFCR_CDMEIF2 | DMA_LIFCR_CFEIF2;
+
+	case (uint32_t)DMA1_Stream3:
+	case (uint32_t)DMA2_Stream3:
+		return DMA_LIFCR_CTCIF3 | DMA_LIFCR_CHTIF3 | DMA_LIFCR_CTEIF3 | DMA_LIFCR_CDMEIF3 | DMA_LIFCR_CFEIF3;
+
+	case (uint32_t)DMA1_Stream4:
+	case (uint32_t)DMA2_Stream4:
+		return DMA_HIFCR_CTCIF4 | DMA_HIFCR_CHTIF4 | DMA_HIFCR_CTEIF4 | DMA_HIFCR_CDMEIF4 | DMA_HIFCR_CFEIF4;
+
+	case (uint32_t)DMA1_Stream5:
+	case (uint32_t)DMA2_Stream5:
+		return DMA_HIFCR_CTCIF5 | DMA_HIFCR_CHTIF5 | DMA_HIFCR_CTEIF5 | DMA_HIFCR_CDMEIF5 | DMA_HIFCR_CFEIF5;
+
+	case (uint32_t)DMA1_Stream6:
+	case (uint32_t)DMA2_Stream6:
+		return DMA_HIFCR_CTCIF6 | DMA_HIFCR_CHTIF6 | DMA_HIFCR_CTEIF6 | DMA_HIFCR_CDMEIF6 | DMA_HIFCR_CFEIF6;
+
+	case (uint32_t)DMA1_Stream7:
+	case (uint32_t)DMA2_Stream7:
+		return DMA_HIFCR_CTCIF7 | DMA_HIFCR_CHTIF7 | DMA_HIFCR_CTEIF7 | DMA_HIFCR_CDMEIF7 | DMA_HIFCR_CFEIF7;
+
+	default:
+		// Whoops. Don't.
+		PIOS_Assert(0);
+	}
+}
+
+/**
+ * @brief Returns the transfer complete flag for a stream.
+ */
+uint32_t quickdma_tcflag_map(DMA_Stream_TypeDef *stream)
+{
+	/* Ugly as sin. */
+	switch ((uint32_t)stream) {
+	case (uint32_t)DMA1_Stream0:
+	case (uint32_t)DMA2_Stream0:
+		return DMA_LIFCR_CTCIF0;
+	case (uint32_t)DMA1_Stream1:
+	case (uint32_t)DMA2_Stream1:
+		return DMA_LIFCR_CTCIF1;
+	case (uint32_t)DMA1_Stream2:
+	case (uint32_t)DMA2_Stream2:
+		return DMA_LIFCR_CTCIF2;
+	case (uint32_t)DMA1_Stream3:
+	case (uint32_t)DMA2_Stream3:
+		return DMA_LIFCR_CTCIF3;
+	case (uint32_t)DMA1_Stream4:
+	case (uint32_t)DMA2_Stream4:
+		return DMA_HIFCR_CTCIF4 | HIFCR_FLAG;
+	case (uint32_t)DMA1_Stream5:
+	case (uint32_t)DMA2_Stream5:
+		return DMA_HIFCR_CTCIF5 | HIFCR_FLAG;
+	case (uint32_t)DMA1_Stream6:
+	case (uint32_t)DMA2_Stream6:
+		return DMA_HIFCR_CTCIF6 | HIFCR_FLAG;
+	case (uint32_t)DMA1_Stream7:
+	case (uint32_t)DMA2_Stream7:
+		return DMA_HIFCR_CTCIF7 | HIFCR_FLAG;
+	default:
+		// Whoops. Don't.
+		PIOS_Assert(0);
+	}
+}
+
+/**
+ * @brief Maps quickdma memory size parameter to a DMA flag.
+ */
+inline uint32_t quickdma_trsize_mem(uint8_t x)
+{
+	switch (x) {
+	case QUICKDMA_SIZE_BYTE:
+		return 0;
+	case QUICKDMA_SIZE_HALFWORD:
+		return DMA_SxCR_MSIZE_0;
+	case QUICKDMA_SIZE_WORD:
+		return DMA_SxCR_MSIZE_1;
+	default:
+		PIOS_Assert(0);
+	}
+}
+
+/**
+ * @brief Maps quickdma peripheral size parameter to a DMA flag.
+ */
+inline uint32_t quickdma_trsize_ph(uint8_t x)
+{
+	switch (x) {
+	case QUICKDMA_SIZE_BYTE:
+		return 0;
+	case QUICKDMA_SIZE_HALFWORD:
+		return DMA_SxCR_PSIZE_0;
+	case QUICKDMA_SIZE_WORD:
+		return DMA_SxCR_PSIZE_1;
+	default:
+		PIOS_Assert(0);
+	}
+}
+
+/**
+ * @brief Maps quickdma priority parameter to a DMA flag.
+ */
+inline uint32_t quickdma_priority(uint8_t x)
+{
+	switch (x) {
+	case QUICKDMA_PRIORITY_LOW:
+		return 0;
+	case QUICKDMA_PRIORITY_MEDIUM:
+		return DMA_SxCR_PL_0;
+	case QUICKDMA_PRIORITY_HIGH:
+		return DMA_SxCR_PL_1;
+	case QUICKDMA_PRIORITY_VERYHIGH:
+		return DMA_SxCR_PL_0 | DMA_SxCR_PL_1;
+	default:
+		PIOS_Assert(0);
+	}
+}
+
+/**
+ * @brief Runs a deinitialization of a DMA stream.
+ */
+void quickdma_deinit(DMA_Stream_TypeDef *s)
+{
+	s->CR &= ~DMA_SxCR_EN;
+	while (s->CR & DMA_SxCR_EN) ;
+
+	s->CR = 0;
+	s->NDTR = 0;
+	s->PAR = 0;
+	s->M0AR = 0;
+	s->M1AR = 0,
+	s->FCR = 0x00000021; /* Stdlib does that. */
+
+	DMA_TypeDef *dma = s < DMA2_Stream0 ? DMA1 : DMA2;
+	volatile uint32_t *IFCR = (quickdma_tcflag_map(s) & HIFCR_FLAG) ? &dma->HIFCR : &dma->LIFCR;
+
+	*IFCR = quickdma_ifcflag_mask(s);
+}
+
+/**
+ * @brief		Initializes and configures a DMA stream/channel for transfers.
+ *
+ * @param[in] stream 			DMA stream in question.
+ * @param[in] channel			DMA channel on the stream.
+ * @param[in] fifo 				Whether to allow auto-FIFO configuration or not.
+ *
+ * @returns Configuration struct for further use.
+ */
+quickdma_transfer_t quickdma_initialize(DMA_Stream_TypeDef *stream, uint32_t channel, bool fifo)
+{
+	quickdma_transfer_t tr = PIOS_malloc_no_dma(sizeof(*tr));
+	PIOS_Assert(tr);
+	memset(tr, 0, sizeof(*tr));
+
+	tr->stream = stream;
+	tr->channel = channel;
+	tr->tcflag = quickdma_tcflag_map(stream);
+	tr->fifo = fifo ? 1 : 0;
+
+	return tr;
+}
+
+/**
+ * @brief		Sets up a DMA stream/channel to memory-to-peripheral direction.
+ *
+ * @param[in] tr 				DMA configuration.
+ * @param[in] memaddr 			Address of source data.
+ * @param[in] phaddr 			Address of peripheral to send to.
+ * @param[in] len 				Length of the transfer.
+ * @param[in] datasize 			Transfer chunk size of the data.
+ */
+void quickdma_mem_to_peripheral(quickdma_transfer_t tr, uint32_t memaddr, uint32_t phaddr, uint16_t len, uint8_t datasize)
+{
+	PIOS_Assert(tr);
+	PIOS_Assert(tr->stream);
+
+	DMA_Stream_TypeDef *s = tr->stream;
+
+	s->CR &= ~DMA_SxCR_EN;
+	while (s->CR & DMA_SxCR_EN) ;
+
+	quickdma_deinit(s);
+
+	s->CR = tr->channel |
+	        //DMA_SxCR_PFCTRL |					/* Peripheral does flow control. */
+	        DMA_SxCR_DIR_0 |					/* Mem to peripheral. */
+	        DMA_SxCR_MINC |						/* Memory pointer increase. */
+	        quickdma_trsize_ph(datasize) |		/* Periph. data size */
+	        quickdma_trsize_mem(datasize);		/* Mem. data size */
+
+	if (tr->fifo && (memaddr % 16) == 0) {
+		/* Aligned to 16 bytes, do burst. */
+
+		s->FCR |= DMA_SxFCR_FTH_0 | DMA_SxFCR_FTH_1 | DMA_SxFCR_DMDIS;	/* Full threshold */
+		switch (datasize) {
+		case QUICKDMA_SIZE_BYTE:
+			s->CR |= DMA_SxCR_MBURST_0 | DMA_SxCR_MBURST_1;	/* INC16 */
+			break;
+		case QUICKDMA_SIZE_HALFWORD:
+			s->CR |= DMA_SxCR_MBURST_1;						/* INC8 */
+			break;
+		case QUICKDMA_SIZE_WORD:
+			s->CR |= DMA_SxCR_MBURST_0;						/* INC4 */
+			break;
+		/*
+			Doesn't need default case, if the value is invalid, it'll crash
+			via quickdma_trsize_mem.
+		*/
+		}
+	} else {
+		/* Clear FIFO flags. */
+		s->FCR &= ~(DMA_SxFCR_FTH | DMA_SxFCR_DMDIS);
+		s->CR &= ~DMA_SxCR_MBURST;
+	}
+
+	tr->memaddr = memaddr;
+	tr->phaddr = phaddr;
+	tr->transfer_length = len;
+}
+
+/**
+ * @brief		Sets up a DMA stream/channel to peripheral-to-memory direction.
+ *
+ * @param[in] tr 				DMA configuration.
+ * @param[in] phaddr 			Address of peripheral to send to.
+ * @param[in] memaddr 			Address of source data.
+ * @param[in] len 				Length of the transfer.
+ * @param[in] datasize 			Transfer chunk size of the data.
+ */
+void quickdma_peripheral_to_mem(quickdma_transfer_t tr, uint32_t phaddr, uint32_t memaddr, uint16_t len, uint8_t datasize)
+{
+	PIOS_Assert(tr);
+	PIOS_Assert(tr->stream);
+
+	DMA_Stream_TypeDef *s = tr->stream;
+
+	s->CR &= ~DMA_SxCR_EN;
+	while (s->CR & DMA_SxCR_EN) ;
+
+	quickdma_deinit(s);
+
+	s->CR = tr->channel |
+	        //DMA_SxCR_PFCTRL |					/* Peripheral does flow control. */
+	        									/* Peripheral to mem. */
+	        DMA_SxCR_MINC |						/* Memory pointer increase. */
+	        quickdma_trsize_ph(datasize) |		/* Periph. data size */
+	        quickdma_trsize_mem(datasize);		/* Mem. data size */
+
+	/* Don't do FIFO in this direction yet. */
+	s->FCR &= ~(DMA_SxFCR_FTH | DMA_SxFCR_DMDIS);
+	s->CR &= ~DMA_SxCR_MBURST;
+
+	tr->memaddr = memaddr;
+	tr->phaddr = phaddr;
+	tr->transfer_length = len;
+}
+
+/**
+ * @brief		Sets the priority of the DMA transfer.
+ *
+ * @param[in] tr 				DMA configuration.
+ * @param[in] priority 			The transfer priority, in case of contention.
+ *
+ * @note Default priority is low.
+ */
+void quickdma_set_priority(quickdma_transfer_t tr, uint8_t priority)
+{
+	PIOS_Assert(tr);
+	PIOS_Assert(tr->stream);
+	PIOS_Assert(priority <= QUICKDMA_PRIORITY_VERYHIGH);
+
+	DMA_Stream_TypeDef *s = tr->stream;
+
+	s->CR &= ~DMA_SxCR_PL;
+	s->CR |= quickdma_priority(priority);
+}
+
+/**
+ * @brief		Stops an ongoing transfer.
+ *
+ * @param[in] tr 				DMA configuration.
+ */
+void quickdma_stop_transfer(quickdma_transfer_t tr)
+{
+	PIOS_Assert(tr);
+	PIOS_Assert(tr->stream);
+
+	DMA_Stream_TypeDef *s = tr->stream;
+	DMA_TypeDef *dma = tr->stream < DMA2_Stream0 ? DMA1 : DMA2;
+	volatile uint32_t *IFCR = (tr->tcflag & HIFCR_FLAG) ? &dma->HIFCR : &dma->LIFCR;
+	uint32_t tcflag = tr->tcflag & ~HIFCR_FLAG;
+
+	s->CR &= ~DMA_SxCR_EN;
+	while (s->CR & DMA_SxCR_EN) ;
+
+	*IFCR |= tcflag;
+}
+
+/**
+ * @brief		Starts a DMA transfer.
+ *
+ * @param[in] tr 				DMA configuration.
+ *
+ * @returns true if the DMA transfer started successfully, false if it didn't 
+ *          (likely caused by an already ongoing transfer).
+ */
+bool quickdma_start_transfer(quickdma_transfer_t tr)
+{
+	PIOS_Assert(tr);
+	PIOS_Assert(tr->stream);
+
+	DMA_Stream_TypeDef *s = tr->stream;
+	DMA_TypeDef *dma = tr->stream < DMA2_Stream0 ? DMA1 : DMA2;
+	volatile uint32_t *ISR = (tr->tcflag & HIFCR_FLAG) ? &dma->HISR : &dma->LISR;
+	volatile uint32_t *IFCR = (tr->tcflag & HIFCR_FLAG) ? &dma->HIFCR : &dma->LIFCR;
+	uint32_t tcflag = tr->tcflag & ~HIFCR_FLAG;
+
+	if ((s->CR & DMA_SxCR_EN) && !(*ISR & tcflag)) {
+		/* DMA is going, can't start. */
+		return false;
+	}
+
+	/* Wait for DMA to disable. */
+	s->CR &= ~DMA_SxCR_EN;
+	while (s->CR & DMA_SxCR_EN) ;
+
+	*IFCR |= tcflag;
+
+	s->M0AR = tr->memaddr;
+	s->PAR = tr->phaddr;
+	s->NDTR = tr->transfer_length;
+
+	s->CR |= DMA_SxCR_EN;
+
+	return true;
+}
+
+/**
+ * @brief		Waits for a DMA transfer to finish.
+ *
+ * @param[in] tr 				DMA configuration.
+ */
+void quickdma_wait_for_transfer(quickdma_transfer_t tr)
+{
+	PIOS_Assert(tr);
+	PIOS_Assert(tr->stream);
+
+	DMA_Stream_TypeDef *s = tr->stream;
+	DMA_TypeDef *dma = tr->stream < DMA2_Stream0 ? DMA1 : DMA2;
+	volatile uint32_t *ISR = (tr->tcflag & HIFCR_FLAG) ? &dma->HISR : &dma->LISR;
+	uint32_t tcflag = tr->tcflag & ~HIFCR_FLAG;
+
+	if (!(s->CR & DMA_SxCR_EN)) {
+		/* DMA not going. */
+		return;
+	}
+
+	while (!(*ISR & tcflag)) ;
+}
+
+/**
+ * @brief		Checks whether there's a DMA transfer going.
+ *
+ * @param[in] tr 				DMA configuration.
+ *
+ * @returns true if a transfer is ongoing, false is it's not.
+ */
+bool quickdma_is_transferring(quickdma_transfer_t tr)
+{
+	PIOS_Assert(tr);
+	PIOS_Assert(tr->stream);
+
+	DMA_Stream_TypeDef *s = tr->stream;
+	DMA_TypeDef *dma = tr->stream < DMA2_Stream0 ? DMA1 : DMA2;
+	volatile uint32_t *ISR = (tr->tcflag & HIFCR_FLAG) ? &dma->HISR : &dma->LISR;
+	uint32_t tcflag = tr->tcflag & ~HIFCR_FLAG;
+
+	if (!(s->CR & DMA_SxCR_EN)) {
+		/* DMA not going. */
+		return false;
+	}
+
+	if (*ISR & tcflag) {
+		/* DMA has finished. */
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * @brief		Overrides memory pointer increase policy.
+ *
+ * @param[in] tr 				DMA configuration.
+ * @param[in] enabled 			Whether to increase the memory pointer during transfers.
+ *
+ * @note Use this if you want to send dummy data from or to a peripheral, without the need
+ *       to allocate a lot of memory.
+ */
+void quickdma_set_meminc(quickdma_transfer_t tr, bool enabled)
+{
+	PIOS_Assert(tr);
+	PIOS_Assert(tr->stream);
+
+	DMA_Stream_TypeDef *s = tr->stream;
+
+	if (enabled) {
+		s->CR |= DMA_SxCR_MINC;
+	} else {
+		s->CR &= ~DMA_SxCR_MINC;
+	}
+}

--- a/flight/PiOS/inc/pios_spi_priv.h
+++ b/flight/PiOS/inc/pios_spi_priv.h
@@ -35,10 +35,30 @@
 #include <pios_stm32.h>
 #include "pios_semaphore.h"
 
+#if defined(STM32F4XX)
+#include "stm32f4xx_dma.h"
+#include "pios_quickdma.h"
+#endif
+
 struct pios_spi_dev {
 	const struct pios_spi_cfg *cfg;
 	struct pios_semaphore *busy;
+#if defined(STM32F4XX)
+	quickdma_transfer_t dma_send;
+	quickdma_transfer_t dma_recv;
+
+	uint8_t dummy_send;
+	uint8_t dummy_recv;
+#endif
 };
+
+#if defined(STM32F4XX)
+
+struct pios_spi_dma {
+	struct quickdma_config send;
+	struct quickdma_config recv;
+};
+#endif
 
 struct pios_spi_cfg {
 	SPI_TypeDef *regs;
@@ -48,6 +68,9 @@ struct pios_spi_cfg {
 	struct stm32_gpio miso;
 	struct stm32_gpio mosi;
 	uint32_t slave_count;
+#if defined(STM32F4XX)
+	struct pios_spi_dma spi_dma;
+#endif
 #ifdef PIOS_INCLUDE_VIDEO
 	// XXX Hack: pios_video uses pios_spi's config structure and expects the
 	// DMA information to be filled in properly

--- a/flight/targets/revolution/board-info/board_hw_defs.c
+++ b/flight/targets/revolution/board-info/board_hw_defs.c
@@ -168,7 +168,17 @@ static const struct pios_spi_cfg pios_spi_gyro_cfg = {
 			.GPIO_OType = GPIO_OType_PP,
 			.GPIO_PuPd = GPIO_PuPd_UP
 		} }
-	}
+	},
+	.spi_dma = {
+		.send = {
+			.stream = DMA2_Stream3,
+			.channel = DMA_Channel_3
+		},
+		.recv = {
+			.stream = DMA2_Stream2,
+			.channel = DMA_Channel_3
+		}
+	},
 };
 
 /*

--- a/flight/targets/seppuku/board-info/board_hw_defs.c
+++ b/flight/targets/seppuku/board-info/board_hw_defs.c
@@ -174,6 +174,16 @@ static const struct pios_spi_cfg pios_spi_gyro_accel_cfg = {
 			},
 		},
 	},
+	.spi_dma = {
+		.send = {
+			.stream = DMA1_Stream7,
+			.channel = DMA_Channel_0
+		},
+		.recv = {
+			.stream = DMA1_Stream0,
+			.channel = DMA_Channel_0
+		}
+	}
 };
 
 uint32_t pios_spi_gyro_accel_id;
@@ -994,12 +1004,6 @@ static const struct pios_dmashot_timer_cfg dmashot_tim_cfg[] = {
 		.channel = DMA_Channel_5,
 		.tcif = DMA_FLAG_TCIF2,
 	},
-	{
-		.timer = TIM5,
-		.stream = DMA1_Stream0,
-		.channel = DMA_Channel_6,
-		.tcif = DMA_FLAG_TCIF0,
-	}
 };
 
 static const struct pios_dmashot_cfg dmashot_config = {


### PR DESCRIPTION
I was suggested on IRC this might be useful, to maximize SPI bandwidth. Apparently it does something. One does DMA, one doesn't:

![timing](https://cloud.githubusercontent.com/assets/4010813/26288395/d232d2e2-3e91-11e7-8693-0db54f3878a7.png)

Gonna look into F3 eventually, since apparently it does the same thing.