### PR TITLE
Flight: Add IRQ Pro/Epilogue to ADC handler

### DIFF
--- a/flight/PiOS/STM32F30x/pios_dma_hooks.c
+++ b/flight/PiOS/STM32F30x/pios_dma_hooks.c
@@ -72,39 +72,122 @@ static inline void PIOS_DMA_Mapper(uint32_t index)
 }
 
 static void PIOS_DMA_11_irq_handler(void){
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_PROLOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 	PIOS_DMA_Mapper(0);
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_EPILOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 }
+
 static void PIOS_DMA_12_irq_handler(void){
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_PROLOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 	PIOS_DMA_Mapper(1);
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_EPILOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 }
+
 static void PIOS_DMA_13_irq_handler(void){
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_PROLOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 	PIOS_DMA_Mapper(2);
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_EPILOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 }
+
 static void PIOS_DMA_14_irq_handler(void){
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_PROLOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 	PIOS_DMA_Mapper(3);
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_EPILOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 }
+
 static void PIOS_DMA_15_irq_handler(void){
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_PROLOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 	PIOS_DMA_Mapper(4);
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_EPILOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 }
+
 static void PIOS_DMA_16_irq_handler(void){
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_PROLOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 	PIOS_DMA_Mapper(5);
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_EPILOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 }
+
 static void PIOS_DMA_17_irq_handler(void){
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_PROLOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 	PIOS_DMA_Mapper(6);
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_EPILOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 }
+
 static void PIOS_DMA_21_irq_handler(void){
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_PROLOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 	PIOS_DMA_Mapper(7);
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_EPILOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 }
+
 static void PIOS_DMA_22_irq_handler(void){
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_PROLOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 	PIOS_DMA_Mapper(8);
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_EPILOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 }
+
 static void PIOS_DMA_23_irq_handler(void){
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_PROLOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 	PIOS_DMA_Mapper(9);
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_EPILOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 }
+
 static void PIOS_DMA_24_irq_handler(void){
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_PROLOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 	PIOS_DMA_Mapper(10);
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_EPILOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 }
+
 static void PIOS_DMA_25_irq_handler(void){
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_PROLOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 	PIOS_DMA_Mapper(11);
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_EPILOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 }
 #endif /* PIOS_INCLUDE_DMA_CB_SUBSCRIBING_FUNCTION */

--- a/flight/PiOS/STM32F4xx/pios_internal_adc.c
+++ b/flight/PiOS/STM32F4xx/pios_internal_adc.c
@@ -402,8 +402,12 @@ void accumulate(uint16_t *buffer, uint32_t count)
  */
 void PIOS_INTERNAL_ADC_DMA_Handler(void)
 {
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_PROLOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
+
 	if (!PIOS_INTERNAL_ADC_validate(pios_adc_dev))
-		return;
+		goto out;
 
 #if defined(PIOS_INCLUDE_ADC)
 	/* terminal count, buffer has flipped */
@@ -419,6 +423,11 @@ void PIOS_INTERNAL_ADC_DMA_Handler(void)
 		}
 	}
 #endif
+
+out:
+#if defined(PIOS_INCLUDE_CHIBIOS)
+	CH_IRQ_EPILOGUE();
+#endif /* PIOS_INCLUDE_CHIBIOS */
 }
 
 /**


### PR DESCRIPTION
Essentially this was an issue I, and probably everyone else running at least the Seppuku, had likely since the beginning:

![sds1202x-e13](https://cloud.githubusercontent.com/assets/4010813/26499651/b2c0a7e0-4233-11e7-855b-1101d82d9e95.png)

Every 200-300ms the servo output signal jitters like this. Turns out it was the ADC IRQ handler doing this and making the system have a ball. Sticking the (missing?) ChibiOS IRQ pro- and epilogue stuff (which also does some thread rescheduling from what I've seen) into the IRQ handler of the ADC mitigates the issue.

So as a precaution, I've also stuck it in the PIOS DMA IRQ handlers on F3.