### PR TITLE
adc: make interrupt rates sane, clean up

### DIFF
--- a/flight/targets/seppuku/board-info/pios_board.h
+++ b/flight/targets/seppuku/board-info/pios_board.h
@@ -238,9 +238,7 @@ extern ws2811_dev_t pios_ws2811;
 //-------------------------
 #define PIOS_ADC_SUB_DRIVER_MAX_INSTANCES       3
 
-// PIOS_ADC_PinGet(0) = IN7
-// PIOS_ADC_PinGet(1) = IN8
-#define PIOS_ADC_MAX_OVERSAMPLING       2
+#define PIOS_ADC_MAX_OVERSAMPLING       4
 #define VREF_PLUS                     3.3
 
 //-------------------------


### PR DESCRIPTION
Needs test and review.

Came across from #1788-- It's good to have the epilogue on the IRQ, but since the IRQ doesn't wake anyone it can't be the real root cause for jitter / things not waking.  OTOH, caused us to observe that the ADC interrupt is called **fast** on F4 because of suck, wasting a whole ton of CPU.  (And running reschedules frequently undoubtedly papers over whatever other problem there is).