### PR TITLE
pios,chibios: No flash instruction/data cache for buggy F4 revisions.

### DIFF
--- a/flight/PiOS/STM32/inc/board.h
+++ b/flight/PiOS/STM32/inc/board.h
@@ -29,6 +29,10 @@
 
 #include "pios_chibios_transition_priv.h"
 
+/* Some older STM32F4 revisions might get antsy when flash prefetching is enabled.
+   This makes sure the affected revs don't get enabled by ChibiOS. */
+#define STM32_USE_REVISION_A_FIX
+
 /*
  * Board oscillators-related settings.
  * NOTE: LSE not fitted.


### PR DESCRIPTION
Apparently there's older revisions of the F4 MCU out there, that don't get flaky if the caches are enabled. ChibiOS can deal with it, if you specify a certain #define.

https://github.com/d-ronin/dRonin/blob/b323ecce4bc16b80aa638fdff07793a872d2e3f7/flight/PiOS/Common/Libraries/ChibiOS/os/hal/platforms/STM32F4xx/hal_lld.c#L258