### PR TITLE
PipX: Don't pass FirmwareIAP commands through

### DIFF
--- a/flight/Libraries/inc/uavtalk.h
+++ b/flight/Libraries/inc/uavtalk.h
@@ -64,6 +64,7 @@ int32_t UAVTalkReceiveObject(UAVTalkConnection connectionHandle);
 void UAVTalkGetStats(UAVTalkConnection connection, UAVTalkStats *stats);
 uint32_t UAVTalkGetPacketObjId(UAVTalkConnection connection);
 uint32_t UAVTalkGetPacketInstId(UAVTalkConnection connection);
+bool UAVTalkPacketIsObjectUpdate(UAVTalkConnection connection);
 
 #endif // UAVTALK_H
 /**

--- a/flight/Libraries/inc/uavtalk_priv.h
+++ b/flight/Libraries/inc/uavtalk_priv.h
@@ -68,7 +68,7 @@ typedef struct {
 	uint16_t packet_size;
 	uint32_t objId;
 	uint16_t instId;
-	uint32_t length;
+	uint32_t length; /**< The length of the object payload (valid after UAVTALK_STATE_OBJID) */
 	uint8_t instanceLength;
 	uint8_t cs;
 	int32_t rxCount;

--- a/flight/Libraries/uavtalk.c
+++ b/flight/Libraries/uavtalk.c
@@ -515,9 +515,9 @@ uint32_t UAVTalkGetPacketObjId(UAVTalkConnection connectionHandle)
 }
 
 /**
- * Get the object ID of the current packet.
+ * Get the instance ID of the current packet.
  * \param[in] connectionHandle UAVTalkConnection to be used
- * \return The object ID, or 0 on error.
+ * \return The instance ID, or 0 on error.
  */
 uint32_t UAVTalkGetPacketInstId(UAVTalkConnection connectionHandle)
 {
@@ -526,6 +526,20 @@ uint32_t UAVTalkGetPacketInstId(UAVTalkConnection connectionHandle)
 	CHECKCONHANDLE(connectionHandle, connection, return 0);
 
 	return connection->iproc.instId;
+}
+
+/**
+ * Check if the current packet contains an object update
+ * \param[in] connectionHandle UAVTalkConnection to be used
+ * \return true if the packet contains on update (i.e. a payload)
+ */
+bool UAVTalkPacketIsObjectUpdate(UAVTalkConnection connectionHandle)
+{
+	UAVTalkConnectionData *connection;
+
+	CHECKCONHANDLE(connectionHandle, connection, return 0);
+
+	return connection->iproc.length > 0;
 }
 
 /**

--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -57,6 +57,7 @@
 #include "velocityactual.h"
 #include "baroaltitude.h"
 #include "modulesettings.h"
+#include "firmwareiapobj.h"
 
 #include "pios_thread.h"
 #include "pios_queue.h"
@@ -596,6 +597,16 @@ static void ProcessTelemetryStream(UAVTalkConnection inConnectionHandle,
 			}
 		}
 			break;
+
+		case FIRMWAREIAPOBJ_OBJID:
+			/* Do not pass FirmwareIAP commands through to the flight board.
+			 * It can't do anything useful with them over radio, and it would
+			 * be dangerous if they're in-flight. We can't block the object
+			 * entirely because GCS uses it to identify the board type */
+			if (!UAVTalkPacketIsObjectUpdate(inConnectionHandle))
+				UAVTalkRelayPacket(inConnectionHandle, outConnectionHandle);
+			break;
+
 		default:
 			// all other packets are transparently relayed to the remote modem
 			UAVTalkRelayPacket(inConnectionHandle, outConnectionHandle);


### PR DESCRIPTION
The flight board cannot do anything useful with them through a radio link, and they are actually quite dangerous if we're in-flight etc. Fixes (for us) https://github.com/TauLabs/TauLabs/issues/1860