### PR TITLE
Flight:SPRF3E: Remove pios_dma.c from Makefile

### DIFF
--- a/flight/targets/sprf3e/fw/Makefile
+++ b/flight/targets/sprf3e/fw/Makefile
@@ -126,7 +126,6 @@ SRC += pios_flashfs_logfs.c
 SRC += printf-stdarg.c
 SRC += pios_usb_desc_hid_cdc.c
 SRC += pios_usb_util.c
-SRC += pios_dma.c
 SRC += pios_adc.c
 SRC += pios_heap.c
 SRC += pios_semaphore.c


### PR DESCRIPTION
Already included by library_chibios.mk
`
mike@mike-desktop:~/dev/dronin$ make sprf3e 1>/dev/null
/home/mike/dev/dronin/make/firmware-common.mk:46: warning: overriding recipe for target '/home/mike/dev/dronin/build/fw_sprf3e/pios_dma.o'
/home/mike/dev/dronin/make/firmware-common.mk:46: warning: ignoring old recipe for target '/home/mike/dev/dronin/build/fw_sprf3e/pios_dma.o'
`