### PR TITLE
Make: Add rule to check GCS code with clazy

### DIFF
--- a/ground/tools.pri
+++ b/ground/tools.pri
@@ -11,9 +11,11 @@ isEmpty(PYTHON_LOCAL) {
 }
 
 # use ccache with gcc and clang in debug config
-CONFIG(debug, debug|release):*-g++*|*-clang* {
-    QMAKE_CC=$$(CCACHE_BIN) $$QMAKE_CC
-    QMAKE_CXX=$$(CCACHE_BIN) $$QMAKE_CXX
+CONFIG(debug, debug|release) {
+    *-g++*|*-clang* {
+        QMAKE_CC=$$(CCACHE_BIN) $$QMAKE_CC
+        QMAKE_CXX=$$(CCACHE_BIN) $$QMAKE_CXX
+    }
 }
 
 DR_QT_MAJOR_VERSION=5

--- a/make/linux.mk
+++ b/make/linux.mk
@@ -7,6 +7,7 @@
 #   respective default installation locations,  or made available on the system path.
 
 QT_SPEC ?= linux-g++
+QT_CLANG_SPEC ?= linux-clang
 
 # Check for and find Python 2
 

--- a/make/macosx.mk
+++ b/make/macosx.mk
@@ -36,5 +36,6 @@ export PYTHON
 
 
 QT_SPEC ?= macx-g++
+QT_CLANG_SPEC ?= macx-clang
 
 UAVOBJGENERATOR="$(BUILD_DIR)/ground/uavobjgenerator/uavobjgenerator"

--- a/make/windows.mk
+++ b/make/windows.mk
@@ -16,6 +16,7 @@ PYTHON := python
 export PYTHON
 
 QT_SPEC ?= win32-g++
+QT_CLANG_SPEC ?= win32-clang-msvc2015
 
 # this might need to switch on debug/release
 UAVOBJGENERATOR := "$(BUILD_DIR)/ground/uavobjgenerator/debug/uavobjgenerator.exe"


### PR DESCRIPTION
Allows the compiler to understand Qt semantics and check code for compliance + recommended practice. https://github.com/KDE/clazy