### PR TITLE
gcs: uavtalk: SIGNIFICANT performance improvement

### DIFF
--- a/ground/gcs/src/plugins/uavtalk/telemetry.cpp
+++ b/ground/gcs/src/plugins/uavtalk/telemetry.cpp
@@ -377,7 +377,7 @@ void Telemetry::transactionTimeout(ObjectTransactionInfo *transInfo)
     transInfo->timer->stop();
     // Check if more retries are pending
     if (transInfo->retriesRemaining > 0) {
-        qDebug() << QString("[telemetry.cpp] Transaction timeout:%0 Instance:%1 Retrying")
+        qInfo() << QString("[telemetry.cpp] Transaction timeout:%0 Instance:%1 Retrying")
                 .arg(transInfo->obj->getName()
                      + QString(QString(" 0x")
                                + QString::number(transInfo->obj->getObjID(), 16).toUpper()))
@@ -386,7 +386,7 @@ void Telemetry::transactionTimeout(ObjectTransactionInfo *transInfo)
         processObjectTransaction(transInfo);
         ++txRetries;
     } else {
-        qDebug() << QString("[telemetry.cpp] Transaction timeout:%0 Instance:%1 no more retries. FAILED "
+        qInfo() << QString("[telemetry.cpp] Transaction timeout:%0 Instance:%1 no more retries. FAILED "
                     "TRANSACT")
                 .arg(transInfo->obj->getName()
                      + QString(QString(" 0x")
@@ -439,7 +439,7 @@ void Telemetry::processObjectUpdates(UAVObject *obj, EventMask event, bool allIn
             ++txErrors;
             obj->emitTransactionCompleted(false);
             obj->emitTransactionCompleted(false, false);
-            qDebug() << QString(tr("Telemetry: priority event queue is full, event lost (%1)")
+            qWarning() << QString(tr("Telemetry: priority event queue is full, event lost (%1)")
                             .arg(obj->getName()));
         }
     } else {
@@ -449,7 +449,7 @@ void Telemetry::processObjectUpdates(UAVObject *obj, EventMask event, bool allIn
             ++txErrors;
             obj->emitTransactionCompleted(false, false);
             obj->emitTransactionCompleted(false);
-            qDebug() << QString(tr("Telemetry: event queue is full, event lost (%1)")
+            qWarning() << QString(tr("Telemetry: event queue is full, event lost (%1)")
                             .arg(obj->getName()));
         }
     }

--- a/ground/gcs/src/plugins/uavtalk/telemetry.cpp
+++ b/ground/gcs/src/plugins/uavtalk/telemetry.cpp
@@ -377,23 +377,21 @@ void Telemetry::transactionTimeout(ObjectTransactionInfo *transInfo)
     transInfo->timer->stop();
     // Check if more retries are pending
     if (transInfo->retriesRemaining > 0) {
-        TELEMETRY_QXTLOG_DEBUG(
-            QString("[telemetry.cpp] Transaction timeout:%0 Instance:%1 Retrying")
+        qDebug() << QString("[telemetry.cpp] Transaction timeout:%0 Instance:%1 Retrying")
                 .arg(transInfo->obj->getName()
                      + QString(QString(" 0x")
                                + QString::number(transInfo->obj->getObjID(), 16).toUpper()))
-                .arg(transInfo->obj->getInstID()));
+                .arg(transInfo->obj->getInstID());
         --transInfo->retriesRemaining;
         processObjectTransaction(transInfo);
         ++txRetries;
     } else {
-        TELEMETRY_QXTLOG_DEBUG(
-            QString("[telemetry.cpp] Transaction timeout:%0 Instance:%1 no more retries. FAILED "
+        qDebug() << QString("[telemetry.cpp] Transaction timeout:%0 Instance:%1 no more retries. FAILED "
                     "TRANSACT")
                 .arg(transInfo->obj->getName()
                      + QString(QString(" 0x")
                                + QString::number(transInfo->obj->getObjID(), 16).toUpper()))
-                .arg(transInfo->obj->getInstID()));
+                .arg(transInfo->obj->getInstID());
         transInfo->timer->stop();
         transactionFailure(transInfo->obj);
         ++txErrors;
@@ -441,9 +439,8 @@ void Telemetry::processObjectUpdates(UAVObject *obj, EventMask event, bool allIn
             ++txErrors;
             obj->emitTransactionCompleted(false);
             obj->emitTransactionCompleted(false, false);
-            TELEMETRY_QXTLOG_DEBUG(
-                QString(tr("Telemetry: priority event queue is full, event lost (%1)")
-                            .arg(obj->getName())));
+            qDebug() << QString(tr("Telemetry: priority event queue is full, event lost (%1)")
+                            .arg(obj->getName()));
         }
     } else {
         if (objQueue.length() < MAX_QUEUE_SIZE) {
@@ -452,6 +449,8 @@ void Telemetry::processObjectUpdates(UAVObject *obj, EventMask event, bool allIn
             ++txErrors;
             obj->emitTransactionCompleted(false, false);
             obj->emitTransactionCompleted(false);
+            qDebug() << QString(tr("Telemetry: event queue is full, event lost (%1)")
+                            .arg(obj->getName()));
         }
     }
     // Process the transaction queue

--- a/ground/gcs/src/plugins/uavtalk/telemetry.h
+++ b/ground/gcs/src/plugins/uavtalk/telemetry.h
@@ -91,8 +91,10 @@ signals:
 
 private:
     // Constants
-    static const int REQ_TIMEOUT_MS = 250;
-    static const int MAX_RETRIES = 2;
+    static const int REQ_TIMEOUT_MS = 1500;
+    // Would be nice to dynamically scale the request timeout... this 1500 value
+    // is about what's necessary for 9600bps uavtalk links.
+    static const int MAX_RETRIES = 4;
     static const int MAX_UPDATE_PERIOD_MS = 1000;
     static const int MIN_UPDATE_PERIOD_MS = 1;
     static const int MAX_QUEUE_SIZE = 20;

--- a/ground/gcs/src/plugins/uavtalk/telemetry.h
+++ b/ground/gcs/src/plugins/uavtalk/telemetry.h
@@ -91,9 +91,10 @@ signals:
 
 private:
     // Constants
+
+    // TODO: Would be nice to dynamically scale the request timeout... 
+    // This 1500 value is about what's necessary for 9600bps uavtalk links.
     static const int REQ_TIMEOUT_MS = 1500;
-    // Would be nice to dynamically scale the request timeout... this 1500 value
-    // is about what's necessary for 9600bps uavtalk links.
     static const int MAX_RETRIES = 4;
     static const int MAX_UPDATE_PERIOD_MS = 1000;
     static const int MIN_UPDATE_PERIOD_MS = 1;

--- a/ground/gcs/src/plugins/uavtalk/telemetrymonitor.h
+++ b/ground/gcs/src/plugins/uavtalk/telemetrymonitor.h
@@ -94,6 +94,7 @@ private:
     static const int STATS_UPDATE_PERIOD_MS = 1600;
     static const int STATS_CONNECT_PERIOD_MS = 350;
     static const int CONNECTION_TIMEOUT_MS = 8000;
+    static const int MAX_REQUESTS_IN_FLIGHT = 3;
     connectionStatusEnum connectionStatus;
     UAVObjectManager *objMngr;
     Telemetry *tel;
@@ -111,6 +112,8 @@ private:
     QTimer *sessionRetrieveTimeout;
     QTimer *sessionInitialRetrieveTimeout;
     int retries;
+    int requestsInFlight;
+
     void changeObjectInstances(quint32 objID, quint32 instID, bool delayed);
     void startSessionRetrieving(UAVObject *session);
     void sessionFallback();

--- a/ground/gcs/src/plugins/uavtalk/uavtalk.cpp
+++ b/ground/gcs/src/plugins/uavtalk/uavtalk.cpp
@@ -125,7 +125,9 @@ void UAVTalk::processInputStream()
         int bytes = io->read((char *) (rxBuffer + filledBytes),
                 sizeof(rxBuffer) - filledBytes);
 
-        if (bytes <= 0) return;
+        if (bytes <= 0) {
+            return;
+        }
 
         filledBytes += bytes;
         stats.rxBytes += bytes;
@@ -260,7 +262,7 @@ bool UAVTalk::processInput()
 
     UAVObject *rxObj = objMngr->getObject(rxObjId);
 
-    if (rxObj == NULL) {
+    if (rxObj == Q_NULLPTR) {
         stats.rxErrors++;
         UAVTALK_QXTLOG_DEBUG("UAVTalk: unknown object");
 
@@ -321,7 +323,7 @@ bool UAVTalk::processInput()
 bool UAVTalk::receiveObject(quint8 type, quint32 objId, quint16 instId, quint8 *data, qint32 length)
 {
     Q_UNUSED(length);
-    UAVObject *obj = NULL;
+    UAVObject *obj = Q_NULLPTR;
     bool error = false;
     bool allInstances = (instId == ALL_INSTANCES);
 
@@ -332,7 +334,7 @@ bool UAVTalk::receiveObject(quint8 type, quint32 objId, quint16 instId, quint8 *
         if (!allInstances) {
             // Get object and update its data
             obj = updateObject(objId, instId, data);
-            if (obj == NULL) {
+            if (obj == Q_NULLPTR) {
                 UAVTALK_QXTLOG_DEBUG(
                     QString("[uavtalk.cpp  ] Received a UAVObject update for a UAVObject we don't "
                             "know about OBJID:%0 INSTID:%1")
@@ -350,7 +352,7 @@ bool UAVTalk::receiveObject(quint8 type, quint32 objId, quint16 instId, quint8 *
             // Get object and update its data
             obj = updateObject(objId, instId, data);
             // Transmit ACK
-            if (obj != NULL) {
+            if (obj != Q_NULLPTR) {
                 transmitObject(obj, TYPE_ACK, false);
             } else {
                 UAVTALK_QXTLOG_DEBUG(QString("[uavtalk.cpp  ] Received an acknowledged UAVObject "
@@ -373,7 +375,7 @@ bool UAVTalk::receiveObject(quint8 type, quint32 objId, quint16 instId, quint8 *
             obj = objMngr->getObject(objId, instId);
         }
         // If object was found transmit it
-        if (obj != NULL) {
+        if (obj != Q_NULLPTR) {
             transmitObject(obj, TYPE_OBJ, allInstances);
         } else {
             // Object was not found, transmit a NACK with the
@@ -389,7 +391,7 @@ bool UAVTalk::receiveObject(quint8 type, quint32 objId, quint16 instId, quint8 *
             // Get object
             obj = objMngr->getObject(objId, instId);
             // Check if object exists:
-            if (obj != NULL) {
+            if (obj != Q_NULLPTR) {
                 UAVTALK_QXTLOG_DEBUG(
                     QString("[uavtalk.cpp  ] The %0 UAVObject does not exist on the remote end, "
                             "got a Nack")
@@ -417,7 +419,7 @@ bool UAVTalk::receiveObject(quint8 type, quint32 objId, quint16 instId, quint8 *
                     .arg(QString(QString("0x") + QString::number(objId, 16).toUpper())));
             // Check if we actually know this object (tiny chance the ObjID
             // could be unknown and got through CRC check...)
-            if (obj != NULL) {
+            if (obj != Q_NULLPTR) {
                 UAVTALK_QXTLOG_DEBUG(
                     QString("[uavtalk.cpp  ] UAVObject name:%0").arg(obj->getName()));
                 emit ackReceived(obj);
@@ -443,21 +445,21 @@ UAVObject *UAVTalk::updateObject(quint32 objId, quint16 instId, quint8 *data)
     // Get object
     UAVObject *obj = objMngr->getObject(objId, instId);
     // If the instance does not exist create it
-    if (obj == NULL) {
+    if (obj == Q_NULLPTR) {
         // Get the object type
         UAVObject *tobj = objMngr->getObject(objId);
-        if (tobj == NULL) {
-            return NULL;
+        if (tobj == Q_NULLPTR) {
+            return Q_NULLPTR;
         }
         // Make sure this is a data object
         UAVDataObject *dobj = dynamic_cast<UAVDataObject *>(tobj);
-        if (dobj == NULL) {
-            return NULL;
+        if (dobj == Q_NULLPTR) {
+            return Q_NULLPTR;
         }
         // Create a new instance, unpack and register
         UAVDataObject *instobj = dobj->clone(instId);
         if (!objMngr->registerObject(instobj)) {
-            return NULL;
+            return Q_NULLPTR;
         }
         instobj->unpack(data);
         return instobj;

--- a/ground/gcs/src/plugins/uavtalk/uavtalk.cpp
+++ b/ground/gcs/src/plugins/uavtalk/uavtalk.cpp
@@ -38,7 +38,7 @@
 #include <extensionsystem/pluginmanager.h>
 #include <coreplugin/generalsettings.h>
 
-//#define UAVTALK_DEBUG
+// #define UAVTALK_DEBUG
 #ifdef UAVTALK_DEBUG
 #define UAVTALK_QXTLOG_DEBUG(...) qDebug() << __VA_ARGS__
 #else // UAVTALK_DEBUG
@@ -75,24 +75,12 @@ UAVTalk::UAVTalk(QIODevice *iodev, UAVObjectManager *objMngr)
 
     this->objMngr = objMngr;
 
-    rxState = STATE_SYNC;
-    rxPacketLength = 0;
+    startOffset = 0;
+    filledBytes = 0;
 
     memset(&stats, 0, sizeof(ComStats));
 
     connect(io.data(), &QIODevice::readyRead, this, &UAVTalk::processInputStream);
-    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
-    Core::Internal::GeneralSettings *settings = pm->getObject<Core::Internal::GeneralSettings>();
-    useUDPMirror = settings->useUDPMirror();
-    UAVTALK_QXTLOG_DEBUG(QString("[uavtalk.cpp  ] Use UDP:%0").arg(useUDPMirror));
-    if (useUDPMirror) {
-        udpSocketTx = new QUdpSocket(this);
-        udpSocketRx = new QUdpSocket(this);
-        udpSocketTx->bind(9000);
-        udpSocketRx->connectToHost(QHostAddress::LocalHost, 9000);
-        connect(udpSocketTx, &QIODevice::readyRead, this, &UAVTalk::dummyUDPRead);
-        connect(udpSocketRx, &QIODevice::readyRead, this, &UAVTalk::dummyUDPRead);
-    }
 }
 
 UAVTalk::~UAVTalk()
@@ -123,23 +111,26 @@ UAVTalk::ComStats UAVTalk::getStats()
  */
 void UAVTalk::processInputStream()
 {
-    quint8 tmp;
+    while (io && io->isReadable()) {
+        if (startOffset > (sizeof(rxBuffer) - MAX_PACKET_LENGTH)) {
+            /* If we're not sure there's room for a frame, shift things left in
+             * the buffer so that we can do a bigger read.
+             */
+            memmove(rxBuffer, rxBuffer + startOffset, filledBytes - startOffset);
 
-    if (io && io->isReadable()) {
-        while (io->bytesAvailable() > 0) {
-            io->read((char *)&tmp, 1);
-            processInputByte(tmp);
+            filledBytes -= startOffset;
+            startOffset = 0;
         }
-    }
-}
 
-void UAVTalk::dummyUDPRead()
-{
-    QUdpSocket *socket = qobject_cast<QUdpSocket *>(sender());
-    QByteArray junk;
-    while (socket->hasPendingDatagrams()) {
-        junk.resize(socket->pendingDatagramSize());
-        socket->readDatagram(junk.data(), junk.size());
+        int bytes = io->read((char *) (rxBuffer + filledBytes),
+                sizeof(rxBuffer) - filledBytes);
+
+        if (bytes <= 0) return;
+
+        filledBytes += bytes;
+        stats.rxBytes += bytes;
+
+        while (processInput());
     }
 }
 
@@ -191,243 +182,127 @@ bool UAVTalk::objectTransaction(UAVObject *obj, quint8 type, bool allInstances)
 }
 
 /**
- * Process a byte from the telemetry stream.
- * \param[in] rxbyte Received byte
- * \return Success (true), Failure (false)
+ * Process a frame from input, if available.
+ * \return False if there was insufficient data for a frame, true if trying
+ * again is worthwhile.
  */
-bool UAVTalk::processInputByte(quint8 rxbyte)
+bool UAVTalk::processInput()
 {
-    // Update stats
-    stats.rxBytes++;
+    unsigned int bytesAvail = filledBytes - startOffset;
 
-    rxPacketLength++; // update packet byte count
-
-    if (useUDPMirror)
-        rxDataArray.append(rxbyte);
-
-    // Receive state machine
-    switch (rxState) {
-    case STATE_SYNC:
-
-        if (rxbyte != SYNC_VAL) {
-            UAVTALK_QXTLOG_DEBUG("UAVTalk: Sync->Sync (" + QString::number(rxbyte) + " "
-                                 + QString("0x%1").arg(rxbyte, 2, 16) + ")");
-            break;
-        }
-
-        // Initialize and update CRC
-        rxCS = updateCRC(0, rxbyte);
-
-        rxPacketLength = 1;
-
-        if (useUDPMirror) {
-            rxDataArray.clear();
-            rxDataArray.append(rxbyte);
-        }
-
-        rxState = STATE_TYPE;
-        UAVTALK_QXTLOG_DEBUG("UAVTalk: Sync->Type");
-        break;
-
-    case STATE_TYPE:
-
-        // Update CRC
-        rxCS = updateCRC(rxCS, rxbyte);
-
-        if ((rxbyte & TYPE_MASK) != TYPE_VER) {
-            rxState = STATE_SYNC;
-            UAVTALK_QXTLOG_DEBUG("UAVTalk: Type->Sync");
-            break;
-        }
-
-        rxType = rxbyte;
-
-        packetSize = 0;
-
-        rxState = STATE_SIZE;
-        UAVTALK_QXTLOG_DEBUG("UAVTalk: Type->Size");
-        rxCount = 0;
-        break;
-
-    case STATE_SIZE:
-
-        // Update CRC
-        rxCS = updateCRC(rxCS, rxbyte);
-
-        if (rxCount == 0) {
-            packetSize += rxbyte;
-            rxCount++;
-            UAVTALK_QXTLOG_DEBUG("UAVTalk: Size->Size");
-            break;
-        }
-
-        packetSize += (quint32)rxbyte << 8;
-
-        if (packetSize < MIN_HEADER_LENGTH
-            || packetSize > MAX_HEADER_LENGTH + MAX_PAYLOAD_LENGTH) { // incorrect packet size
-            rxState = STATE_SYNC;
-            UAVTALK_QXTLOG_DEBUG("UAVTalk: Size->Sync");
-            break;
-        }
-
-        rxCount = 0;
-        rxState = STATE_OBJID;
-        UAVTALK_QXTLOG_DEBUG("UAVTalk: Size->ObjID");
-        break;
-
-    case STATE_OBJID:
-
-        // Update CRC
-        rxCS = updateCRC(rxCS, rxbyte);
-
-        rxTmpBuffer[rxCount++] = rxbyte;
-        if (rxCount < 4) {
-            UAVTALK_QXTLOG_DEBUG("UAVTalk: ObjID->ObjID");
-            break;
-        }
-
-        // Search for object, if not found reset state machine
-        rxObjId = (qint32)qFromLittleEndian<quint32>(rxTmpBuffer);
-        {
-            UAVObject *rxObj = objMngr->getObject(rxObjId);
-            if (rxObj == NULL && rxType != TYPE_OBJ_REQ) {
-                stats.rxErrors++;
-                rxState = STATE_SYNC;
-                UAVTALK_QXTLOG_DEBUG("UAVTalk: ObjID->Sync (badtype)");
-                break;
-            } else if (rxObj == NULL) {
-                // This is a non-existing object, just skip to checksum
-                // and we'll send a NACK next.
-                rxState = STATE_CS;
-                UAVTALK_QXTLOG_DEBUG("UAVTalk: ObjID->CSum (no obj)");
-                rxInstId = 0;
-                rxCount = 0;
-                break;
-            }
-
-            // Determine data length
-            if (rxType == TYPE_OBJ_REQ || rxType == TYPE_ACK || rxType == TYPE_NACK) {
-                rxLength = 0;
-            } else {
-                rxLength = rxObj->getNumBytes();
-            }
-
-            // Check length and determine next state
-            if (rxLength >= MAX_PAYLOAD_LENGTH) {
-                stats.rxErrors++;
-                rxState = STATE_SYNC;
-                UAVTALK_QXTLOG_DEBUG("UAVTalk: ObjID->Sync (oversize)");
-                break;
-            }
-
-            quint8 rxInstanceLength = (rxObj->isSingleInstance() ? 0 : 2);
-            if ((rxPacketLength + rxInstanceLength + rxLength)
-                != packetSize) { // packet error - mismatched packet size
-                stats.rxErrors++;
-                rxState = STATE_SYNC;
-                UAVTALK_QXTLOG_DEBUG("UAVTalk: ObjID->Sync (length mismatch)");
-                break;
-            }
-
-            if (rxObj->isSingleInstance()) { // Check if this is a single instance object (i.e. if
-                                             // the instance ID field is coming next)
-                // If there is a payload get it, otherwise receive checksum
-                if (rxLength > 0) {
-                    rxState = STATE_DATA;
-                    UAVTALK_QXTLOG_DEBUG("UAVTalk: ObjID->Data (needs data)");
-                } else {
-                    rxState = STATE_CS;
-                    UAVTALK_QXTLOG_DEBUG("UAVTalk: ObjID->Checksum");
-                }
-                rxInstId = 0;
-                rxCount = 0;
-            } else {
-                rxState = STATE_INSTID;
-                UAVTALK_QXTLOG_DEBUG("UAVTalk: ObjID->InstID");
-                rxCount = 0;
-            }
-        }
-
-        break;
-
-    case STATE_INSTID:
-
-        // Update CRC
-        rxCS = updateCRC(rxCS, rxbyte);
-
-        rxTmpBuffer[rxCount++] = rxbyte;
-        if (rxCount < 2) {
-            UAVTALK_QXTLOG_DEBUG("UAVTalk: InstID->InstID");
-            break;
-        }
-
-        rxInstId = (qint16)qFromLittleEndian<quint16>(rxTmpBuffer);
-
-        rxCount = 0;
-
-        // If there is a payload get it, otherwise receive checksum
-        if (rxLength > 0) {
-            rxState = STATE_DATA;
-            UAVTALK_QXTLOG_DEBUG("UAVTalk: InstID->Data");
-        } else {
-            rxState = STATE_CS;
-            UAVTALK_QXTLOG_DEBUG("UAVTalk: InstID->CSum");
-        }
-        break;
-
-    case STATE_DATA:
-
-        // Update CRC
-        rxCS = updateCRC(rxCS, rxbyte);
-
-        rxBuffer[rxCount++] = rxbyte;
-        if (rxCount < rxLength) {
-            // UAVTALK_QXTLOG_DEBUG("UAVTalk: Data->Data");
-            break;
-        }
-
-        rxState = STATE_CS;
-        UAVTALK_QXTLOG_DEBUG("UAVTalk: Data->CSum");
-        rxCount = 0;
-        break;
-
-    case STATE_CS:
-
-        // The CRC byte
-        rxCSPacket = rxbyte;
-
-        if (rxCS != rxCSPacket) { // packet error - faulty CRC
-            stats.rxErrors++;
-            rxState = STATE_SYNC;
-            UAVTALK_QXTLOG_DEBUG("UAVTalk: CSum->Sync (badcrc)");
-            break;
-        }
-
-        if (rxPacketLength != packetSize + 1) { // packet error - mismatched packet size
-            stats.rxErrors++;
-            rxState = STATE_SYNC;
-            UAVTALK_QXTLOG_DEBUG("UAVTalk: CSum->Sync (length mismatch)");
-            break;
-        }
-
-        receiveObject(rxType, rxObjId, rxInstId, rxBuffer, rxLength);
-        if (useUDPMirror) {
-            udpSocketTx->writeDatagram(rxDataArray, QHostAddress::LocalHost,
-                                       udpSocketRx->localPort());
-        }
-        stats.rxObjectBytes += rxLength;
-        stats.rxObjects++;
-
-        rxState = STATE_SYNC;
-        UAVTALK_QXTLOG_DEBUG("UAVTalk: CSum->Sync (OK)");
-        break;
-
-    default:
-        rxState = STATE_SYNC;
-        stats.rxErrors++;
-        UAVTALK_QXTLOG_DEBUG("UAVTalk: \?\?\?->Sync"); // Use the escape character for '?' so that
-                                                       // the tripgraph isn't triggered.
+    if (bytesAvail < sizeof(UAVTalkHeader)) {
+        return false;
     }
+
+    UAVTalkHeader *hdr = (UAVTalkHeader *) (rxBuffer + startOffset);
+
+    /* Basic framing checks.  If these fail, skip forward one byte and retry
+     * to capture stream sync.
+     */
+    if (hdr->sync != SYNC_VAL) {
+        startOffset++;
+        stats.rxErrors++;
+
+        return true;
+    }
+
+    if ((hdr->type & VER_MASK) != TYPE_VER) {
+        startOffset++;
+        stats.rxErrors++;
+
+        return true;
+    }
+
+    if (hdr->size < sizeof(UAVTalkHeader)) {
+        startOffset++;
+        stats.rxErrors++;
+
+        return true;
+    }
+
+    /* OK, let's ensure we have enough bytes for the whole frame. 
+     * Size doesn't include CRC, so add one.
+     */
+
+    if ((hdr->size + 1u) > bytesAvail) {
+        return false;
+    }
+
+    quint8 ourCrc = updateCRC(0, rxBuffer + startOffset, hdr->size);
+    quint8 *theirCrc = rxBuffer + startOffset + hdr->size;
+
+    if (ourCrc != *theirCrc) {
+        /* Since we can't trust hdr->size for sure, we should just skip
+         * forward one byte.
+         */
+
+        startOffset++;
+        stats.rxErrors++;
+
+        return true;
+    }
+
+    quint8 *payload = rxBuffer + startOffset + sizeof(*hdr);
+    unsigned int payloadBytes = hdr->size - sizeof(*hdr);
+
+    /* At this point, we'll advance startOffset for the entire length of
+     * frame, and not touch startOffset again this function!
+     */
+    startOffset += hdr->size + 1;
+
+    /* OK, we have a complete frame as encoded on the wire.  Time to do things
+     * with it.
+     */
+
+    quint8 rxType = hdr->type & TYPE_MASK;
+
+    quint32 rxObjId = qFromLittleEndian(hdr->objId);
+
+    UAVObject *rxObj = objMngr->getObject(rxObjId);
+
+    if (rxObj == NULL) {
+        stats.rxErrors++;
+        UAVTALK_QXTLOG_DEBUG("UAVTalk: unknown object");
+
+        if (rxType == TYPE_OBJ_REQ || rxType == TYPE_OBJ_ACK) {
+            UAVTALK_QXTLOG_DEBUG("UAVTalk: (transmitting NACK)");
+            transmitNack(rxObjId);
+        }
+
+        return true;
+    }
+
+    quint16 rxInstId = 0;
+
+    if (!rxObj->isSingleInstance()) {
+        rxInstId = *(payload++);
+        rxInstId |= *(payload++) << 8;
+
+        payloadBytes -= 2;
+    }
+
+    /* XXX timestamps */
+
+    // Check data length
+    if (rxType == TYPE_OBJ_REQ || rxType == TYPE_ACK || rxType == TYPE_NACK) {
+        if (payloadBytes != 0) {
+            UAVTALK_QXTLOG_DEBUG("UAVTalk: Unexpected data in req/ack/nack");
+            stats.rxErrors++;
+
+            return true;
+        }
+    } else {
+        if (payloadBytes != rxObj->getNumBytes()) {
+            UAVTALK_QXTLOG_DEBUG("UAVTalk: Unexpected payload size for obj");
+            stats.rxErrors++;
+
+            return true;
+        }
+    }
+
+    receiveObject(rxType, rxObjId, rxInstId, payload, payloadBytes);
+    stats.rxObjectBytes += payloadBytes;
+    stats.rxObjects++;
 
     // Done
     return true;
@@ -645,21 +520,18 @@ bool UAVTalk::transmitNack(quint32 objId)
     int dataOffset = 8;
 
     txBuffer[0] = SYNC_VAL;
-    txBuffer[1] = TYPE_NACK;
+    txBuffer[1] = TYPE_VER | TYPE_NACK;
+
+    qToLittleEndian<quint16>(dataOffset, &txBuffer[2]);
+
     qToLittleEndian<quint32>(objId, &txBuffer[4]);
 
     // Calculate checksum
     txBuffer[dataOffset] = updateCRC(0, txBuffer, dataOffset);
 
-    qToLittleEndian<quint16>(dataOffset, &txBuffer[2]);
-
     // Send buffer, check that the transmit backlog does not grow above limit
-    if (io && io->isWritable() && io->bytesToWrite() < TX_BUFFER_SIZE) {
+    if (io && io->isWritable() && io->bytesToWrite() < TX_BACKLOG_SIZE) {
         io->write((const char *)txBuffer, dataOffset + CHECKSUM_LENGTH);
-        if (useUDPMirror) {
-            udpSocketRx->writeDatagram((const char *)txBuffer, dataOffset + CHECKSUM_LENGTH,
-                                       QHostAddress::LocalHost, udpSocketTx->localPort());
-        }
     } else {
         ++stats.txErrors;
         return false;
@@ -689,7 +561,7 @@ bool UAVTalk::transmitSingleObject(UAVObject *obj, quint8 type, bool allInstance
     // Setup type and object id fields
     objId = obj->getObjID();
     txBuffer[0] = SYNC_VAL;
-    txBuffer[1] = type;
+    txBuffer[1] = TYPE_VER | type;
     qToLittleEndian<quint32>(objId, &txBuffer[4]);
 
     // Setup instance ID if one is required
@@ -731,14 +603,10 @@ bool UAVTalk::transmitSingleObject(UAVObject *obj, quint8 type, bool allInstance
     txBuffer[dataOffset + length] = updateCRC(0, txBuffer, dataOffset + length);
 
     // Send buffer, check that the transmit backlog does not grow above limit
-    if (!io.isNull() && io->isWritable() && io->bytesToWrite() < TX_BUFFER_SIZE) {
+    if (!io.isNull() && io->isWritable() && io->bytesToWrite() < TX_BACKLOG_SIZE) {
         io->write((const char *)txBuffer, dataOffset + length + CHECKSUM_LENGTH);
-        if (useUDPMirror) {
-            udpSocketRx->writeDatagram((const char *)txBuffer,
-                                       dataOffset + length + CHECKSUM_LENGTH,
-                                       QHostAddress::LocalHost, udpSocketTx->localPort());
-        }
     } else {
+        UAVTALK_QXTLOG_DEBUG("UAVTalk: TX refused");
         ++stats.txErrors;
         return false;
     }
@@ -770,10 +638,7 @@ bool UAVTalk::transmitSingleObject(UAVObject *obj, quint8 type, bool allInstance
  * \param length   Number of bytes in the \a data buffer.
  * \return         The updated crc value.
  */
-quint8 UAVTalk::updateCRC(quint8 crc, const quint8 data)
-{
-    return crc_table[crc ^ data];
-}
+
 quint8 UAVTalk::updateCRC(quint8 crc, const quint8 *data, qint32 length)
 {
     while (length--)

--- a/ground/uavobjgenerator/uavobjectparser.h
+++ b/ground/uavobjgenerator/uavobjectparser.h
@@ -37,9 +37,12 @@
 #include <QByteArray>
 
 /**
- * The maximum size of UAVOs is limited by the FlashFS filesystem in the flight code
- * The flash slot size is 256 bytes which is comprised of the FlashFS header (12 bytes)
- * and the UAVO. This leaves a maximum of 244 bytes for the UAVO.
+ * The maximum size of UAVOs is limited by the FlashFS filesystem in the flight
+ * code; the flash slot size is 256 bytes which is comprised of the FlashFS
+ * header (12 bytes) and the UAVO. This leaves a maximum of 244 bytes for the
+ * UAVO.
+ *
+ * Shave another byte off (243) so that a UAVTalk frame is always 256 bytes or less.
  */
 #define UAVO_MAX_SIZE 243
 

--- a/ground/uavobjgenerator/uavobjectparser.h
+++ b/ground/uavobjgenerator/uavobjectparser.h
@@ -41,7 +41,7 @@
  * The flash slot size is 256 bytes which is comprised of the FlashFS header (12 bytes)
  * and the UAVO. This leaves a maximum of 244 bytes for the UAVO.
  */
-#define UAVO_MAX_SIZE 244
+#define UAVO_MAX_SIZE 243
 
 // Types
 typedef enum {


### PR DESCRIPTION
Rewrote uavtalk to remove state machine, not read just a byte at a
time, and be cleaner.

I am not really clear why this is such a large change-- the old code
was inefficient but didn't look **that** bad.

Without: GCS over USB comes up at about flighttime=7.  With this,
GCS over USB comes up at about flighttime=3, and is obviously
significantly more responsive.

Over TCP, the differences are even more extreme.