### PR TITLE
gcs: hwsettings: handle uint32 data

### DIFF
--- a/ground/gcs/src/plugins/config/defaulthwsettingswidget.cpp
+++ b/ground/gcs/src/plugins/config/defaulthwsettingswidget.cpp
@@ -65,18 +65,22 @@ DefaultHwSettingsWidget::DefaultHwSettingsWidget(UAVObject *settingsObj, QWidget
         case UAVObjectField::INT16:
         case UAVObjectField::INT32:
         case UAVObjectField::UINT8:
-        case UAVObjectField::UINT16:
-        case UAVObjectField::UINT32: {
+        case UAVObjectField::UINT16: {
             QSpinBox *sbx = new QSpinBox(this);
             if (fields[i]->getUnits().length())
                 sbx->setSuffix(QString(" %1").arg(fields[i]->getUnits()));
             wdg = sbx;
             break;
         }
+        case UAVObjectField::UINT32:
         case UAVObjectField::FLOAT32: {
             QDoubleSpinBox *sbx = new QDoubleSpinBox(this);
             if (fields[i]->getUnits().length())
                 sbx->setSuffix(QString(" %1").arg(fields[i]->getUnits()));
+
+            if (fields[i]->getType() == UAVObjectField::UINT32)
+                sbx->setDecimals(0);
+
             wdg = sbx;
             break;
         }


### PR DESCRIPTION
Namely, radio IDs.  If the value exceeded 2^31, it was clipped to 0.
This meant if you saved the hardware page it'd unbind your OpLink, etc.

Now, use a double spinbox to represent these values.  Though there is
still an unsightly thing of the units "hex" being displayed when the
value is decidedly not hexy.