### PR TITLE
UAVO: Remove incorrect "hex" unit from Rfm CoordID fields

### DIFF
--- a/shared/uavobjectdefinition/hwrevolution.xml
+++ b/shared/uavobjectdefinition/hwrevolution.xml
@@ -132,7 +132,7 @@
 		<field name="Radio" units="" type="enum" elements="1" parent="HwShared.RadioPort" defaultvalue="Disabled">
 			<description>Function for the radio port</description>
 		</field>
-		<field name="CoordID" units="hex" type="uint32" elements="1" defaultvalue="0">
+		<field name="CoordID" units="" type="uint32" elements="1" defaultvalue="0">
 			<description>ID of the coordinator to allow binding to. 0 indicates allow all connections</description>
 		</field>
 		<!-- radio settings -->

--- a/shared/uavobjectdefinition/hwsparky2.xml
+++ b/shared/uavobjectdefinition/hwsparky2.xml
@@ -85,7 +85,7 @@
 		<field name="Radio" units="" type="enum" elements="1" parent="HwShared.RadioPort" defaultvalue="Disabled">
 			<description>Function for the radio port</description>
 		</field>
-		<field name="CoordID" units="hex" type="uint32" elements="1" defaultvalue="0">
+		<field name="CoordID" units="" type="uint32" elements="1" defaultvalue="0">
 			<description>ID of the coordinator to allow binding to. 0 indicates allow all connections</description>
 		</field>
 		<!-- radio settings -->

--- a/shared/uavobjectdefinition/hwtaulink.xml
+++ b/shared/uavobjectdefinition/hwtaulink.xml
@@ -9,7 +9,7 @@
 		<field name="Radio" units="" type="enum" elements="1" options="Disabled,Telem,Telem+PPM,PPM" parent="HwShared.RadioPort" defaultvalue="Disabled">
 			<description>Function for the radio port</description>
 		</field>
-		<field name="CoordID" units="hex" type="uint32" elements="1" defaultvalue="0">
+		<field name="CoordID" units="" type="uint32" elements="1" defaultvalue="0">
 			<description>ID of the coordinator to allow binding to. 0 indicates allow all connections</description>
 		</field>
 		<!-- Function of the main serial port -->


### PR DESCRIPTION
Clearly bogus. 

TODO: Future PR should make it possible to set default display base that is used in UAVO Browser, default Hardware form, and ConfigTaskWidget relations.