### PR TITLE
pios: f4: flash_internal: erase flash from RAM

### DIFF
--- a/flight/Modules/ManualControl/manualcontrol.c
+++ b/flight/Modules/ManualControl/manualcontrol.c
@@ -73,6 +73,8 @@ static int32_t control_event_arm();
 static int32_t control_event_arming();
 static int32_t control_event_disarm();
 
+bool vehicle_is_armed = false;
+
 // This is exposed to transmitter_control
 bool ok_to_arm(void);
 
@@ -208,6 +210,7 @@ static int32_t control_event_arm()
 		if (flightStatus.Armed != FLIGHTSTATUS_ARMED_ARMED) {
 			flightStatus.Armed = FLIGHTSTATUS_ARMED_ARMED;
 			FlightStatusSet(&flightStatus);
+			vehicle_is_armed = true;
 		}
 	}
 	return 0;
@@ -221,6 +224,7 @@ static int32_t control_event_arming()
 	if (flightStatus.Armed != FLIGHTSTATUS_ARMED_ARMING) {
 		flightStatus.Armed = FLIGHTSTATUS_ARMED_ARMING;
 		FlightStatusSet(&flightStatus);
+		vehicle_is_armed = true;
 	}
 	return 0;
 }
@@ -233,6 +237,7 @@ static int32_t control_event_disarm()
 	if (flightStatus.Armed != FLIGHTSTATUS_ARMED_DISARMED) {
 		flightStatus.Armed = FLIGHTSTATUS_ARMED_DISARMED;
 		FlightStatusSet(&flightStatus);
+		vehicle_is_armed = false;
 	}
 	return 0;
 }

--- a/flight/PiOS/STM32F4xx/link_STM32F446xx_sections.ld
+++ b/flight/PiOS/STM32F4xx/link_STM32F446xx_sections.ld
@@ -71,6 +71,8 @@ SECTIONS
         _sdata = .;
         *(.data .data.*)
         . = ALIGN(4);
+        *(.ramtext)
+        . = ALIGN(4);
         _edata = . ;
     } > SRAM
 

--- a/flight/PiOS/STM32F4xx/link_STM32F4xx_sections.ld
+++ b/flight/PiOS/STM32F4xx/link_STM32F4xx_sections.ld
@@ -71,6 +71,8 @@ SECTIONS
         _sdata = .;
         *(.data .data.*)
         . = ALIGN(4);
+        *(.ramtext)
+        . = ALIGN(4);
         _edata = . ;
     } > SRAM
 

--- a/flight/PiOS/STM32F4xx/pios_flash_internal.c
+++ b/flight/PiOS/STM32F4xx/pios_flash_internal.c
@@ -7,6 +7,8 @@
  *
  * @file       pios_flash_internal.c  
  * @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2013
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2017
+ *
  * @brief Provides a flash driver for the STM32 internal flash sectors
  *****************************************************************************/
 /* 
@@ -33,6 +35,9 @@
 #include "pios_wdg.h"
 #include "pios_semaphore.h"
 #include <stdbool.h>
+
+/* Todo: consider relocating to a good header */
+bool __attribute__((weak)) vehicle_is_armed = false;
 
 static const uint16_t sector_to_st_sector_map[] = {
 	[0] = FLASH_Sector_0,
@@ -171,8 +176,7 @@ static int32_t PIOS_Flash_Internal_EraseSector(uintptr_t chip_id, uint32_t chip_
 
 int32_t PIOS_Flash_Internal_EraseSector_FromRam(uint16_t st_sector)
 {
-	/* XXX armed-check infrastructure */
-	if (0) {
+	if (vehicle_is_armed) {
 		return -1;
 	}
 

--- a/flight/PiOS/STM32F4xx/pios_flash_internal.c
+++ b/flight/PiOS/STM32F4xx/pios_flash_internal.c
@@ -164,7 +164,11 @@ static int32_t PIOS_Flash_Internal_EraseSector(uintptr_t chip_id, uint32_t chip_
 		return ret;
 	}
 
-	return FLASH_GetStatus();
+	if (FLASH_GetStatus() != FLASH_COMPLETE) {
+		return -1;
+	}
+
+	return 0;
 }
 
 int32_t PIOS_Flash_Internal_EraseSector_FromRam(uint16_t st_sector)

--- a/flight/PiOS/STM32F4xx/pios_flash_internal.c
+++ b/flight/PiOS/STM32F4xx/pios_flash_internal.c
@@ -36,7 +36,9 @@
 #include "pios_semaphore.h"
 #include <stdbool.h>
 
-/* Todo: consider relocating to a good header */
+/* TODO: Build an armed infrastructure for PiOS as a whole-- figure out
+ * a good header to put it in, and use accessor functions from outside
+ * PiOS. */
 bool __attribute__((weak)) vehicle_is_armed = false;
 
 static const uint16_t sector_to_st_sector_map[] = {

--- a/flight/PiOS/STM32F4xx/pios_flash_internal.c
+++ b/flight/PiOS/STM32F4xx/pios_flash_internal.c
@@ -132,10 +132,8 @@ static int32_t PIOS_Flash_Internal_EndTransaction(uintptr_t chip_id)
 	return 0;
 }
 
-// XXX eliminate section attribute warning by adding new section to
-// linker scripts
 int32_t PIOS_Flash_Internal_EraseSector_FromRam(uint16_t st_sector)
-	__attribute__ ((section (".data"),long_call));
+	__attribute__ ((section (".ramtext"),long_call));
 
 static int32_t PIOS_Flash_Internal_EraseSector(uintptr_t chip_id, uint32_t chip_sector, uint32_t chip_offset)
 {

--- a/flight/targets/aq32/board-info/board-info.mk
+++ b/flight/targets/aq32/board-info/board-info.mk
@@ -1,6 +1,6 @@
 BOARD_TYPE          := 0x94
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x00
 
 CHIP                := STM32F407VGT6

--- a/flight/targets/aq32/board-info/board_hw_defs.c
+++ b/flight/targets/aq32/board-info/board_hw_defs.c
@@ -508,7 +508,7 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.size         = (3 - 2 + 1) * FLASH_SECTOR_16KB, // 32KB
 	},
 
-    /* NOTE: sector 4 of internal flash is currently unallocated */
+	/* NOTE: sector 4 of internal flash is currently unallocated */
 
 	{
 		.label        = FLASH_PARTITION_LABEL_FW,
@@ -525,10 +525,14 @@ static const struct pios_flash_partition pios_flash_partition_table[] = {
 		.label        = FLASH_PARTITION_LABEL_AUTOTUNE,
 		.chip_desc    = &pios_flash_chip_internal,
 		.first_sector = 10,
-		.last_sector  = 11,
+		.last_sector  = 10,
 		.chip_offset  = (4 * FLASH_SECTOR_16KB) + (1 * FLASH_SECTOR_64KB) + (5 * FLASH_SECTOR_128KB), // 0x080C 0000
-		.size         = (11 - 10 + 1) * FLASH_SECTOR_128KB,                                           // 256KB
+		.size         = (10 - 10 + 1) * FLASH_SECTOR_128KB,                                           // 128KB
 	},
+
+	/* Sector 11 is unallocated, but in old bootloaders was allocated to
+	 * waypoints/autotune.
+	 */
 };
 
 const struct pios_flash_partition * PIOS_BOARD_HW_DEFS_GetPartitionTable (uint32_t board_revision, uint32_t * num_partitions)


### PR DESCRIPTION
Need to have this one little routine in RAM, so that we can do
lengthy flash operations without hanging long enough for watchdog
to expire.

Still needs to have a way to test arming status at the outset. I'm
thinking probably a weak symbol or something like that (as this code can
be used in the loader, too).

fixes #1482