### PR TITLE
GCS:LongLongSpinBox: Fix use of C limits

### DIFF
--- a/ground/gcs/src/libs/utils/longlongspinbox.cpp
+++ b/ground/gcs/src/libs/utils/longlongspinbox.cpp
@@ -34,6 +34,8 @@
 #include <QEvent>
 #include <QStyle>
 
+#include <limits>
+
 LongLongSpinBox::LongLongSpinBox(QWidget *parent)
     : QAbstractSpinBox(parent), m_value(0), m_singleStep(1), m_min(0), m_max(100),
       m_displayBase(10)
@@ -151,7 +153,8 @@ QString LongLongSpinBox::textFromValue(qint64 val) const
     QString str;
     if (m_displayBase == 10) {
         str = locale().toString(val);
-        if (!m_showGroupSeparator && (qAbs(val) >= 1000 || val == LONG_LONG_MIN))
+        if (!m_showGroupSeparator
+                && (qAbs(val) >= 1000 || val == std::numeric_limits<qint64>::min()))
             str.remove(locale().groupSeparator());
     } else {
         QLatin1String prefix = val < 0 ? QLatin1String("-") : QLatin1String();


### PR DESCRIPTION
C standard doesn't include nearly as much, which means it doesn't require LONG_LONG_MIN (it is a GNU and MSVC extension apparently). Broke build on macOS.

`qint64` is a typedef for `long long` except with MSVC where it is `__int64`. MSVC defines `std:numeric_limts<__int64>` and linux + mac have `std::numeric_limits<long long>`.