### PR TITLE
GCS: Support preferred integer display base other than 10 for UAVO fields

### DIFF
--- a/ground/gcs/src/plugins/config/defaulthwsettingswidget.cpp
+++ b/ground/gcs/src/plugins/config/defaulthwsettingswidget.cpp
@@ -70,6 +70,8 @@ DefaultHwSettingsWidget::DefaultHwSettingsWidget(UAVObject *settingsObj, QWidget
             QSpinBox *sbx = new QSpinBox(this);
             if (fields[i]->getUnits().length())
                 sbx->setSuffix(QString(" %1").arg(fields[i]->getUnits()));
+            sbx->setDisplayIntegerBase(fields[i]->getDisplayIntegerBase());
+            sbx->setPrefix(fields[i]->getDisplayPrefix());
             wdg = sbx;
             break;
         }
@@ -77,6 +79,8 @@ DefaultHwSettingsWidget::DefaultHwSettingsWidget(UAVObject *settingsObj, QWidget
             LongLongSpinBox *sbx = new LongLongSpinBox(this);
             if (fields[i]->getUnits().length())
                 sbx->setSuffix(QString(" %1").arg(fields[i]->getUnits()));
+            sbx->setDisplayIntegerBase(fields[i]->getDisplayIntegerBase());
+            sbx->setPrefix(fields[i]->getDisplayPrefix());
             wdg = sbx;
             break;
         }

--- a/ground/gcs/src/plugins/uavobjectbrowser/fieldtreeitem.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/fieldtreeitem.h
@@ -46,7 +46,7 @@
 #define QUINT16MAX std::numeric_limits<quint16>::max()
 #define QINT32MIN std::numeric_limits<qint32>::min()
 #define QINT32MAX std::numeric_limits<qint32>::max()
-#define QUINT32MAX std::numeric_limits<qint32>::max()
+#define QUINT32MAX std::numeric_limits<quint32>::max()
 
 class FieldTreeItem : public TreeItem
 {
@@ -343,8 +343,8 @@ public:
 
 private:
     UAVObjectField *m_field;
-    int m_minValue;
-    int m_maxValue;
+    qint64 m_minValue;
+    qint64 m_maxValue;
 };
 
 class FloatFieldTreeItem : public FieldTreeItem

--- a/ground/gcs/src/plugins/uavobjectbrowser/fieldtreeitem.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/fieldtreeitem.h
@@ -212,12 +212,16 @@ public:
         {
             LongLongSpinBox *editor = new LongLongSpinBox(parent);
             editor->setRange(m_minValue, m_maxValue);
+            editor->setDisplayIntegerBase(m_field->getDisplayIntegerBase());
+            editor->setPrefix(m_field->getDisplayPrefix());
             return editor;
         }
         default:
         {
             QSpinBox *editor = new QSpinBox(parent);
             editor->setRange(m_minValue, m_maxValue);
+            editor->setDisplayIntegerBase(m_field->getDisplayIntegerBase());
+            editor->setPrefix(m_field->getDisplayPrefix());
             return editor;
         }
         }
@@ -315,6 +319,26 @@ public:
         UAVDataObject *obj = qobject_cast<UAVDataObject *>(m_field->getObject());
         if (obj && obj->isSettings())
             setIsDefaultValue(m_field->isDefaultValue(m_index));
+    }
+    QString formattedData()
+    {
+        QString formatted = m_field->getDisplayPrefix();
+        switch (m_field->getType()) {
+        case UAVObjectField::INT8:
+        case UAVObjectField::INT16:
+        case UAVObjectField::INT32:
+            formatted += QString::number(TreeItem::data().toInt(), m_field->getDisplayIntegerBase());
+            break;
+        case UAVObjectField::UINT8:
+        case UAVObjectField::UINT16:
+        case UAVObjectField::UINT32:
+            formatted += QString::number(TreeItem::data().toUInt(), m_field->getDisplayIntegerBase());
+            break;
+        default:
+            Q_ASSERT(false);
+            break;
+        }
+        return formatted;
     }
 
 private:

--- a/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/uavobjecttreemodel.cpp
@@ -480,6 +480,9 @@ QVariant UAVObjectTreeModel::data(const QModelIndex &index, int role) const
             int enumIndex = fieldItem->data(index.column()).toInt();
             return fieldItem->enumOptions(enumIndex);
         }
+        IntFieldTreeItem *intFieldItem = dynamic_cast<IntFieldTreeItem *>(item);
+        if (intFieldItem)
+            return intFieldItem->formattedData();
     }
 
     return item->data(index.column());
@@ -577,3 +580,8 @@ void UAVObjectTreeModel::presentOnHardwareChangedCB(UAVDataObject *obj)
     Q_UNUSED(obj);
     emit presentOnHardwareChanged();
 }
+
+/**
+ * @}
+ * @}
+ */

--- a/ground/gcs/src/plugins/uavobjects/uavobjectfield.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectfield.cpp
@@ -40,7 +40,8 @@
 UAVObjectField::UAVObjectField(const QString &name, const QString &units, FieldType type,
                                quint32 numElements, const QStringList &options,
                                const QList<int> &indices, const QString &limits,
-                               const QString &description, const QList<QVariant> defaultValues)
+                               const QString &description, const QList<QVariant> defaultValues,
+                               const DisplayType display)
 {
     QStringList elementNames;
     // Set element names
@@ -49,23 +50,25 @@ UAVObjectField::UAVObjectField(const QString &name, const QString &units, FieldT
     }
     // Initialize
     constructorInitialize(name, units, type, elementNames, options, indices, limits, description,
-                          defaultValues);
+                          defaultValues, display);
 }
 
 UAVObjectField::UAVObjectField(const QString &name, const QString &units, FieldType type,
                                const QStringList &elementNames, const QStringList &options,
                                const QList<int> &indices, const QString &limits,
-                               const QString &description, const QList<QVariant> defaultValues)
+                               const QString &description, const QList<QVariant> defaultValues,
+                               const DisplayType display)
 {
     constructorInitialize(name, units, type, elementNames, options, indices, limits, description,
-                          defaultValues);
+                          defaultValues, display);
 }
 
 void UAVObjectField::constructorInitialize(const QString &name, const QString &units,
                                            FieldType type, const QStringList &elementNames,
                                            const QStringList &options, const QList<int> &indices,
                                            const QString &limits, const QString &description,
-                                           const QList<QVariant> defaultValues)
+                                           const QList<QVariant> defaultValues,
+                                           const DisplayType display)
 {
     // Copy params
     this->name = name;
@@ -79,6 +82,8 @@ void UAVObjectField::constructorInitialize(const QString &name, const QString &u
     this->obj = NULL;
     this->elementNames = elementNames;
     this->description = description;
+    this->display = display;
+
     // Set field size
     switch (type) {
     case INT8:
@@ -1150,6 +1155,34 @@ bool UAVObjectField::isDefaultValue(quint32 index)
 
     Q_ASSERT(false);
     return false;
+}
+
+int UAVObjectField::getDisplayIntegerBase()
+{
+    switch (display) {
+    case HEX:
+        return 16;
+    case BIN:
+        return 2;
+    case OCT:
+        return 8;
+    default:
+        return 10;
+    }
+}
+
+QString UAVObjectField::getDisplayPrefix()
+{
+    switch (display) {
+    case HEX:
+        return QStringLiteral("0x");
+    case BIN:
+        return QStringLiteral("0b");
+    case OCT:
+        return QStringLiteral("0o");
+    default:
+        return QString();
+    }
 }
 
 /**

--- a/ground/gcs/src/plugins/uavobjects/uavobjectfield.h
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectfield.h
@@ -55,6 +55,8 @@ public:
         STRING
     } FieldType;
     typedef enum { EQUAL, NOT_EQUAL, BETWEEN, BIGGER, SMALLER } LimitType;
+    enum DisplayType { DEC, HEX, BIN, OCT };
+
     typedef struct
     {
         LimitType type;
@@ -65,12 +67,14 @@ public:
     UAVObjectField(const QString &name, const QString &units, FieldType type, quint32 numElements,
                    const QStringList &options, const QList<int> &indices,
                    const QString &limits = QString(), const QString &description = QString(),
-                   const QList<QVariant> defaultValues = QList<QVariant>());
+                   const QList<QVariant> defaultValues = QList<QVariant>(),
+                   const DisplayType display = DEC);
     UAVObjectField(const QString &name, const QString &units, FieldType type,
                    const QStringList &elementNames, const QStringList &options,
                    const QList<int> &indices, const QString &limits = QString(),
                    const QString &description = QString(),
-                   const QList<QVariant> defaultValues = QList<QVariant>());
+                   const QList<QVariant> defaultValues = QList<QVariant>(),
+                   const DisplayType display = DEC);
     void initialize(quint8 *data, quint32 dataOffset, UAVObject *obj);
     UAVObject *getObject();
     FieldType getType();
@@ -112,6 +116,16 @@ public:
      * @return true if set to default
      */
     bool isDefaultValue(quint32 index = 0);
+    /**
+     * @brief Get the preferred integer base for this field
+     * @return Preferred base
+     */
+    int getDisplayIntegerBase();
+    /**
+     * @brief Get the prefix for the preferred display format
+     * @return "0x" for hex, "0b" for binary etc.
+     */
+    QString getDisplayPrefix();
 
     bool isWithinLimits(QVariant var, quint32 index, int board = 0);
     QVariant getMaxLimit(quint32 index, int board = 0);
@@ -134,11 +148,14 @@ protected:
     QMap<quint32, QList<LimitStruct>> elementLimits;
     QString description;
     QList<QVariant> defaultValues;
+    DisplayType display;
+
     void clear();
     void constructorInitialize(const QString &name, const QString &units, FieldType type,
                                const QStringList &elementNames, const QStringList &options,
                                const QList<int> &indices, const QString &limits,
-                               const QString &description, const QList<QVariant> defaultValues);
+                               const QString &description, const QList<QVariant> defaultValues,
+                               const DisplayType display);
     void limitsInitialize(const QString &limits);
 };
 

--- a/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.cpp
+++ b/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.cpp
@@ -41,6 +41,8 @@ bool UAVObjectGeneratorGCS::generate(UAVObjectParser* parser,QString templatepat
     fieldTypeStrCPPClass << "INT8" << "INT16" << "INT32"
         << "UINT8" << "UINT16" << "UINT32" << "FLOAT32" << "ENUM";
 
+    displayTypeStrCPPClass << "DEC" << "HEX" << "BIN" << "OCT";
+
     gcsCodePath = QDir( templatepath + QString(GCS_CODE_DIR));
     gcsOutputPath = QDir( outputpath + QString("gcs") );
     gcsOutputPath.mkpath(gcsOutputPath.absolutePath());
@@ -353,13 +355,14 @@ bool UAVObjectGeneratorGCS::process_object(ObjectInfo* info)
         else {
             const QString defaultValuesInit = info->fields[n]->defaultValues.join(',');
 
-            finit.append( QString("    fields.append( new UAVObjectField(QString(\"%1\"), QString(\"%2\"), UAVObjectField::%3, %4, QStringList(), QList<int>(), QString(\"%5\"), FIELD_DESCRIPTIONS[\"%1\"], QList<QVariant>({%7})));\n")
+            finit.append( QString("    fields.append( new UAVObjectField(QString(\"%1\"), QString(\"%2\"), UAVObjectField::%3, %4, QStringList(), QList<int>(), QString(\"%5\"), FIELD_DESCRIPTIONS[\"%1\"], QList<QVariant>({%7}), UAVObjectField::%8));\n")
                           .arg(info->fields[n]->name)
                           .arg(info->fields[n]->units)
                           .arg(fieldTypeStrCPPClass[info->fields[n]->type])
                           .arg(varElemName)
                           .arg(info->fields[n]->limitValues)
-                          .arg(defaultValuesInit));
+                          .arg(defaultValuesInit)
+                          .arg(displayTypeStrCPPClass[info->fields[n]->display]));
         }
     }
     outCode.replace(QString("$(FIELDSINIT)"), finit);

--- a/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.h
+++ b/ground/uavobjgenerator/generators/gcs/uavobjectgeneratorgcs.h
@@ -43,7 +43,7 @@ private:
     QString escape_raw_string(QString raw);
 
     QString gcsCodeTemplate,gcsIncludeTemplate;
-    QStringList fieldTypeStrCPP,fieldTypeStrCPPClass;
+    QStringList fieldTypeStrCPP,fieldTypeStrCPPClass, displayTypeStrCPPClass;
     QDir gcsCodePath;
     QDir gcsOutputPath;
 };

--- a/ground/uavobjgenerator/uavobjectparser.cpp
+++ b/ground/uavobjgenerator/uavobjectparser.cpp
@@ -48,6 +48,7 @@ UAVObjectParser::UAVObjectParser()
 
     accessModeStrXML << "readwrite" << "readonly";
 
+    displayTypeStrXML << "dec" << "hex" << "bin" << "oct";
 }
 
 /**
@@ -826,6 +827,15 @@ QString UAVObjectParser::processObjectFields(QDomNode& childNode, ObjectInfo* in
             field->description = description.nodeValue().trimmed();
         }
     }
+
+    // Display type for human interface
+    elemAttr = elemAttributes.namedItem("display");
+    QString display = elemAttr.isNull() ? "dec" : elemAttr.nodeValue();
+    index = displayTypeStrXML.indexOf(display);
+    if (index >= 0)
+        field->display = (DisplayType)index;
+    else
+        return QString("Object:field:display attribute value is invalid, allowed values are: ") + displayTypeStrXML.join(", ");
 
     // Add field to object
     info->fields.append(field);

--- a/ground/uavobjgenerator/uavobjectparser.h
+++ b/ground/uavobjgenerator/uavobjectparser.h
@@ -55,6 +55,13 @@ typedef enum {
     FIELDTYPE_ENUM
 } FieldType;
 
+typedef enum {
+    DISPLAYTYPE_DEC,
+    DISPLAYTYPE_HEX,
+    DISPLAYTYPE_BIN,
+    DISPLAYTYPE_OCT,
+} DisplayType;
+
 typedef struct FieldInfo_s FieldInfo;
 typedef struct ObjectInfo_s ObjectInfo;
 
@@ -71,6 +78,7 @@ struct FieldInfo_s {
     QStringList defaultValues;
     QString limitValues;
     QString description;
+    DisplayType display;
 
     FieldInfo *parent;
     ObjectInfo *parentObj;
@@ -150,6 +158,7 @@ private:
     QStringList accessModeStr;
     QStringList accessModeStrXML;
     quint64 uavoHash;
+    QStringList displayTypeStrXML;
 
     QString genErrorMsg(QString& fileName, QString errMsg, int errorLine, int errorCol);
 

--- a/shared/uavobjectdefinition/firmwareiapobj.xml
+++ b/shared/uavobjectdefinition/firmwareiapobj.xml
@@ -4,9 +4,9 @@
 		<description>Queries board for SN, model, revision, and sends reset command</description>
 		<field name="Command" units="" type="uint16" elements="1"/>
 		<field name="Description" units="" type="uint8" elements="100"/>
-		<field name="CPUSerial" units="" type="uint8" elements="12"/>
+		<field name="CPUSerial" units="" type="uint8" elements="12" display="hex"/>
 		<field name="BoardRevision" units="" type="uint16" elements="1"/>
-		<field name="BoardType" units="" type="uint8" elements="1"/>
+		<field name="BoardType" units="" type="uint8" elements="1" display="hex"/>
 		<field name="ArmReset" units="" type="uint8" elements="1"/>
 		<field name="crc" units="" type="uint32" elements="1"/>
 		<access gcs="readwrite" flight="readwrite"/>

--- a/shared/uavobjectdefinition/hwrevolution.xml
+++ b/shared/uavobjectdefinition/hwrevolution.xml
@@ -132,7 +132,7 @@
 		<field name="Radio" units="" type="enum" elements="1" parent="HwShared.RadioPort" defaultvalue="Disabled">
 			<description>Function for the radio port</description>
 		</field>
-		<field name="CoordID" units="" type="uint32" elements="1" defaultvalue="0">
+		<field name="CoordID" units="" type="uint32" elements="1" defaultvalue="0" display="hex">
 			<description>ID of the coordinator to allow binding to. 0 indicates allow all connections</description>
 		</field>
 		<!-- radio settings -->

--- a/shared/uavobjectdefinition/hwsparky2.xml
+++ b/shared/uavobjectdefinition/hwsparky2.xml
@@ -85,7 +85,7 @@
 		<field name="Radio" units="" type="enum" elements="1" parent="HwShared.RadioPort" defaultvalue="Disabled">
 			<description>Function for the radio port</description>
 		</field>
-		<field name="CoordID" units="" type="uint32" elements="1" defaultvalue="0">
+		<field name="CoordID" units="" type="uint32" elements="1" defaultvalue="0" display="hex">
 			<description>ID of the coordinator to allow binding to. 0 indicates allow all connections</description>
 		</field>
 		<!-- radio settings -->

--- a/shared/uavobjectdefinition/hwtaulink.xml
+++ b/shared/uavobjectdefinition/hwtaulink.xml
@@ -9,7 +9,7 @@
 		<field name="Radio" units="" type="enum" elements="1" options="Disabled,Telem,Telem+PPM,PPM" parent="HwShared.RadioPort" defaultvalue="Disabled">
 			<description>Function for the radio port</description>
 		</field>
-		<field name="CoordID" units="" type="uint32" elements="1" defaultvalue="0">
+		<field name="CoordID" units="" type="uint32" elements="1" defaultvalue="0" display="hex">
 			<description>ID of the coordinator to allow binding to. 0 indicates allow all connections</description>
 		</field>
 		<!-- Function of the main serial port -->


### PR DESCRIPTION
Supports dec (0), hex (0x0), bin (0b0), oct (0o0).