### PR TITLE
GCS:Browser: Propagate default value state up to objects

### DIFF
--- a/ground/gcs/src/plugins/uavobjectbrowser/fieldtreeitem.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/fieldtreeitem.h
@@ -55,20 +55,25 @@ public:
     FieldTreeItem(int index, const QList<QVariant> &data, TreeItem *parent = 0)
         : TreeItem(data, parent)
         , m_index(index)
+        , m_defaultValue(true)
     {
     }
     FieldTreeItem(int index, const QVariant &data, TreeItem *parent = 0)
         : TreeItem(data, parent)
         , m_index(index)
+        , m_defaultValue(true)
     {
     }
     bool isEditable() { return true; }
+    void setIsDefaultValue(bool isDefault) { m_defaultValue = isDefault; }
+    virtual bool isDefaultValue() const override { return m_defaultValue; }
     virtual QWidget *createEditor(QWidget *parent) = 0;
     virtual QVariant getEditorValue(QWidget *editor) = 0;
     virtual void setEditorValue(QWidget *editor, QVariant value) = 0;
     virtual void apply() {}
 protected:
     int m_index;
+    bool m_defaultValue;
 };
 
 class EnumFieldTreeItem : public FieldTreeItem

--- a/ground/gcs/src/plugins/uavobjectbrowser/treeitem.cpp
+++ b/ground/gcs/src/plugins/uavobjectbrowser/treeitem.cpp
@@ -104,7 +104,6 @@ TreeItem::TreeItem(const QList<QVariant> &data, TreeItem *parent)
     , m_highlight(false)
     , m_changed(false)
     , m_updated(false)
-    , m_defaultValue(true)
 {
 }
 
@@ -115,7 +114,6 @@ TreeItem::TreeItem(const QVariant &data, TreeItem *parent)
     , m_highlight(false)
     , m_changed(false)
     , m_updated(false)
-    , m_defaultValue(true)
 {
     m_data << data << ""
            << "";
@@ -238,16 +236,6 @@ void TreeItem::removeHighlight()
 void TreeItem::setHighlightManager(HighLightManager *mgr)
 {
     m_highlightManager = mgr;
-}
-
-void TreeItem::setIsDefaultValue(bool isDefault)
-{
-    m_defaultValue = isDefault;
-}
-
-bool TreeItem::isDefaultValue()
-{
-    return m_defaultValue;
 }
 
 QList<MetaObjectTreeItem *> TopTreeItem::getMetaObjectItems()

--- a/ground/gcs/src/plugins/uavobjectbrowser/treeitem.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/treeitem.h
@@ -174,8 +174,15 @@ public:
         return 0;
     }
 
-    bool isDefaultValue();
-    void setIsDefaultValue(bool isDefault);
+    virtual bool isDefaultValue() const { return true; }
+
+protected:
+    bool childrenAreDefaultValue() const {
+        bool ret = true;
+        for (const auto item : treeChildren())
+            ret &= item->isDefaultValue();
+        return ret;
+    }
 
 private slots:
 
@@ -188,7 +195,6 @@ private:
     bool m_highlight;
     bool m_changed;
     bool m_updated;
-    bool m_defaultValue;
     HighLightManager *m_highlightManager;
     static int m_highlightTimeMs;
 
@@ -342,6 +348,10 @@ public:
         }
         isPresentOnHardware = value;
     }
+
+    virtual bool isDefaultValue() const override { return childrenAreDefaultValue(); }
+
+
 protected slots:
     virtual void doRefreshHiddenObjects(UAVDataObject *dobj)
     {
@@ -403,6 +413,8 @@ public:
         : TreeItem(data, parent)
     {
     }
+
+    virtual bool isDefaultValue() const override { return childrenAreDefaultValue(); }
 };
 
 class CategoryTreeItem : public TreeItem


### PR DESCRIPTION
Show objects in bold when any field is non-default.