### PR TITLE
GCS:Output: Stop curve fit/calibrate getting squashed

### DIFF
--- a/ground/gcs/src/plugins/config/output.ui
+++ b/ground/gcs/src/plugins/config/output.ui
@@ -1048,7 +1048,7 @@ Leave at 50Hz for fixed wing.</string>
                 <property name="sizeHint" stdset="0">
                  <size>
                   <width>20</width>
-                  <height>542</height>
+                  <height>0</height>
                  </size>
                 </property>
                </spacer>


### PR DESCRIPTION
By fixing size hint on vertical spacer