### PR TITLE
GCS:App: Remove obsolete Qt::AA_X11InitThreads

### DIFF
--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -227,11 +227,6 @@ int main(int argc, char **argv)
     }
 #endif
 
-#ifdef Q_OS_LINUX
-    // This should have faster performance on linux
-    QApplication::setAttribute(Qt::AA_X11InitThreads, true);
-#endif
-
     QApplication app(argc, argv);
 
 #ifdef USE_CRASHREPORTING


### PR DESCRIPTION
https://doc-snapshots.qt.io/qt5-5.8/qt.html
"Qt::AA_X11InitThreads	10	This value is obsolete and has no effect."