### PR TITLE
flightgear: add drprotocol file; omitted by mistake before

### DIFF
--- a/flight/targets/simulation/drprotocol.xml
+++ b/flight/targets/simulation/drprotocol.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PropertyList>
+<generic>
+
+   <input>
+      <line_separator>\n</line_separator>
+      <var_separator>,</var_separator>
+
+      <chunk>
+         <name>aileron</name>
+         <node>/controls/flight/aileron</node>
+         <type>float</type>
+         <format>%f</format>
+       </chunk>
+
+      <chunk>
+         <name>elevator</name>
+         <node>/controls/flight/elevator</node>
+         <type>float</type>
+         <format>%f</format>
+       </chunk>
+
+      <chunk>
+         <name>rudder</name>
+         <node>/controls/flight/rudder</node>
+         <type>float</type>
+         <format>%f</format>
+       </chunk>
+
+      <chunk>
+         <name>throttle</name>
+         <node>/controls/engines/current-engine/throttle</node>
+         <type>double</type>
+         <format>%f</format>
+       </chunk>
+
+      <chunk>
+         <name>udpRecvByFGcount</name>
+         <node>/OP/udp-counter</node>
+         <type>int</type>
+         <format>%d</format>
+       </chunk>
+
+   </input>
+
+   <output>
+      <line_separator>\n</line_separator>
+      <var_separator>,</var_separator>
+
+      <chunk>
+         <name>xAccel</name>
+         <node>/accelerations/pilot/x-accel-fps_sec</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>yAccel</name>
+         <node>/accelerations/pilot/y-accel-fps_sec</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>zAccel</name>
+         <node>/accelerations/pilot/z-accel-fps_sec</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>RollRate</name>
+         <node>/orientation/roll-rate-degps</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>PitchRate</name>
+         <node>/orientation/pitch-rate-degps</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>YawRate</name>
+         <node>/orientation/yaw-rate-degps</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>Latitude</name>
+         <node>/position/latitude-deg</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>Longitude</name>
+         <node>/position/longitude-deg</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>Altitude</name>
+         <node>/position/altitude-ft</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>VelNorth</name>
+         <node>/velocities/speed-north-fps</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>VelEast</name>
+         <node>/velocities/speed-east-fps</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>VelDown</name>
+         <node>/velocities/speed-down-fps</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>Temperature</name>
+         <node>/environment/temperature-degc</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>Pressure</name>
+         <node>/environment/pressure-inhg</node>
+         <type>float</type>
+         <format>%f</format>
+      </chunk>
+
+      <chunk>
+         <name>udpRecvByFGcount</name>
+         <node>/OP/udp-counter</node>
+         <type>int</type>
+         <format>%d</format>
+       </chunk>
+
+   </output>
+
+</generic>
+</PropertyList>


### PR DESCRIPTION
The necessary steps to use this are something like this:

1. Install file in flightgear install.  for me, this is
cp drprotocol.xml /usr/share/games/flightgear/Protocol/
2. Start flightgear-- command line like:
fgfs --generic=socket,out,30,127.0.0.1,4444,udp,drprotocol
--generic=socket,in,30,127.0.0.1,4445,udp,drprotocol

2.b. it's worth familiarizing yourself with flightgear some.
In particular, things I do on the menus are
Cessna 172P-Aircraft Options: and then turn on "Start with engine
running"/
Location-Position Aircraft in Air is useful, too, to drop the plane in
air at like 5000ft, though then I need to do Cessna 172P-Autostart manually.

3. Start GCS-- note that GCS and flightgear must be on the same screen
(though FG can be made into a tiny window) because it doesn't do the
physics model at full rate if it's not visible.
4. Get the aircraft into whatever starting condition you want the sim to
experience.
5. Start the sim: ./build/sim/sim.elf -g 4444
6. Connect GCS to localhost:9000, and then go through an arming sequence
and pick a flight mode.  You can fly the simulator around in rate mode,
etc.

What's still needed is a bit of work for the magnetometer and
gpsposition and gpsvelocity objects to be set based on what flightgear
is returning-- then it should be possible to fly entire fixed wing
scenarios with a good physics model.