### PR TITLE
bu: move to -lc instead of -lc_nano

### DIFF
--- a/flight/targets/bu/f1/Makefile
+++ b/flight/targets/bu/f1/Makefile
@@ -171,7 +171,7 @@ ASFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
 #    --cref:    add cross reference to  map file
 LDFLAGS = -nostartfiles -Wl,-Map=$(OUTDIR)/$(TARGET).map,--cref,--gc-sections
 LDFLAGS += -Wl,-static
-LDFLAGS += -lc_nano -lgcc 
+LDFLAGS += -lc -lgcc 
 LDFLAGS += -Wl,--warn-common
 LDFLAGS += -Wl,--fatal-warnings
 

--- a/flight/targets/bu/f3/Makefile
+++ b/flight/targets/bu/f3/Makefile
@@ -147,7 +147,7 @@ ASFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
 #    --cref:    add cross reference to  map file
 LDFLAGS = -nostartfiles -Wl,-Map=$(OUTDIR)/$(TARGET).map,--cref,--gc-sections
 LDFLAGS += -Wl,-static
-LDFLAGS += -lc_nano -lgcc 
+LDFLAGS += -lc -lgcc 
 LDFLAGS += -Wl,--warn-common
 LDFLAGS += -Wl,--fatal-warnings
 

--- a/flight/targets/bu/f4/Makefile
+++ b/flight/targets/bu/f4/Makefile
@@ -151,7 +151,7 @@ ASFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
 #    --cref:    add cross reference to  map file
 LDFLAGS = -nostartfiles -Wl,-Map=$(OUTDIR)/$(TARGET).map,--cref,--gc-sections
 LDFLAGS += -Wl,-static
-LDFLAGS += -lc_nano -lgcc 
+LDFLAGS += -lc -lgcc
 LDFLAGS += -Wl,--warn-common
 LDFLAGS += -Wl,--fatal-warnings
 


### PR DESCRIPTION
Relates to #1689 , though I don't think it can be cause because the commit in question was after the reports started coming in.

With this change, bu on sparky2 works.  Without it, it doesn't.  I don't understand why-- perhaps some kind of weird alignment thing or minimum image size thing that we're triggering.