### PR TITLE
Change Revo's DShot back to GPIO

### DIFF
--- a/flight/targets/revolution/board-info/board_hw_defs.c
+++ b/flight/targets/revolution/board-info/board_hw_defs.c
@@ -1432,12 +1432,12 @@ static const struct pios_dmashot_timer_cfg dmashot_tim_cfg[] = {
 	},
 	{
 		.timer = TIM9,
-		.master_timer = TIM1,
+		.master_timer = TIM4,
 		.master_config = TIM_DMA_Update | TIM_DMABase_CCR2,
 
-		.stream = DMA2_Stream5,
-		.channel = DMA_Channel_6,
-		.tcif = DMA_FLAG_TCIF5,
+		.stream = DMA1_Stream6,
+		.channel = DMA_Channel_2,
+		.tcif = DMA_FLAG_TCIF6,
 	},
 	{
 		.timer = TIM2,

--- a/flight/targets/revolution/board-info/board_hw_defs.c
+++ b/flight/targets/revolution/board-info/board_hw_defs.c
@@ -1407,60 +1407,6 @@ static const struct pios_tim_channel pios_tim_servoport_rcvrport_pins[] = {
 };
 
 #if defined(PIOS_INCLUDE_SERVO) && defined(PIOS_INCLUDE_TIM)
-
-#if defined(PIOS_INCLUDE_DMASHOT)
-
-#include <pios_dmashot.h>
-
-/*
-TIM3 C3,C4
-TIM9 C2
-TIM2 C3
-TIM5 C2,C1
-
-DShot is mostly just popular with miniquads, those being actual quads,
-at most hex. So six is enough. Rest is gonna use bitbanging, if user
-wants to use these pins.
-*/
-
-static const struct pios_dmashot_timer_cfg dmashot_tim_cfg[] = {
-	{
-		.timer = TIM3,
-		.stream = DMA1_Stream2,
-		.channel = DMA_Channel_5,
-		.tcif = DMA_FLAG_TCIF2,
-	},
-	{
-		.timer = TIM9,
-		.master_timer = TIM4,
-		.master_config = TIM_DMA_Update | TIM_DMABase_CCR2,
-
-		.stream = DMA1_Stream6,
-		.channel = DMA_Channel_2,
-		.tcif = DMA_FLAG_TCIF6,
-	},
-	{
-		.timer = TIM2,
-		.stream = DMA1_Stream1,
-		.channel = DMA_Channel_3,
-		.tcif = DMA_FLAG_TCIF1,
-	},
-	{
-		.timer = TIM5,
-		.stream = DMA1_Stream0,
-		.channel = DMA_Channel_6,
-		.tcif = DMA_FLAG_TCIF0,
-	}
-};
-
-static const struct pios_dmashot_cfg dmashot_config = {
-	.timer_cfg = &dmashot_tim_cfg[0],
-	.num_timers = NELEMENTS(dmashot_tim_cfg)
-};
-
-#endif /* defined(PIOS_INCLUDE_DMASHOT) */
-
-
 /*
  * Servo outputs
  */

--- a/flight/targets/revolution/fw/pios_board.c
+++ b/flight/targets/revolution/fw/pios_board.c
@@ -417,10 +417,6 @@ void PIOS_Board_Init(void) {
 	PIOS_DEBUG_Init(&pios_tim_servo_all_channels, NELEMENTS(pios_tim_servo_all_channels));
 #endif
 
-#if defined(PIOS_INCLUDE_DMASHOT)
-	PIOS_DMAShot_Init(&dmashot_config);
-#endif
-
 	HwRevolutionData hwRevoMini;
 	HwRevolutionGet(&hwRevoMini);
 

--- a/flight/targets/revolution/fw/pios_config.h
+++ b/flight/targets/revolution/fw/pios_config.h
@@ -79,8 +79,6 @@
 /* Supported receiver interfaces */
 #define PIOS_INCLUDE_PWM
 
-#define PIOS_INCLUDE_DMASHOT
-
 //#define PIOS_INCLUDE_DEBUG_CONSOLE
 
 /* Flags that alter behaviors - mostly to lower resources for CC */


### PR DESCRIPTION
On Revo, you can configure WS2811 to output to pins PA0, PB12 and PD2.

When WS2811 is enabled and set to pin PD2, DMAShot works just fine on the Revo. When however pins PA0 or PB12 are configured, the DMA stream for servo pin 3, which shares a DMA channel with WS2811, appears to get interrupted if their DMA requests collide. The DMA update function waits for all previous DMAShot updates to finish by checking the transfer complete flag (IMO unnecessary), and when the DMA request gets stopped, it'll never trigger, thus the board crashes in the watchdog because it's stuck in that wait. See this:

![drama2](https://user-images.githubusercontent.com/4010813/27512093-1b6ac76c-5936-11e7-819d-cbf85b4e1f7a.png)

The initial naive fix was to ditch the TC flag wait, which kept the board working. Except above still happens, at least until it gets reset by the next update from DMAShot. If you could rely on ESCs noticing that there's too much data incoming, this would be a kludgy fix. Practically, this will likely not be the case, and thanks to XOR checksums, the ESC will likely parse it as disarm when the DMA got interrupted sending an 0-bit, or go full throttle if it happened on an 1-bit.

I'm at a loss as to why this happens. The documentation says not to run two DMA streams on the same DMA channel, but why it only causes drama for two third of the WS2811 pins, I'm not sure.

There aren't any relevant CPU savings between DMAShot and GPIO shot, anyway. Former just allows for IRQs to run, e.g. to prevent Seppuku video from wobbling, otherwise there's no real advantage (other than mixed DShot rates).

So disabling DMAShot is the best option. GPIO works just fine on the Revo.