### PR TITLE
gcs: setupwizard: increase leveling timeout

### DIFF
--- a/ground/gcs/src/plugins/setupwizard/pages/biascalibrationpage.cpp
+++ b/ground/gcs/src/plugins/setupwizard/pages/biascalibrationpage.cpp
@@ -94,7 +94,7 @@ void BiasCalibrationPage::performCalibration()
 
     QTimer *timer = new QTimer(this);
     timer->setSingleShot(true);
-    timer->setInterval(20000);
+    timer->setInterval(30000);
 
     connect(m_calibrationUtil, &Calibration::levelingProgressChanged, this,
             &BiasCalibrationPage::calibrationProgress);


### PR DESCRIPTION
Unfortunately, the way the timeouts stack in the bias calibration
tool and the bias calibration page is dumb/not ideal, and at this
level a series of UAVO transactions before the calibration is also
timed.  Increase the timeout to a value that comfortably works at
100kbps pipxtreme 2 rooms away :D

Fixes #598