### PR TITLE
GCS:UAVSettingsImportExport: Hax to avoid circular dll dep on Windows

### DIFF
--- a/ground/gcs/src/plugins/uavsettingsimportexport/uavsettingsimportexportmanager.cpp
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/uavsettingsimportexportmanager.cpp
@@ -96,12 +96,15 @@ UAVSettingsImportExportManager::UAVSettingsImportExportManager(QObject *parent)
 
 void UAVSettingsImportExportManager::extensionsInitialized()
 {
+        // problems with circular lib dep on windows, probably related to uploader
+#ifndef Q_OS_WIN
     auto pm = ExtensionSystem::PluginManager::instance();
     auto telemetry = pm->getObject<TelemetryManager>();
     // enabled/disabled commands when board is connected/disconnected
     connect(telemetry, &TelemetryManager::connectedChanged,
             this, &UAVSettingsImportExportManager::setCommandsEnabled);
     setCommandsEnabled(telemetry->isConnected());
+#endif
 }
 
 bool UAVSettingsImportExportManager::importUAVSettings(const QByteArray &settings, bool quiet)


### PR DESCRIPTION
Just disable functionality for Windows users, while everyone else can still enjoy it.