### PR TITLE
Improve error message for incompatible QT version

### DIFF
--- a/ground/gcs/gcs.pro
+++ b/ground/gcs/gcs.pro
@@ -15,7 +15,7 @@ unix:!macx:!isEmpty(copydata) {
 }
 
 !equals(QT_MAJOR_VERSION, $$DR_QT_MAJOR_VERSION) | !equals(QT_MINOR_VERSION, $$DR_QT_MINOR_VERSION) | !equals(QT_PATCH_VERSION, $$DR_QT_PATCH_VERSION) {
-    error("Qt $${DR_QT_MAJOR_VERSION}.$${DR_QT_MINOR_VERSION}.$${DR_QT_PATCH_VERSION} required. Please run 'make qt_sdk_install'.")
+    error("Qt $${DR_QT_MAJOR_VERSION}.$${DR_QT_MINOR_VERSION}.$${DR_QT_PATCH_VERSION} required (Qt $${QT_MAJOR_VERSION}.$${QT_MINOR_VERSION}.$${QT_PATCH_VERSION} installed). Please run 'make qt_sdk_install'.")
 }
 
 copydata.file = copydata.pro

--- a/ground/uavobjgenerator/uavobjgenerator.pro
+++ b/ground/uavobjgenerator/uavobjgenerator.pro
@@ -10,7 +10,7 @@ macx {
 # we are a bit looser on Qt release for uavogen
 # lets doc builders etc. use PPAs which always carry only latest patch release
 !equals(QT_MAJOR_VERSION, $$DR_QT_MAJOR_VERSION) | !equals(QT_MINOR_VERSION, $$DR_QT_MINOR_VERSION) | lessThan(QT_PATCH_VERSION, $$DR_QT_PATCH_VERSION) {
-    error("Qt $${DR_QT_MAJOR_VERSION}.$${DR_QT_MINOR_VERSION}.$${DR_QT_PATCH_VERSION}+ required. Please run 'make qt_sdk_install'.")
+    error("Qt $${DR_QT_MAJOR_VERSION}.$${DR_QT_MINOR_VERSION}.$${DR_QT_PATCH_VERSION}+ required (Qt $${QT_MAJOR_VERSION}.$${QT_MINOR_VERSION}.$${QT_PATCH_VERSION} installed). Please run 'make qt_sdk_install'.")
 }
 
 cache()


### PR DESCRIPTION
gcs and uavobjgenerator now print out the detected qt version when an
incompatible version is detected.