### PR TITLE
GCS:Utils: Implement minimumSizeHint for LongLongSpinBox

### DIFF
--- a/ground/gcs/src/libs/utils/longlongspinbox.h
+++ b/ground/gcs/src/libs/utils/longlongspinbox.h
@@ -67,6 +67,10 @@ public:
     int displayIntegerBase() const;
     void setDisplayIntegerBase(int base);
 
+    virtual QSize minimumSizeHint() const override;
+
+    virtual bool event(QEvent *event) override;
+
 protected:
     QValidator::State validate(QString &input, int &pos) const override;
     virtual qint64 valueFromText(const QString &text);
@@ -95,6 +99,7 @@ private:
     QString m_prefix, m_suffix;
     int m_displayBase;
     bool m_showGroupSeparator;
+    mutable QSize m_cachedMinSize;
 
     Q_DISABLE_COPY(LongLongSpinBox)
 };


### PR DESCRIPTION
Otherwise widgets with fixed/minimum size policies end up too short. If only Qt made QAbstractSpinBox able to take care of things like this without private headers.. Also made a small performance improvement by caching the text interpretation result (as the upstream QSpinBox impl. does).

This is useful for default hw widget on macOS.