### PR TITLE
BL/BU: Handle bad bootloaders

### DIFF
--- a/flight/PiOS/STM32/chibi_main.c
+++ b/flight/PiOS/STM32/chibi_main.c
@@ -73,7 +73,7 @@ int main()
 	PIOS_heap_initialize_blocks();
 
 	halInit();
-	chSysInit();
+	chSysInit();	/* Enables interrupts */
 
 	boardInit();
 

--- a/flight/PiOS/STM32F30x/startup.c
+++ b/flight/PiOS/STM32F30x/startup.c
@@ -67,6 +67,9 @@ _main(void)
 	// that might bounds-check the stack
 	asm volatile ("mov r10, %0" : : "r" (&irq_stack[0]) : );
 
+	/* Disable all interrupts, until proper table etc is installed. */
+	__disable_irq();
+
 	/* enable usage, bus and memory faults */
 	SCB->SHCSR |= SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_BUSFAULTENA_Msk | SCB_SHCSR_MEMFAULTENA_Msk;
 

--- a/flight/PiOS/STM32F4xx/startup.c
+++ b/flight/PiOS/STM32F4xx/startup.c
@@ -67,6 +67,9 @@ _main(void)
 	// that might bounds-check the stack
 	asm volatile ("mov r10, %0" : : "r" (&irq_stack[0]) : );
 
+	/* Disable all interrupts, until proper table etc is installed. */
+	__disable_irq();
+
 	/* enable usage, bus and memory faults */
 	SCB->SHCSR |= SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_BUSFAULTENA_Msk | SCB_SHCSR_MEMFAULTENA_Msk;
 

--- a/flight/PiOS/STM32F4xx/startup.c
+++ b/flight/PiOS/STM32F4xx/startup.c
@@ -63,8 +63,11 @@ struct cm3_vectors {
 void
 _main(void)
 {
-	// load the stack base for the current stack before we attempt to branch to any function
-	// that might bounds-check the stack
+	/* At least some bootloaders increment the MSP off the top of the stack
+	 * before jumping to here. Let's set it ourselves to make sure it's good */
+	asm volatile ("msr msp, %0" : : "r" (&irq_stack[sizeof(irq_stack)]) : );
+	/* load the stack base for the current stack before we attempt to branch to
+	 * any function that might bounds-check the stack */
 	asm volatile ("mov r10, %0" : : "r" (&irq_stack[0]) : );
 
 	/* Disable all interrupts, until proper table etc is installed. */

--- a/flight/targets/aq32/board-info/board-info.mk
+++ b/flight/targets/aq32/board-info/board-info.mk
@@ -1,12 +1,12 @@
 BOARD_TYPE          := 0x94
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x00
 
 CHIP                := STM32F407VGT6
 BOARD               := STM32F4xx_AQ32
 MODEL               := HD
-MODEL_SUFFIX        := 
+MODEL_SUFFIX        :=
 
 USB_VEND            := "AeroQuad"
 USB_PROD            := "AQ32"

--- a/flight/targets/bl/common/main.c
+++ b/flight/targets/bl/common/main.c
@@ -434,6 +434,9 @@ static void process_packet_rx(struct bl_fsm_context * context, const struct bl_m
 
 int main(void)
 {
+	/* Interrupts are OK immediately for the loader */
+	__enable_irq();
+
 	/* Configure and enable system clocks */
 	PIOS_SYS_Init();
 

--- a/flight/targets/bl/common/main.c
+++ b/flight/targets/bl/common/main.c
@@ -357,7 +357,7 @@ static void go_jumping_to_app(struct bl_fsm_context * context)
 	__set_MSP(initial_sp);
 
 	/* Jump to the application entry point */
-	((void (*)(void))initial_pc)();
+	asm volatile("bx %r0" : : "r" (initial_pc) : );
 }
 
 static void go_dfu_idle(struct bl_fsm_context * context)

--- a/flight/targets/brain/board-info/board-info.mk
+++ b/flight/targets/brain/board-info/board-info.mk
@@ -1,12 +1,12 @@
 BOARD_TYPE          := 0x8A
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x00		# seems to be unused
 
 CHIP                := STM32F405RGT
 BOARD               := STM32F4xx_BRAIN
 MODEL               := HD
-MODEL_SUFFIX        := 
+MODEL_SUFFIX        :=
 
 USB_VEND            := "BrainFPV"
 USB_PROD            := "BrainFPV"

--- a/flight/targets/brainre1/board-info/board-info.mk
+++ b/flight/targets/brainre1/board-info/board-info.mk
@@ -1,12 +1,12 @@
 BOARD_TYPE          := 0x8B
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x00		# seems to be unused
 
 CHIP                := STM32F446RET
 BOARD               := STM32F4xx_BRAINFPVRE1
 MODEL               := HD
-MODEL_SUFFIX        := 
+MODEL_SUFFIX        :=
 
 USB_VEND            := "BrainFPV"
 USB_PROD            := "RE1"
@@ -35,4 +35,3 @@ SYSCLK_FREQ         := 180000000
 # Include these here, so they get included in the firmware and bootloader
 SRC += $(BOARD_INFO_DIR)/../re1fpga/fpga_drv.c
 EXTRAINCDIRS += $(BOARD_INFO_DIR)/../re1fpga/
-

--- a/flight/targets/dtfc/board-info/board-info.mk
+++ b/flight/targets/dtfc/board-info/board-info.mk
@@ -1,12 +1,12 @@
 BOARD_TYPE          := 0xD7
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x00
 
 CHIP                := STM32F303VCT
 BOARD               := STM32F30x_DTFc
 MODEL               := HD
-MODEL_SUFFIX        := 
+MODEL_SUFFIX        :=
 
 USB_VEND            := "DTF Air"
 USB_PROD            := "DTFc"
@@ -31,4 +31,3 @@ EF_BANK_SIZE        := 0x00040000  # Size of the entire flash image (from bootlo
 
 OSCILLATOR_FREQ     :=   8000000
 SYSCLK_FREQ         :=  72000000
-

--- a/flight/targets/lux/board-info/board-info.mk
+++ b/flight/targets/lux/board-info/board-info.mk
@@ -1,12 +1,12 @@
 BOARD_TYPE          := 0xCA
 BOARD_REVISION      := 0x02
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x00		# seems to be unused
 
 CHIP                := STM32F303VCT
 BOARD               := STM32F30x_lux
 MODEL               := HD
-MODEL_SUFFIX        := 
+MODEL_SUFFIX        :=
 
 USB_VEND            := "Lumenier"
 USB_PROD            := "LUX"
@@ -31,4 +31,3 @@ EF_BANK_SIZE        := 0x00040000  # Size of the entire flash image (from bootlo
 
 OSCILLATOR_FREQ     :=   8000000
 SYSCLK_FREQ         :=  72000000
-

--- a/flight/targets/pikoblx/board-info/board-info.mk
+++ b/flight/targets/pikoblx/board-info/board-info.mk
@@ -1,12 +1,12 @@
 BOARD_TYPE          := 0xA2
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x00		# seems to be unused
 
 CHIP                := STM32F303VCT
 BOARD               := STM32F30x_PIKOBLX
 MODEL               := HD
-MODEL_SUFFIX        := 
+MODEL_SUFFIX        :=
 
 USB_VEND            := "dRonin"
 USB_PROD            := "PikoBLX"
@@ -31,4 +31,3 @@ EF_BANK_SIZE        := 0x00040000  # Size of the entire flash image (from bootlo
 
 OSCILLATOR_FREQ     :=   8000000
 SYSCLK_FREQ         :=  72000000
-

--- a/flight/targets/pipxtreme/board-info/board-info.mk
+++ b/flight/targets/pipxtreme/board-info/board-info.mk
@@ -1,6 +1,6 @@
 BOARD_TYPE          := 0x03
 BOARD_REVISION      := 0x02
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x01
 
 CHIP                := STM32F103CBT
@@ -28,4 +28,3 @@ EF_BANK_SIZE        := 0x00020000  # Size of the entire flash image (from bootlo
 
 OSCILLATOR_FREQ     :=   8000000
 SYSCLK_FREQ         :=  72000000
-

--- a/flight/targets/playuavosd/board-info/board-info.mk
+++ b/flight/targets/playuavosd/board-info/board-info.mk
@@ -1,6 +1,6 @@
 BOARD_TYPE          := 0xCB
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x00		# seems to be unused
 
 CHIP                := STM32F405RGT

--- a/flight/targets/quanton/board-info/board-info.mk
+++ b/flight/targets/quanton/board-info/board-info.mk
@@ -1,12 +1,12 @@
 BOARD_TYPE          := 0x86
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x00		# seems to be unused
 
 CHIP                := STM32F405RGT
 BOARD               := STM32F4xx_QUANTON
 MODEL               := HD
-MODEL_SUFFIX        := 
+MODEL_SUFFIX        :=
 
 USB_VEND            := "Quantec"
 USB_PROD            := "Quanton"

--- a/flight/targets/revolution/board-info/board-info.mk
+++ b/flight/targets/revolution/board-info/board-info.mk
@@ -1,12 +1,12 @@
 BOARD_TYPE          := 0x09
 BOARD_REVISION      := 0x03
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x00
 
 CHIP                := STM32F405RGT
 BOARD               := STM32F4xx_RM
 MODEL               := HD
-MODEL_SUFFIX        := 
+MODEL_SUFFIX        :=
 
 USB_VEND            := "OpenPilot"
 USB_PROD            := "Revolution"

--- a/flight/targets/seppuku/board-info/board-info.mk
+++ b/flight/targets/seppuku/board-info/board-info.mk
@@ -1,12 +1,12 @@
 BOARD_TYPE          := 0xA1
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x88
+BOOTLOADER_VERSION  := 0x89
 HW_TYPE             := 0x00		# seems to be unused
 
 CHIP                := STM32F405RGT
 BOARD               := STM32F4xx_SEPPUKU
 MODEL               := HD
-MODEL_SUFFIX        := 
+MODEL_SUFFIX        :=
 
 USB_VEND            := "dRonin"
 USB_PROD            := "Seppuku"

--- a/flight/targets/sparky/board-info/board-info.mk
+++ b/flight/targets/sparky/board-info/board-info.mk
@@ -1,12 +1,12 @@
 BOARD_TYPE          := 0x88
 BOARD_REVISION      := 0x02
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x00		# seems to be unused
 
 CHIP                := STM32F303VCT
 BOARD               := STM32F30x_SPARKY
 MODEL               := HD
-MODEL_SUFFIX        := 
+MODEL_SUFFIX        :=
 
 USB_VEND            := "Tau Labs"
 USB_PROD            := "Sparky"
@@ -31,4 +31,3 @@ EF_BANK_SIZE        := 0x00040000  # Size of the entire flash image (from bootlo
 
 OSCILLATOR_FREQ     :=   8000000
 SYSCLK_FREQ         :=  72000000
-

--- a/flight/targets/sparky2/board-info/board-info.mk
+++ b/flight/targets/sparky2/board-info/board-info.mk
@@ -1,12 +1,12 @@
 BOARD_TYPE          := 0x92
 BOARD_REVISION      := 0x01
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x00
 
 CHIP                := STM32F405RGT
 BOARD               := STM32F4xx_RM
 MODEL               := HD
-MODEL_SUFFIX        := 
+MODEL_SUFFIX        :=
 
 USB_VEND            := "Tau Labs"
 USB_PROD            := "Sparky2"

--- a/flight/targets/sprf3e/board-info/board-info.mk
+++ b/flight/targets/sprf3e/board-info/board-info.mk
@@ -1,12 +1,12 @@
 BOARD_TYPE          := 0xCF
 BOARD_REVISION      := 0x02
-BOOTLOADER_VERSION  := 0x87
+BOOTLOADER_VERSION  := 0x88
 HW_TYPE             := 0x00		# seems to be unused
 
 CHIP                := STM32F303CCT
 BOARD               := STM32F30x_sprf3e
 MODEL               := HD
-MODEL_SUFFIX        := 
+MODEL_SUFFIX        :=
 
 USB_VEND            := "dRonin"
 USB_PROD            := "SPRF3E"
@@ -31,4 +31,3 @@ EF_BANK_SIZE        := 0x00040000  # Size of the entire flash image (from bootlo
 
 OSCILLATOR_FREQ     :=   8000000
 SYSCLK_FREQ         :=  72000000
-


### PR DESCRIPTION
Tested and working on Revo:
- Latest Librepilot bootloader (v6) -> flash BU from this branch -> flash dR firmware from this branch
- BL from this branch -> flash BU from this branch -> flash dR firmware from this branch
- BL from this branch -> flash BU from Release-20160720.1 linux release -> flash BU from this branch -> flash dR firmware from this branch

Fixes #1689 (issue detailed in https://github.com/d-ronin/dRonin/issues/1689#issuecomment-312568385)

Remaining questions:
- ~~~Is it just our bootloader that started generating garbage code between __set_MSP and bx <initial_sp>?~~~ No, LP and our older releases have the same isssue.
- How does it affect firmware? #1875