### PR TITLE
Flight: Implement Stack Unused Checks

### DIFF
--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -744,6 +744,7 @@ static void updateStats()
 
 	// Get Irq stack status
 	stats.IRQStackRemaining = (uint16_t)PIOS_SYS_IrqStackUnused();
+	stats.OSStackRemaining = (uint16_t)PIOS_SYS_OsStackUnused();
 
 	// When idleCounterClear was not reset by the idle-task, it means the idle-task did not run
 	if (idleCounterClear) {

--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -731,33 +731,6 @@ static void updateRfm22bStats() {
 /**
  * Called periodically to update the system stats
  */
-static uint16_t GetFreeIrqStackSize(void)
-{
-	uint32_t i = 0x200;
-
-#if !defined(ARCH_POSIX) && !defined(ARCH_WIN32) && defined(CHECK_IRQ_STACK)
-	extern uint32_t _irq_stack_top;
-	extern uint32_t _irq_stack_end;
-	uint32_t pattern = 0x0000A5A5;
-	uint32_t *ptr = &_irq_stack_end;
-
-	uint32_t stack_size = (((uint32_t)&_irq_stack_top - (uint32_t)&_irq_stack_end) & ~3 ) / 4;
-
-	for (i=0; i< stack_size; i++)
-	{
-		if (ptr[i] != pattern)
-		{
-			i=i*4;
-			break;
-		}
-	}
-#endif
-	return i;
-}
-
-/**
- * Called periodically to update the system stats
- */
 static void updateStats()
 {
 	static uint32_t lastTickCount = 0;
@@ -770,7 +743,7 @@ static void updateStats()
 	stats.FastHeapRemaining = PIOS_fastheap_get_free_size();
 
 	// Get Irq stack status
-	stats.IRQStackRemaining = GetFreeIrqStackSize();
+	stats.IRQStackRemaining = (uint16_t)PIOS_SYS_IrqStackUnused();
 
 	// When idleCounterClear was not reset by the idle-task, it means the idle-task did not run
 	if (idleCounterClear) {

--- a/flight/PiOS/STM32F0xx/pios_sys.c
+++ b/flight/PiOS/STM32F0xx/pios_sys.c
@@ -191,6 +191,11 @@ int32_t PIOS_SYS_SerialNumberGet(char *str)
 	return 0;
 }
 
+size_t PIOS_SYS_IrqStackUnused(void)
+{
+	return 0;
+}
+
 /**
 * Configures SysTick
 */

--- a/flight/PiOS/STM32F0xx/pios_sys.c
+++ b/flight/PiOS/STM32F0xx/pios_sys.c
@@ -196,6 +196,11 @@ size_t PIOS_SYS_IrqStackUnused(void)
 	return 0;
 }
 
+size_t PIOS_SYS_OsStackUnused(void)
+{
+	return 0;
+}
+
 /**
 * Configures SysTick
 */

--- a/flight/PiOS/STM32F10x/pios_sys.c
+++ b/flight/PiOS/STM32F10x/pios_sys.c
@@ -164,10 +164,18 @@ static inline size_t unused_mem(uint32_t *top, uint32_t *bot, uint32_t pattern)
 /* c.f. linker */
 extern uint32_t __main_stack_base__;
 extern uint32_t __main_stack_end__;
+extern uint32_t __process_stack_base__;
+extern uint32_t __process_stack_end__;
 
 size_t PIOS_SYS_IrqStackUnused(void)
 {
 	return unused_mem(&__main_stack_end__, &__main_stack_base__,
+		CRT0_STACKS_FILL_PATTERN);
+}
+
+size_t PIOS_SYS_OsStackUnused(void)
+{
+	return unused_mem(&__process_stack_end__, &__process_stack_base__,
 		CRT0_STACKS_FILL_PATTERN);
 }
 
@@ -180,6 +188,11 @@ extern uint32_t _irq_stack_top;
 size_t PIOS_SYS_IrqStackUnused(void)
 {
 	return unused_mem(&_irq_stack_top, &_irq_stack_end, 0xa5a5);
+}
+
+size_t PIOS_SYS_OsStackUnused(void)
+{
+	return 0;
 }
 
 #endif /* PIOS_INCLUDE_CHIBIOS */

--- a/flight/PiOS/STM32F10x/pios_sys.c
+++ b/flight/PiOS/STM32F10x/pios_sys.c
@@ -149,6 +149,41 @@ int32_t PIOS_SYS_SerialNumberGet(char *str)
 	return 0;
 }
 
+static inline size_t unused_mem(uint32_t *top, uint32_t *bot, uint32_t pattern)
+{
+	uint32_t *p = bot;
+	for (; p < top && *p == pattern; p++);
+	return (p - bot) * sizeof(uint32_t);
+}
+
+#ifdef PIOS_INCLUDE_CHIBIOS
+
+#if !defined(CRT0_STACKS_FILL_PATTERN)
+#define CRT0_STACKS_FILL_PATTERN    0x55555555 /* ChibiOS ResetHandler */
+#endif
+/* c.f. linker */
+extern uint32_t __main_stack_base__;
+extern uint32_t __main_stack_end__;
+
+size_t PIOS_SYS_IrqStackUnused(void)
+{
+	return unused_mem(&__main_stack_end__, &__main_stack_base__,
+		CRT0_STACKS_FILL_PATTERN);
+}
+
+#else
+
+/* c.f. linker */
+extern uint32_t _irq_stack_end;
+extern uint32_t _irq_stack_top;
+
+size_t PIOS_SYS_IrqStackUnused(void)
+{
+	return unused_mem(&_irq_stack_top, &_irq_stack_end, 0xa5a5);
+}
+
+#endif /* PIOS_INCLUDE_CHIBIOS */
+
 /**
 * Configures Vector Table base location and SysTick
 */

--- a/flight/PiOS/STM32F30x/pios_sys.c
+++ b/flight/PiOS/STM32F30x/pios_sys.c
@@ -235,10 +235,18 @@ static inline size_t unused_mem(uint32_t *top, uint32_t *bot, uint32_t pattern)
 /* c.f. linker */
 extern uint32_t __main_stack_base__;
 extern uint32_t __main_stack_end__;
+extern uint32_t __process_stack_base__;
+extern uint32_t __process_stack_end__;
 
 size_t PIOS_SYS_IrqStackUnused(void)
 {
 	return unused_mem(&__main_stack_end__, &__main_stack_base__,
+		CRT0_STACKS_FILL_PATTERN);
+}
+
+size_t PIOS_SYS_OsStackUnused(void)
+{
+	return unused_mem(&__process_stack_end__, &__process_stack_base__,
 		CRT0_STACKS_FILL_PATTERN);
 }
 
@@ -251,6 +259,11 @@ extern uint32_t _irq_stack_top;
 size_t PIOS_SYS_IrqStackUnused(void)
 {
 	return unused_mem(&_irq_stack_top, &_irq_stack_end, 0xa5a5a5a5);
+}
+
+size_t PIOS_SYS_OsStackUnused(void)
+{
+	return 0;
 }
 
 #endif /* PIOS_INCLUDE_CHIBIOS */

--- a/flight/PiOS/STM32F4xx/pios_sys.c
+++ b/flight/PiOS/STM32F4xx/pios_sys.c
@@ -280,10 +280,18 @@ static inline size_t unused_mem(uint32_t *top, uint32_t *bot, uint32_t pattern)
 /* c.f. linker */
 extern uint32_t __main_stack_base__;
 extern uint32_t __main_stack_end__;
+extern uint32_t __process_stack_base__;
+extern uint32_t __process_stack_end__;
 
 size_t PIOS_SYS_IrqStackUnused(void)
 {
 	return unused_mem(&__main_stack_end__, &__main_stack_base__,
+		CRT0_STACKS_FILL_PATTERN);
+}
+
+size_t PIOS_SYS_OsStackUnused(void)
+{
+	return unused_mem(&__process_stack_end__, &__process_stack_base__,
 		CRT0_STACKS_FILL_PATTERN);
 }
 
@@ -296,6 +304,11 @@ extern uint32_t _irq_stack_top;
 size_t PIOS_SYS_IrqStackUnused(void)
 {
 	return unused_mem(&_irq_stack_top, &_irq_stack_end, 0xa5a5a5a5);
+}
+
+size_t PIOS_SYS_OsStackUnused(void)
+{
+	return 0;
 }
 
 #endif /* PIOS_INCLUDE_CHIBIOS */

--- a/flight/PiOS/STM32F4xx/pios_sys.c
+++ b/flight/PiOS/STM32F4xx/pios_sys.c
@@ -265,6 +265,41 @@ int32_t PIOS_SYS_SerialNumberGet(char *str)
 	return 0;
 }
 
+static inline size_t unused_mem(uint32_t *top, uint32_t *bot, uint32_t pattern)
+{
+	uint32_t *p = bot;
+	for (; p < top && *p == pattern; p++);
+	return (p - bot) * sizeof(uint32_t);
+}
+
+#ifdef PIOS_INCLUDE_CHIBIOS
+
+#if !defined(CRT0_STACKS_FILL_PATTERN)
+#define CRT0_STACKS_FILL_PATTERN    0x55555555 /* ChibiOS ResetHandler */
+#endif
+/* c.f. linker */
+extern uint32_t __main_stack_base__;
+extern uint32_t __main_stack_end__;
+
+size_t PIOS_SYS_IrqStackUnused(void)
+{
+	return unused_mem(&__main_stack_end__, &__main_stack_base__,
+		CRT0_STACKS_FILL_PATTERN);
+}
+
+#else
+
+/* c.f. linker */
+extern uint32_t _irq_stack_end;
+extern uint32_t _irq_stack_top;
+
+size_t PIOS_SYS_IrqStackUnused(void)
+{
+	return unused_mem(&_irq_stack_top, &_irq_stack_end, 0xa5a5a5a5);
+}
+
+#endif /* PIOS_INCLUDE_CHIBIOS */
+
 /**
 * Configures Vector Table base location and SysTick
 */

--- a/flight/PiOS/inc/pios_sys.h
+++ b/flight/PiOS/inc/pios_sys.h
@@ -42,6 +42,7 @@ extern int32_t PIOS_SYS_Reset(void);
 extern int32_t PIOS_SYS_SerialNumberGetBinary(uint8_t array[PIOS_SYS_SERIAL_NUM_BINARY_LEN]);
 extern int32_t PIOS_SYS_SerialNumberGet(char str[PIOS_SYS_SERIAL_NUM_ASCII_LEN+1]);
 extern size_t PIOS_SYS_IrqStackUnused(void);
+extern size_t PIOS_SYS_OsStackUnused(void);
 
 #endif /* PIOS_SYS_H */
 

--- a/flight/PiOS/inc/pios_sys.h
+++ b/flight/PiOS/inc/pios_sys.h
@@ -31,6 +31,8 @@
 #ifndef PIOS_SYS_H
 #define PIOS_SYS_H
 
+#include <stddef.h>
+
 #define PIOS_SYS_SERIAL_NUM_BINARY_LEN 12
 #define PIOS_SYS_SERIAL_NUM_ASCII_LEN (PIOS_SYS_SERIAL_NUM_BINARY_LEN * 2)
 
@@ -39,6 +41,7 @@ extern void PIOS_SYS_Init(void);
 extern int32_t PIOS_SYS_Reset(void);
 extern int32_t PIOS_SYS_SerialNumberGetBinary(uint8_t array[PIOS_SYS_SERIAL_NUM_BINARY_LEN]);
 extern int32_t PIOS_SYS_SerialNumberGet(char str[PIOS_SYS_SERIAL_NUM_ASCII_LEN+1]);
+extern size_t PIOS_SYS_IrqStackUnused(void);
 
 #endif /* PIOS_SYS_H */
 

--- a/flight/PiOS/posix/inc/pios_sys.h
+++ b/flight/PiOS/posix/inc/pios_sys.h
@@ -40,6 +40,7 @@ extern int32_t PIOS_SYS_Reset(void);
 extern int32_t PIOS_SYS_SerialNumberGetBinary(uint8_t array[PIOS_SYS_SERIAL_NUM_BINARY_LEN]);
 extern int32_t PIOS_SYS_SerialNumberGet(char str[PIOS_SYS_SERIAL_NUM_ASCII_LEN+1]);
 extern size_t PIOS_SYS_IrqStackUnused(void);
+extern size_t PIOS_SYS_OsStackUnused(void);
 
 extern void PIOS_SYS_Args(int argc, char *argv[]);
 

--- a/flight/PiOS/posix/inc/pios_sys.h
+++ b/flight/PiOS/posix/inc/pios_sys.h
@@ -39,6 +39,7 @@ extern void PIOS_SYS_Init(void);
 extern int32_t PIOS_SYS_Reset(void);
 extern int32_t PIOS_SYS_SerialNumberGetBinary(uint8_t array[PIOS_SYS_SERIAL_NUM_BINARY_LEN]);
 extern int32_t PIOS_SYS_SerialNumberGet(char str[PIOS_SYS_SERIAL_NUM_ASCII_LEN+1]);
+extern size_t PIOS_SYS_IrqStackUnused(void);
 
 extern void PIOS_SYS_Args(int argc, char *argv[]);
 

--- a/flight/PiOS/posix/pios_sys.c
+++ b/flight/PiOS/posix/pios_sys.c
@@ -865,6 +865,12 @@ int32_t PIOS_SYS_SerialNumberGet(char *str)
 	/* No error */
 	return 0;
 }
+
+size_t PIOS_SYS_IrqStackUnused(void)
+{
+	return 0;
+}
+
 #endif
 
 /**

--- a/flight/PiOS/posix/pios_sys.c
+++ b/flight/PiOS/posix/pios_sys.c
@@ -871,6 +871,11 @@ size_t PIOS_SYS_IrqStackUnused(void)
 	return 0;
 }
 
+size_t PIOS_SYS_OsStackUnused(void)
+{
+	return 0;
+}
+
 #endif
 
 /**

--- a/shared/uavobjectdefinition/systemstats.xml
+++ b/shared/uavobjectdefinition/systemstats.xml
@@ -14,6 +14,9 @@
 		<field name="IRQStackRemaining" units="bytes" type="uint16" elements="1">
 			<description>Unused space on the IRQ stack since boot.</description>
 		</field>
+		<field name="OSStackRemaining" units="bytes" type="uint16" elements="1">
+			<description>Unused space on the main thread OS stack since boot.</description>
+		</field>
 		<field name="CPULoad" units="%" type="uint8" elements="1">
 			<description>Indicative measure of current CPU load.</description>
 		</field>


### PR DESCRIPTION
Chibi uses the following types of stacks:
- main stack, used by interrupts
- process stack, used by main thread from very early init
- per-thread stacks, used by normal threads

This adds missing code to measure the first, and a new measurement for the second. Shows up #1875 when using an old bootloader.