### PR TITLE
GCS: Fix clang compiler warnings

### DIFF
--- a/ground/gcs/src/plugins/boards_dronin/pikoblx.h
+++ b/ground/gcs/src/plugins/boards_dronin/pikoblx.h
@@ -50,9 +50,6 @@ public:
     virtual int queryMaxGyroRate();
     virtual QStringList getAdcNames();
     virtual bool hasAnnunciator(AnnunciatorType annunc);
-
-private:
-    UAVObjectManager *uavoManager;
 };
 
 #endif // PIKOBLX_H_

--- a/ground/gcs/src/plugins/uavobjectbrowser/fieldtreeitem.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/fieldtreeitem.h
@@ -64,13 +64,13 @@ public:
         , m_defaultValue(true)
     {
     }
-    bool isEditable() { return true; }
+    inline virtual bool isEditable() override { return true; }
     void setIsDefaultValue(bool isDefault) { m_defaultValue = isDefault; }
     virtual bool isDefaultValue() const override { return m_defaultValue; }
     virtual QWidget *createEditor(QWidget *parent) = 0;
     virtual QVariant getEditorValue(QWidget *editor) = 0;
     virtual void setEditorValue(QWidget *editor, QVariant value) = 0;
-    virtual void apply() {}
+    virtual void apply() override {}
 protected:
     int m_index;
     bool m_defaultValue;

--- a/ground/gcs/src/plugins/uavobjectbrowser/treeitem.h
+++ b/ground/gcs/src/plugins/uavobjectbrowser/treeitem.h
@@ -302,7 +302,7 @@ public:
         : ObjectTreeItem(data, parent)
     {
     }
-    virtual void apply()
+    virtual void apply() override
     {
         foreach (TreeItem *child, treeChildren()) {
             MetaObjectTreeItem *metaChild = dynamic_cast<MetaObjectTreeItem *>(child);
@@ -310,7 +310,7 @@ public:
                 child->apply();
         }
     }
-    virtual void update()
+    virtual void update() override
     {
         foreach (TreeItem *child, treeChildren()) {
             MetaObjectTreeItem *metaChild = dynamic_cast<MetaObjectTreeItem *>(child);
@@ -318,12 +318,12 @@ public:
                 child->update();
         }
     }
-    void appendChild(TreeItem *child)
+    virtual void appendChild(TreeItem *child)  override
     {
         ObjectTreeItem::appendChild(child);
         child->setIsPresentOnHardware(isPresentOnHardware);
     }
-    void setObject(UAVObject *obj)
+    virtual void setObject(UAVObject *obj) override
     {
         UAVDataObject *dobj = dynamic_cast<UAVDataObject *>(obj);
         if (dobj) {
@@ -340,7 +340,7 @@ public:
             isPresentOnHardware = false;
         }
     }
-    virtual void setIsPresentOnHardware(bool value)
+    virtual void setIsPresentOnHardware(bool value) override
     {
         foreach (TreeItem *item, treeChildren()) {
             if (!dynamic_cast<DataObjectTreeItem *>(item))


### PR DESCRIPTION
clang 3.9 on Linux no longer emits any warnings in our code (hopefully Xcode variant is the same), just these 3rd-party ones (some of which are fixed in #1888):

```
/home/mike/dev/dronin/ground/gcs/src/libs/qwt/src/qwt_date.cpp:325:17: warning: ignoring return value of function declared with warn_unused_result attribute [-Wunused-result]
                dt.addSecs( 1 );
                ^~~~~~~~~~  ~
/home/mike/dev/dronin/ground/gcs/src/libs/qwt/src/qwt_date.cpp:333:17: warning: ignoring return value of function declared with warn_unused_result attribute [-Wunused-result]
                dt.addSecs( 60 );
                ^~~~~~~~~~  ~~
/home/mike/dev/dronin/ground/gcs/src/libs/qwt/src/qwt_date.cpp:341:17: warning: ignoring return value of function declared with warn_unused_result attribute [-Wunused-result]
                dt.addSecs( 3600 );
                ^~~~~~~~~~  ~~~~
/home/mike/dev/dronin/ground/gcs/src/libs/qwt/src/qwt_date.cpp:374:17: warning: ignoring return value of function declared with warn_unused_result attribute [-Wunused-result]
                dt.addMonths( 1 );
                ^~~~~~~~~~~~  ~
/home/mike/dev/dronin/ground/gcs/src/libs/qwt/src/qwt_date.cpp:174:22: warning: unused function 'qwtToJulianDay' [-Wunused-function]
static inline double qwtToJulianDay( int year, int month, int day )
                     ^
/home/mike/dev/dronin/ground/gcs/src/libs/qwt/src/qwt_date.cpp:187:22: warning: unused function 'qwtFloorDiv64' [-Wunused-function]
static inline qint64 qwtFloorDiv64( qint64 a, int b )
                     ^
/home/mike/dev/dronin/ground/gcs/src/libs/qwt/src/qwt_date.cpp:195:22: warning: unused function 'qwtFloorDiv' [-Wunused-function]
static inline qint64 qwtFloorDiv( int a, int b )
                     ^
7 warnings generated.
/home/mike/dev/dronin/ground/gcs/src/libs/qwt/src/qwt_date_scale_engine.cpp:30:27: warning: comparison of constant 8 with expression of type 'QwtDate::IntervalType' is always false [-Wtautological-constant-out-of-range-compare]
    if ( type < 0 || type >= static_cast<int>( sizeof( msecs ) / sizeof( msecs[0] ) ) )
                     ~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
/home/mike/dev/dronin/ground/gcs/src/libs/qwt/src/qwt_plot_tradingcurve.cpp:238:37: warning: comparison of constant 2 with expression of type 'QwtPlotTradingCurve::Direction' is always false [-Wtautological-constant-out-of-range-compare]
    if ( direction < 0 || direction >= 2 )
                          ~~~~~~~~~ ^  ~
/home/mike/dev/dronin/ground/gcs/src/libs/qwt/src/qwt_plot_tradingcurve.cpp:259:37: warning: comparison of constant 2 with expression of type 'QwtPlotTradingCurve::Direction' is always false [-Wtautological-constant-out-of-range-compare]
    if ( direction < 0 || direction >= 2 )
                          ~~~~~~~~~ ^  ~
2 warnings generated.
/home/mike/dev/dronin/ground/gcs/src/plugins/rawhid/hidapi/hidapi_linux.c:329:14: warning: comparison of unsigned enum expression >= 0 is always true [-Wtautological-compare]
     if (key >= 0 && key < DEVICE_STRING_COUNT) {
         ~~~ ^  ~
1 warning generated.
```

Progress on #783 