### PR TITLE
OSD: Use GPS ground speed scalar rather than calculating from vectors

### DIFF
--- a/flight/Modules/OnScreenDisplay/onscreendisplay.c
+++ b/flight/Modules/OnScreenDisplay/onscreendisplay.c
@@ -1380,11 +1380,11 @@ void render_user_page(OnScreenDisplayPageSettingsData * page)
 				sprintf(tmp_str, "%s", "GND");
 				break;
 			case ONSCREENDISPLAYPAGESETTINGS_SPEEDSCALESOURCE_GPS:
-				if (GPSVelocityHandle()) {
-					GPSVelocityNorthGet(&tmp);
-					GPSVelocityEastGet(&tmp1);
-					tmp = sqrt(tmp * tmp + tmp1 * tmp1);
-					speed_valid = has_gps;
+				if (has_gps && GPSPositionHandle()) {
+					GPSPositionGroundspeedGet(&tmp);
+					uint8_t fix;
+					GPSPositionStatusGet(&fix);
+					speed_valid = fix != GPSPOSITION_STATUS_NOFIX;
 				}
 				sprintf(tmp_str, "%s", "GND");
 				break;


### PR DESCRIPTION
UBLOX provides ground speed in both polar (2D) and cartesian (3D) co-ordinates. OSD was calculating the magnitude from the cartesian co-ordinates rather than using the scalar magnitude from the polar co-ordinates. NMEA only provides velocity in polar form and our impl. doesn't do the conversion to cartesian for GPSVelocity UAVO.

Summary: saved some math and made it work for both UBLOX and NMEA.