### PR TITLE
GCS:Config:Autotune: Move save button to right

### DIFF
--- a/ground/gcs/src/plugins/config/autotune.ui
+++ b/ground/gcs/src/plugins/config/autotune.ui
@@ -124,6 +124,20 @@ p, li { white-space: pre-wrap; }
          </spacer>
         </item>
         <item>
+         <widget class="QPushButton" name="adjustTune">
+          <property name="text">
+           <string>Adjust previous autotune...</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="fromDataFileBtn">
+          <property name="text">
+           <string>From data file...</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QPushButton" name="saveStabilizationToSD_6">
           <property name="minimumSize">
            <size>
@@ -144,20 +158,6 @@ p, li { white-space: pre-wrap; }
            <stringlist>
             <string>button:save</string>
            </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="adjustTune">
-          <property name="text">
-           <string>Adjust previous autotune...</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="fromDataFileBtn">
-          <property name="text">
-           <string>From data file...</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Consistent with all other config widgets. I think this should go in current cycle because it's __really__ annoying (at least I found it to be so when I end up clicking the wrong button each time), really low risk, and it would be a shame to stick around for a whole cycle.

Fixes #1887 