### PR TITLE
Build system improvements (ccache, qbs, clazy)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ gcs_ts: tools_required_qt
 gcs_clazy: CLAZY_CHECKS ?= level0
 gcs_clazy: $(UAVOBJECT_MARKER) | tools_required_qt
 	echo $(CLAZY)
-ifeq ($(shell which clazy),)
+ifeq ($(shell which clazy 2>/dev/null),)
 	$(error Please install clazy and ensure it is on PATH first. https://github.com/KDE/clazy#build-instructions)
 endif
 	$(V1) mkdir -p $(BUILD_DIR)/ground/$@

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ ALL_BOARDS :=
 include $(ROOT_DIR)/flight/targets/*/target-defs.mk
 
 # OpenPilot GCS build configuration (debug | release)
-GCS_BUILD_CONF ?= debug
+GCS_BUILD_CONF ?= debug ccache
 
 # And the flight build configuration (debug | default | release)
 export FLIGHT_BUILD_CONF ?= default
@@ -97,9 +97,9 @@ endif
 
 # Checking for $(GCS_BUILD_CONF) to be sane
 ifdef GCS_BUILD_CONF
- ifneq ($(GCS_BUILD_CONF), release)
-  ifneq ($(GCS_BUILD_CONF), debug)
-   $(error Only debug or release are allowed for GCS_BUILD_CONF)
+ ifneq ($(filter release, $(GCS_BUILD_CONF)), release)
+  ifneq ($(filter debug, $(GCS_BUILD_CONF)), debug)
+   $(error Either debug or release are required for GCS_BUILD_CONF)
   endif
  endif
 endif

--- a/ground/tools.pri
+++ b/ground/tools.pri
@@ -10,8 +10,8 @@ isEmpty(PYTHON_LOCAL) {
     macx: PYTHON_LOCAL = python
 }
 
-# use ccache with gcc and clang in debug config
-CONFIG(debug, debug|release) {
+# if ccache is in CONFIG, use it
+ccache {
     *-g++*|*-clang* {
         QMAKE_CC=$$(CCACHE_BIN) $$QMAKE_CC
         QMAKE_CXX=$$(CCACHE_BIN) $$QMAKE_CXX

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -589,8 +589,8 @@ breakpad_install: | breakpad_clean
 	$(V0) @echo " BUILDING     $(BREAKPAD_REPO) @ $(BREAKPAD_REV)"
 	$(V1) ( \
 	  cd $(BREAKPAD_BUILD_DIR) ; \
-	  $(QBS) install --install-root $(BREAKPAD_DIR) profile:$(QBS_PROFILE) release ; \
-	  $(QBS) install --install-root $(BREAKPAD_DIR) -p breakpad_client profile:$(QBS_PROFILE) debug ; \
+	  $(QBS) install --settings-dir "$(QBS_SETTINGS_DIR)" --install-root $(BREAKPAD_DIR) profile:$(QBS_PROFILE) release ; \
+	  $(QBS) install --settings-dir "$(QBS_SETTINGS_DIR)" --install-root $(BREAKPAD_DIR) -p breakpad_client profile:$(QBS_PROFILE) debug ; \
 	)
 
 breakpad_clean:
@@ -611,6 +611,7 @@ endif
 #
 ##############################
 
+QBS_SETTINGS_DIR := $(TOOLS_DIR)/qbs
 ifeq ($(shell [ -d "$(QT_SDK_DIR)" ] && echo "exists"), exists)
   QMAKE = $(QT_SDK_QMAKE_PATH)
   QBS = $(QT_SDK_QBS_PATH)
@@ -623,12 +624,12 @@ endif
 .PHONY: tools_required_qbs
 
 tools_required_qbs: | tools_required_qt
-ifeq (,$(shell $(QBS) config --list profiles))
+ifeq (,$(shell $(QBS) config --settings-dir "$(QBS_SETTINGS_DIR)" --list profiles))
 # empty profile config, detect toolchains
-	$(V1) $(QBS) setup-toolchains --detect
-else ifeq (,$(shell $(QBS) config --list | grep "profiles\.$(QBS_PROFILE)\.qbs"))
+	$(V1) $(QBS) setup-toolchains --settings-dir "$(QBS_SETTINGS_DIR)" --detect
+else ifeq (,$(shell $(QBS) config --settings-dir "$(QBS_SETTINGS_DIR)" --list | grep "profiles\.$(QBS_PROFILE)\.qbs"))
 # profile we want is missing. let user know so they can decide if they want to overwrite their config (needed since we don't own Qt install on Windows)
-	$(error "QBS profile '$(QBS_PROFILE)' not found. Try running '$(QBS) setup-toolchains --detect'")
+	$(error "QBS profile '$(QBS_PROFILE)' not found. Try running '$(QBS) setup-toolchains --settings-dir "$(QBS_SETTINGS_DIR)" --detect'")
 endif
 
 ifeq ($(shell [ -d "$(ARM_SDK_DIR)" ] && echo "exists"), exists)


### PR DESCRIPTION
# ccache
Makes ccache a CONFIG option. This means it can be used for release builds as well, which is very handy when working on packaging etc., and it can be disabled for debug builds, even more handy to avoid polluting your cache when testing alternate compilers etc. The default is still debug with ccache. The cases are:
- make gcs
- GCS_BUILD_CONF="debug ccache" make gcs 
    * debug with ccache
- GCS_BUILD_CONF=debug make gcs
    * debug without ccache
- GCS_BUILD_CONF=release make gcs
    * release without ccache
- GCS_BUILD_CONF="release ccache" make gcs
    * release with ccache

i.e. behaves almost exactly the same as before, and with some new options you can build release with ccache and debug without ccache.

# nits
- `which clazy` was emitting warnings on stderr when not found on some platforms (Fedora and Windows at least)
- Use our own qbs settings dir rather than altering the global one

Fixes #1880