### PR TITLE
ManualControl: Prevent arming, if TX is sending arming signal during craft power-up.

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -106,6 +106,7 @@ enum arm_state {
 	ARM_STATE_DISARMED_STILL_HOLDING
 };
 static enum arm_state arm_state = ARM_STATE_DISARMED;
+static bool disarmed_on_powerup = false;
 
 // Private functions
 static float get_thrust_source(ManualControlCommandData *manual_control_command, SystemSettingsAirframeTypeOptions * airframe_type, bool normalize_positive);
@@ -552,8 +553,8 @@ static void set_armed_if_changed(uint8_t new_arm) {
  */
 static bool arming_position(ManualControlCommandData * cmd, ManualControlSettingsData * settings) {
 
-	// If system is not appropriate to arm, do not even attempt
-	if (!ok_to_arm())
+	// If system is not appropriate to arm, do not even attempt.
+	if (!ok_to_arm() || !disarmed_on_powerup)
 		return false;
 
 	bool lowThrottle = cmd->Throttle <= 0;
@@ -677,6 +678,8 @@ static void process_transmitter_events(ManualControlCommandData * cmd, ManualCon
 		} else if (arm) {
 			armedDisarmStart = lastSysTime;
 			arm_state = ARM_STATE_ARMING;
+		} else if (disarming_position(cmd, settings) && valid) {
+			disarmed_on_powerup = true;
 		}
 
 		last_arm = arm;


### PR DESCRIPTION
When the transmitter is sending an arming signal, e.g. if you have switch arming enabled and the switch is flipped on the TX, while you're powering up your quad, it immediately goes to arm. Not so much a problem, if +Throttle is also enabled, because idle motor spin won't cut your fingers, but without +Throttle, there's a possibility for drama.

This patch makes sure that the craft has been in a disarmed state, before allowing arming.

Tested on my Seppuku quad with a Crossfire system. If I power the quad up, while the arming switch is flipped on the transmitter, I need to disarm and rearm for the motors to spin. Otherwise, if the transmitter was disarmed (powering up the transmitter before or after quad power-up), everything works as before, quad arms fine.

Still gonna have to dig out one of my old FrSky receivers to test, whether it immediately sends transmitter commands, or does other silly stuff during boot.