### PR TITLE
flight: pid refactor: move dt to configuration time

### DIFF
--- a/flight/Libraries/math/pid.c
+++ b/flight/Libraries/math/pid.c
@@ -43,11 +43,12 @@ static float deriv_gamma = 1.0;
  * Update the PID computation
  * @param[in] pid The PID struture which stores temporary information
  * @param[in] err The error term
- * @param[in] dT  The time step
  * @returns Output the computed controller value
  */
-float pid_apply(struct pid *pid, const float err, float dT)
-{	
+float pid_apply(struct pid *pid, const float err)
+{
+	float dT = pid->dT;
+
 	if (pid->i == 0) {
 		// If Ki is zero, do not change the integrator. We do not reset to zero
 		// because sometimes the accumulator term is set externally
@@ -82,8 +83,10 @@ float pid_apply(struct pid *pid, const float err, float dT)
  *  chapter.
  */
 float pid_apply_antiwindup(struct pid *pid, const float err,
-	float min_bound, float max_bound, float dT)
-{	
+	float min_bound, float max_bound)
+{
+	float dT = pid->dT;
+
 	if (pid->i == 0) {
 		// If Ki is zero, do not change the integrator. We do not reset to zero
 		// because sometimes the accumulator term is set externally
@@ -123,15 +126,16 @@ float pid_apply_antiwindup(struct pid *pid, const float err,
  * @param[in] pid The PID struture which stores temporary information
  * @param[in] setpoint The setpoint to use
  * @param[in] measured The measured value of output
- * @param[in] dT  The time step
  * @returns Output the computed controller value
  *
  * This version of apply uses setpoint weighting for the derivative component so the gain
  * on the gyro derivative can be different than the gain on the setpoint derivative
  */
 float pid_apply_setpoint(struct pid *pid, struct pid_deadband *deadband, const float setpoint,
-	const float measured, float dT)
+	const float measured)
 {
+	float dT = pid->dT;
+
 	float err = setpoint - measured;
 	float err_d = (deriv_gamma * setpoint - measured);
 
@@ -196,7 +200,7 @@ void pid_configure_derivative(float cutoff, float g)
  * @param[in] i The integral term
  * @param[in] d The derivative term
  */
-void pid_configure(struct pid *pid, float p, float i, float d, float iLim)
+void pid_configure(struct pid *pid, float p, float i, float d, float iLim, float dT)
 {
 	if (!pid)
 		return;
@@ -205,6 +209,7 @@ void pid_configure(struct pid *pid, float p, float i, float d, float iLim)
 	pid->i = i;
 	pid->d = d;
 	pid->iLim = iLim;
+	pid->dT = dT;
 }
 
 /**

--- a/flight/Libraries/math/pid.h
+++ b/flight/Libraries/math/pid.h
@@ -44,17 +44,20 @@ struct pid {
 	float i;
 	float d;
 	float iLim;
+
+	float dT;
+
 	float iAccumulator;
 	float lastErr;
 	float lastDer;
 };
 
 //! Methods to use the pid structures
-float pid_apply(struct pid *pid, const float err, float dT);
-float pid_apply_antiwindup(struct pid *pid, const float err, float min_bound, float max_bound, float dT);
-float pid_apply_setpoint(struct pid *pid, struct pid_deadband *deadband, const float setpoint, const float measured, float dT);
+float pid_apply(struct pid *pid, const float err);
+float pid_apply_antiwindup(struct pid *pid, const float err, float min_bound, float max_bound);
+float pid_apply_setpoint(struct pid *pid, struct pid_deadband *deadband, const float setpoint, const float measured);
 void pid_zero(struct pid *pid);
-void pid_configure(struct pid *pid, float p, float i, float d, float iLim);
+void pid_configure(struct pid *pid, float p, float i, float d, float iLim, float dT);
 void pid_configure_derivative(float cutoff, float gamma);
 void pid_configure_deadband(struct pid_deadband *deadband, float width, float slope);
 

--- a/flight/Modules/Stabilization/virtualflybar.c
+++ b/flight/Modules/Stabilization/virtualflybar.c
@@ -53,7 +53,7 @@ int stabilization_virtual_flybar(float gyro, float command, float *output, float
 	vbar_integral[axis] = bound(vbar_integral[axis], settings->VbarMaxAngle);
 
 	// Compute the normal PID controller output
-	float pid_out = pid_apply_setpoint(pid, NULL,  0,  gyro, dT);
+	float pid_out = pid_apply_setpoint(pid, NULL,  0,  gyro);
 
 	// Command signal can indicate how much to disregard the gyro feedback (fast flips)
 	if (settings->VbarGyroSuppress > 0.0f) {

--- a/flight/Modules/VtolPathFollower/vtol_follower_fsm.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_fsm.c
@@ -60,7 +60,6 @@
 const static float RTH_MIN_ALTITUDE = 15.f;  //!< Hover at least 15 m above home */
 const static float RTH_ALT_ERROR    = 0.8f;  //!< The altitude to come within for RTH */
 const static float RTH_MIN_RISE     = 1.5f;  //!< Always climb at least this much.
-const static float DT               = 0.05f; // TODO: make the self monitored
 const static float RTH_CLIMB_SPEED  = 1.0f;  //!< Climb at 1m/s 
 
 //! Events that can be be injected into the FSM and trigger state changes
@@ -404,7 +403,7 @@ static float vtol_hold_position_ned[3];
  */
 static int32_t do_hold()
 {
-	if (vtol_follower_control_endpoint(DT, vtol_hold_position_ned) == 0) {
+	if (vtol_follower_control_endpoint(vtol_hold_position_ned) == 0) {
 		if (vtol_follower_control_attitude(DT, NULL) == 0) {
 			return 0;
 		}
@@ -429,7 +428,7 @@ static PathDesiredData vtol_fsm_path_desired = {
 static int32_t do_path()
 {
 	struct path_status progress;
-	if (vtol_follower_control_path(DT, &vtol_fsm_path_desired, &progress) == 0) {
+	if (vtol_follower_control_path(&vtol_fsm_path_desired, &progress) == 0) {
 		if (vtol_follower_control_attitude(DT, NULL) == 0) {
 
 			if (progress.fractional_progress >= 1.0f) {
@@ -480,7 +479,7 @@ static int32_t do_requested_path()
 static int32_t do_land()
 {
 	bool landed;
-	if (vtol_follower_control_land(DT, vtol_hold_position_ned, &landed) == 0) {
+	if (vtol_follower_control_land(vtol_hold_position_ned, &landed) == 0) {
 		if (vtol_follower_control_attitude(DT, NULL) == 0) {
 			return 0;
 		}
@@ -511,7 +510,7 @@ static int32_t do_loiter()
 		hold_position(hold_pos[0], hold_pos[1], hold_pos[2]);
 	}
 
-	if (vtol_follower_control_altrate(DT, vtol_hold_position_ned,
+	if (vtol_follower_control_altrate(vtol_hold_position_ned,
 				alt_adj) == 0) {
 		if (vtol_follower_control_attitude(DT, att_adj) == 0) {
 			return 0;
@@ -531,7 +530,7 @@ static int32_t do_loiter()
  */
 static int32_t do_slow_altitude_change(float descent_rate)
 {
-	if (vtol_follower_control_altrate(DT, vtol_hold_position_ned,
+	if (vtol_follower_control_altrate(vtol_hold_position_ned,
 				descent_rate) == 0) {
 		if (vtol_follower_control_attitude(DT, NULL) == 0) {
 			return 0;

--- a/flight/Modules/VtolPathFollower/vtol_follower_priv.h
+++ b/flight/Modules/VtolPathFollower/vtol_follower_priv.h
@@ -32,6 +32,8 @@
 #include "pathdesired.h"
 #include "paths.h"
 
+const static float DT               = 0.05f; // TODO: make the self monitored
+
 /**
  * The set of goals the VTOL follower will attempt to achieve this selects
  * the particular FSM that is running. These goals are determined by the
@@ -57,12 +59,12 @@ enum vtol_pid {
 };
 
 // Control code public API methods
-int32_t vtol_follower_control_path(const float dT, const PathDesiredData *pathDesired, struct path_status *progress);
-int32_t vtol_follower_control_endpoint(const float dT, const float *hold_pos_ned);
-int32_t vtol_follower_control_altrate(const float dT, const float *hold_pos_ned,
+int32_t vtol_follower_control_path(const PathDesiredData *pathDesired, struct path_status *progress);
+int32_t vtol_follower_control_endpoint(const float *hold_pos_ned);
+int32_t vtol_follower_control_altrate(const float *hold_pos_ned,
 		float alt_adj);
 int32_t vtol_follower_control_attitude(const float dT, const float *att_adj);
-int32_t vtol_follower_control_land(const float dT, const float *hold_pos_ned, bool *landed);
+int32_t vtol_follower_control_land(const float *hold_pos_ned, bool *landed);
 bool vtol_follower_control_loiter(float dT, float *hold_pos, float *att_adj,
 		float *alt_adj);
 void vtol_follower_control_settings_updated(UAVObjEvent * ev, void *ctx,


### PR DESCRIPTION
No longer allow time to vary from timestep to timestep.  This doesn't do
much right now, but it's for two upcoming reasons-- to allow
precomputing the derivative filter, and to allow precomputing a leaky
integral.