### PR TITLE
fixedwingpathfollower: add position feedforward

### DIFF
--- a/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
+++ b/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
@@ -349,7 +349,13 @@ static void updatePathVelocity()
 	VelocityActualData velocityActual;
 	VelocityActualGet(&velocityActual);
 
-	float cur[3] = {positionActual.North, positionActual.East, positionActual.Down};
+	float cur[3] = {
+		positionActual.North +
+			velocityActual.North * fixedwingpathfollowerSettings.PositionFeedforward,
+		positionActual.East +
+			velocityActual.East * fixedwingpathfollowerSettings.PositionFeedforward,
+		positionActual.Down
+	};
 	struct path_status progress;
 
 	path_progress(&pathDesired, cur, &progress);

--- a/shared/uavobjectdefinition/fixedwingpathfollowersettings.xml
+++ b/shared/uavobjectdefinition/fixedwingpathfollowersettings.xml
@@ -40,6 +40,9 @@
 		<field name="UpdatePeriod" units="ms" type="int16" elements="1" defaultvalue="100">
 			<description/>
 		</field>
+		<field name="PositionFeedforward" units="s" type="float" elements="1" defaultvalue="0.5">
+			<description>The amount of time of the current velocity to feed-forward into position to compensate for turns taking time.</description>
+		</field>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
When evaluating path segments and path error, feed forward the current
velocity 0.5 seconds forward into position.  This way, we begin turning
early, since a plane cannot instantly translate in the desired
direction.