### PR TITLE
GCS:UAVObjectField: Return QChar for bitfields

### DIFF
--- a/ground/gcs/src/plugins/uavobjects/uavobjectfield.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectfield.cpp
@@ -883,7 +883,7 @@ QVariant UAVObjectField::getValue(int index) const
     case BITFIELD: {
         d = &data[offset + elementSize * static_cast<unsigned>(index / 8)];
         quint8 val = (*static_cast<const quint8 *>(d) >> (index % 8)) & 1;
-        return QVariant::fromValue(val);
+        return QVariant::fromValue(val > 0 ? QChar('1') : QChar('0'));
     }
     case STRING:
         return QVariant::fromValue(QString::fromLatin1(static_cast<const char *>(d),


### PR DESCRIPTION
quint8 == unsigned char, so QVariant::toString (used in UAVObjectBrowser TreeModel code) treats it as a char rather than an int. Give it an actual char so it can continue to use the same code for enums and bitfields.

Fixes #1919