### PR TITLE
pipxtreme: cope with slow clients

### DIFF
--- a/flight/Modules/RadioComBridge/RadioComBridge.c
+++ b/flight/Modules/RadioComBridge/RadioComBridge.c
@@ -511,7 +511,8 @@ static int32_t UAVTalkSendHandler(void *ctx, uint8_t * buf, int32_t length)
 #endif /* PIOS_INCLUDE_USB */
 
 	if (outputPort) {
-		ret = PIOS_COM_SendBuffer(outputPort, buf, length);
+		ret = PIOS_COM_SendBufferStallTimeout(outputPort, buf, length,
+				RETRY_TIMEOUT_MS);
 	} else {
 		ret = -1;
 	}
@@ -534,7 +535,8 @@ static int32_t RadioSendHandler(void *ctx, uint8_t * buf, int32_t length)
 
 	// Don't send any data unless the radio port is available.
 	if (outputPort && PIOS_COM_Available(outputPort)) {
-		return PIOS_COM_SendBuffer(outputPort, buf, length);
+		return PIOS_COM_SendBufferStallTimeout(outputPort, buf, length,
+				RETRY_TIMEOUT_MS);
 	} else {
 		return -1;
 	}

--- a/flight/PiOS/inc/pios_com.h
+++ b/flight/PiOS/inc/pios_com.h
@@ -55,6 +55,7 @@ extern int32_t PIOS_COM_ChangeBaud(uintptr_t com_id, uint32_t baud);
 extern int32_t PIOS_COM_SendCharNonBlocking(uintptr_t com_id, char c);
 extern int32_t PIOS_COM_SendChar(uintptr_t com_id, char c);
 extern int32_t PIOS_COM_SendBufferNonBlocking(uintptr_t com_id, const uint8_t *buffer, uint16_t len);
+extern int32_t PIOS_COM_SendBufferStallTimeout(uintptr_t com_id, const uint8_t *buffer, uint16_t len, uint32_t max_ms);
 extern int32_t PIOS_COM_SendBuffer(uintptr_t com_id, const uint8_t *buffer, uint16_t len);
 extern int32_t PIOS_COM_SendStringNonBlocking(uintptr_t com_id, const char *str);
 extern int32_t PIOS_COM_SendString(uintptr_t com_id, const char *str);


### PR DESCRIPTION
radiocombridge: use time-blocking-variants of calls

Technically this isn't sufficient, because we could be unlucky and have very slow throughput that is sufficient to prevent this from tripping but still hits the watchdog.  In practice it's fine, as the principal issue (USB never draining at all while it is present) is fixed.