### PR TITLE
hangtime: implement a leaky bucket algorithm

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -560,26 +560,7 @@ static void normalize_input_data(uint32_t this_systime,
 		throttle_val = -1;
 	}
 
-	static uint32_t last_pos_throttle_time = 0;
-
-	*stabilize_now = *armed && (throttle_val > 0.0f);
-
-	if (*stabilize_now) {
-		if (actuatorSettings.LowPowerStabilizationMaxTime) {
-			last_pos_throttle_time = this_systime;
-		}
-
-		// Could consider stabilizing on a positive arming edge,
-		// but this seems problematic.
-	} else if (last_pos_throttle_time) {
-		if ((this_systime - last_pos_throttle_time) <
-				1000.0f * actuatorSettings.LowPowerStabilizationMaxTime) {
-			*stabilize_now = true;
-			throttle_val = 0.0f;
-		} else {
-			last_pos_throttle_time = 0;
-		}
-	}
+	*stabilize_now = throttle_val > 0.0f;
 
 	float val1 = throt_curve(throttle_val, curve1,
 			MIXERSETTINGS_THROTTLECURVE1_NUMELEM);

--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -311,14 +311,61 @@ static void fill_desired_vector(
 	 */
 }
 
-static void post_process_scale_and_commit(float *motor_vect, float dT,
-		bool armed, bool spin_while_armed, bool stabilize_now)
+static void post_process_scale_and_commit(float *motor_vect,
+		float *desired_vect, float dT,
+		bool armed, bool spin_while_armed, bool stabilize_now,
+		float *maxpoweradd_bucket)
 {
 	float min_chan = INFINITY;
 	float max_chan = -INFINITY;
 	float neg_clip = 0;
 	int num_motors = 0;
 	ActuatorCommandData command;
+
+	const float hangtime_leakybucket_timeconstant = 0.3f;
+
+	/* Hangtime maximum power add is now a "leaky bucket" system, ensuring
+	 * that the average added power in the long term is the configured value
+	 * but allowing higher values briefly.
+	 *
+	 * The intention is to allow more aggressive maneuvers than hangtime
+	 * previously did, while still providing similar safety properties.
+	 * A secondary motivation is to prevent tumbling when throttle is
+	 * chopped during fast-forward-flight and more than hangtime power
+	 * levels are needed for stabilization (because of aerodynamic forces).
+	 *
+	 * The "maximum" stored is based on recent throttle history-- it decays
+	 * with time; at high throttle it corresponds to 300ms of the current
+	 * power; at lower throttle it corresponds to 300ms of double the
+	 * configured value.
+	 */
+	float maxpoweradd_softlimit = MAX(
+			2 * actuatorSettings.LowPowerStabilizationMaxPowerAdd,
+			desired_vect[MIXERSETTINGS_MIXER1VECTOR_THROTTLECURVE1])
+		* hangtime_leakybucket_timeconstant;
+
+	/* If we're under the limit, add this tick's hangtime power allotment */
+	if (*maxpoweradd_bucket < maxpoweradd_softlimit) {
+		*maxpoweradd_bucket += actuatorSettings.LowPowerStabilizationMaxPowerAdd * dT;
+	} else {
+		/* Otherwise, decay towards the current limit on a 300ms
+		 * time constant.
+		 */
+		float alpha = dT / (dT + hangtime_leakybucket_timeconstant);
+
+		*maxpoweradd_bucket = alpha * maxpoweradd_softlimit +
+			(1-alpha) * (*maxpoweradd_bucket);
+	}
+
+	/* The maximum power add is what would spend the current allotment in
+	 * 300ms.  In other words, in the absence of recent high-throttle,
+	 * start from double the hangtime configured percentage and decay on
+	 * a 300ms time constant IF IT IS ACTUALLY USED.
+	 *
+	 * This is separate from the above decay, so we could actually be
+	 * decaying twice as fast if both are in play.
+	 */
+	float maxpoweradd = (*maxpoweradd_bucket) / hangtime_leakybucket_timeconstant;
 
 	for (int ct = 0; ct < MAX_MIX_ACTUATORS; ct++) {
 		switch (types_mixer[ct]) {
@@ -404,13 +451,20 @@ static void post_process_scale_and_commit(float *motor_vect, float dT,
 		 * if neg_clip is 5%, and maxpoweradd is 10%, we can add up to
 		 * 5% to all motors to further fix clipping.
 		 */
-		offset = neg_clip + actuatorSettings.LowPowerStabilizationMaxPowerAdd;
+		offset = neg_clip + maxpoweradd;
 
 		/* Add the lesser of--
 		 * A) the amount the lowest channel is out of range.
 		 * B) the above calculated offset.
 		 */
 		offset = MIN(-min_chan, offset);
+
+		/* The amount actually added is the above offset, plus the
+		 * amount that came from negative clipping.  (It's negative
+		 * though, so subtract instead of add).  Spend this from
+		 * the leaky bucket. 
+		 */
+		*maxpoweradd_bucket -= (offset - neg_clip) * dT;
 	}
 
 	for (int ct = 0; ct < MAX_MIX_ACTUATORS; ct++) {
@@ -571,6 +625,8 @@ static void actuator_task(void* parameters)
 	uint32_t last_systime = PIOS_Thread_Systime();
 	float desired_vect[MIXERSETTINGS_MIXER1VECTOR_NUMELEM] = { 0 };
 	float dT = 0.0f;
+	
+	float maxpoweradd_bucket = 0.0f;
 
 	// Main task loop
 	while (1) {
@@ -683,8 +739,9 @@ static void actuator_task(void* parameters)
 		 *
 		 * Program the actual values to the timer subsystem.
 		 */
-		post_process_scale_and_commit(motor_vect, dT, armed,
-				spin_while_armed, stabilize_now);
+		post_process_scale_and_commit(motor_vect, desired_vect,
+				dT, armed, spin_while_armed, stabilize_now,
+				&maxpoweradd_bucket);
 
 		/* If we got this far, everything is OK. */
 		AlarmsClear(SYSTEMALARMS_ALARM_ACTUATOR);

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -92,6 +92,9 @@ DONT_BUILD_IF((MAX_AXES+0 != 3), stabAxisWrongCount);
 // Please adapt changes here also to the init of the plots  in /ground/gcs/src/plugins/config/configstabilizationwidget.cpp
 #define HORIZON_MODE_MAX_BLEND               0.85f
 
+//! Minimum sane positive value for throttle.
+#define THROTTLE_EPSILON 0.000001f
+
 enum {
 	PID_GROUP_RATE,   // Rate controller settings
 	PID_RATE_ROLL = PID_GROUP_RATE,
@@ -429,7 +432,7 @@ static void stabilizationTask(void* parameters)
 
 		static uint32_t last_pos_thrust_time = 0;
 
-		if (stabDesired.Thrust > 0.0f) {
+		if (stabDesired.Thrust > THROTTLE_EPSILON) {
 			if (settings.LowPowerStabilizationMaxTime) {
 				last_pos_thrust_time = this_systime;
 			}
@@ -439,11 +442,10 @@ static void stabilizationTask(void* parameters)
 				/* Choose a barely-positive value to trigger
 				 * low-power stabilization in actuator.
 				 */
-				actuatorDesired.Thrust = 0.000001f;
+				actuatorDesired.Thrust = THROTTLE_EPSILON;
 			} else {
 				last_pos_thrust_time = 0;
 
-				/* XXX Problematic for 3D */
 				actuatorDesired.Thrust = 0.0f;
 			}
 		} else {

--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -50,6 +50,7 @@
 
 #include "actuatorcommand.h"
 #include "actuatorsettings.h"
+#include "stabilizationsettings.h"
 #include "systemsettings.h"
 
 // The fraction of range to place the neutral position in
@@ -1934,11 +1935,11 @@ void ConfigInputWidget::checkArmingConfig()
 
     // check hangtime, recommend switch arming if enabled
     bool hangtime = false;
-    ActuatorSettings *actuatorSettings =
-        qobject_cast<ActuatorSettings *>(getObjectManager()->getObject(ActuatorSettings::NAME));
-    Q_ASSERT(actuatorSettings);
-    if (actuatorSettings)
-        hangtime = actuatorSettings->getLowPowerStabilizationMaxTime() > 0;
+    StabilizationSettings *stabilizationSettings =
+        qobject_cast<StabilizationSettings *>(getObjectManager()->getObject(StabilizationSettings::NAME));
+    Q_ASSERT(stabilizationSettings);
+    if (stabilizationSettings)
+        hangtime = stabilizationSettings->getLowPowerStabilizationMaxTime() > 0;
 
     if (hangtime) {
         m_config->lblRecommendedArm->setText(tr("Switch"));

--- a/ground/gcs/src/plugins/config/stabilization.ui
+++ b/ground/gcs/src/plugins/config/stabilization.ui
@@ -5054,7 +5054,7 @@ border-radius: 5;</string>
                 </property>
                 <property name="objrelation" stdset="0">
                  <stringlist>
-                  <string>objname:ActuatorSettings</string>
+                  <string>objname:StabilizationSettings</string>
                   <string>fieldname:LowPowerStabilizationMaxTime</string>
                   <string>buttongroup:10</string>
                   <string>haslimits:yes</string>

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -20,9 +20,6 @@
 		<field name="LowPowerStabilizationMaxPowerAdd" units="" type="float" elements="1" defaultvalue="0.07" limits="%BE:0.0:0.15">
 			<description>Maximum power to add to ensure stabilization at low power.  Always select a value well under hover power.</description>
 		</field>
-		<field name="LowPowerStabilizationMaxTime" units="s" type="float" elements="1" defaultvalue="0" limits="%BE:0.0:4.5">
-			<description>Maximum time in seconds to add power when at zero throttle to ensure stabilization.  Choosing 0 prevents adding power at zero throttle.</description>
-		</field>
 		<field name="MotorInputOutputCurveFit" units="" type="float" elements="1" defaultvalue="0.9">
 			<description>Actuator mapping of input in [-1,1] to output on [-1,1], using power equation of type x^value. This is intended to correct for the non-linear relationship between input command and output power inherent in brushless ESC/motor combinations. A setting below 1.0 will improve high-throttle control stability.</description>
 		</field>

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -55,6 +55,9 @@
 		<field name="RCControlSmoothing" units="" type="enum" elementnames="Axes,Thrust" options="None,Normal,Extended" defaultvalue="None">
 			<description>Enables different ways of input signal smoothing, to reduce excessive P- and D-term excitation in the PID controller. Normal and Extended modes chamfer the leading edges in combination with some amount of prediction, to avoid delay.</description>
 		</field>
+		<field name="LowPowerStabilizationMaxTime" units="s" type="float" elements="1" defaultvalue="0" limits="%BE:0.0:5.0">
+			<description>Maximum time in seconds to add power when at zero throttle to ensure stabilization.  Choosing 0 prevents adding power at zero throttle.</description>
+		</field>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>
 		<telemetryflight acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
This allows power added to exceed the configured value for a short
time-- to prevent tumbling when chopping throttle from
fast-forward-flight (where aerodynamic loads require high stabilization
power) and to allow entry to aggressive maneuvers while in hangtime
regimes.