### PR TITLE
python-api: small nits

### DIFF
--- a/python/dronin/telemetry.py
+++ b/python/dronin/telemetry.py
@@ -494,6 +494,9 @@ class TelemetryBase(with_metaclass(ABCMeta)):
             if (finish_time is not None) and (time.time() >= finish_time):
                 break
 
+            if self.eof:
+                break
+
     @abstractmethod
     def _receive(self, finish_time):
         return

--- a/python/dronin/uavtalk.py
+++ b/python/dronin/uavtalk.py
@@ -147,14 +147,12 @@ def process_stream(uavo_defs, use_walltime=False, gcs_timestamps=None,
 
                 buf = buf + rx
 
-            for i in range(buf_offset, len(buf)):
-                if indexbytes(buf, i) == SYNC_VAL:
-                    break
-
-            #print "skipping from %d to %d"%(buf_offset, i)
-
-            # Trim off irrelevant stuff, loop and try again
-            buf_offset = i
+            try:
+                buf_offset = buf.index(int2byte(SYNC_VAL), buf_offset)
+            except ValueError:
+                # No sync value
+                buf = b''
+                buf_offset = 0
 
         (sync, pack_type, pack_len, objId) = header_fmt.unpack_from(buf, buf_offset)
 


### PR DESCRIPTION
1. correct an issue where dronin-dumplog can get stuck and never find EOF with recent changes.
2. Previously, when out of sync, the searching-for-new-sync process was **very** expensive.  This is improved somewhat in this branch-- reading @peabody124's test file where there are lots of unknown uavobjects (and possibly just invalid data?) reads 8 times faster-- from 80s to 10s.