### PR TITLE
Windows build env: download latest Win32OpenSSL

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -697,7 +697,11 @@ endif
 
 # OPENSSL download URL
 ifdef WINDOWS
-  openssl_install: OPENSSL_URL  := https://slproweb.com/download/Win32OpenSSL-1_0_2k.exe
+  openssl_install: OPENSSL_URL  := https://slproweb.com$(shell \
+          curl -s https://slproweb.com/products/Win32OpenSSL.html \
+          | grep -P 'Win32OpenSSL-[0-9]*_[0-9]*_[0-9]*[a-z].exe' \
+          | sed 's|.*\(/download/Win32OpenSSL.*\.exe\).*|\1|g'\
+  )
 
 openssl_install: OPENSSL_FILE := $(notdir $(OPENSSL_URL))
 OPENSSL_DIR = $(TOOLS_DIR)/win32openssl

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -699,7 +699,8 @@ endif
 ifdef WINDOWS
   openssl_install: OPENSSL_URL  := https://slproweb.com$(shell \
           curl -s https://slproweb.com/products/Win32OpenSSL.html \
-          | grep -P 'Win32OpenSSL-[0-9]*_[0-9]*_[0-9]*[a-z].exe' \
+          | grep -P 'Win32OpenSSL-1_0_[0-9]*[A-Za-z].exe' \
+          | head -1 \
           | sed 's|.*\(/download/Win32OpenSSL.*\.exe\).*|\1|g'\
   )
 


### PR DESCRIPTION
Added code to search Win32OpenSSL download page for the latest
Win32OpenSSL version, vs. hard-coding the version.

Depends on curl, grep, and sed (I *think* these are included with
Windows git bash)