### PR TITLE
make: tools: remove extra space in zip30 url

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -540,7 +540,7 @@ libkml_clean:
 	$(V1) [ ! -d "$(LIBKML_BUILD_DIR)" ] || $(RM) -rf "$(LIBKML_BUILD_DIR)"
 
 # ZIP download URL
-zip_install: ZIP_URL  := http://pkgs.fedoraproject.org/repo/pkgs/zip/zip30.tar.gz/7b74551e63f8ee6aab6fbc86676c0d37/zip30.tar.gz 
+zip_install: ZIP_URL  := http://pkgs.fedoraproject.org/repo/pkgs/zip/zip30.tar.gz/7b74551e63f8ee6aab6fbc86676c0d37/zip30.tar.gz
 
 zip_install: ZIP_FILE := $(notdir $(ZIP_URL))
 


### PR DESCRIPTION
An extra space at the end of the zip30 download url was failing 'make
zip_install'.