### PR TITLE
make: tools: find latest Win32OpenSSL_1_0_*

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -697,7 +697,12 @@ endif
 
 # OPENSSL download URL
 ifdef WINDOWS
-  openssl_install: OPENSSL_URL  := https://slproweb.com/download/Win32OpenSSL-1_0_2k.exe
+  openssl_install: OPENSSL_URL  := https://slproweb.com$(shell \
+          curl -s https://slproweb.com/products/Win32OpenSSL.html \
+          | grep -P 'Win32OpenSSL-1_0_[0-9]*[A-Za-z].exe' \
+          | head -1 \
+          | sed 's|.*\(/download/Win32OpenSSL.*\.exe\).*|\1|g'\
+  )
 
 openssl_install: OPENSSL_FILE := $(notdir $(OPENSSL_URL))
 OPENSSL_DIR = $(TOOLS_DIR)/win32openssl

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -697,14 +697,14 @@ endif
 
 # OPENSSL download URL
 ifdef WINDOWS
-  openssl_install: OPENSSL_URL  := https://slproweb.com$(shell \
+  openssl_install: OPENSSL_URL  = https://slproweb.com$(shell \
           curl -s https://slproweb.com/products/Win32OpenSSL.html \
           | grep -P 'Win32OpenSSL-1_0_[0-9]*[A-Za-z].exe' \
           | head -1 \
           | sed 's|.*\(/download/Win32OpenSSL.*\.exe\).*|\1|g'\
   )
 
-openssl_install: OPENSSL_FILE := $(notdir $(OPENSSL_URL))
+openssl_install: OPENSSL_FILE = $(notdir $(OPENSSL_URL))
 OPENSSL_DIR = $(TOOLS_DIR)/win32openssl
 # order-only prereq on directory existance:
 openssl_install : | $(DL_DIR) $(TOOLS_DIR)


### PR DESCRIPTION
Eliminates the need to modify make/tools.mk every time slproweb.com
updates their Win32OpenSSL packages

use curl to get https://slproweb.com/prodcuts/Win32OpenSSL.html
use grep to find lines with 'Win32OpenSSL-1_0_*'
use head to grab the first matching line (in case they decide to make
two versions available)
use sed to get the .exe's URL