### PR TITLE
Serial receivers: Bumped failsafe timer to prevent intermittent radio issues from entering failsafe for just fractions of a second.

### DIFF
--- a/flight/PiOS/Common/pios_crossfire.c
+++ b/flight/PiOS/Common/pios_crossfire.c
@@ -374,7 +374,8 @@ bool PIOS_Crossfire_IsFailsafed(uintptr_t crsf_id)
 	if(!PIOS_Crossfire_Validate(dev))
 		PIOS_Assert(0);
 
-	return dev->failsafe_timer > 32;
+	/* ~250ms to failsafe. */
+	return dev->failsafe_timer > 156;
 }
 
 #endif // PIOS_INCLUDE_CROSSFIRE

--- a/flight/PiOS/Common/pios_dsm.c
+++ b/flight/PiOS/Common/pios_dsm.c
@@ -444,8 +444,8 @@ static void PIOS_DSM_Supervisor(uintptr_t dsm_id)
 		state->receive_timer = 0;
 	}
 
-	/* activate failsafe if no frames have arrived in 102.4ms */
-	if (++state->failsafe_timer > 64) {
+	/* activate failsafe if no frames have arrived in ~250ms */
+	if (++state->failsafe_timer > 156) {
 		PIOS_DSM_ResetChannels(dsm_dev);
 		state->failsafe_timer = 0;
 	}

--- a/flight/PiOS/Common/pios_hsum.c
+++ b/flight/PiOS/Common/pios_hsum.c
@@ -387,8 +387,8 @@ static void PIOS_HSUM_Supervisor(uintptr_t hsum_id)
 		state->frame_length = HSUM_MAX_FRAME_LENGTH;
 	}
 
-	/* activate failsafe if no frames have arrived in 102.4ms */
-	if (++state->failsafe_timer > 64) {
+	/* activate failsafe if no frames have arrived in ~250ms */
+	if (++state->failsafe_timer > 156) {
 		PIOS_HSUM_ResetChannels(hsum_dev);
 		state->failsafe_timer = 0;
 		state->tx_connected = 0;

--- a/flight/PiOS/Common/pios_ibus.c
+++ b/flight/PiOS/Common/pios_ibus.c
@@ -236,7 +236,8 @@ static void PIOS_IBus_Supervisor(uintptr_t context)
 	if (++dev->rx_timer > 3)
 		PIOS_IBus_ResetBuffer(dev);
 
-	if (++dev->failsafe_timer > 32)
+	/* ~250ms to failsafe. */
+	if (++dev->failsafe_timer > 156)
 		PIOS_IBus_SetAllChannels(dev, PIOS_RCVR_TIMEOUT);
 }
 

--- a/flight/PiOS/Common/pios_sbus.c
+++ b/flight/PiOS/Common/pios_sbus.c
@@ -287,8 +287,8 @@ static void PIOS_SBus_Supervisor(uintptr_t sbus_id)
 		state->receive_timer = 0;
 	}
 
-	/* activate failsafe if no frames have arrived in 48ms */
-	if (++state->failsafe_timer > 30) {
+	/* Activate failsafe if no frames have arrived in ~250ms. */
+	if (++state->failsafe_timer > 156) {
 		PIOS_SBus_ResetChannels(state);
 		state->failsafe_timer = 0;
 	}

--- a/flight/PiOS/Common/pios_srxl.c
+++ b/flight/PiOS/Common/pios_srxl.c
@@ -311,12 +311,12 @@ void PIOS_SRXL_Supervisor(uintptr_t id)
 	 * RTC runs this callback at 625 Hz (T=1.6 ms)
 	 * Frame period is either 14 ms or 21 ms
 	 * We will reset the rx buffer if nothing is received for 8 ms (5 ticks)
-	 * We will failsafe if 4 frames (low rate) are lost
-	 * (4 * 21) / 1.6 ~ 53 ticks
+	 * We will failsafe if 12 frames (low rate) are lost
+	 * (12 * 21) / 1.6 ~ 158 ticks
 	 */
 	if (++dev->rx_timer >= 5)
 		dev->rx_buffer_pos = 0;
-	if (++dev->failsafe_timer >= 53)
+	if (++dev->failsafe_timer >= 158)
 		PIOS_SRXL_ResetChannels(dev, PIOS_RCVR_TIMEOUT);
 }
 


### PR DESCRIPTION
Whenever Crossfire switches from 50hz link rate to 150hz, say because it's switching between the two due to difficult radio conditions, there appears to be a gap of ~68ms in serial communication, before it actually bumps back to 150hz. The previous failsafe timeout was 50ms in the Crossfire driver, and might force the quad into very brief amounts failsafe.

This patch raises it to 80ms. That should still be acceptable I think.

I've been tracking down a source of these odd unpredictable twitches. Hoping this might be it.

![sds00001](https://user-images.githubusercontent.com/4010813/30062840-e5d07f3e-924c-11e7-935a-cc165dc4c060.png)
