### PR TITLE
GCS: Fix attitude algorithm tooltip

### DIFF
--- a/ground/gcs/src/plugins/config/attitude.ui
+++ b/ground/gcs/src/plugins/config/attitude.ui
@@ -513,13 +513,8 @@ arming it in that case!</string>
              </item>
              <item row="0" column="1">
               <widget class="QComboBox" name="algorithm">
-               <property name="toolTip">
-                <string>Select the sensor integration algorithm here.
-&quot;Simple&quot; only uses accelerometer values
-&quot;INSGPS&quot; the full featured algorithm integrating all sensors</string>
-               </property>
                <property name="objrelation" stdset="0">
-                <stringlist>
+                <stringlist notr="true">
                  <string>objname:StateEstimation</string>
                  <string>fieldname:AttitudeFilter</string>
                 </stringlist>
@@ -536,7 +531,7 @@ arming it in that case!</string>
              <item row="1" column="1">
               <widget class="QComboBox" name="comboBox">
                <property name="objrelation" stdset="0">
-                <stringlist>
+                <stringlist notr="true">
                  <string>objname:StateEstimation</string>
                  <string>fieldname:NavigationFilter</string>
                 </stringlist>
@@ -644,7 +639,7 @@ new home location unless it is in indoor mode.</string>
                  <double>0.001000000000000</double>
                 </property>
                 <property name="objrelation" stdset="0">
-                 <stringlist>
+                 <stringlist notr="true">
                   <string>objname:AttitudeSettings</string>
                   <string>fieldname:AccKi</string>
                   <string>buttongroup:1</string>
@@ -670,7 +665,7 @@ new home location unless it is in indoor mode.</string>
                  <double>0.100000000000000</double>
                 </property>
                 <property name="objrelation" stdset="0">
-                 <stringlist>
+                 <stringlist notr="true">
                   <string>objname:AttitudeSettings</string>
                   <string>fieldname:AccKp</string>
                   <string>buttongroup:1</string>
@@ -705,7 +700,7 @@ new home location unless it is in indoor mode.</string>
                  <number>3</number>
                 </property>
                 <property name="objrelation" stdset="0">
-                 <stringlist>
+                 <stringlist notr="true">
                   <string>objname:AttitudeSettings</string>
                   <string>fieldname:AccelTau</string>
                   <string>buttongroup:1</string>

--- a/shared/uavobjectdefinition/stateestimation.xml
+++ b/shared/uavobjectdefinition/stateestimation.xml
@@ -2,7 +2,16 @@
 <xml>
 	<object name="StateEstimation" singleinstance="true" settings="true">
 		<description>Settings for how to estimate the state</description>
-		<field name="AttitudeFilter" units="" type="enum" elements="1" options="Complementary,INSIndoor,INSOutdoor" defaultvalue="Complementary"/>
+		<field name="AttitudeFilter" units="" type="enum" elements="1" defaultvalue="Complementary">
+			<options>
+				<option>Complementary</option>
+				<option>INSIndoor</option>
+				<option>INSOutdoor</option>
+			</options>
+			<description>
+				Algorithm used for sensor fusion. Complementary is good for general purpose use, and INSOutdoor is recommended for navigation. INSIndoor should only be used for testing (and will not allow you to fly).
+			</description>
+		</field>
 		<field name="NavigationFilter" units="" type="enum" elements="1" options="None,Raw,INS" defaultvalue="None"/>
 		<access gcs="readwrite" flight="readwrite"/>
 		<telemetrygcs acked="true" updatemode="onchange" period="0"/>


### PR DESCRIPTION
- Use the UAVO description so it shows up in UAVOBrowser etc.
- Disabled translation of UAVO relations also (this makes no sense and just clutters tr files).

Fixes #1907