### PR TITLE
smoothcontrol: Add linear interpolation, user-specified duty cycle. Rename UAVO to ManualControlInterpolation.

### DIFF
--- a/flight/Libraries/math/smoothcontrol.c
+++ b/flight/Libraries/math/smoothcontrol.c
@@ -86,6 +86,12 @@ void smoothcontrol_reinit(smoothcontrol_state state, uint8_t axis_num, float new
 	state->axis[axis_num].current = new_signal;
 }
 
+// Resets the thrust state.
+void smoothcontrol_reinit_thrust(smoothcontrol_state state, float new_signal)
+{
+	smoothcontrol_reinit(state, 3, new_signal);
+}
+
 // Sets mode for an axis.
 void smoothcontrol_set_mode(smoothcontrol_state state, uint8_t axis_num, uint8_t mode, uint8_t duty_cycle)
 {

--- a/flight/Libraries/math/smoothcontrol.c
+++ b/flight/Libraries/math/smoothcontrol.c
@@ -38,6 +38,9 @@ struct smoothcontrol_state_internal {
 	// Control interval determined by the ringer.
 	uint8_t control_interval;
 
+	// Duty cycle to use.
+	float duty_cycle;
+
 	// RPY+Thrust.
 	struct smoothcontrol_axis_state axis[4];
 };
@@ -46,6 +49,7 @@ struct smoothcontrol_state_internal {
 static void smoothcontrol_update(smoothcontrol_state state, struct smoothcontrol_axis_state *axis, const float new_signal)
 {
 	float signal_diff = new_signal - axis->signal;
+	float cycles = MIN((float)state->control_interval * state->duty_cycle, state->control_interval);
 
 	switch(axis->mode) {
 		default:
@@ -57,11 +61,14 @@ static void smoothcontrol_update(smoothcontrol_state state, struct smoothcontrol
 
 		// icee's proposal, creates chamfered steps with signal prediction
 		case SMOOTHCONTROL_NORMAL:
-		case SMOOTHCONTROL_EXTENDED:
 			axis->differential = signal_diff * SMOOTHCONTROL_PREDICTOR_SLOPE / (float)state->control_interval;
 			axis->current = axis->signal + signal_diff * SMOOTHCONTROL_CHAMFER_START;
-			axis->integrator_timeout = (uint8_t)MIN((float)state->control_interval *
-				(axis->mode == SMOOTHCONTROL_NORMAL ? SMOOTHCONTROL_DUTY_CYCLE : SMOOTHCONTROL_EXTENDED_DUTY_CYCLE), 255);
+			axis->integrator_timeout = (uint8_t)cycles;
+			break;
+
+		case SMOOTHCONTROL_LINEAR:
+			axis->differential = (new_signal - axis->current) / cycles;
+			axis->integrator_timeout = (uint8_t)cycles;
 			break;
 	}
 
@@ -80,15 +87,15 @@ void smoothcontrol_reinit(smoothcontrol_state state, uint8_t axis_num, float new
 }
 
 // Sets mode for an axis.
-void smoothcontrol_set_mode(smoothcontrol_state state, uint8_t axis_num, uint8_t mode)
+void smoothcontrol_set_mode(smoothcontrol_state state, uint8_t axis_num, uint8_t mode, uint8_t duty_cycle)
 {
 	PIOS_Assert(state && axis_num <= 3);
-	state->axis[axis_num].mode = mode;
+	state->duty_cycle = bound_min_max((float)duty_cycle, 0, 100) / 100.0f;
 	smoothcontrol_reinit(state, axis_num, state->axis[axis_num].signal);
 }
 
 // Processes the signal, if internal state allows it.
-void smoothcontrol_run(smoothcontrol_state state, uint8_t axis_num, float *new_signal, float limit)
+void smoothcontrol_run(smoothcontrol_state state, uint8_t axis_num, float *new_signal)
 {
 	PIOS_Assert(state && axis_num <= 3);
 
@@ -123,12 +130,12 @@ void smoothcontrol_run_thrust(smoothcontrol_state state, float *new_signal)
 	 * non-zero.
 	 */
 
-	if (*new_signal == 0) {
+	if (*new_signal == 0 || *new_signal != *new_signal) {
 		smoothcontrol_reinit(state, 3, 0);
 	} else {
 		bool sign = *new_signal > 0;
 
-		smoothcontrol_run(state, 3, new_signal, 1.0f);
+		smoothcontrol_run(state, 3, new_signal);
 
 		// If prediction undershoots while original signal is positive
 		// bound it to zero.

--- a/flight/Libraries/math/smoothcontrol.h
+++ b/flight/Libraries/math/smoothcontrol.h
@@ -35,6 +35,7 @@ void smoothcontrol_next(smoothcontrol_state state);
 void smoothcontrol_run(smoothcontrol_state state, uint8_t axis_num, float *new_signal);
 void smoothcontrol_run_thrust(smoothcontrol_state state, float *new_signal);
 void smoothcontrol_reinit(smoothcontrol_state state, uint8_t axis_num, float new_signal);
+void smoothcontrol_reinit_thrust(smoothcontrol_state state, float new_signal);
 void smoothcontrol_set_mode(smoothcontrol_state state, uint8_t axis_num, uint8_t mode, uint8_t duty_cycle);
 bool* smoothcontrol_get_ringer(smoothcontrol_state state);
 

--- a/flight/Libraries/math/smoothcontrol.h
+++ b/flight/Libraries/math/smoothcontrol.h
@@ -8,9 +8,6 @@
 // Defines ratio of inter-signal timing to run a prediction algorithm for.
 #define SMOOTHCONTROL_DUTY_CYCLE					0.5f
 
-// Same for extended mode.
-#define SMOOTHCONTROL_EXTENDED_DUTY_CYCLE			0.75f
-
 // Controls steepness of prediction slope.
 #define SMOOTHCONTROL_PREDICTOR_SLOPE				0.8f
 
@@ -25,8 +22,8 @@ enum {
 	// icee's idea.
 	SMOOTHCONTROL_NORMAL,
 
-	// Same but with extended duty cycle.
-	SMOOTHCONTROL_EXTENDED,
+	// Linear interpolate control input.
+	SMOOTHCONTROL_LINEAR,
 };
 
 typedef struct smoothcontrol_state_internal* smoothcontrol_state;
@@ -35,10 +32,10 @@ typedef struct smoothcontrol_state_internal* smoothcontrol_state;
 void smoothcontrol_initialize(smoothcontrol_state *state);
 void smoothcontrol_update_dT(smoothcontrol_state state, float dT);
 void smoothcontrol_next(smoothcontrol_state state);
-void smoothcontrol_run(smoothcontrol_state state, uint8_t axis_num, float *new_signal, float limit);
+void smoothcontrol_run(smoothcontrol_state state, uint8_t axis_num, float *new_signal);
 void smoothcontrol_run_thrust(smoothcontrol_state state, float *new_signal);
 void smoothcontrol_reinit(smoothcontrol_state state, uint8_t axis_num, float new_signal);
-void smoothcontrol_set_mode(smoothcontrol_state state, uint8_t axis_num, uint8_t mode);
+void smoothcontrol_set_mode(smoothcontrol_state state, uint8_t axis_num, uint8_t mode, uint8_t duty_cycle);
 bool* smoothcontrol_get_ringer(smoothcontrol_state state);
 
 #endif // SMOOTHCONTROL_H

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -1258,7 +1258,12 @@ static void stabilizationTask(void* parameters)
 		}
 
 		// Run the smoothing over the throttle stick.
-		smoothcontrol_run_thrust(rc_smoothing, &actuatorDesired.Thrust);
+		if (actuatorDesired.Thrust > THROTTLE_EPSILON || actuatorDesired.Thrust < -THROTTLE_EPSILON){
+			smoothcontrol_run_thrust(rc_smoothing, &actuatorDesired.Thrust);
+		} else {
+			/* Between the epsilons, we're at zero thrust. Reset smoothcontrol and leave ActuatorDesired be. */
+			smoothcontrol_reinit_thrust(rc_smoothing, 0);
+		}
 
 		// Register loop.
 		smoothcontrol_next(rc_smoothing);

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -209,8 +209,8 @@
         <elementname>Yaw</elementname>
       </elementnames>
     </field>
-    <field defaultvalue="None" name="RCControlSmoothing" type="enum" units="">
-      <description>Enables different ways of input signal smoothing, to reduce excessive P- and D-term excitation in the PID controller. Normal and Extended modes chamfer the leading edges in combination with some amount of prediction, to avoid delay.</description>
+    <field defaultvalue="None" name="ManualControlSmoothing" type="enum" units="">
+      <description>Enables different ways of input signal smoothing, to reduce excessive P- and D-term excitation in the PID controller. Normal mode chamfer the leading edges in combination with some amount of prediction, to avoid delay. Linear uses linear prediction to smooth control input.</description>
       <elementnames>
         <elementname>Axes</elementname>
         <elementname>Thrust</elementname>
@@ -218,8 +218,11 @@
       <options>
         <option>None</option>
         <option>Normal</option>
-        <option>Extended</option>
+        <option>Linear</option>
       </options>
+    </field>
+    <field defaultvalue="50" elements="1" name="ManualControlSmoothingDutyCycle" type="uint8" units="%">
+      <description>The timespan, defined in percent of the receiver update rate, the smoothing should operate after each control update.</description>
     </field>
     <field defaultvalue="0.0" elements="1" limits="%BE:0.0:5.0" name="LowPowerStabilizationMaxTime" type="float" units="s">
       <description>Maximum time in seconds to add power when at zero throttle to ensure stabilization.  Choosing 0 prevents adding power at zero throttle.</description>


### PR DESCRIPTION
This patch enables the Normal mode by default, which works by capping the differential to 80% and then starts predicting a 80% slope of the differential at 50% of the manual control update cycle (say with S.Bus updating at 9ms, it'll predict for 4.5ms). There's two limits in play, for one, the 50% of the update cycle, and if for whatever reason that value is completely wrong (say the receiver troddling along drawing out the measured cycle time), there's a 20ms hard-limit (incidentally like PPM).

The linear interpolation modes, which seemed to be mysteriously broken a long while back, until I've found the issue and fixed with it #1902, are back. What regular linear interpolation does is obvious (if anyone wants BFs auto RC smoothing, it's basically that), the psychic mode does linear interpolation between the end values predicted by the Extended mode (does the same things as Normal, except it does 75% duty cycle on predicting).

Normal and Extended modes seems to work fine, without any apparent ill-effects. I'm however flying Crossfire and it's fast update rate. Feedback from someone used to flying slower protocols would be appreciated.

Been flying RPY on Psychic mode and throttle on linear interpolation for a while, though, results in smooth flying.

Gonna add UI in another patch.