### PR TITLE
python-api: logfs: correct regression (from_bytes)

### DIFF
--- a/python/dronin/logfs.py
+++ b/python/dronin/logfs.py
@@ -121,7 +121,7 @@ class LogFSImport(dict):
             if obj is not None:
                 # print "  slot state=%08x, objid=%08x, instid=%04x, size=%d"%(state, obj_id, inst_id, size)
 
-                objInstance = obj.from_bytes(contents, 0, None, offset=offset)
+                objInstance = obj.from_bytes(contents, 0, offset=offset)
 
                 self[obj._name] = objInstance
 


### PR DESCRIPTION
25ccba0648fa43a changed it so that from_bytes takes one fewer arg; all
actual telemetry path things were fixed up, but not the log-filesystem
importer.  That's happy now.