### PR TITLE
GCS: Make unit tests feasible for CI, add basic tests to UAVObjects

### DIFF
--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -255,7 +255,7 @@ int main(int argc, char **argv)
         QStringList() << "t" << COMMAND_LINE_TEST,
         QCoreApplication::translate("main", "Runs tests on the plugin. (Requires compiling with -D "
                                             "WITH_TESTS, look in the uploader plugin for example "
-                                            "usage)"),
+                                            "usage). Special argument 'all' will run all tests."),
         QCoreApplication::translate("main", "plugin name"), "");
     parser.addOption(doTestsOption);
     QCommandLineOption pluginOption(

--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -229,37 +229,6 @@ int main(int argc, char **argv)
 
     QApplication app(argc, argv);
 
-#ifdef USE_CRASHREPORTING
-    QString dirName(GCS_REVISION_PRETTY);
-    dirName = dirName.replace("%@%", "_");
-    // Limit to alphanumerics plus dots, because this will be a filename
-    // component.
-    dirName = dirName.replace(QRegularExpression("[^A-Za-z0-9.]+"), "_");
-    dirName = QDir::tempPath() + QDir::separator() + GCS_PROJECT_BRANDING + "_" + dirName;
-    QDir().mkdir(dirName);
-    new CrashReporter::Handler(dirName, true, "crashreporterapp");
-#endif
-
-    RunGuard &guard = RunGuard::instance(QStringLiteral(GCS_PROJECT_BRANDING)
-                                         + QStringLiteral("_gcs_run_guard"));
-    if (!guard.tryToRun()) {
-        std::cerr << "GCS already running!" << std::endl;
-        return 1;
-    }
-
-    // suppress SSL warnings generated during startup (handy if you want to use QT_FATAL_WARNINGS)
-    QLoggingCategory::setFilterRules("qt.network.ssl.warning=false");
-
-    // disable QML disk caching, this caches paths in qmlc files which break when the GCS
-    // installation is moved. TODO: see if we can work around that
-    qputenv("QML_DISABLE_DISK_CACHE", "true");
-
-    QString locale = QLocale::system().name();
-
-    // Must be done before any QSettings class is created
-    QSettings::setPath(XmlConfig::XmlSettingsFormat, QSettings::SystemScope,
-                       QCoreApplication::applicationDirPath() + QLatin1String(SHARE_PATH));
-
     QCommandLineParser parser;
     parser.setApplicationDescription(GCS_PROJECT_BRANDING_PRETTY " GCS");
     const QCommandLineOption helpOption = parser.addHelpOption();
@@ -301,11 +270,48 @@ int main(int argc, char **argv)
     parser.addPositionalArgument(
         "config", QCoreApplication::translate("main", "Use the specified configuration file."),
         QCoreApplication::translate("main", "config file"));
+
     if (!parser.parse(QCoreApplication::arguments())) {
         displayError(parser.errorText());
         displayHelpText(parser.helpText());
         return 1;
     }
+
+#ifdef USE_CRASHREPORTING
+    // Only use crash reporter if we're not doing unit tests
+    // This means we won't hang CI, and QtTest will give us a nice stack trace
+    if (parser.values(doTestsOption).isEmpty()) {
+        QString dirName(GCS_REVISION_PRETTY);
+        dirName = dirName.replace("%@%", "_");
+        // Limit to alphanumerics plus dots, because this will be a filename
+        // component.
+        dirName = dirName.replace(QRegularExpression("[^A-Za-z0-9.]+"), "_");
+        dirName = QDir::tempPath() + QDir::separator() + GCS_PROJECT_BRANDING + "_" + dirName;
+        QDir().mkdir(dirName);
+        new CrashReporter::Handler(dirName, true, "crashreporterapp");
+    }
+#endif
+
+    RunGuard &guard = RunGuard::instance(QStringLiteral(GCS_PROJECT_BRANDING)
+                                         + QStringLiteral("_gcs_run_guard"));
+    if (!guard.tryToRun()) {
+        std::cerr << "GCS already running!" << std::endl;
+        return 1;
+    }
+
+    // suppress SSL warnings generated during startup (handy if you want to use QT_FATAL_WARNINGS)
+    QLoggingCategory::setFilterRules("qt.network.ssl.warning=false");
+
+    // disable QML disk caching, this caches paths in qmlc files which break when the GCS
+    // installation is moved. TODO: see if we can work around that
+    qputenv("QML_DISABLE_DISK_CACHE", "true");
+
+    QString locale = QLocale::system().name();
+
+    // Must be done before any QSettings class is created
+    QSettings::setPath(XmlConfig::XmlSettingsFormat, QSettings::SystemScope,
+                       QCoreApplication::applicationDirPath() + QLatin1String(SHARE_PATH));
+
     QString settingsFilename;
     QStringList positionalArguments = parser.positionalArguments();
     {

--- a/ground/gcs/src/libs/extensionsystem/optionsparser.cpp
+++ b/ground/gcs/src/libs/extensionsystem/optionsparser.cpp
@@ -47,6 +47,12 @@ QStringList OptionsParser::parse(QStringList pluginOptions, QStringList pluginTe
 
 void OptionsParser::checkForTestOption(QStringList pluginTests)
 {
+    if (pluginTests.length() == 1 && pluginTests.at(0).toLower() == QStringLiteral("all")) {
+        for (auto spec : m_pmPrivate->pluginSpecs)
+            m_pmPrivate->testSpecs.append(spec);
+        return;
+    }
+
     foreach (QString plugin, pluginTests) {
         PluginSpec *spec = m_pmPrivate->pluginByName(plugin);
         if (!spec) {

--- a/ground/gcs/src/libs/extensionsystem/pluginmanager.cpp
+++ b/ground/gcs/src/libs/extensionsystem/pluginmanager.cpp
@@ -396,6 +396,8 @@ void PluginManager::formatPluginVersions(QTextStream &str) const
 void PluginManager::startTests()
 {
 #ifdef WITH_TESTS
+    bool failed = false;
+
     foreach (PluginSpec *pluginSpec, d->testSpecs) {
         const QMetaObject *mo = pluginSpec->plugin()->metaObject();
         QStringList methods;
@@ -407,9 +409,16 @@ void PluginManager::startTests()
                 methods.append(method.left(method.size()-2));
             }
         }
-        QTest::qExec(pluginSpec->plugin(), methods);
-
+        if (QTest::qExec(pluginSpec->plugin(), methods) != 0) {
+            failed = true;
+            qWarning() << "Tests failed for plugin:" << pluginSpec->name();
+        }
     }
+
+    if (failed)
+        QCoreApplication::exit(1);
+    else if (runningTests())
+        QCoreApplication::exit(0);
 #endif
 }
 

--- a/ground/gcs/src/libs/extensionsystem/pluginmanager.cpp
+++ b/ground/gcs/src/libs/extensionsystem/pluginmanager.cpp
@@ -409,7 +409,7 @@ void PluginManager::startTests()
                 methods.append(method.left(method.size()-2));
             }
         }
-        if (QTest::qExec(pluginSpec->plugin(), methods) != 0) {
+        if (methods.length() > 1 && QTest::qExec(pluginSpec->plugin(), methods) != 0) {
             failed = true;
             qWarning() << "Tests failed for plugin:" << pluginSpec->name();
         }

--- a/ground/gcs/src/plugins/uavobjects/uavobjects.pro
+++ b/ground/gcs/src/plugins/uavobjects/uavobjects.pro
@@ -28,6 +28,10 @@ SOURCES += uavobject.cpp \
     uavobjectfield.cpp \
     uavobjectsplugin.cpp
 
+contains(DEFINES, WITH_TESTS) {
+    SOURCES += uavobjectstests.cpp
+}
+
 OTHER_FILES += UAVObjects.pluginspec
 
 # Add in all of the synthetic/generated uavobject files

--- a/ground/gcs/src/plugins/uavobjects/uavobjectsplugin.h
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectsplugin.h
@@ -44,6 +44,12 @@ public:
     void extensionsInitialized();
     bool initialize(const QStringList &arguments, QString *errorString);
     void shutdown();
+
+#ifdef WITH_TESTS
+private Q_SLOTS:
+    void testEnumFields();
+    void testIntFields();
+#endif
 };
 
 #endif // UAVOBJECTSPLUGIN_H

--- a/ground/gcs/src/plugins/uavobjects/uavobjectstests.cpp
+++ b/ground/gcs/src/plugins/uavobjects/uavobjectstests.cpp
@@ -1,0 +1,70 @@
+/**
+ ******************************************************************************
+ * @file       uavobjectstests.cpp
+ * @author     dRonin, http://dRonin.org/, Copyright (C) 2017
+ * @addtogroup GCSPlugins GCS Plugins
+ * @{
+ * @addtogroup UAVObjectsPlugin UAVObjects Plugin
+ * @{
+ * @brief      The UAVUObjects GCS plugin
+ *****************************************************************************/
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * Additional note on redistribution: The copyright and license notices above
+ * must be maintained in each individual source file that is a derivative work
+ * of this source file; otherwise redistribution is prohibited.
+ */
+
+#include "uavobjectsplugin.h"
+
+#include "uavdataobject.h"
+#include "uavobjectfield.h"
+
+#include <QTest>
+#include <memory>
+
+
+void UAVObjectsPlugin::testEnumFields()
+{
+    auto field = new UAVObjectField("TestEnum", "photons", UAVObjectField::ENUM, 2, {"Yes", "No"},
+                                    {0, 1}, QString(), QStringLiteral("Test some stuff"), {"No", "Yes"});
+    quint8 testData[255] = {};
+
+    field->initialize(testData, 0, nullptr);
+    QCOMPARE(field->getName(), QStringLiteral("TestEnum"));
+    QCOMPARE(field->getValue(0).toString(), QStringLiteral("Yes"));
+    QCOMPARE(field->getValue(1).toString(), QStringLiteral("Yes"));
+    QVERIFY(!field->isDefaultValue(0));
+    QVERIFY(field->isDefaultValue(1));
+}
+
+void UAVObjectsPlugin::testIntFields()
+{
+    std::unique_ptr<UAVObjectField> field(new UAVObjectField("TestUInt8", "photons", UAVObjectField::UINT8, 2, {},
+                                    {}, QString(), QStringLiteral("Test some stuff"), {254, 0}));
+    quint8 testData[255] = {};
+
+    field->initialize(testData, 0, nullptr);
+    QCOMPARE(field->getName(), QStringLiteral("TestUInt8"));
+    QVERIFY(field->getValue(0).toUInt() == 0);
+    QVERIFY(field->getValue(1).toUInt() == 0);
+    QVERIFY(!field->isDefaultValue(0));
+    QVERIFY(field->isDefaultValue(1));
+}
+
+/**
+ * @}
+ * @}
+ */


### PR DESCRIPTION
To run all tests, compile a debug build, run `build/ground/gcs/bin/drgcs --test all`. Will exit with 0 on success, or 1 on failure. Crash reporter is disabled when running tests (avoids hanging CI with the submit crash report dialog, and QtTest will print a nice stacktrace to stderr if you crash, yay!).