### PR TITLE
GCS:Config: Hax ConfigOutputWidget to save the UAVObject

### DIFF
--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -138,6 +138,7 @@ ConfigOutputWidget::ConfigOutputWidget(QWidget *parent)
     addWidget(m_config->cb_outputRate2);
     addWidget(m_config->cb_outputRate1);
     addWidget(m_config->spinningArmed);
+    addUAVObject("ActuatorSettings");
 }
 
 void ConfigOutputWidget::enableControls(bool enable)


### PR DESCRIPTION
TODO: Rewrite it in modern style, and then make the ConfigTaskWidget functions non-virtual so nobody can ever override them.

fixes #1968.