### PR TITLE
Flight: Fix debug build

### DIFF
--- a/flight/Libraries/rscode/berlekamp.c
+++ b/flight/Libraries/rscode/berlekamp.c
@@ -248,7 +248,7 @@ Find_Roots (void)
     if (sum == 0) 
       { 
 	ErrorLocs[NErrors] = (255-r); NErrors++; 
-	//if (DEBUG) fprintf(stderr, "Root found at r = %d, (255-r) = %d\n", r, (255-r));
+	//if (rscode_debug) fprintf(stderr, "Root found at r = %d, (255-r) = %d\n", r, (255-r));
       }
   }
 }
@@ -289,7 +289,7 @@ correct_errors_erasures (unsigned char codeword[],
     /* first check for illegal error locs */
     for (r = 0; r < NErrors; r++) {
       if (ErrorLocs[r] >= csize) {
-				//if (DEBUG) fprintf(stderr, "Error loc i=%d outside of codeword length %d\n", i, csize);
+				//if (rscode_debug) fprintf(stderr, "Error loc i=%d outside of codeword length %d\n", i, csize);
 	return(0);
       }
     }
@@ -310,14 +310,14 @@ correct_errors_erasures (unsigned char codeword[],
       }
       
       err = gmult(num, ginv(denom));
-      //if (DEBUG) fprintf(stderr, "Error magnitude %#x at loc %d\n", err, csize-i);
+      //if (rscode_debug) fprintf(stderr, "Error magnitude %#x at loc %d\n", err, csize-i);
       
       codeword[csize-i-1] ^= err;
     }
     return(1);
   }
   else {
-    //if (DEBUG && NErrors) fprintf(stderr, "Uncorrectable codeword\n");
+    //if (rscode_debug && NErrors) fprintf(stderr, "Uncorrectable codeword\n");
     return(0);
   }
 }

--- a/flight/Libraries/rscode/ecc.h
+++ b/flight/Libraries/rscode/ecc.h
@@ -68,7 +68,7 @@ extern int pBytes[MAXDEG];
 extern int synBytes[MAXDEG];
 
 /* print debugging info */
-extern int DEBUG;
+extern int rscode_debug;
 
 /* Reed Solomon encode/decode routines */
 void initialize_ecc (void);

--- a/flight/Libraries/rscode/rs.c
+++ b/flight/Libraries/rscode/rs.c
@@ -38,7 +38,7 @@ int synBytes[MAXDEG];
 /* generator polynomial */
 int genPoly[MAXDEG*2];
 
-int DEBUG = FALSE;
+int rscode_debug = FALSE;
 
 static void
 compute_genpoly (int nbytes, int genpoly[]);

--- a/flight/PiOS/Common/Libraries/Debug/cm3_fault_handlers.c
+++ b/flight/PiOS/Common/Libraries/Debug/cm3_fault_handlers.c
@@ -7,13 +7,15 @@
 
 #include <stdint.h>
 #include "dcc_stdio.h"
-#if defined(STM32F10X)
+#if defined(STM32F0XX)
+# include "stm32f0xx.h"
+#elif defined(STM32F10X)
 # include "stm32f10x.h"
 #elif defined(STM32F2XX)
 # include "stm32f2xx.h"
 #elif defined(STM32F30X)
 # include "stm32f30x.h"
-#elif defined(STM32F4XX)
+#elif defined(STM32F40_41xxx) || defined(STM32F446xx)
 # include "stm32f4xx.h"
 #else
 #error Unsupported CPU

--- a/flight/PiOS/inc/pios_debug.h
+++ b/flight/PiOS/inc/pios_debug.h
@@ -6,24 +6,24 @@
  * @brief Debugging functionality
  * @{
  *
- * @file       pios_i2c.h  
+ * @file       pios_i2c.h
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @brief      Debug helper functions header.
  * @see        The GNU Public License (GPL) Version 3
  *
  *****************************************************************************/
-/* 
- * This program is free software; you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation; either version 3 of the License, or 
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
- * 
- * You should have received a copy of the GNU General Public License along 
+ *
+ * You should have received a copy of the GNU General Public License along
  * with this program; if not, see <http://www.gnu.org/licenses/>
  */
 
@@ -42,7 +42,7 @@ void PIOS_DEBUG_PinHigh(uint8_t pin);
 void PIOS_DEBUG_PinLow(uint8_t pin);
 void PIOS_DEBUG_PinValue8Bit(uint8_t value);
 void PIOS_DEBUG_PinValue4BitL(uint8_t value);
-void PIOS_DEBUG_Panic(const char *msg);
+void PIOS_DEBUG_Panic(const char *msg) __attribute__((noreturn));
 
 #ifdef DEBUG
 #define PIOS_DEBUG_Assert(test) if (!(test)) PIOS_DEBUG_Panic(PIOS_DEBUG_AssertMsg);

--- a/flight/PiOS/posix/pios_debug.c
+++ b/flight/PiOS/posix/pios_debug.c
@@ -10,20 +10,20 @@
  * @author     The OpenPilot Team, http://www.openpilot.org Copyright (C) 2010.
  * @brief      Debugging Functions
  * @see        The GNU Public License (GPL) Version 3
- * 
+ *
  *****************************************************************************/
-/* 
- * This program is free software; you can redistribute it and/or modify 
- * it under the terms of the GNU General Public License as published by 
- * the Free Software Foundation; either version 3 of the License, or 
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
- * 
- * You should have received a copy of the GNU General Public License along 
+ *
+ * You should have received a copy of the GNU General Public License along
  * with this program; if not, see <http://www.gnu.org/licenses/>
  */
 
@@ -80,12 +80,7 @@ void PIOS_DEBUG_Panic(const char *msg)
 	// tell the user whats going on on commandline too
 	fprintf(stderr,"CRITICAL ERROR: %s\n",msg);
 
-	// this helps debugging: causing a div by zero allows a backtrace
-	// and/or ends execution
-	int b = 0;
-	int a = (2/b);
-	b=a;
-
+	abort();
 }
 
 /**

--- a/flight/targets/aq32/fw/Makefile
+++ b/flight/targets/aq32/fw/Makefile
@@ -3,9 +3,9 @@
 # @author     The OpenPilot Team, http://www.openpilot.org, Copyright (C) 2009.
 # @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
 # @author     dRonin, http://dronin.org Copyright (C) 2015-2016
-# @addtogroup 
+# @addtogroup
 # @{
-# @addtogroup 
+# @addtogroup
 # @{
 # @brief Makefile to build firmware for the Aq32 board.
 ###############################################################################
@@ -22,7 +22,7 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>
-# 
+#
 # Additional note on redistribution: The copyright and license notices above
 # must be maintained in each individual source file that is a derivative work
 # of this source file; otherwise redistribution is prohibited.
@@ -35,7 +35,7 @@ DEBUG ?= NO
 
 # List of modules to include
 MODULES = Sensors
-MODULES += Attitude 
+MODULES += Attitude
 MODULES += Actuator
 MODULES += ManualControl
 MODULES += Stabilization
@@ -43,8 +43,8 @@ MODULES += FirmwareIAP
 MODULES += Telemetry
 
 OPTMODULES += GPS
-OPTMODULES += AltitudeHold 
-OPTMODULES += VtolPathFollower 
+OPTMODULES += AltitudeHold
+OPTMODULES += VtolPathFollower
 OPTMODULES += FixedWingPathFollower
 OPTMODULES += PathPlanner
 OPTMODULES += CameraStab
@@ -199,14 +199,13 @@ EXTRA_LIBS =
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F4XX)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0
-CFLAGS += -DGENERAL_COV
-CFLAGS += -finstrument-functions -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif

--- a/flight/targets/brain/fw/Makefile
+++ b/flight/targets/brain/fw/Makefile
@@ -203,19 +203,16 @@ LIBS += $(FLIGHTLIBFILE)
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F4XX)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0
-CFLAGS += -DGENERAL_COV
-# CFLAGS += -finstrument-functions -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif
-
-
 
 # common architecture-specific flags from the device-specific library makefile
 CFLAGS += $(ARCHFLAGS)

--- a/flight/targets/brainre1/fw/Makefile
+++ b/flight/targets/brainre1/fw/Makefile
@@ -209,19 +209,16 @@ LIBS += $(FLIGHTLIBFILE)
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F4XX)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0
-CFLAGS += -DGENERAL_COV
-# CFLAGS += -finstrument-functions -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
-CFLAGS += -Os
+CFLAGS += -Os -fconserve-stack
 endif
-
-
 
 # common architecture-specific flags from the device-specific library makefile
 CFLAGS += $(ARCHFLAGS)

--- a/flight/targets/dtfc/fw/Makefile
+++ b/flight/targets/dtfc/fw/Makefile
@@ -189,12 +189,13 @@ EXTRA_LIBS =
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F30X)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0 -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif

--- a/flight/targets/flyingpio/fw/Makefile
+++ b/flight/targets/flyingpio/fw/Makefile
@@ -21,7 +21,7 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>
-# 
+#
 # Additional note on redistribution: The copyright and license notices above
 # must be maintained in each individual source file that is a derivative work
 # of this source file; otherwise redistribution is prohibited.
@@ -33,8 +33,8 @@ include $(MAKE_INC_DIR)/firmware-defs.mk
 DEBUG ?= NO
 
 # List of modules to include
-MODULES = 
-OPTMODULES = 
+MODULES =
+OPTMODULES =
 
 # Paths
 OPUAVOBJINC = $(OPUAVOBJ)/inc
@@ -144,12 +144,13 @@ EXTRA_LIBS =
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F0XX)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0 -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif

--- a/flight/targets/flyingpio/fw/main.c
+++ b/flight/targets/flyingpio/fw/main.c
@@ -186,7 +186,7 @@ static void process_pio_message_impl(int *resp_len)
 			PIOS_Assert(0);
 			break;
 	}
-			
+
 	/* If we get an edge and no clocking.. make sure the message is
 	 * invalidated / not reused */
 	rx_buf.id = 0;
@@ -211,10 +211,8 @@ int main()
 	/* Brings up System using CMSIS functions, enables the LEDs. */
 	PIOS_SYS_Init();
 
-	const struct pios_board_info *bdinfo = &pios_board_info_blob;
-
 #if defined(PIOS_INCLUDE_ANNUNC)
-	const struct pios_annunc_cfg *led_cfg = PIOS_BOARD_HW_DEFS_GetLedCfg(bdinfo->board_rev);
+	const struct pios_annunc_cfg *led_cfg = PIOS_BOARD_HW_DEFS_GetLedCfg(0);
 	PIOS_Assert(led_cfg);
 	PIOS_ANNUNC_Init(led_cfg);
 #endif	/* PIOS_INCLUDE_ANNUNC */

--- a/flight/targets/lux/fw/Makefile
+++ b/flight/targets/lux/fw/Makefile
@@ -189,12 +189,13 @@ EXTRA_LIBS =
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F30X)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0 -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif

--- a/flight/targets/omnibusf3/fw/Makefile
+++ b/flight/targets/omnibusf3/fw/Makefile
@@ -192,12 +192,13 @@ EXTRA_LIBS =
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F30X)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0 -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif

--- a/flight/targets/pikoblx/fw/Makefile
+++ b/flight/targets/pikoblx/fw/Makefile
@@ -21,7 +21,7 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>
-# 
+#
 # Additional note on redistribution: The copyright and license notices above
 # must be maintained in each individual source file that is a derivative work
 # of this source file; otherwise redistribution is prohibited.
@@ -193,12 +193,13 @@ EXTRA_LIBS =
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F30X)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0 -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif

--- a/flight/targets/pipxtreme/fw/Makefile
+++ b/flight/targets/pipxtreme/fw/Makefile
@@ -8,7 +8,7 @@
  # Tau Labs, http://taulabs.org, Copyright (C) 2013-2014
  # dRonin, http://dronin.org Copyright (C) 2015-2016
  #
- # 
+ #
  # This program is free software; you can redistribute it and/or modify
  # it under the terms of the GNU General Public License as published by
  # the Free Software Foundation; either version 3 of the License, or
@@ -166,7 +166,7 @@ CPPSRCARM =
 # Even though the DOS/Win* filesystem matches both .s and .S the same,
 # it will preserve the spelling of the filenames, and gcc itself does
 # care about how the name is spelled on its command-line.
-ASRC = 
+ASRC =
 
 # List Assembler source files here which must be assembled in ARM-Mode..
 ASRCARM =
@@ -286,7 +286,7 @@ CSTANDARD = -std=gnu99
 # Flags for C and C++ (arm-elf-gcc/arm-elf-g++)
 
 ifeq ($(DEBUG),YES)
-CFLAGS = -DDEBUG
+CFLAGS += -DDEBUG
 endif
 
 ifneq (,$(filter YES,$(STACK_DIAGNOSTICS) $(ALL_DIGNOSTICS)))
@@ -365,4 +365,3 @@ LDFLAGS += -T$(LINKERSCRIPTPATH)/sections_chibios.ld
 NO_AUTO_UAVO=YES
 
 include $(MAKE_INC_DIR)/firmware-common.mk
-

--- a/flight/targets/playuavosd/fw/Makefile
+++ b/flight/targets/playuavosd/fw/Makefile
@@ -173,19 +173,16 @@ LIBS += $(FLIGHTLIBFILE)
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F4XX)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0
-CFLAGS += -DGENERAL_COV
-# CFLAGS += -finstrument-functions -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif
-
-
 
 # common architecture-specific flags from the device-specific library makefile
 CFLAGS += $(ARCHFLAGS)

--- a/flight/targets/quanton/fw/Makefile
+++ b/flight/targets/quanton/fw/Makefile
@@ -3,7 +3,7 @@
 # @author     The OpenPilot Team, http://www.openpilot.org, Copyright (C) 2009.
 # @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
 # @author     dRonin, http://dronin.org Copyright (C) 2015-2016
-# @addtogroup 
+# @addtogroup
 # @{
 # @addtogroup
 # @{
@@ -22,7 +22,7 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>
-# 
+#
 # Additional note on redistribution: The copyright and license notices above
 # must be maintained in each individual source file that is a derivative work
 # of this source file; otherwise redistribution is prohibited.
@@ -35,7 +35,7 @@ DEBUG ?= NO
 
 # List of modules to include
 MODULES = Sensors
-MODULES += Attitude 
+MODULES += Attitude
 MODULES += Actuator
 MODULES += ManualControl
 MODULES += Stabilization
@@ -43,8 +43,8 @@ MODULES += FirmwareIAP
 MODULES += Telemetry
 
 OPTMODULES += GPS
-OPTMODULES += AltitudeHold 
-OPTMODULES += VtolPathFollower 
+OPTMODULES += AltitudeHold
+OPTMODULES += VtolPathFollower
 OPTMODULES += FixedWingPathFollower
 OPTMODULES += PathPlanner
 OPTMODULES += CameraStab
@@ -200,19 +200,16 @@ EXTRA_LIBS =
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F4XX)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0
-CFLAGS += -DGENERAL_COV
-CFLAGS += -finstrument-functions -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif
-
-
 
 # common architecture-specific flags from the device-specific library makefile
 CFLAGS += $(ARCHFLAGS)

--- a/flight/targets/revolution/fw/Makefile
+++ b/flight/targets/revolution/fw/Makefile
@@ -3,9 +3,9 @@
 # @author     The OpenPilot Team, http://www.openpilot.org, Copyright (C) 2012.
 # @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
 # @author     dRonin, http://dronin.org Copyright (C) 2015-2016
-# @addtogroup 
+# @addtogroup
 # @{
-# @addtogroup 
+# @addtogroup
 # @{
 # @brief Makefile to build firmware for the Revolution board.
 ###############################################################################
@@ -22,7 +22,7 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>
-# 
+#
 # Additional note on redistribution: The copyright and license notices above
 # must be maintained in each individual source file that is a derivative work
 # of this source file; otherwise redistribution is prohibited.
@@ -35,7 +35,7 @@ DEBUG ?= NO
 
 # List of modules to include
 MODULES = Sensors
-MODULES += Attitude 
+MODULES += Attitude
 MODULES += ManualControl
 MODULES += Stabilization
 MODULES += Actuator
@@ -43,9 +43,9 @@ MODULES += FirmwareIAP
 MODULES += Telemetry
 
 OPTMODULES += GPS
-OPTMODULES += AltitudeHold 
+OPTMODULES += AltitudeHold
 OPTMODULES += PathPlanner
-OPTMODULES += VtolPathFollower 
+OPTMODULES += VtolPathFollower
 OPTMODULES += FixedWingPathFollower
 OPTMODULES += CameraStab
 OPTMODULES += Autotune
@@ -88,7 +88,7 @@ DEBUG_CM3_DIR_INC = $(DEBUG_CM3_DIR)/inc
 OPUAVOBJINC = $(OPUAVOBJ)/inc
 MAVLINKINC = $(FLIGHTLIB)/mavlink/v1.0/common
 
-SRC = 
+SRC =
 # optional component libraries
 include $(APPLIBDIR)/ChibiOS/library.mk
 
@@ -231,14 +231,13 @@ EXTRA_LIBS =
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F4XX)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0
-CFLAGS += -DGENERAL_COV
-CFLAGS += -finstrument-functions -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif

--- a/flight/targets/seppuku/fw/Makefile
+++ b/flight/targets/seppuku/fw/Makefile
@@ -3,7 +3,7 @@
 # @author     The OpenPilot Team, http://www.openpilot.org, Copyright (C) 2009.
 # @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2014
 # @author     dRonin, http://dronin.org Copyright (C) 2015-2016
-# @addtogroup 
+# @addtogroup
 # @{
 # @addtogroup
 # @{
@@ -22,7 +22,7 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>
-# 
+#
 # Additional note on redistribution: The copyright and license notices above
 # must be maintained in each individual source file that is a derivative work
 # of this source file; otherwise redistribution is prohibited.
@@ -35,7 +35,7 @@ DEBUG ?= NO
 
 # List of modules to include
 MODULES += Sensors
-MODULES += Attitude 
+MODULES += Attitude
 MODULES += Actuator
 MODULES += ManualControl
 MODULES += Stabilization
@@ -43,8 +43,8 @@ MODULES += FirmwareIAP
 MODULES += Telemetry
 
 OPTMODULES += GPS
-OPTMODULES += AltitudeHold 
-OPTMODULES += VtolPathFollower 
+OPTMODULES += AltitudeHold
+OPTMODULES += VtolPathFollower
 OPTMODULES += FixedWingPathFollower
 OPTMODULES += PathPlanner
 OPTMODULES += CameraStab
@@ -208,19 +208,16 @@ EXTRA_LIBS =
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F4XX)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0
-CFLAGS += -DGENERAL_COV
-CFLAGS += -finstrument-functions -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif
-
-
 
 # common architecture-specific flags from the device-specific library makefile
 CFLAGS += $(ARCHFLAGS)

--- a/flight/targets/sparky/fw/Makefile
+++ b/flight/targets/sparky/fw/Makefile
@@ -21,7 +21,7 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>
-# 
+#
 # Additional note on redistribution: The copyright and license notices above
 # must be maintained in each individual source file that is a derivative work
 # of this source file; otherwise redistribution is prohibited.
@@ -193,12 +193,13 @@ EXTRA_LIBS =
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F30X)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0 -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif

--- a/flight/targets/sparky2/fw/Makefile
+++ b/flight/targets/sparky2/fw/Makefile
@@ -2,9 +2,9 @@
 # @file       Makefile
 # @author     Tau Labs, http://taulabs.org, Copyright (C) 2012-2015
 # @author     dRonin, http://dronin.org Copyright (C) 2015-2016
-# @addtogroup 
+# @addtogroup
 # @{
-# @addtogroup 
+# @addtogroup
 # @{
 # @brief Makefile to build firmware for the Sparky2 board.
 ###############################################################################
@@ -21,7 +21,7 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>
-# 
+#
 # Additional note on redistribution: The copyright and license notices above
 # must be maintained in each individual source file that is a derivative work
 # of this source file; otherwise redistribution is prohibited.
@@ -34,7 +34,7 @@ DEBUG ?= NO
 
 # List of modules to include
 MODULES = Sensors
-MODULES += Attitude 
+MODULES += Attitude
 MODULES += ManualControl
 MODULES += Stabilization
 MODULES += Actuator
@@ -42,9 +42,9 @@ MODULES += FirmwareIAP
 MODULES += Telemetry
 
 OPTMODULES += GPS
-OPTMODULES += AltitudeHold 
+OPTMODULES += AltitudeHold
 OPTMODULES += PathPlanner
-OPTMODULES += VtolPathFollower 
+OPTMODULES += VtolPathFollower
 OPTMODULES += FixedWingPathFollower
 OPTMODULES += CameraStab
 OPTMODULES += Autotune
@@ -86,7 +86,7 @@ DEBUG_CM3_DIR_INC = $(DEBUG_CM3_DIR)/inc
 OPUAVOBJINC = $(OPUAVOBJ)/inc
 MAVLINKINC = $(FLIGHTLIB)/mavlink/v1.0/common
 
-SRC = 
+SRC =
 # optional component libraries
 include $(APPLIBDIR)/ChibiOS/library.mk
 
@@ -230,20 +230,17 @@ EXTRA_LIBS =
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F4XX)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0
-CFLAGS += -DGENERAL_COV
-CFLAGS += -finstrument-functions -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif
 
-
-   
 # common architecture-specific flags from the device-specific library makefile
 CFLAGS += $(ARCHFLAGS)
 
@@ -366,7 +363,7 @@ LDFLAGS += -lgcc
 LDFLAGS += -Wl,--warn-common
 LDFLAGS += -Wl,--fatal-warnings
 
-#Linker scripts                                                                                                                                                                                                              
+#Linker scripts
 LDFLAGS += -T memory.ld $(addprefix -T,$(LINKER_SCRIPTS_APP))
 
 include $(MAKE_INC_DIR)/firmware-common.mk

--- a/flight/targets/sprf3e/fw/Makefile
+++ b/flight/targets/sprf3e/fw/Makefile
@@ -190,12 +190,13 @@ EXTRA_LIBS =
 # Path to Linker-Scripts
 LINKERSCRIPTPATH = $(PIOSSTM32F30X)
 
-# Optimization level, can be [0, 1, 2, 3, s].
-# 0 = turn off optimization. s = optimize for size.
-# (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
-
+# debug (un)optimization, see gcc docs
 ifeq ($(DEBUG),YES)
-CFLAGS += -O0 -ffixed-r10
+CFLAGS += -Og
+CFLAGS += -ffixed-r10
+# finstrument-functions adds __cyg_profile_func_enter/exit to every function
+# we currently don't have that symbol implemented anywhere
+#CFLAGS += -finstrument-functions
 else
 CFLAGS += -Os -fconserve-stack
 endif


### PR DESCRIPTION
Compiles and links now on everything except Sparky, SPRF3E, and PikoBLX targets (DTFc is fine), which all overflow flash:
Sparky: 15896 bytes
SPRF3E: 19764 bytes
PikoBLX: 7168 bytes