### PR TITLE
windows build: bash_profile: small change

### DIFF
--- a/make/winx86/bash_profile
+++ b/make/winx86/bash_profile
@@ -2,7 +2,7 @@
 # Michael Lyle - 2015-2016
 
 QT_VERSION_FULL=5.9.2
-QT_VERSION=`echo "$QT_VERSION_FULL" | cut -d '.' -f1-2`
+QT_VERSION=`echo "$QT_VERSION_FULL" | cut -d '.' -f1-3`
 QT_BASEDIR="/C/Qt"
 
 # This is really unfortunate on the part of Qt.


### PR DESCRIPTION
all 3 version numbers are in the path name now, not just the
major/minor.