### PR TITLE
omnibusf3: hwdefs: fix AF mapping for PWM1/2

### DIFF
--- a/flight/targets/omnibusf3/board-info/board_hw_defs.c
+++ b/flight/targets/omnibusf3/board-info/board_hw_defs.c
@@ -600,7 +600,7 @@ static const struct pios_tim_channel pios_tim_servoport_pins[] = {
 	{ // Ch1 TIM8_CH2 (PB8)
 		.timer = TIM8,
 		.timer_chan = TIM_Channel_2,
-		.remap = GPIO_AF_2,
+		.remap = GPIO_AF_10,
 		.pin = {
 			.gpio = GPIOB,
 			.init = {
@@ -616,7 +616,7 @@ static const struct pios_tim_channel pios_tim_servoport_pins[] = {
 	{ // Ch2 TIM8_CH3 (PB9)
 		.timer = TIM8,
 		.timer_chan = TIM_Channel_3,
-		.remap = GPIO_AF_2,
+		.remap = GPIO_AF_10,
 		.pin = {
 			.gpio = GPIOB,
 			.init = {


### PR DESCRIPTION
woops.  swore i'd tested oneshot, but it seems maybe i only tested dshot.