### PR TITLE
stabilization: autotune is an attitude mode

### DIFF
--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -337,6 +337,7 @@ static void calculate_attitude_errors(uint8_t *axis_mode, float *raw_input,
 			case STABILIZATIONDESIRED_STABILIZATIONMODE_HORIZON:
 			case STABILIZATIONDESIRED_STABILIZATIONMODE_WEAKLEVELING:
 			case STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE:
+			case STABILIZATIONDESIRED_STABILIZATIONMODE_SYSTEMIDENT:
 				break;
 			default:
 				/* If the axis isn't in an attitude mode,


### PR DESCRIPTION
Regressed in #1975 --- the new algorithm requires a complete enumeration of attitude-using stabilizations, from which systemident was missing.