### PR TITLE
Revert "gcs: fix relation: LowPowerStabilizationMaxPowerAdd"

### DIFF
--- a/ground/gcs/src/plugins/config/stabilization.ui
+++ b/ground/gcs/src/plugins/config/stabilization.ui
@@ -5003,7 +5003,7 @@ border-radius: 5;</string>
                 </property>
                 <property name="objrelation" stdset="0">
                  <stringlist>
-                  <string>objname:StabilizationSettings</string>
+                  <string>objname:ActuatorSettings</string>
                   <string>fieldname:LowPowerStabilizationMaxPowerAdd</string>
                   <string>scale:.01</string>
                   <string>buttongroup:10</string>


### PR DESCRIPTION
Not sure why I did this.  I think I may have gotten fooled by a log message from upgrade, where we get those error messages spuriously.

Reverts d-ronin/dRonin#1976