### PR TITLE
sensors: allow polling from sensor task, use for pios_mpu

### DIFF
--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -108,7 +108,7 @@ int32_t AltitudeHoldInitialize()
 	}
 #endif
 
-	if (!PIOS_SENSORS_GetQueue(PIOS_SENSOR_BARO)) {
+	if (!PIOS_SENSORS_IsRegistered(PIOS_SENSOR_BARO)) {
 		module_enabled = false;
 		return -1;
 	}

--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -521,7 +521,7 @@ static int32_t updateAttitudeComplementary(float dT, bool first_run, bool second
 		magData.z = 0;
 
 		// Wait for a mag reading if a magnetometer was registered
-		if (PIOS_SENSORS_GetQueue(PIOS_SENSOR_MAG) != NULL) {
+		if (PIOS_SENSORS_IsRegistered(PIOS_SENSOR_MAG)) {
 			if (!secondary && PIOS_Queue_Receive(magQueue, &ev, 20) != true) {
 				return -1;
 			}

--- a/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
+++ b/flight/Modules/FixedWingPathFollower/fixedwingpathfollower.c
@@ -130,13 +130,13 @@ int32_t FixedWingPathFollowerInitialize()
 	}
 #endif
  
-	if (!PIOS_SENSORS_GetQueue(PIOS_SENSOR_BARO)) {
+	if (!PIOS_SENSORS_IsRegistered(PIOS_SENSOR_BARO)) {
 		module_enabled = false;
 		return -1;
 	}
 
 
-	if (!PIOS_SENSORS_GetQueue(PIOS_SENSOR_MAG)) {
+	if (!PIOS_SENSORS_IsRegistered(PIOS_SENSOR_MAG)) {
 		module_enabled = false;
 		return -1;
 	}

--- a/flight/Modules/Sensors/sensors.c
+++ b/flight/Modules/Sensors/sensors.c
@@ -177,7 +177,7 @@ int32_t SensorsInitialize(void)
 		break;
 	}
 
-	if (PIOS_SENSORS_GetQueue(PIOS_SENSOR_OPTICAL_FLOW) != NULL ) {
+	if (PIOS_SENSORS_IsRegistered(PIOS_SENSOR_OPTICAL_FLOW)) {
 		if (OpticalFlowInitialize() == -1) {
 			return -1;
 		}
@@ -185,7 +185,7 @@ int32_t SensorsInitialize(void)
 #endif /* PIOS_INCLUDE_OPTICALFLOW */
 
 #if defined (PIOS_INCLUDE_RANGEFINDER)
-	if (PIOS_SENSORS_GetQueue(PIOS_SENSOR_RANGEFINDER) != NULL ) {
+	if (PIOS_SENSORS_IsRegistered(PIOS_SENSOR_RANGEFINDER)) {
 		if (RangefinderInitialize() == -1) {
 			return -1;
 		}
@@ -255,20 +255,17 @@ static void SensorsTask(void *parameters)
 		uint32_t timeval = PIOS_DELAY_GetRaw();
 
 		//Block on gyro data but nothing else
-		struct pios_queue *queue;
-		queue = PIOS_SENSORS_GetQueue(PIOS_SENSOR_GYRO);
-		if (queue == NULL || PIOS_Queue_Receive(queue, &gyros, SENSOR_PERIOD) == false) {
+		if (PIOS_SENSORS_GetData(PIOS_SENSOR_GYRO, &gyros, SENSOR_PERIOD) == false) {
 			good_runs = 0;
 			continue;
 		}
 
-		queue = PIOS_SENSORS_GetQueue(PIOS_SENSOR_ACCEL);
-		if (queue == NULL || PIOS_Queue_Receive(queue, &accels, 0) == false) {
+		if (PIOS_SENSORS_GetData(PIOS_SENSOR_ACCEL, &accels, 0) == false) {
 			//If no new accels data is ready, reuse the latest sample
 			AccelsSet(&accelsData);
-		}
-		else
+		} else {
 			update_accels(&accels);
+		}
 
 		// Update gyros after the accels since the rest of the code expects
 		// the accels to be available first
@@ -276,8 +273,7 @@ static void SensorsTask(void *parameters)
 
 		bool test_good_run = good_runs > REQUIRED_GOOD_CYCLES;
 
-		queue = PIOS_SENSORS_GetQueue(PIOS_SENSOR_MAG);
-		if (queue != NULL && PIOS_Queue_Receive(queue, &mags, 0) != false) {
+		if (PIOS_SENSORS_GetData(PIOS_SENSOR_MAG, &mags, 0) != false) {
 			update_mags(&mags);
 #ifdef PIOS_TOLERATE_MISSING_SENSORS
 		} else if (test_good_run) {
@@ -291,46 +287,38 @@ static void SensorsTask(void *parameters)
 #endif
 		}
 
-		queue = PIOS_SENSORS_GetQueue(PIOS_SENSOR_BARO);
-		if (queue != NULL) {
-			if (PIOS_Queue_Receive(queue, &baro, 0) != false) {
-				// we can use the timeval because it contains the current time stamp (PIOS_DELAY_GetRaw())
-				last_baro_update_time = timeval;
-				update_baro(&baro);
-				AlarmsClear(SYSTEMALARMS_ALARM_TEMPBARO);
-			} else {
-				// Check that we got valid sensor datas
-				uint32_t dT_baro_datas = PIOS_DELAY_DiffuS(last_baro_update_time);
-				// if the last valid sensor datas older than 100 ms report an error
-				if (dT_baro_datas > MAX_TIME_BETWEEN_VALID_BARO_DATAS_MS) {
-					AlarmsSet(SYSTEMALARMS_ALARM_TEMPBARO, SYSTEMALARMS_ALARM_ERROR);
-				}
-			}
-
+		if (PIOS_SENSORS_GetData(PIOS_SENSOR_BARO, &baro, 0) != false) {
+			// we can use the timeval because it contains the current time stamp (PIOS_DELAY_GetRaw())
+			last_baro_update_time = timeval;
+			update_baro(&baro);
+			AlarmsClear(SYSTEMALARMS_ALARM_TEMPBARO);
 #ifdef PIOS_TOLERATE_MISSING_SENSORS
-		} else {
-			if (PIOS_SENSORS_GetMissing(PIOS_SENSOR_BARO)) {
-				// Keep alarm asserted
-				test_good_run = false;
+		} else if (PIOS_SENSORS_GetMissing(PIOS_SENSOR_BARO)) {
+			// Keep alarm asserted
+			test_good_run = false;
 
-				AlarmsSet(SYSTEMALARMS_ALARM_TEMPBARO,
-						missing_sensor_severity);
-			}
+			AlarmsSet(SYSTEMALARMS_ALARM_TEMPBARO,
+					missing_sensor_severity);
 #endif
+		} else {
+			// Check that we got valid sensor datas
+			uint32_t dT_baro_datas = PIOS_DELAY_DiffuS(last_baro_update_time);
+			// if the last valid sensor datas older than 100 ms report an error
+			if (dT_baro_datas > MAX_TIME_BETWEEN_VALID_BARO_DATAS_MS) {
+				AlarmsSet(SYSTEMALARMS_ALARM_TEMPBARO, SYSTEMALARMS_ALARM_ERROR);
+			}
 		}
 
 #if defined(PIOS_INCLUDE_OPTICALFLOW)
 		struct pios_sensor_optical_flow_data optical_flow;
-		queue = PIOS_SENSORS_GetQueue(PIOS_SENSOR_OPTICAL_FLOW);
-		if (queue != NULL && PIOS_Queue_Receive(queue, &optical_flow, 0) != false) {
+		if (PIOS_SENSORS_GetData(PIOS_SENSOR_OPTICAL_FLOW, &optical_flow, 0) != false) {
 			update_optical_flow(&optical_flow);
 		}
 #endif /* PIOS_INCLUDE_OPTICALFLOW */
 
 #if defined(PIOS_INCLUDE_RANGEFINDER)
 		struct pios_sensor_rangefinder_data rangefinder;
-		queue = PIOS_SENSORS_GetQueue(PIOS_SENSOR_RANGEFINDER);
-		if (queue != NULL && PIOS_Queue_Receive(queue, &rangefinder, 0) != false) {
+		if (PIOS_SENSORS_GetData(PIOS_SENSOR_RANGEFINDER, &rangefinder, 0) != false) {
 			update_rangefinder(&rangefinder);
 		}
 #endif /* PIOS_INCLUDE_RANGEFINDER */

--- a/flight/Modules/Sensors/sensors.c
+++ b/flight/Modules/Sensors/sensors.c
@@ -300,7 +300,7 @@ static void SensorsTask(void *parameters)
 			AlarmsSet(SYSTEMALARMS_ALARM_TEMPBARO,
 					missing_sensor_severity);
 #endif
-		} else {
+		} else if (PIOS_SENSORS_IsRegistered(PIOS_SENSOR_BARO)) {
 			// Check that we got valid sensor datas
 			uint32_t dT_baro_datas = PIOS_DELAY_DiffuS(last_baro_update_time);
 			// if the last valid sensor datas older than 100 ms report an error

--- a/flight/Modules/UAVOFrSKYSPortBridge/UAVOFrSKYSPortBridge.c
+++ b/flight/Modules/UAVOFrSKYSPortBridge/UAVOFrSKYSPortBridge.c
@@ -212,7 +212,7 @@ static int32_t uavoFrSKYSPortBridgeStart(void)
 		frsky->frsky_settings.batt_cell_count = frsky->frsky_settings.battery_settings.NbCells;
 	}
 	if (BaroAltitudeHandle() != NULL
-			&& PIOS_SENSORS_GetQueue(PIOS_SENSOR_BARO) != NULL)
+			&& PIOS_SENSORS_IsRegistered(PIOS_SENSOR_BARO))
 		frsky->frsky_settings.use_baro_sensor = true;
 
 	struct pios_thread *task;

--- a/flight/Modules/VtolPathFollower/vtolpathfollower.c
+++ b/flight/Modules/VtolPathFollower/vtolpathfollower.c
@@ -112,12 +112,12 @@ int32_t VtolPathFollowerInitialize()
 	}
 #endif
 
-	if (!PIOS_SENSORS_GetQueue(PIOS_SENSOR_BARO)) {
+	if (!PIOS_SENSORS_IsRegistered(PIOS_SENSOR_BARO)) {
 		module_enabled = false;
 		return -1;
 	}
 
-	if (!PIOS_SENSORS_GetQueue(PIOS_SENSOR_MAG)) {
+	if (!PIOS_SENSORS_IsRegistered(PIOS_SENSOR_MAG)) {
 		module_enabled = false;
 		return -1;
 	}

--- a/flight/PiOS/Common/pios_sensors.c
+++ b/flight/PiOS/Common/pios_sensors.c
@@ -35,8 +35,8 @@ typedef bool (*PIOS_SENSOR_Callback_t)(void *ctx, void *output,
 		int ms_to_wait, int *next_call);
 
 static struct PIOS_Sensor {
-	PIOS_SENSOR_Callback_t cb_func;
-	void *cb_ctx;
+	PIOS_SENSOR_Callback_t getdata_cb;
+	void *getdata_ctx;
 
 	uint16_t sample_rate;
 	uint16_t missing : 1;
@@ -68,8 +68,8 @@ int32_t PIOS_SENSORS_RegisterCallback(enum pios_sensor_type type,
 
 	struct PIOS_Sensor *sensor = &sensors[type];
 
-	sensor->cb_ctx = ctx;
-	sensor->cb_func = callback;
+	sensor->getdata_ctx = ctx;
+	sensor->getdata_cb = callback;
 	sensor->missing = 0;
 
 	return 0;
@@ -93,7 +93,7 @@ bool PIOS_SENSORS_IsRegistered(enum pios_sensor_type type)
 		return false;
 	}
 
-	return sensor->cb_func != NULL;
+	return sensor->getdata_cb != NULL;
 }
 
 bool PIOS_SENSORS_GetData(enum pios_sensor_type type, void *buf, int ms_to_wait)
@@ -104,13 +104,13 @@ bool PIOS_SENSORS_GetData(enum pios_sensor_type type, void *buf, int ms_to_wait)
 
 	struct PIOS_Sensor *sensor = &sensors[type];
 
-	if (!sensor->cb_func) {
+	if (!sensor->getdata_cb) {
 		return false;
 	}
 
 	int next_time;
 
-	bool ret = sensor->cb_func(sensor->cb_ctx, buf, ms_to_wait,
+	bool ret = sensor->getdata_cb(sensor->getdata_ctx, buf, ms_to_wait,
 			&next_time);
 
 	/* TODO: keep track of next time it *could* have data to use in

--- a/flight/PiOS/Common/pios_sensors.c
+++ b/flight/PiOS/Common/pios_sensors.c
@@ -70,12 +70,21 @@ bool PIOS_SENSORS_IsRegistered(enum pios_sensor_type type)
 	return false;
 }
 
-struct pios_queue *PIOS_SENSORS_GetQueue(enum pios_sensor_type type)
+static inline struct pios_queue *PIOS_SENSORS_GetQueue(enum pios_sensor_type type)
 {
 	if (type >= PIOS_SENSOR_LAST)
 		return NULL;
 
 	return queues[type];
+}
+
+bool PIOS_SENSORS_GetData(enum pios_sensor_type type, void *buf, int ms_to_wait)
+{
+	struct pios_queue *q = PIOS_SENSORS_GetQueue(type);
+
+	if (q == NULL) return false;
+
+	return PIOS_Queue_Receive(q, buf, ms_to_wait);
 }
 
 void PIOS_SENSORS_SetMaxGyro(int32_t rate)

--- a/flight/PiOS/inc/pios_sensors.h
+++ b/flight/PiOS/inc/pios_sensors.h
@@ -90,14 +90,22 @@ enum pios_sensor_type
 	PIOS_SENSOR_BARO,
 	PIOS_SENSOR_OPTICAL_FLOW,
 	PIOS_SENSOR_RANGEFINDER,
-	PIOS_SENSOR_LAST
+	PIOS_SENSOR_NUM
 };
+
+//! Function that calls into sensor to get data.
+typedef bool (*PIOS_SENSOR_Callback_t)(void *ctx, void *output,
+		int ms_to_wait, int *next_call);
 
 //! Initialize the PIOS_SENSORS interface
 int32_t PIOS_SENSORS_Init();
 
-//! Register a sensor with the PIOS_SENSORS interface
+//! Register a queue-based sensor with the PIOS_SENSORS interface
 int32_t PIOS_SENSORS_Register(enum pios_sensor_type type, struct pios_queue *queue);
+
+//! Register a callback-based sensor with the PIOS_SENSORS interface
+int32_t PIOS_SENSORS_RegisterCallback(enum pios_sensor_type type,
+		PIOS_SENSOR_Callback_t callback, void *ctx);
 
 //! Checks if a sensor type is registered with the PIOS_SENSORS interface
 bool PIOS_SENSORS_IsRegistered(enum pios_sensor_type type);

--- a/flight/PiOS/inc/pios_sensors.h
+++ b/flight/PiOS/inc/pios_sensors.h
@@ -102,8 +102,8 @@ int32_t PIOS_SENSORS_Register(enum pios_sensor_type type, struct pios_queue *que
 //! Checks if a sensor type is registered with the PIOS_SENSORS interface
 bool PIOS_SENSORS_IsRegistered(enum pios_sensor_type type);
 
-//! Get the data queue for a sensor type
-struct pios_queue *PIOS_SENSORS_GetQueue(enum pios_sensor_type type);
+//! Get the data for a sensor type
+bool PIOS_SENSORS_GetData(enum pios_sensor_type type, void *buf, int ms_to_wait);
 
 //! Set the maximum gyro rate in deg/s
 void PIOS_SENSORS_SetMaxGyro(int32_t rate);


### PR DESCRIPTION
So far, bench tested on Sparky2, Revolution, and OMF3

* baseline
  * revo 27..28 system cpu used, 96496 heap, 53052 fastheap sensors 4%, 376 bytes free in sensors task stack imu 2%, 128 bytes free in imu task stack, codesize 302952
  * spk2 31..32 system cpu used, 99600 heap, 53284 fastheap sensors 4%, 368 bytes free in sensors task stack imu 3%, 168 bytes free in imu task stack codesize 238444 
  * omf3 72..76 system cpu used, 12728 heap, sensors 10%, 376 bytes free in sensors task imu 7%, 168 bytes free in imu task stack codesize 194364
* this stage 1 change
  * revo 27..28 system cpu used, 96972 heap, 53312 fastheap sensors 7%, 352 bytes free in sensors task stack codesize 302936
  * spk2 30..31 system CPU used, 100148 heap, 53656 fastheap sensors 7%, 368 bytes free in sensors task stack codesize 238460
  * omf3 71..73 system cpu used, 13544 heap, sensors 18%, 376 bytes free in sensors ask stack codesize 194348

Goals this time were modest-- just moving in the right direction, freeing up some resources.  The change outline will allow multiple sensors to be scheduled well, etc, which will be a bigger win.