### PR TITLE
telemetry: improvements

### DIFF
--- a/ground/gcs/src/plugins/uavtalk/telemetry.cpp
+++ b/ground/gcs/src/plugins/uavtalk/telemetry.cpp
@@ -377,12 +377,13 @@ void Telemetry::transactionTimeout(ObjectTransactionInfo *transInfo)
     transInfo->timer->stop();
     // Check if more retries are pending
     if (transInfo->retriesRemaining > 0) {
-        qInfo() << QString("[telemetry.cpp] Transaction timeout:%0 Instance:%1 Retrying")
+        --transInfo->retriesRemaining;
+        qInfo() << QString("[telemetry.cpp] Transaction timeout:%0 Instance:%1 Retrying remaining=%3")
                 .arg(transInfo->obj->getName()
                      + QString(QString(" 0x")
                                + QString::number(transInfo->obj->getObjID(), 16).toUpper()))
-                .arg(transInfo->obj->getInstID());
-        --transInfo->retriesRemaining;
+                .arg(transInfo->obj->getInstID())
+                .arg(transInfo->retriesRemaining);
         processObjectTransaction(transInfo);
         ++txRetries;
     } else {

--- a/ground/gcs/src/plugins/uavtalk/telemetrymonitor.h
+++ b/ground/gcs/src/plugins/uavtalk/telemetrymonitor.h
@@ -73,11 +73,9 @@ public slots:
     void transactionCompleted(UAVObject *obj, bool success);
     void processStatsUpdates();
     void flightStatsUpdated(UAVObject *obj);
-    void checkSessionObjNacked(UAVObject *, bool, bool);
 private slots:
     void sessionObjUnpackedCB(UAVObject *obj);
     void objectRetrieveTimeoutCB();
-    void sessionRetrieveTimeoutCB();
     void sessionInitialRetrieveTimeoutCB();
     void saveSession();
     void newInstanceSlot(UAVObject *);
@@ -110,7 +108,6 @@ private:
     quint16 sessionID;
     quint8 numberOfObjects;
     QTimer *objectRetrieveTimeout;
-    QTimer *sessionRetrieveTimeout;
     QTimer *sessionInitialRetrieveTimeout;
     int retries;
     int requestsInFlight;


### PR DESCRIPTION
neuter old session managing.  Make the connection timeout an
inactivity-related one rather than absolute.  Output better debug info.