### PR TITLE
unbreak build: canonicalize old UAVO XML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -494,7 +494,12 @@ $$(UAVO_COLLECTION_DIR)/$(1)/uavo-xml: $$(UAVO_COLLECTION_DIR)/$(1)/uavo-xml.tar
 	$$(V1) rm -rf $$@
 	$$(V1) mkdir -p $$@
 	$$(V1) tar -C $$(call toprel, $$@) -xf $$(call toprel, $$<) || rm -rf $$@
+	$$(V1) python/dronin-canonicalize $$(call toprel, $$@)/shared/uavobjectdefinition
+	$$(V1) rm -f $$(call toprel, $$@)/shared/uavobjectdefinition/vtxconfig.xml
+
+# Last two statements are a hack for old UAVOs using mish-mash formats
 endef
+
 
 # Map the current working directory into the set of UAVO collections
 $(UAVO_COLLECTION_DIR)/srctree:

--- a/python/dronin-canonicalize
+++ b/python/dronin-canonicalize
@@ -2,8 +2,14 @@
 
 from dronin import uavo_collection
 
+from sys import argv, exit
+
+if len(argv) != 2:
+    print("usage: %s path"%argv[0])
+    exit(1)
+
 uavo_defs = uavo_collection.UAVOCollection()
 
-uavo_defs.from_uavo_xml_path('../shared/uavobjectdefinition')
+uavo_defs.from_uavo_xml_path(argv[1])
 
-uavo_defs.emit_canonical_xml('outxml')
+uavo_defs.emit_canonical_xml(argv[1])


### PR DESCRIPTION
This is necessary because of the AndroidGCS  running old stuff through UAVOGen.  Only visible in artifact builds.