### PR TITLE
pios_sensors: remove redundant typedef

### DIFF
--- a/flight/PiOS/Common/pios_sensors.c
+++ b/flight/PiOS/Common/pios_sensors.c
@@ -30,10 +30,7 @@
 #include "pios_sensors.h"
 #include <stddef.h>
 
-//! The list of queue handles
-typedef bool (*PIOS_SENSOR_Callback_t)(void *ctx, void *output,
-		int ms_to_wait, int *next_call);
-
+//! The list of queue handles / callbacks
 static struct PIOS_Sensor {
 	PIOS_SENSOR_Callback_t getdata_cb;
 	void *getdata_ctx;


### PR DESCRIPTION
I guess we were broken in two ways; mac os x sim target didn't like this.