### PR TITLE
flyingpio: change "ready" light pattern

### DIFF
--- a/flight/targets/flyingpio/fw/main.c
+++ b/flight/targets/flyingpio/fw/main.c
@@ -256,9 +256,11 @@ int main()
 
 		if (!inited) {
 			// Distinctive "ready" blip when host is not controlling
-			// LED.
-			if ((i == 0xc000) || (i == 0) || (i==0x18000)) {
-				PIOS_ANNUNC_Toggle(PIOS_LED_HEARTBEAT);
+			// LED.  On most of the time, which 3 quick flashes off.
+			if ((i == 0) || (i == 0x8000) || (i == 0x10000)) {
+				PIOS_ANNUNC_Off(PIOS_LED_HEARTBEAT);
+			} else if ((i == 0x4000) || (i == 0xc000) || (i == 0x14000)) {
+				PIOS_ANNUNC_On(PIOS_LED_HEARTBEAT);
 			}
 		}
 	}


### PR DESCRIPTION
Before it was a very slow morse R.  When firmware starts, it's a normal
R.  This isn't enough to tell reliably or to explain to new users.

Now it is solid on, except for 3 quick flashes off, and can't be
confused with anything firmware does.