### PR TITLE
GCS:Seppuku: Remove minimum size of config form

### DIFF
--- a/ground/gcs/src/plugins/boards_dronin/seppuku.ui
+++ b/ground/gcs/src/plugins/boards_dronin/seppuku.ui
@@ -16,12 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="minimumSize">
-   <size>
-    <width>950</width>
-    <height>671</height>
-   </size>
-  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
@@ -42,8 +36,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>930</width>
-        <height>651</height>
+        <width>916</width>
+        <height>692</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">


### PR DESCRIPTION
Let the scroll area do it's job. Fixes #2008 