### PR TITLE
rgbled: dim when usb power present

### DIFF
--- a/flight/Modules/System/rgbleds.c
+++ b/flight/Modules/System/rgbleds.c
@@ -318,6 +318,14 @@ void systemmod_process_rgb_leds(bool led_override, bool led_override_active,
 	RGBLEDSettingsRangeColorBlendModeOptions blend_mode =
 		rgbSettings.RangeColorBlendMode;
 
+#ifdef PIOS_INCLUDE_USB
+	if (rgbSettings.DimWhenUSB == RGBLEDSETTINGS_DIMWHENUSB_TRUE) {
+		if (PIOS_USB_CableConnected(0)) {
+			force_dim = true;
+		}
+	}
+#endif
+
 	if (!is_armed) {
 		blend_source = rgbSettings.RangeColorBlendUnarmedSource;
 	}
@@ -436,12 +444,6 @@ void systemmod_process_rgb_leds(bool led_override, bool led_override_active,
 			break;
 	}
 
-	if (force_dim) {
-		range_color[0] /= 2;
-		range_color[1] /= 2;
-		range_color[2] /= 2;
-	}
-
 	uint8_t alarm_color[3] = { 0, 0, 0 };
 
 	if (led_override && led_override_active) {
@@ -460,6 +462,18 @@ void systemmod_process_rgb_leds(bool led_override, bool led_override_active,
 			alarm_color[1] = 200;
 			alarm_color[2] = 32;
 		}
+	}
+
+	if (force_dim) {
+		range_color[0] /= 2;
+		range_color[1] /= 2;
+		range_color[2] /= 2;
+		alarm_color[0] /= 2;
+		alarm_color[1] /= 2;
+		alarm_color[2] /= 2;
+		rgbSettings.DefaultColor[0] /= 2;
+		rgbSettings.DefaultColor[1] /= 2;
+		rgbSettings.DefaultColor[2] /= 2;
 	}
 
 	for (int i = 0; i < num_leds; i++) {

--- a/flight/Modules/System/rgbleds.c
+++ b/flight/Modules/System/rgbleds.c
@@ -465,15 +465,15 @@ void systemmod_process_rgb_leds(bool led_override, bool led_override_active,
 	}
 
 	if (force_dim) {
-		range_color[0] /= 2;
-		range_color[1] /= 2;
-		range_color[2] /= 2;
-		alarm_color[0] /= 2;
-		alarm_color[1] /= 2;
-		alarm_color[2] /= 2;
-		rgbSettings.DefaultColor[0] /= 2;
-		rgbSettings.DefaultColor[1] /= 2;
-		rgbSettings.DefaultColor[2] /= 2;
+		range_color[0] = (range_color[0] + 2) / 3;
+		range_color[1] = (range_color[1] + 2) / 3;
+		range_color[2] = (range_color[2] + 2) / 3;
+		alarm_color[0] = (alarm_color[0] + 2) / 3;
+		alarm_color[1] = (alarm_color[1] + 2) / 3;
+		alarm_color[2] = (alarm_color[2] + 2) / 3;
+		rgbSettings.DefaultColor[0] = (rgbSettings.DefaultColor[0] + 2) / 3;
+		rgbSettings.DefaultColor[1] = (rgbSettings.DefaultColor[1] + 2) / 3;
+		rgbSettings.DefaultColor[2] = (rgbSettings.DefaultColor[2] + 2) / 3;
 	}
 
 	for (int i = 0; i < num_leds; i++) {

--- a/flight/targets/bl/common/led_pwm.c
+++ b/flight/targets/bl/common/led_pwm.c
@@ -122,8 +122,8 @@ bool led_pwm_update_leds(struct led_pwm_state *leds)
 	if ((leds->uptime_us - leds->last_ws2811_us) >= WS2811_UPDATE_INTERVAL) {
 		leds->last_ws2811_us = leds->uptime_us;
 
-		PIOS_WS2811_set_all(pios_ws2811, led1_fraction,
-			led2_fraction / 2, 0);
+		PIOS_WS2811_set_all(pios_ws2811, led1_fraction / 2,
+			led2_fraction / 3, 0);
 		PIOS_WS2811_trigger_update(pios_ws2811);
 	}
 #endif

--- a/shared/uavobjectdefinition/rgbledsettings.xml
+++ b/shared/uavobjectdefinition/rgbledsettings.xml
@@ -40,6 +40,13 @@
         <option>Time- 4 Second Period</option>
       </options>
     </field>
+    <field defaultvalue="TRUE" elements="1" name="DimWhenUSB" type="enum" units="">
+      <description>If true, when USB is connected at startup the LEDs will be run at half brightness.</description>
+      <options>
+        <option>FALSE</option>
+        <option>TRUE</option>
+      </options>
+    </field>
     <field defaultvalue="Time- Second Period" elements="1" name="RangeColorBlendUnarmedSource" parent="RGBLEDSettings.RangeColorBlendSource" type="enum" units="function">
       <description>What chooses the mix of basecolor and endcolor to use when disarmed</description>
     </field>


### PR DESCRIPTION
Fixes #1740.  ~~Doesn't help Seppuku, because it doesn't know whether USB is present in firmware.~~  I lied, transfer_possible does the right thing on seppuku.