### PR TITLE
pios_flight_library: remove printf-stdarg.c

### DIFF
--- a/flight/PiOS/pios_flight_library.mk
+++ b/flight/PiOS/pios_flight_library.mk
@@ -11,7 +11,6 @@ SRC += pios_sensors.c
 SRC += pios_flash.c
 SRC += pios_flash_jedec.c
 SRC += pios_flashfs_logfs.c
-SRC += printf-stdarg.c
 SRC += pios_usb_desc_hid_cdc.c
 SRC += pios_usb_desc_hid_only.c
 SRC += pios_usb_util.c

--- a/flight/targets/dtfc/fw/Makefile
+++ b/flight/targets/dtfc/fw/Makefile
@@ -96,6 +96,7 @@ SRC += chibi_main.c
 SRC += pios_board.c
 SRC += pios_usb_board_data.c
 SRC += $(OPUAVOBJ)/uavobjectmanager.c
+SRC += printf-stdarg.c
 
 ifeq ($(DEBUG),YES)
 SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c

--- a/flight/targets/lux/fw/Makefile
+++ b/flight/targets/lux/fw/Makefile
@@ -96,6 +96,7 @@ SRC += chibi_main.c
 SRC += pios_board.c
 SRC += pios_usb_board_data.c
 SRC += $(OPUAVOBJ)/uavobjectmanager.c
+SRC += printf-stdarg.c
 
 ifeq ($(DEBUG),YES)
 SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c

--- a/flight/targets/pikoblx/fw/Makefile
+++ b/flight/targets/pikoblx/fw/Makefile
@@ -94,6 +94,7 @@ SRC += chibi_main.c
 SRC += pios_board.c
 SRC += pios_usb_board_data.c
 SRC += $(OPUAVOBJ)/uavobjectmanager.c
+SRC += printf-stdarg.c
 
 ifeq ($(DEBUG),YES)
 SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c

--- a/flight/targets/pipxtreme/fw/Makefile
+++ b/flight/targets/pipxtreme/fw/Makefile
@@ -90,6 +90,7 @@ SRC += ${OPMODULEDIR}/System/rgbleds.c
 SRC += chibi_main.c
 SRC += pios_board.c
 SRC += $(OPUAVOBJ)/uavobjectmanager.c
+SRC += printf-stdarg.c
 
 ## PIOS Hardware (STM32F10x)
 SRC += pios_sys.c

--- a/flight/targets/quanton/fw/Makefile
+++ b/flight/targets/quanton/fw/Makefile
@@ -98,6 +98,7 @@ SRC += chibi_main.c
 SRC += pios_board.c
 SRC += pios_usb_board_data.c
 SRC += $(OPUAVOBJ)/uavobjectmanager.c
+SRC += printf-stdarg.c
 
 ifeq ($(DEBUG),YES)
 SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c

--- a/flight/targets/sparky/fw/Makefile
+++ b/flight/targets/sparky/fw/Makefile
@@ -94,6 +94,7 @@ SRC += chibi_main.c
 SRC += pios_board.c
 SRC += pios_usb_board_data.c
 SRC += $(OPUAVOBJ)/uavobjectmanager.c
+SRC += printf-stdarg.c
 
 ifeq ($(DEBUG),YES)
 SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c

--- a/flight/targets/sparky2/fw/Makefile
+++ b/flight/targets/sparky2/fw/Makefile
@@ -100,6 +100,7 @@ SRC += chibi_main.c
 SRC += pios_board.c
 SRC += pios_usb_board_data.c
 SRC += $(OPUAVOBJ)/uavobjectmanager.c
+SRC += printf-stdarg.c
 
 ifeq ($(DEBUG),YES)
 SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c

--- a/flight/targets/sprf3e/fw/Makefile
+++ b/flight/targets/sprf3e/fw/Makefile
@@ -28,7 +28,6 @@
 
 include $(MAKE_INC_DIR)/firmware-defs.mk
 
-
 # Set developer code and compile options
 # Set to YES for debugging
 DEBUG ?= NO
@@ -93,6 +92,7 @@ SRC += chibi_main.c
 SRC += pios_board.c
 SRC += pios_usb_board_data.c
 SRC += $(OPUAVOBJ)/uavobjectmanager.c
+SRC += printf-stdarg.c
 
 ifeq ($(DEBUG),YES)
 SRC += $(DEBUG_CM3_DIR)/dcc_stdio.c


### PR DESCRIPTION
Instead include it on the individual non-OSD targets.

Thanks to @droney for the report.  Fixes #2022 