### PR TITLE
smoothcontrol,stabilization: Do bounds checking on the smoothed output.

### DIFF
--- a/flight/Libraries/math/smoothcontrol.c
+++ b/flight/Libraries/math/smoothcontrol.c
@@ -88,7 +88,7 @@ void smoothcontrol_set_mode(smoothcontrol_state state, uint8_t axis_num, uint8_t
 }
 
 // Processes the signal, if internal state allows it.
-void smoothcontrol_run(smoothcontrol_state state, uint8_t axis_num, float *new_signal, float limit)
+void smoothcontrol_run(smoothcontrol_state state, uint8_t axis_num, float *new_signal)
 {
 	PIOS_Assert(state && axis_num <= 3);
 
@@ -123,12 +123,12 @@ void smoothcontrol_run_thrust(smoothcontrol_state state, float *new_signal)
 	 * non-zero.
 	 */
 
-	if (*new_signal == 0) {
+	if (*new_signal == 0 || *new_signal != *new_signal) {
 		smoothcontrol_reinit(state, 3, 0);
 	} else {
 		bool sign = *new_signal > 0;
 
-		smoothcontrol_run(state, 3, new_signal, 1.0f);
+		smoothcontrol_run(state, 3, new_signal);
 
 		// If prediction undershoots while original signal is positive
 		// bound it to zero.

--- a/flight/Libraries/math/smoothcontrol.h
+++ b/flight/Libraries/math/smoothcontrol.h
@@ -35,7 +35,7 @@ typedef struct smoothcontrol_state_internal* smoothcontrol_state;
 void smoothcontrol_initialize(smoothcontrol_state *state);
 void smoothcontrol_update_dT(smoothcontrol_state state, float dT);
 void smoothcontrol_next(smoothcontrol_state state);
-void smoothcontrol_run(smoothcontrol_state state, uint8_t axis_num, float *new_signal, float limit);
+void smoothcontrol_run(smoothcontrol_state state, uint8_t axis_num, float *new_signal);
 void smoothcontrol_run_thrust(smoothcontrol_state state, float *new_signal);
 void smoothcontrol_reinit(smoothcontrol_state state, uint8_t axis_num, float new_signal);
 void smoothcontrol_set_mode(smoothcontrol_state state, uint8_t axis_num, uint8_t mode);

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -606,9 +606,20 @@ static void stabilizationTask(void* parameters)
 		stabilization_failsafe_checks(&stabDesired, &actuatorDesired, airframe_type,
 			raw_input, axis_mode);
 
+		// A flag to track which stabilization mode each axis is in
+		static uint8_t previous_mode[MAX_AXES] = {255,255,255};
+
 		// Do this before attitude error calc, so it benefits from it.
-		for(int i = 0; i < 3; i++)
-			smoothcontrol_run(rc_smoothing, i, &raw_input[i], settings.ManualRate[i]);
+		for(int i = 0; i < 3; i++) {
+			if (axis_mode[i] != previous_mode[i]) {
+				// Disable the integrator this round, so that it doesn't transition between
+				// different stick scales.
+				// Also allows for setting bounds properly, lower in the loop.
+				smoothcontrol_reinit(rc_smoothing, i, raw_input[i]);
+			} else {
+				smoothcontrol_run(rc_smoothing, i, &raw_input[i]);
+			}
+		}
 
 		float horizon_rate_fraction;
 		float local_attitude_error[MAX_AXES];
@@ -624,9 +635,6 @@ static void stabilizationTask(void* parameters)
 
 		static float max_rate_filtered[MAX_AXES];
 
-		// A flag to track which stabilization mode each axis is in
-		static uint8_t previous_mode[MAX_AXES] = {255,255,255};
-
 		actuatorDesired.SystemIdentCycle = 0xffff;
 
 		uint16_t max_safe_rate = PIOS_SENSORS_GetMaxGyro() * 0.9f;
@@ -636,12 +644,6 @@ static void stabilizationTask(void* parameters)
 		{
 			// Check whether this axis mode needs to be reinitialized
 			bool reinit = (axis_mode[i] != previous_mode[i]);
-
-			if(reinit && previous_mode[i] != 255) {
-				// Disable the integrator this round. And only do so on real mode switches.
-				smoothcontrol_reinit(rc_smoothing, i, raw_input[i]);
-			}
-
 			previous_mode[i] = axis_mode[i];
 
 			// Apply the selected control law
@@ -652,7 +654,7 @@ static void stabilizationTask(void* parameters)
 					break;
 
 				case STABILIZATIONDESIRED_STABILIZATIONMODE_RATE:
-					if(reinit) {
+					if (reinit) {
 						pids[PID_GROUP_RATE + i].iAccumulator = 0;
 					}
 
@@ -666,10 +668,12 @@ static void stabilizationTask(void* parameters)
 					break;
 
 				case STABILIZATIONDESIRED_STABILIZATIONMODE_ACRODYNE:
-					if(reinit) {
+					if (reinit) {
 						pids[PID_GROUP_RATE + i].iAccumulator = 0;
 						max_rate_filtered[i] = settings.ManualRate[i];
 					}
+
+					raw_input[i] = bound_sym(raw_input[i], 1.0f);
 
 					float curve_cmd = expoM(raw_input[i],
 							settings.RateExpo[i],
@@ -713,9 +717,11 @@ static void stabilizationTask(void* parameters)
 				case STABILIZATIONDESIRED_STABILIZATIONMODE_ACROPLUS:
 					// this implementation is based on the Openpilot/Librepilot Acro+ flightmode
 					// and our previous MWRate flightmodes
-					if(reinit) {
+					if (reinit) {
 						pids[PID_GROUP_RATE + i].iAccumulator = 0;
 					}
+
+					raw_input[i] = bound_sym(raw_input[i], 1.0f);
 
 					// The factor for gyro suppression / mixing raw stick input into the output; scaled by raw stick input
 					float factor = fabsf(raw_input[i]) * settings.AcroInsanityFactor / 100.0f;
@@ -737,7 +743,7 @@ static void stabilizationTask(void* parameters)
 					break;
 
 				case STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE:
-					if(reinit) {
+					if (reinit) {
 						pids[PID_GROUP_ATT + i].iAccumulator = 0;
 						pids[PID_GROUP_RATE + i].iAccumulator = 0;
 					}
@@ -753,6 +759,8 @@ static void stabilizationTask(void* parameters)
 					break;
 
 				case STABILIZATIONDESIRED_STABILIZATIONMODE_VIRTUALBAR:
+					raw_input[i] = bound_sym(raw_input[i], 1.0f);
+
 					// Store for debugging output
 					rateDesiredAxis[i] = raw_input[i];
 
@@ -766,6 +774,7 @@ static void stabilizationTask(void* parameters)
 					if (reinit) {
 						pids[PID_GROUP_RATE + i].iAccumulator = 0;
 					}
+					raw_input[i] = bound_sym(raw_input[i], settings.ManualRate[i]);
 
 					float weak_leveling = local_attitude_error[i] * weak_leveling_kp;
 					weak_leveling = bound_sym(weak_leveling, weak_leveling_max);
@@ -807,6 +816,8 @@ static void stabilizationTask(void* parameters)
 					if(reinit) {
 						pids[PID_GROUP_RATE + i].iAccumulator = 0;
 					}
+
+					raw_input[i] = bound_sym(raw_input[i], 1.0f);
 
 					// Do not allow outer loop integral to wind up in this mode since the controller
 					// is often disengaged.
@@ -953,6 +964,8 @@ static void stabilizationTask(void* parameters)
 								pids[PID_RATE_YAW].iAccumulator = 0;
 								axis_lock_accum[YAW] = 0;
 							}
+
+							raw_input[i] = bound_sym(raw_input[i], 1.0f);
 
 							//If we are not in roll attitude mode, trigger an error
 							if (axis_mode[ROLL] != STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE)


### PR DESCRIPTION
I'm a smidge nervous about this, because I can't test all modes (yet) to see whether I inferred all stick scales correctly. Playing with rate and attitude mode, and switching back and forth between them, in my living room, the quad acts normal for whatever I can test in that space.

Also, turns out the axis reset happened late, which might have led to actuator blipping for one gyro update cycle under certain conditions (switching from high rates to attitude or a mode with -1..1 stick scale).
 
This deals with #1974.