### PR TITLE
telemetry: further improvements

### DIFF
--- a/flight/Libraries/inc/uavtalk.h
+++ b/flight/Libraries/inc/uavtalk.h
@@ -33,6 +33,7 @@
 // Public types
 typedef int32_t (*UAVTalkOutputCb)(void *ctx, uint8_t *data, int32_t length);
 typedef void (*UAVTalkAckCb)(void *ctx, uint32_t obj_id, uint16_t inst_id);
+typedef void (*UAVTalkReqCb)(void *ctx, uint32_t obj_id, uint16_t inst_id);
 typedef int32_t (*UAVTalkFileCb)(void *ctx, uint8_t *buf,
 		uint32_t file_id, uint32_t offset, uint32_t len);
 
@@ -54,9 +55,10 @@ typedef enum {UAVTALK_STATE_ERROR = 0, UAVTALK_STATE_SYNC, UAVTALK_STATE_TYPE, U
 	      UAVTALK_STATE_DATA, UAVTALK_STATE_CS, UAVTALK_STATE_COMPLETE} UAVTalkRxState;
 
 // Public functions
-UAVTalkConnection UAVTalkInitialize(void *ctx, UAVTalkOutputCb outputStream, UAVTalkAckCb ackCallback, UAVTalkFileCb fileCallback);
+UAVTalkConnection UAVTalkInitialize(void *ctx, UAVTalkOutputCb outputStream, UAVTalkAckCb ackCallback, UAVTalkReqCb reqCallback, UAVTalkFileCb fileCallback);
 int32_t UAVTalkSendObject(UAVTalkConnection connection, UAVObjHandle obj, uint16_t instId, uint8_t acked);
 int32_t UAVTalkSendObjectTimestamped(UAVTalkConnection connectionHandle, UAVObjHandle obj, uint16_t instId);
+int32_t UAVTalkSendNack(UAVTalkConnection connectionHandle, uint32_t objId);
 void UAVTalkProcessInputStream(UAVTalkConnection connectionHandle, uint8_t *rxbytes,
 		int numbytes);
 UAVTalkRxState UAVTalkProcessInputStreamQuiet(UAVTalkConnection connection, uint8_t rxbyte);

--- a/flight/Libraries/inc/uavtalk_priv.h
+++ b/flight/Libraries/inc/uavtalk_priv.h
@@ -98,6 +98,7 @@ typedef struct {
 
 	UAVTalkOutputCb outCb;
 	UAVTalkAckCb ackCb;
+	UAVTalkReqCb reqCb;
 	UAVTalkFileCb fileCb;
 	void *cbCtx;
 } UAVTalkConnectionData;

--- a/flight/Modules/Logging/logging.c
+++ b/flight/Modules/Logging/logging.c
@@ -181,7 +181,8 @@ int32_t LoggingInitialize(void)
 	}
 
 	// Initialise UAVTalk
-	uavTalkCon = UAVTalkInitialize(NULL, &send_data_nonblock, NULL, NULL);
+	uavTalkCon = UAVTalkInitialize(NULL, &send_data_nonblock,
+			NULL, NULL, NULL);
 
 	if (!uavTalkCon) {
 		module_enabled = false;

--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -144,7 +144,7 @@ uintptr_t pios_com_debug_id;
 #endif
 
 #ifndef PIOS_COM_TELEM_USB_RX_BUF_LEN
-#define PIOS_COM_TELEM_USB_RX_BUF_LEN 65
+#define PIOS_COM_TELEM_USB_RX_BUF_LEN 129
 #endif
 
 #ifndef PIOS_COM_TELEM_USB_TX_BUF_LEN

--- a/flight/PiOS/STM32F30x/pios_usb_hid.c
+++ b/flight/PiOS/STM32F30x/pios_usb_hid.c
@@ -306,7 +306,7 @@ static void PIOS_USB_HID_EP_OUT_Callback(void)
 #ifdef PIOS_USB_BOARD_BL_HID_HAS_NO_LENGTH_BYTE
 	(usb_hid_dev->rx_in_cb)(usb_hid_dev->rx_in_context,
 				&usb_hid_dev->rx_packet_buffer[1],
-				sizeof(usb_hid_dev->rx_packet_buffer)-1,
+				DataLength-1,
 				&headroom,
 				&need_yield);
 #else

--- a/ground/gcs/src/plugins/uavtalk/telemetry.h
+++ b/ground/gcs/src/plugins/uavtalk/telemetry.h
@@ -96,8 +96,8 @@ private:
 
     // TODO: Would be nice to dynamically scale the request timeout... 
     // This 1500 value is about what's necessary for 9600bps uavtalk links.
-    static const int REQ_TIMEOUT_MS = 1500;
-    static const int MAX_RETRIES = 4;
+    static const int REQ_TIMEOUT_MS = 2000;
+    static const int MAX_RETRIES = 5;
     static const int MAX_UPDATE_PERIOD_MS = 1000;
     static const int MIN_UPDATE_PERIOD_MS = 1;
     static const int MAX_QUEUE_SIZE = 20;

--- a/ground/gcs/src/plugins/uavtalk/telemetrymonitor.cpp
+++ b/ground/gcs/src/plugins/uavtalk/telemetrymonitor.cpp
@@ -44,9 +44,9 @@
 #define SESSION_RETRIEVE_TIMEOUT 20000
 // Number of retries for the session object fetching during negotiation
 #define SESSION_OBJ_RETRIEVE_RETRIES 3
-// Timeout for the object fetching fase, the system will stop fetching objects and emit connected
+// Timeout for the object fetching phase, the system will stop fetching objects and emit connected
 // after this
-#define OBJECT_RETRIEVE_TIMEOUT 7000
+#define OBJECT_RETRIEVE_TIMEOUT 20000
 // IAP object is very important, retry if not able to get it the first time
 #define IAP_OBJECT_RETRIES 3
 
@@ -251,7 +251,7 @@ void TelemetryMonitor::retrieveNextObject()
             connectionStatus = CON_CONNECTED_MANAGED;
         } else {
             TELEMETRYMONITOR_QXTLOG_DEBUG(
-                QString("%0 connectionStatus set to CON_CONNECTED_MANAGED( %1 )")
+                QString("%0 connectionStatus set to CON_CONNECTED_UNMANAGED( %1 )")
                     .arg(Q_FUNC_INFO)
                     .arg(connectionStatus));
             connectionStatus = CON_CONNECTED_UNMANAGED;
@@ -322,9 +322,9 @@ void TelemetryMonitor::transactionCompleted(UAVObject *obj, bool success)
 
         retrieveNextObject();
     } else {
-        TELEMETRYMONITOR_QXTLOG_DEBUG(
+        qInfo() <<
             QString("%0 connection lost while retrieving objects, stopped object retrievel")
-                .arg(Q_FUNC_INFO));
+                .arg(Q_FUNC_INFO);
         queue.clear();
         objectRetrieveTimeout->stop();
         sessionInitialRetrieveTimeout->stop();
@@ -427,6 +427,9 @@ void TelemetryMonitor::sessionObjUnpackedCB(UAVObject *obj)
 
 void TelemetryMonitor::objectRetrieveTimeoutCB()
 {
+    qInfo() <<
+        QString("%0 reached timeout for object retrieval, clearing queue")
+        .arg(Q_FUNC_INFO);
     queue.clear();
 }
 


### PR DESCRIPTION
* Improved ground-side constants
* Fixed a dumb bug in F3 HID handling
* Increase flight-side buffers for received data a little bit
* The big one: add a request queue, ensure that requests take priority over all things telemetered.

This has behaved well in both local and radio tests-- before F3 doing weird things and objects being lost was 1 in 3 or 1 in 4 of connections, but now in dozens of tests have not been able to repro.  There is some remaining issue that does cause occasional loss of frames and re-requests, but never significant numbers of the permitted retries.

I also saw an anomaly with the RFM bind wizard once (where the FC & the oplink ended up set to different max link speeds), but in all subsequent tests it has been fine.