### PR TITLE
pios_usart on F4: DMA send/receive implementation (WIP)

### DIFF
--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -813,6 +813,7 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 
 	case HWSHARED_PORTTYPES_OPENLOG:
 #if defined(PIOS_INCLUDE_OPENLOG)
+		usart_port_params.flags = PIOS_USART_ALLOW_TRANSMIT_DMA;
 		PIOS_HAL_ConfigureCom(usart_port_cfg, &usart_port_params, 0, PIOS_COM_OPENLOG_TX_BUF_LEN, com_driver, &port_driver_id);
 		target = &pios_com_openlog_logging_id;
 #endif /* PIOS_INCLUDE_OPENLOG */
@@ -874,6 +875,7 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 			usart_port_params.init.USART_StopBits            = USART_StopBits_2;
 			usart_port_params.init.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
 			usart_port_params.init.USART_Mode                = USART_Mode_Rx;
+			usart_port_params.flags                          = PIOS_USART_ALLOW_RECEIVE_DMA;
 
 			if (port_type == HWSHARED_PORTTYPES_SBUS)
 				usart_port_params.rx_invert = true;
@@ -919,6 +921,7 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 			usart_port_params.init.USART_StopBits            = USART_StopBits_1;
 			usart_port_params.init.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
 			usart_port_params.init.USART_Mode                = USART_Mode_Rx;
+			usart_port_params.flags                          = PIOS_USART_ALLOW_RECEIVE_DMA;
 
 			PIOS_HAL_ConfigureSRXL(usart_port_cfg, &usart_port_params, com_driver);
 		}
@@ -934,6 +937,7 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 			usart_port_params.init.USART_StopBits            = USART_StopBits_1;
 			usart_port_params.init.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
 			usart_port_params.init.USART_Mode                = USART_Mode_Rx;
+			usart_port_params.flags                          = PIOS_USART_ALLOW_RECEIVE_DMA;
 
 			PIOS_HAL_ConfigureIBus(usart_port_cfg, &usart_port_params, com_driver);
 		}
@@ -949,6 +953,7 @@ void PIOS_HAL_ConfigurePort(HwSharedPortTypesOptions port_type,
 			usart_port_params.init.USART_StopBits            = USART_StopBits_1;
 			usart_port_params.init.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
 			usart_port_params.init.USART_Mode                = USART_Mode_Rx|USART_Mode_Tx;
+			usart_port_params.flags                          = PIOS_USART_ALLOW_RECEIVE_DMA | PIOS_USART_ALLOW_TRANSMIT_DMA;
 
 			PIOS_HAL_ConfigureTbsCrossfire(usart_port_cfg, &usart_port_params, com_driver);
 			PIOS_Modules_Enable(PIOS_MODULE_UAVOCROSSFIRETELEMETRY);

--- a/flight/PiOS/STM32/inc/pios_usart_priv.h
+++ b/flight/PiOS/STM32/inc/pios_usart_priv.h
@@ -69,8 +69,25 @@ extern int32_t PIOS_USART_Init(uintptr_t * usart_id, const struct pios_usart_cfg
 extern const struct pios_usart_cfg * PIOS_USART_GetConfig(uintptr_t usart_id);
 
 #if defined(STM32F4XX)
-extern void PIOS_USART_dma_irq_tx_handler(const struct pios_usart_cfg *cfg);
-extern void PIOS_USART_dma_irq_rx_handler(const struct pios_usart_cfg *cfg);
+
+extern void PIOS_USART_1_dmarx_irq_handler(void);
+extern void PIOS_USART_1_dmatx_irq_handler(void);
+
+extern void PIOS_USART_2_dmarx_irq_handler(void);
+extern void PIOS_USART_2_dmatx_irq_handler(void);
+
+extern void PIOS_USART_3_dmarx_irq_handler(void);
+extern void PIOS_USART_3_dmatx_irq_handler(void);
+
+extern void PIOS_USART_4_dmarx_irq_handler(void);
+extern void PIOS_USART_4_dmatx_irq_handler(void);
+
+extern void PIOS_USART_5_dmarx_irq_handler(void);
+extern void PIOS_USART_5_dmatx_irq_handler(void);
+
+extern void PIOS_USART_6_dmarx_irq_handler(void);
+extern void PIOS_USART_6_dmatx_irq_handler(void);
+
 #endif
 
 #endif /* PIOS_USART_PRIV_H */

--- a/flight/PiOS/STM32/inc/pios_usart_priv.h
+++ b/flight/PiOS/STM32/inc/pios_usart_priv.h
@@ -34,6 +34,9 @@
 #include <pios_stm32.h>
 #include "pios_usart.h"
 
+#define PIOS_USART_ALLOW_RECEIVE_DMA	0x1
+#define PIOS_USART_ALLOW_TRANSMIT_DMA	0x2
+
 extern const struct pios_com_driver pios_usart_com_driver;
 
 #if defined(STM32F4XX)
@@ -63,6 +66,7 @@ struct pios_usart_params {
 	bool tx_invert;
 	bool rxtx_swap;
 	bool single_wire;
+	uint8_t flags;
 };
 
 extern int32_t PIOS_USART_Init(uintptr_t * usart_id, const struct pios_usart_cfg * cfg, struct pios_usart_params * params);

--- a/flight/PiOS/STM32/inc/pios_usart_priv.h
+++ b/flight/PiOS/STM32/inc/pios_usart_priv.h
@@ -36,12 +36,25 @@
 
 extern const struct pios_com_driver pios_usart_com_driver;
 
+#if defined(STM32F4XX)
+struct pios_usart_dma_cfg {
+	DMA_Stream_TypeDef *stream;
+	DMA_InitTypeDef init;
+	uint32_t tcif;
+	NVIC_InitTypeDef irq;
+};
+#endif
+
 struct pios_usart_cfg {
 	USART_TypeDef *regs;
 	uint32_t remap;		/* GPIO_Remap_* */
 	struct stm32_gpio rx;
 	struct stm32_gpio tx;
 	struct stm32_irq irq;
+#if defined(STM32F4XX)
+	struct pios_usart_dma_cfg *dma_send;
+	struct pios_usart_dma_cfg *dma_recv;
+#endif
 };
 
 struct pios_usart_params {
@@ -54,6 +67,11 @@ struct pios_usart_params {
 
 extern int32_t PIOS_USART_Init(uintptr_t * usart_id, const struct pios_usart_cfg * cfg, struct pios_usart_params * params);
 extern const struct pios_usart_cfg * PIOS_USART_GetConfig(uintptr_t usart_id);
+
+#if defined(STM32F4XX)
+extern void PIOS_USART_dma_irq_tx_handler(const struct pios_usart_cfg *cfg);
+extern void PIOS_USART_dma_irq_rx_handler(const struct pios_usart_cfg *cfg);
+#endif
 
 #endif /* PIOS_USART_PRIV_H */
 

--- a/flight/PiOS/STM32F4xx/pios_usart.c
+++ b/flight/PiOS/STM32F4xx/pios_usart.c
@@ -226,7 +226,7 @@ int32_t PIOS_USART_Init(uintptr_t * usart_id, const struct pios_usart_cfg * cfg,
 	// FIXME XXX Clear / reset uart here - sends NUL char else
 
 	/* Check DMA transmit configuration and prepare DMA. */
-	if (cfg->dma_send) {
+	if (cfg->dma_send && (params->flags & PIOS_USART_ALLOW_TRANSMIT_DMA)) {
 		usart_dev->dma_send_buffer = (uint32_t)PIOS_malloc(PIOS_USART_DMA_SEND_BUFFER_SZ);
 
 		if (usart_dev->dma_send_buffer) {
@@ -237,7 +237,7 @@ int32_t PIOS_USART_Init(uintptr_t * usart_id, const struct pios_usart_cfg * cfg,
 	}
 
 	/* Check DMA receive configuration, and setup and start DMA. */
-	if (cfg->dma_recv) {
+	if (cfg->dma_recv && (params->flags & PIOS_USART_ALLOW_RECEIVE_DMA)) {
 		usart_dev->dma_recv_buffer = (uint32_t)PIOS_malloc(PIOS_USART_DMA_RECV_BUFFER_SZ);
 
 		if (usart_dev->dma_recv_buffer) {

--- a/flight/PiOS/STM32F4xx/pios_usart.c
+++ b/flight/PiOS/STM32F4xx/pios_usart.c
@@ -153,6 +153,7 @@ static void PIOS_USART_6_irq_handler (void)
 	PIOS_IRQ_Epilogue();
 }
 
+
 /**
 * Initialise a single USART device
 */
@@ -435,42 +436,20 @@ static void PIOS_USART_generic_irq_handler(uintptr_t usart_id)
 	}
 }
 
-static uintptr_t PIOS_USART_GetDevice(const struct pios_usart_cfg *cfg)
+void PIOS_USART_dma_irq_tx_handler(uintptr_t usart_id)
 {
-	PIOS_Assert(cfg);
-
-	switch((uint32_t)cfg->regs) {
-		case (uint32_t)USART1:
-			return PIOS_USART_1_id;
-		case (uint32_t)USART2:
-			return PIOS_USART_2_id;
-		case (uint32_t)USART3:
-			return PIOS_USART_3_id;
-		case (uint32_t)UART4:
-			return PIOS_USART_4_id;
-		case (uint32_t)UART5:
-			return PIOS_USART_5_id;
-		case (uint32_t)USART6:
-			return PIOS_USART_6_id;
-		default:
-			return 0;
-	}
-}
-
-void PIOS_USART_dma_irq_tx_handler(const struct pios_usart_cfg *cfg)
-{
-	PIOS_IRQ_Prologue();
-
-	struct pios_usart_dev *usart_dev = (struct pios_usart_dev*)PIOS_USART_GetDevice(cfg);
+	struct pios_usart_dev *usart_dev = (struct pios_usart_dev*)usart_id;
 	if (!usart_dev)
-		goto get_out;
+		return;
 
-	struct pios_usart_dma_cfg *dmacfg = usart_dev->cfg->dma_send;
+	const struct pios_usart_cfg *cfg = usart_dev->cfg;
+
+	struct pios_usart_dma_cfg *dmacfg = cfg->dma_send;
 	PIOS_Assert(dmacfg);
 
 	if (DMA_GetFlagStatus(dmacfg->stream, dmacfg->tcif) == SET) {
 		/* TX handler*/
-		USART_DMACmd(usart_dev->cfg->regs, USART_DMAReq_Tx, DISABLE);
+		USART_DMACmd(cfg->regs, USART_DMAReq_Tx, DISABLE);
 
 		DMA_Cmd(dmacfg->stream, DISABLE);
 		while (DMA_GetCmdStatus(dmacfg->stream) == ENABLE) ;
@@ -480,20 +459,15 @@ void PIOS_USART_dma_irq_tx_handler(const struct pios_usart_cfg *cfg)
 		DMA_ClearFlag(dmacfg->stream, dmacfg->tcif);
 
 		/* Re-enable TXE interrupt, which kicks off the next data transfer, if there's stuff. */
-		USART_ITConfig(usart_dev->cfg->regs, USART_IT_TXE, ENABLE);
+		USART_ITConfig(cfg->regs, USART_IT_TXE, ENABLE);
 	}
-
-get_out:
-	PIOS_IRQ_Epilogue();
 }
 
-void PIOS_USART_dma_irq_rx_handler(const struct pios_usart_cfg *cfg)
+void PIOS_USART_dma_irq_rx_handler(uintptr_t usart_id)
 {
-	PIOS_IRQ_Prologue();
-
-	struct pios_usart_dev *usart_dev = (struct pios_usart_dev*)PIOS_USART_GetDevice(cfg);
+	struct pios_usart_dev *usart_dev = (struct pios_usart_dev*)usart_id;
 	if (!usart_dev)
-		goto get_out;
+		return;
 
 	struct pios_usart_dma_cfg *dmacfg = usart_dev->cfg->dma_recv;
 	PIOS_Assert(dmacfg);
@@ -522,8 +496,83 @@ void PIOS_USART_dma_irq_rx_handler(const struct pios_usart_cfg *cfg)
 		DMA_SetCurrDataCounter(dmacfg->stream, PIOS_USART_DMA_RECV_BUFFER_SZ);
 		DMA_Cmd(dmacfg->stream, ENABLE);
 	}
+}
 
-get_out:
+void PIOS_USART_1_dmarx_irq_handler(void)
+{
+	PIOS_IRQ_Prologue();
+	PIOS_USART_dma_irq_rx_handler(PIOS_USART_1_id);
+	PIOS_IRQ_Epilogue();
+}
+void PIOS_USART_1_dmatx_irq_handler(void)
+{
+	PIOS_IRQ_Prologue();
+	PIOS_USART_dma_irq_tx_handler(PIOS_USART_1_id);
+	PIOS_IRQ_Epilogue();
+}
+
+void PIOS_USART_2_dmarx_irq_handler(void)
+{
+	PIOS_IRQ_Prologue();
+	PIOS_USART_dma_irq_rx_handler(PIOS_USART_2_id);
+	PIOS_IRQ_Epilogue();
+}
+void PIOS_USART_2_dmatx_irq_handler(void)
+{
+	PIOS_IRQ_Prologue();
+	PIOS_USART_dma_irq_tx_handler(PIOS_USART_2_id);
+	PIOS_IRQ_Epilogue();
+}
+
+void PIOS_USART_3_dmarx_irq_handler(void)
+{
+	PIOS_IRQ_Prologue();
+	PIOS_USART_dma_irq_rx_handler(PIOS_USART_3_id);
+	PIOS_IRQ_Epilogue();
+}
+void PIOS_USART_3_dmatx_irq_handler(void)
+{
+	PIOS_IRQ_Prologue();
+	PIOS_USART_dma_irq_tx_handler(PIOS_USART_3_id);
+	PIOS_IRQ_Epilogue();
+}
+
+void PIOS_USART_4_dmarx_irq_handler(void)
+{
+	PIOS_IRQ_Prologue();
+	PIOS_USART_dma_irq_rx_handler(PIOS_USART_4_id);
+	PIOS_IRQ_Epilogue();
+}
+void PIOS_USART_4_dmatx_irq_handler(void)
+{
+	PIOS_IRQ_Prologue();
+	PIOS_USART_dma_irq_tx_handler(PIOS_USART_4_id);
+	PIOS_IRQ_Epilogue();
+}
+
+void PIOS_USART_5_dmarx_irq_handler(void)
+{
+	PIOS_IRQ_Prologue();
+	PIOS_USART_dma_irq_rx_handler(PIOS_USART_5_id);
+	PIOS_IRQ_Epilogue();
+}
+void PIOS_USART_5_dmatx_irq_handler(void)
+{
+	PIOS_IRQ_Prologue();
+	PIOS_USART_dma_irq_tx_handler(PIOS_USART_5_id);
+	PIOS_IRQ_Epilogue();
+}
+
+void PIOS_USART_6_dmarx_irq_handler(void)
+{
+	PIOS_IRQ_Prologue();
+	PIOS_USART_dma_irq_rx_handler(PIOS_USART_6_id);
+	PIOS_IRQ_Epilogue();
+}
+void PIOS_USART_6_dmatx_irq_handler(void)
+{
+	PIOS_IRQ_Prologue();
+	PIOS_USART_dma_irq_tx_handler(PIOS_USART_6_id);
 	PIOS_IRQ_Epilogue();
 }
 

--- a/flight/targets/seppuku/board-info/board_hw_defs.c
+++ b/flight/targets/seppuku/board-info/board_hw_defs.c
@@ -754,11 +754,11 @@ static const struct pios_usart_cfg pios_usart6_cfg = {
 
 void DMA2_Stream2_IRQHandler(void)
 {
-	PIOS_USART_dma_irq_rx_handler(&pios_usart6_cfg);
+	PIOS_USART_6_dmarx_irq_handler();
 }
 void DMA2_Stream7_IRQHandler(void)
 {
-	PIOS_USART_dma_irq_tx_handler(&pios_usart6_cfg);
+	PIOS_USART_6_dmatx_irq_handler();
 }
 
 #endif  /* PIOS_INCLUDE_USART */

--- a/flight/targets/seppuku/board-info/board_hw_defs.c
+++ b/flight/targets/seppuku/board-info/board_hw_defs.c
@@ -661,6 +661,60 @@ static const struct pios_usart_cfg pios_uart4_cfg = {
 	},
 };
 
+/*
+	USART6 DMA config.
+*/
+static struct pios_usart_dma_cfg pios_usart6_dma_rx_cfg = {
+	.stream = DMA2_Stream2,
+	.tcif = DMA_FLAG_TCIF2,
+	.init = {
+		/* Could probably thin out some of these, that are defined to zero anyway. */
+		.DMA_Channel = DMA_Channel_5,
+		.DMA_PeripheralBaseAddr = (uint32_t)&USART6->DR,
+		.DMA_MemoryDataSize = DMA_MemoryDataSize_Byte,
+		.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte,
+		.DMA_MemoryInc = DMA_MemoryInc_Enable,
+		.DMA_PeripheralInc =  DMA_PeripheralInc_Disable,
+		.DMA_DIR = DMA_DIR_PeripheralToMemory,
+		.DMA_Mode = DMA_Mode_Normal,
+		.DMA_Priority = DMA_Priority_High,
+		.DMA_MemoryBurst = DMA_MemoryBurst_Single,
+		.DMA_PeripheralBurst = DMA_PeripheralBurst_Single,
+		.DMA_FIFOMode = DMA_FIFOMode_Disable,
+	},
+	.irq = {
+		.NVIC_IRQChannel = DMA2_Stream2_IRQn,
+		.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_LOW,
+		.NVIC_IRQChannelSubPriority = 0,
+		.NVIC_IRQChannelCmd = ENABLE,
+	}
+};
+static struct pios_usart_dma_cfg pios_usart6_dma_tx_cfg = {
+	.stream = DMA2_Stream7,
+	.tcif = DMA_FLAG_TCIF7,
+	.init = {
+		/* Could probably thin out some of these, that are defined to zero anyway. */
+		.DMA_Channel = DMA_Channel_5,
+		.DMA_PeripheralBaseAddr = (uint32_t)&USART6->DR,
+		.DMA_MemoryDataSize = DMA_MemoryDataSize_Byte,
+		.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte,
+		.DMA_MemoryInc = DMA_MemoryInc_Enable,
+		.DMA_PeripheralInc =  DMA_PeripheralInc_Disable,
+		.DMA_DIR = DMA_DIR_MemoryToPeripheral,
+		.DMA_Mode = DMA_Mode_Normal,
+		.DMA_Priority = DMA_Priority_High,
+		.DMA_MemoryBurst = DMA_MemoryBurst_Single,
+		.DMA_PeripheralBurst = DMA_PeripheralBurst_Single,
+		.DMA_FIFOMode = DMA_FIFOMode_Disable,
+	},
+	.irq = {
+		.NVIC_IRQChannel = DMA2_Stream7_IRQn,
+		.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_LOW,
+		.NVIC_IRQChannelSubPriority = 0,
+		.NVIC_IRQChannelCmd = ENABLE,
+	}
+};
+
 static const struct pios_usart_cfg pios_usart6_cfg = {
 	.regs  = USART6,
 	.remap = GPIO_AF_USART6,
@@ -694,7 +748,18 @@ static const struct pios_usart_cfg pios_usart6_cfg = {
 		},
 		.pin_source = GPIO_PinSource6,
 	},
+	.dma_recv = &pios_usart6_dma_rx_cfg,
+	.dma_send = &pios_usart6_dma_tx_cfg
 };
+
+void DMA2_Stream2_IRQHandler(void)
+{
+	PIOS_USART_dma_irq_rx_handler(&pios_usart6_cfg);
+}
+void DMA2_Stream7_IRQHandler(void)
+{
+	PIOS_USART_dma_irq_tx_handler(&pios_usart6_cfg);
+}
 
 #endif  /* PIOS_INCLUDE_USART */
 


### PR DESCRIPTION
Current implementation switches an USART to DMA RX and/or TX, if there's an respective configuration in board_hw_defs. (Should probably add a bitfield to HwShared to knock out DMA on certain USARTs purpose.)

Test on my Revo clone, which idles at 26%, enabling 250hz fullbore logging, without DMA, it jumps to 63%, however with DMA, just to 34%. (DMA buffer size is currently configured to fixed 64 bytes.)

Using Crossfire on my Seppuku, CPU usage drops by 1.5-2% from 58% (with small dips to 57%) to 56%.

Very likely can't enable all USARTs with DMA, due to eventual stream conflicts with DShot and/or WS2811 and/or Seppuku OSD. Haven't played extensive DMA chart bingo yet. On Seppuku for instance, DMA RX on the dedicated receiver port clashes with DAC.

Can't operate multiple channels per stream without micromanaging everything, i.e. reinitializing DMA stream configuration for each transfer, and scheduling them to avoid collisions, which would require some managing infrastructure.

Not really an issue, tho, since current best use for this would just be OpenLager, from what I can tell. So we'd need theoretically just need a single USART configured for DMA TX. And document it somewhere so that users pick the right pin.

Posted for appraisal.