### PR TITLE
GCS: Allow calibration of mag on boards without internal mag

### DIFF
--- a/ground/gcs/src/plugins/config/configattitudewidget.h
+++ b/ground/gcs/src/plugins/config/configattitudewidget.h
@@ -75,12 +75,9 @@ private:
 
     QMap<QString, UAVObject::Metadata> originalMetaData;
 
-    bool board_has_accelerometer;
-    bool board_has_magnetometer;
-
 private slots:
     //! Overriden method from the configTaskWidget to update UI
-    virtual void refreshWidgetsValues(UAVObject *obj = NULL);
+    virtual void refreshWidgetsValues(UAVObject *obj = nullptr);
 
     //! Display the plane in various positions
     void displayPlane(int i);
@@ -89,6 +86,7 @@ private slots:
     void do_SetDirty();
     void configureSixPoint();
     void onCalibrationBusy(bool busy);
+    void updateCalibrationEnabled();
 };
 
 #endif // CONFIGATTITUDEWIDGET_H

--- a/ground/gcs/src/plugins/config/configattitudewidget.h
+++ b/ground/gcs/src/plugins/config/configattitudewidget.h
@@ -45,6 +45,7 @@
 #include <QGraphicsSvgItem>
 #include <QList>
 #include <QTimer>
+#include <memory>
 
 class Ui_Widget;
 
@@ -63,7 +64,7 @@ protected:
     Calibration calibration;
 
 private:
-    Ui_AttitudeWidget *m_ui;
+    std::unique_ptr<Ui_AttitudeWidget> m_ui;
     QGraphicsSvgItem *paperplane;
 
     int phaseCounter;


### PR DESCRIPTION
To determine if there is a mag, we check if the Magnetometer object is present, and if so, whether any of the fields have been changed since boot (non-default). Also fixed a memory leak.

Supersedes #1908 
Fixes #1896 