### PR TITLE
stm32f0: rtc: change frequency to match other targets

### DIFF
--- a/flight/PiOS/STM32F0xx/pios_delay.c
+++ b/flight/PiOS/STM32F0xx/pios_delay.c
@@ -32,9 +32,9 @@
 /* Project Includes */
 #include <pios.h>
 
-/* This will result in a value like 39062 -- about 16 bits */
-#define SYSTICK_HZ 1024
-#define RTC_DIVIDER 4	/* Must be power of 2; this results in 256Hz "RTC" */
+/* This will result in a value of 32000 -- about 15 bits */
+#define SYSTICK_HZ 1250
+#define RTC_DIVIDER 2	/* Must be power of 2; this results in 625Hz "RTC" */
 
 #define PIOS_RTC_MAX_CALLBACKS 3
 


### PR DESCRIPTION
This may solve PPM-related problems on flyingpi.

Untested.  Hat tip @jihlein for the question on IRC, which made me think of the supervisor-- I hadn't realized that PPM "started working eventually".