### PR TITLE
telemetrymonitor: ensure we retrieve firmwareiap

### DIFF
--- a/ground/gcs/src/plugins/uavtalk/telemetrymonitor.cpp
+++ b/ground/gcs/src/plugins/uavtalk/telemetrymonitor.cpp
@@ -153,7 +153,7 @@ void TelemetryMonitor::startRetrievingObjects()
                 continue;
             }
             queue.enqueue(dobj->getMetaObject());
-            if (dobj->isSettings()) {
+            if (dobj->isSettings() || (dobj->getObjID() == FirmwareIAPObj::OBJID)) {
                 TELEMETRYMONITOR_QXTLOG_DEBUG(
                     QString("%0 queing settings object %1").arg(Q_FUNC_INFO).arg(dobj->getName()));
                 queue.enqueue(obj);


### PR DESCRIPTION
Before, nothing guaranteed we'd get it.  It telemetered only on change
(which only helps you if you are connected *very* early), and it's not a
settings object so we didn't retrieve it at the beginning of a session.

fixes #2047