### PR TITLE
GCS:crashreporter: Fix git version info

### DIFF
--- a/ground/gcs/src/crashreporterapp/crashreporterapp.pro
+++ b/ground/gcs/src/crashreporterapp/crashreporterapp.pro
@@ -30,7 +30,9 @@ GIT_TAG    = $$system(git name-rev --tags --name-only --no-undefined HEAD 2>/dev
 GIT_DIRTY  = true
 system(git diff-index --quiet HEAD --): GIT_DIRTY = false
 
-DEFINES += GIT_COMMIT=\\\"$$GIT_COMMIT\\\" \
-           GIT_BRANCH=\\\"$$GIT_BRANCH\\\" \
-           GIT_TAG=\\\"$$GIT_TAG\\\" \
-           GIT_DIRTY=\\\"$$GIT_DIRTY\\\"
+VERSION_INFO = $$cat($$system_path($$PWD/version.template.h), blob)
+VERSION_INFO = $$replace(VERSION_INFO, __COMMIT__, $$GIT_COMMIT)
+VERSION_INFO = $$replace(VERSION_INFO, __BRANCH__, $$GIT_BRANCH)
+VERSION_INFO = $$replace(VERSION_INFO, __TAG__, $$GIT_TAG)
+VERSION_INFO = $$replace(VERSION_INFO, __DIRTY__, $$GIT_DIRTY)
+write_file($$OUT_PWD/version.h, VERSION_INFO)

--- a/ground/gcs/src/crashreporterapp/crashreporterapp.pro
+++ b/ground/gcs/src/crashreporterapp/crashreporterapp.pro
@@ -25,11 +25,10 @@ RESOURCES += \
 # TODO: should really use the GCS revision rather than crashreporterapp
 # (it is possible to build it seperately, then the results are misleading)
 GIT_COMMIT = $$system(git rev-parse -q --short HEAD)
-GIT_BRANCH = $$system(git for-each-ref --count=1 --format=$$system_quote(%(refname:strip=2)) --contains HEAD refs/heads)
-GIT_TAG    = $$system(git for-each-ref --count=1 --format=$$system_quote(%(refname:strip=2)) --points-at HEAD refs/tags)
-GIT_DIFF   = $$system(git status --porcelain)
+GIT_BRANCH = $$system(git symbolic-ref -q --short HEAD)
+GIT_TAG    = $$system(git name-rev --tags --name-only --no-undefined HEAD 2>/dev/null)
 GIT_DIRTY  = true
-isEmpty(GIT_DIFF): GIT_DIRTY = false
+system(git diff-index --quiet HEAD --): GIT_DIRTY = false
 
 DEFINES += GIT_COMMIT=\\\"$$GIT_COMMIT\\\" \
            GIT_BRANCH=\\\"$$GIT_BRANCH\\\" \

--- a/ground/gcs/src/crashreporterapp/mainwindow.cpp
+++ b/ground/gcs/src/crashreporterapp/mainwindow.cpp
@@ -35,11 +35,13 @@
 #include <QtNetwork/QtNetwork>
 #include <QSysInfo>
 
-const QString MainWindow::postUrl = QString("http://dronin-autotown.appspot.com/storeCrash");
-const QString MainWindow::gitCommit = QString(GIT_COMMIT);
-const QString MainWindow::gitBranch = QString(GIT_BRANCH);
+#include "version.h"
+
+const QString MainWindow::postUrl = QStringLiteral("http://dronin-autotown.appspot.com/storeCrash");
+const QString MainWindow::gitCommit = QStringLiteral(GIT_COMMIT);
+const QString MainWindow::gitBranch = QStringLiteral(GIT_BRANCH);
 const bool MainWindow::gitDirty = GIT_DIRTY;
-const QString MainWindow::gitTag = QString(GIT_TAG);
+const QString MainWindow::gitTag = QStringLiteral(GIT_TAG);
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),

--- a/ground/gcs/src/crashreporterapp/version.template.h
+++ b/ground/gcs/src/crashreporterapp/version.template.h
@@ -1,0 +1,9 @@
+#ifndef __VERSION_H__
+#define __VERSION_H__
+
+#define GIT_COMMIT "__COMMIT__"
+#define GIT_BRANCH "__BRANCH__"
+#define GIT_TAG "__TAG__"
+#define GIT_DIRTY __DIRTY__
+
+#endif


### PR DESCRIPTION
- Hopefully make it work with the ancient git version on the mac builder, whilst sticking with plumbing commands
- Force mainwindow.cpp to recompile (unfortunately always for now)
    - Previously the version info only changed if crashreporterapp was rebuilt for some other reason

Fixes #1767