### PR TITLE
Flight:Airspeed: Add option to use raw ADC value

### DIFF
--- a/flight/Modules/Airspeed/airspeed.c
+++ b/flight/Modules/Airspeed/airspeed.c
@@ -93,7 +93,7 @@
 static struct pios_thread *taskHandle;
 static bool module_enabled = false;
 volatile bool gpsNew = false;
-volatile bool settingsUpdated = false;
+volatile bool settingsUpdated = true;
 static uint8_t airspeedSensorType;
 static uint16_t gpsSamplePeriod_ms;
 

--- a/flight/Modules/Airspeed/airspeed.c
+++ b/flight/Modules/Airspeed/airspeed.c
@@ -82,7 +82,6 @@
 #define GPS_AIRSPEED_BIAS_KP                   0.01f //Needs to be settable in a UAVO
 #define GPS_AIRSPEED_BIAS_KI                   0.01f //Needs to be settable in a UAVO
 #define GPS_AIRSPEED_TIME_CONSTANT_MS        500.0f  //Needs to be settable in a UAVO
-#define BARO_TRUEAIRSPEED_TIME_CONSTANT_S      1.0f  //Needs to be settable in a UAVO
 
 #define BARO_TEMPERATURE_OFFSET 5
 
@@ -95,6 +94,7 @@ volatile bool gpsNew = false;
 volatile bool settingsUpdated = true;
 static uint8_t airspeedSensorType;
 static uint16_t gpsSamplePeriod_ms;
+static float tasFilterTau = 0.1f;
 
 #ifdef BARO_AIRSPEED_PRESENT
 static int8_t airspeedADCPin = -1;
@@ -133,6 +133,7 @@ static void doSettingsUpdate()
 
 	airspeedSensorType = settings.AirspeedSensorType;
 	gpsSamplePeriod_ms = settings.GPSSamplePeriod_ms;
+	tasFilterTau = settings.TASFilterTau;
 
 #if defined(PIOS_INCLUDE_MPXV7002)
 	if (airspeedSensorType==AIRSPEEDSETTINGS_AIRSPEEDSENSORTYPE_DIYDRONESMPXV7002) {
@@ -349,7 +350,7 @@ static void airspeedTask(void *parameters)
  #ifdef BARO_AIRSPEED_PRESENT
 		else if (airspeedData.BaroConnected==BAROAIRSPEED_BAROCONNECTED_TRUE) {
 			//No GPS velocity estimate this loop, so filter true airspeed data with baro airspeed
-			float alpha = delT/(delT + BARO_TRUEAIRSPEED_TIME_CONSTANT_S); //Low pass filter.
+			float alpha = delT/(delT + tasFilterTau); //Low pass filter.
 			airspeedData.TrueAirspeed = airspeed_tas_baro*(alpha) + airspeedData.TrueAirspeed*(1.0f-alpha);
 		}
  #endif

--- a/flight/Modules/Airspeed/airspeed.c
+++ b/flight/Modules/Airspeed/airspeed.c
@@ -60,7 +60,7 @@
  #define GPS_AIRSPEED_PRESENT
 #endif
 
-#if defined (PIOS_INCLUDE_MPXV5004) || defined (PIOS_INCLUDE_MPXV7002) || defined (PIOS_INCLUDE_ETASV3)
+#if defined (PIOS_INCLUDE_MPXV5004) || defined (PIOS_INCLUDE_MPXV7002) || defined (PIOS_INCLUDE_ETASV3) || defined(PIOS_INCLUDE_ADC)
  #define BARO_AIRSPEED_PRESENT
 #endif
 
@@ -371,7 +371,7 @@ void baro_airspeedGet(BaroAirspeedData *baroAirspeedData, uint32_t *lastSysTime,
 	switch (airspeedSensorType) {
 		case AIRSPEEDSETTINGS_AIRSPEEDSENSORTYPE_DIYDRONESMPXV7002:
 		case AIRSPEEDSETTINGS_AIRSPEEDSENSORTYPE_DIYDRONESMPXV5004:
-			//MPXV5004 and MPXV7002 sensors
+		case AIRSPEEDSETTINGS_AIRSPEEDSENSORTYPE_RAWANALOG:
 			baro_airspeedGetAnalog(baroAirspeedData, lastSysTime, airspeedSensorType, airspeedADCPin);
 			break;
 		case AIRSPEEDSETTINGS_AIRSPEEDSENSORTYPE_EAGLETREEAIRSPEEDV3:

--- a/flight/Modules/Airspeed/airspeed.c
+++ b/flight/Modules/Airspeed/airspeed.c
@@ -287,7 +287,7 @@ static void airspeedTask(void *parameters)
 		float delT = (lastSysTime - lastLoopTime) / 1000.0f;
 		lastLoopTime = lastSysTime;
 		if ( ((lastSysTime - lastGPSTime) > 1000 || airspeedSensorType==AIRSPEEDSETTINGS_AIRSPEEDSENSORTYPE_GPSONLY)
-				&& gpsNew) {
+				&& gpsNew && airspeedSensorType != AIRSPEEDSETTINGS_AIRSPEEDSENSORTYPE_RAWANALOG) {
 			lastGPSTime = lastSysTime;
  #else
 		if (gpsNew) {

--- a/flight/Modules/Airspeed/airspeed.c
+++ b/flight/Modules/Airspeed/airspeed.c
@@ -196,7 +196,6 @@ int32_t AirspeedInitialize()
 }
 MODULE_INITCALL(AirspeedInitialize, AirspeedStart);
 
-
 /**
  * Module thread, should not return.
  */
@@ -204,14 +203,18 @@ static void airspeedTask(void *parameters)
 {
 	BaroAirspeedData airspeedData;
 	AirspeedActualData airspeedActualData;
+
+#ifdef BARO_AIRSPEED_PRESENT
+	float airspeedErrInt=0;
 	
-#ifdef BARO_AIRSPEED_PRESENT		
+#ifdef GPS_AIRSPEED_PRESENT
 	uint32_t lastGPSTime = PIOS_Thread_Systime(); //Time since last GPS-derived airspeed calculation
 	uint32_t lastLoopTime= PIOS_Thread_Systime(); //Time since last loop
-
-	float airspeedErrInt=0;
+	float airspeed_tas_baro=0;
 #endif
-	
+
+#endif
+
 	//GPS airspeed calculation variables
 #ifdef GPS_AIRSPEED_PRESENT
 	GPSVelocityConnectCallbackCtx(UAVObjCbSetFlag, &gpsNew);
@@ -240,8 +243,6 @@ static void airspeedTask(void *parameters)
 		}
 
 #ifdef BARO_AIRSPEED_PRESENT
-		float airspeed_tas_baro=0;
-		
 		if(airspeedSensorType != AIRSPEEDSETTINGS_AIRSPEEDSENSORTYPE_GPSONLY) {
 			//Fetch calibrated airspeed from sensors
 			baro_airspeedGet(&airspeedData, &lastSysTime, airspeedSensorType, airspeedADCPin);

--- a/flight/Modules/Airspeed/baro_airspeed_analog.c
+++ b/flight/Modules/Airspeed/baro_airspeed_analog.c
@@ -124,6 +124,10 @@ void baro_airspeedGetAnalog(BaroAirspeedData *baroAirspeedData, uint32_t *lastSy
 		//not. This is something that will have to change on the ADC side of things.
 		baroAirspeedData->SensorValue=PIOS_MPXV5004_Measure(airspeedADCPin);
 
+	} else if (airspeedSensorType == AIRSPEEDSETTINGS_AIRSPEEDSENSORTYPE_RAWANALOG) {
+		// will return raw ADC reading in mV (typically in range [0, 3300])
+		calibratedAirspeed = PIOS_ADC_GetChannelRaw(airspeedADCPin);
+		baroAirspeedData->SensorValue = calibratedAirspeed;
 	}
 	//Filter CAS
 	float alpha=SAMPLING_DELAY_MS_MPXV/(SAMPLING_DELAY_MS_MPXV + ANALOG_BARO_AIRSPEED_TIME_CONSTANT_MS); //Low pass filter.

--- a/flight/Modules/Airspeed/baro_airspeed_analog.c
+++ b/flight/Modules/Airspeed/baro_airspeed_analog.c
@@ -40,7 +40,7 @@
 #include "baroairspeed.h"	// object that will be updated by the module
 #include "pios_thread.h"
 
-#if defined(PIOS_INCLUDE_MPXV7002) || defined (PIOS_INCLUDE_MPXV5004)
+#if defined(PIOS_INCLUDE_MPXV7002) || defined (PIOS_INCLUDE_MPXV5004) || defined (PIOS_INCLUDE_ADC)
 
 #define SAMPLING_DELAY_MS_MPXV                  10     //Update at 100Hz
 #define CALIBRATION_IDLE_MS                     2000   //Time to wait before calibrating, in [ms]
@@ -76,6 +76,7 @@ void baro_airspeedGetAnalog(BaroAirspeedData *baroAirspeedData, uint32_t *lastSy
 		calibrationCount++; /*DO NOT MOVE FROM BEFORE sensorCalibration=... LINE, OR ELSE WILL HAVE DIVIDE BY ZERO */
 
 		uint16_t sensorCalibration;
+#if defined(PIOS_INCLUDE_MPXV7002) || defined (PIOS_INCLUDE_MPXV5004) 
 		if(airspeedSensorType==AIRSPEEDSETTINGS_AIRSPEEDSENSORTYPE_DIYDRONESMPXV7002){
 		sensorCalibration=PIOS_MPXV7002_Calibrate(airspeedADCPin, calibrationCount-CALIBRATION_IDLE_MS/SAMPLING_DELAY_MS_MPXV);
 		PIOS_MPXV7002_UpdateCalibration(sensorCalibration); //This makes sense for the user if the initial calibration was not good and the user does not wish to reboot.
@@ -84,6 +85,7 @@ void baro_airspeedGetAnalog(BaroAirspeedData *baroAirspeedData, uint32_t *lastSy
 		sensorCalibration=PIOS_MPXV5004_Calibrate(airspeedADCPin, calibrationCount-CALIBRATION_IDLE_MS/SAMPLING_DELAY_MS_MPXV);
 		PIOS_MPXV5004_UpdateCalibration(sensorCalibration); //This makes sense for the user if the initial calibration was not good and the user does not wish to reboot.
 		}
+#endif
 
 
 		baroAirspeedData->BaroConnected = BAROAIRSPEED_BAROCONNECTED_TRUE;
@@ -97,6 +99,7 @@ void baro_airspeedGetAnalog(BaroAirspeedData *baroAirspeedData, uint32_t *lastSy
 
 	//Get CAS
 	float calibratedAirspeed=0;
+#if defined(PIOS_INCLUDE_MPXV7002) || defined (PIOS_INCLUDE_MPXV5004) 
 	if(airspeedSensorType==AIRSPEEDSETTINGS_AIRSPEEDSENSORTYPE_DIYDRONESMPXV7002){
 		calibratedAirspeed = PIOS_MPXV7002_ReadAirspeed(airspeedADCPin);
 		if (calibratedAirspeed < 0) //This only occurs when there's a bad ADC reading.
@@ -124,6 +127,9 @@ void baro_airspeedGetAnalog(BaroAirspeedData *baroAirspeedData, uint32_t *lastSy
 		//not. This is something that will have to change on the ADC side of things.
 		baroAirspeedData->SensorValue=PIOS_MPXV5004_Measure(airspeedADCPin);
 
+#else
+	if (false) {
+#endif
 	} else if (airspeedSensorType == AIRSPEEDSETTINGS_AIRSPEEDSENSORTYPE_RAWANALOG) {
 		// will return raw ADC reading in mV (typically in range [0, 3300])
 		calibratedAirspeed = PIOS_ADC_GetChannelRaw(airspeedADCPin);

--- a/flight/PiOS/STM32F4xx/pios_internal_adc.c
+++ b/flight/PiOS/STM32F4xx/pios_internal_adc.c
@@ -83,8 +83,7 @@ const struct pios_adc_driver pios_internal_adc_driver = {
 };
 
 struct adc_accumulator {
-	uint32_t		accumulator;
-	uint32_t		count;
+	volatile uint32_t		accumulator, count;
 };
 
 // Buffers to hold the ADC data
@@ -296,7 +295,8 @@ static int32_t PIOS_INTERNAL_ADC_PinGet(uintptr_t internal_adc_id, uint32_t pin)
 	}
 
 	/* return accumulated result and clear accumulator */
-	result = accumulator[pin].accumulator / (accumulator[pin].count ?: 1);
+	result = accumulator[pin].accumulator /
+		(accumulator[pin].count ? accumulator[pin].count : 1);
 	accumulator[pin].accumulator = result;
 	accumulator[pin].count = 1;
 
@@ -321,7 +321,7 @@ static inline void accumulate(uint16_t *buffer, uint32_t count)
 	 */
 	while (count--) {
 		for (int i = 0; i < pios_adc_dev->cfg->adc_pin_count; i++) {
-			accumulator[i].accumulator += *sp++;
+			accumulator[i].accumulator += *(sp++);
 			accumulator[i].count++;
 			/*
 			 * If the accumulator reaches half-full, rescale in order to

--- a/shared/uavobjectdefinition/airspeedsettings.xml
+++ b/shared/uavobjectdefinition/airspeedsettings.xml
@@ -14,6 +14,9 @@
     <field defaultvalue="1.0" elements="1" name="Scale" type="float" units="raw">
       <description>Scale factor which is used to scale the airspeed coming from the airspeed sensor</description>
     </field>
+    <field defaultvalue="0.1" elements="1" name="TASFilterTau" type="float" units="s">
+      <description>Time constant for TAS filter</description>
+    </field>
     <field defaultvalue="GPSOnly" elements="1" name="AirspeedSensorType" type="enum" units="">
       <description>The type of airspeed sensor connected</description>
       <options>

--- a/shared/uavobjectdefinition/airspeedsettings.xml
+++ b/shared/uavobjectdefinition/airspeedsettings.xml
@@ -21,6 +21,7 @@
         <option>DIYDronesMPXV5004</option>
         <option>DIYDronesMPXV7002</option>
         <option>GPSOnly</option>
+        <option>Raw Analog</option>
       </options>
     </field>
     <field defaultvalue="NONE" elements="1" name="AnalogPin" type="enum" units="">


### PR DESCRIPTION
Can be "borrowed" for other use-cases, already plumbed through telemetry layers etc. Requested by IRC user us1m41 for his wind angle sensor.