### PR TITLE
CharOSD: Fix display of AcroDyne flight mode

### DIFF
--- a/flight/Modules/CharacterOSD/charosd.h
+++ b/flight/Modules/CharacterOSD/charosd.h
@@ -38,6 +38,7 @@
 
 #include "attitudeactual.h"
 #include "flightbatterystate.h"
+#include "flightstatus.h"
 #include "gpsposition.h"
 #include "positionactual.h"
 #include "velocityactual.h"
@@ -53,8 +54,8 @@ typedef struct {
 		float thrust;
 	} manual;
 	struct {
-		uint8_t arm_status;
-		uint8_t mode;
+		FlightStatusArmedOptions arm_status;
+		SharedDefsFlightModeOptions mode;
 	} flight_status;
 	struct {
 		uint32_t flight_time;

--- a/flight/Modules/CharacterOSD/panel.c
+++ b/flight/Modules/CharacterOSD/panel.c
@@ -207,6 +207,9 @@ static void FLIGHTMODE_update(charosd_state_t state, uint8_t x, uint8_t y)
 	case FLIGHTSTATUS_FLIGHTMODE_PATHPLANNER:
 		mode = "PLAN";
 		break;
+	case FLIGHTSTATUS_FLIGHTMODE_ACRODYNE:
+		mode = "ACDN";
+		break;
 	case FLIGHTSTATUS_FLIGHTMODE_FAILSAFE:
 		mode = "FAIL";
 		break;


### PR DESCRIPTION
Use the actual enum types instead of uint8 so the compiler can figure out when a case is missing next time.

Fixes #2065 