### PR TITLE
agcs: bump versions for Wired

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -459,11 +459,9 @@ androidgcs_sign:
 # Supply the git hashes of all recent releases here.  Note if UAVOs do not
 # change in a hotfix the release does not need to be listed here.
 UAVO_GIT_VERSIONS := HEAD \
+	Release-20180212 \
 	Release-20170717 \
 	Release-20170213 \
-	Release-20161004.1 \
-	Release-20160720.1 \
-	Release-20160409.2 \
 	$(shell git log --merges --pretty=tformat:%h -n 18 shared/uavobjectdefinition/)
 
 # All versions includes a pseudo collection called "working" which represents

--- a/androidgcs/AndroidManifest.xml
+++ b/androidgcs/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="org.dronin.androidgcs" android:versionCode="20170826"
-	android:versionName="Neat-1">
+	package="org.dronin.androidgcs" android:versionCode="20180212"
+	android:versionName="Wired">
 	<uses-sdk android:minSdkVersion="14" android:targetSdkVersion="19"/>
 
 	<uses-feature


### PR DESCRIPTION
Also remove support for all versions older than artifice.