### PR TITLE
release tools: properly tag udev rules

### DIFF
--- a/package/release-asset-info.py
+++ b/package/release-asset-info.py
@@ -84,6 +84,8 @@ def main():
             label = "Windows (installer)"
         elif name.endswith('.dmg'):
             label = "macOS"
+        elif name.endswith('.udev'):
+            label = "Linux udev rules"
         else:
             label = name
         asset['new_label'] = label


### PR DESCRIPTION
Helpful for forthcoming releases, if we keep putting udev rules in the
artifacts like this.