### PR TITLE
pios: fix semicolons and assert statements

### DIFF
--- a/flight/PiOS/STM32/pios_i2c.c
+++ b/flight/PiOS/STM32/pios_i2c.c
@@ -225,7 +225,7 @@ static void i2c_adapter_reset_bus(struct pios_i2c_adapter *i2c_adapter)
 int32_t PIOS_I2C_CheckClear(pios_i2c_t i2c_adapter)
 {
 	bool valid = PIOS_I2C_validate(i2c_adapter);
-	PIOS_Assert(valid)
+	PIOS_Assert(valid);
 
 	if (PIOS_Mutex_Lock(i2c_adapter->lock, 0) == false)
 		return -1;
@@ -293,7 +293,7 @@ out_fail:
 int32_t PIOS_I2C_Transfer(pios_i2c_t i2c_adapter, const struct pios_i2c_txn txn_list[], uint32_t num_txns)
 {
 	bool valid = PIOS_I2C_validate(i2c_adapter);
-	PIOS_Assert(valid)
+	PIOS_Assert(valid);
 
 	PIOS_DEBUG_Assert(txn_list);
 	PIOS_DEBUG_Assert(num_txns);
@@ -986,7 +986,7 @@ void PIOS_I2C_EV_IRQ_Handler(pios_i2c_t i2c_adapter)
 {
 	PIOS_IRQ_Prologue();
 
-	PIOS_Assert(PIOS_I2C_validate(i2c_adapter) == true)
+	PIOS_Assert(PIOS_I2C_validate(i2c_adapter) == true);
 
 	bool woken = false;
 
@@ -1070,7 +1070,7 @@ void PIOS_I2C_ER_IRQ_Handler(pios_i2c_t i2c_adapter)
 	PIOS_IRQ_Prologue();
 
 	bool valid = PIOS_I2C_validate(i2c_adapter);
-	PIOS_Assert(valid)
+	PIOS_Assert(valid);
 
 	bool woken = false;
 

--- a/flight/PiOS/STM32/pios_spi.c
+++ b/flight/PiOS/STM32/pios_spi.c
@@ -228,7 +228,7 @@ int32_t PIOS_SPI_SetClockSpeed(pios_spi_t spi_dev, uint32_t spi_speed)
 int32_t PIOS_SPI_ClaimBus(pios_spi_t spi_dev)
 {
 	bool valid = PIOS_SPI_validate(spi_dev);
-	PIOS_Assert(valid)
+	PIOS_Assert(valid);
 
 	if (PIOS_Semaphore_Take(spi_dev->busy, PIOS_SEMAPHORE_TIMEOUT_MAX) != true)
 		return -1;
@@ -239,7 +239,7 @@ int32_t PIOS_SPI_ClaimBus(pios_spi_t spi_dev)
 int32_t PIOS_SPI_ReleaseBus(pios_spi_t spi_dev)
 {
 	bool valid = PIOS_SPI_validate(spi_dev);
-	PIOS_Assert(valid)
+	PIOS_Assert(valid);
 
 	PIOS_Semaphore_Give(spi_dev->busy);
 
@@ -249,8 +249,8 @@ int32_t PIOS_SPI_ReleaseBus(pios_spi_t spi_dev)
 int32_t PIOS_SPI_RC_PinSet(pios_spi_t spi_dev, uint32_t slave_id, bool pin_value)
 {
 	bool valid = PIOS_SPI_validate(spi_dev);
-	PIOS_Assert(valid)
-	PIOS_Assert(slave_id <= spi_dev->cfg->slave_count)
+	PIOS_Assert(valid);
+	PIOS_Assert(slave_id <= spi_dev->cfg->slave_count);
 
 	if (pin_value) {
 		GPIO_SetBits(spi_dev->cfg->ssel[slave_id].gpio, spi_dev->cfg->ssel[slave_id].init.GPIO_Pin);
@@ -264,7 +264,7 @@ int32_t PIOS_SPI_RC_PinSet(pios_spi_t spi_dev, uint32_t slave_id, bool pin_value
 uint8_t PIOS_SPI_TransferByte(pios_spi_t spi_dev, uint8_t b)
 {
 	bool valid = PIOS_SPI_validate(spi_dev);
-	PIOS_Assert(valid)
+	PIOS_Assert(valid);
 
 	uint8_t rx_byte;
 
@@ -315,7 +315,7 @@ static int32_t SPI_PIO_TransferBlock(pios_spi_t spi_dev,
 	uint8_t b;
 
 	bool valid = PIOS_SPI_validate(spi_dev);
-	PIOS_Assert(valid)
+	PIOS_Assert(valid);
 
 	while (len--) {
 		/* get the byte to send */

--- a/flight/PiOS/STM32F30x/pios_flash_internal.c
+++ b/flight/PiOS/STM32F30x/pios_flash_internal.c
@@ -156,7 +156,7 @@ static int32_t PIOS_Flash_Internal_ReadData(uintptr_t chip_id, uint32_t chip_off
 static int32_t PIOS_Flash_Internal_WriteData(uintptr_t chip_id, uint32_t chip_offset, const uint8_t *data, uint16_t len)
 {
 	PIOS_Assert(data);
-	PIOS_Assert((chip_offset & 0x0001) == 0)
+	PIOS_Assert((chip_offset & 0x0001) == 0);
 
 	struct pios_internal_flash_dev *flash_dev = (struct pios_internal_flash_dev *)chip_id;
 

--- a/flight/PiOS/inc/pios_debug.h
+++ b/flight/PiOS/inc/pios_debug.h
@@ -45,11 +45,11 @@ void PIOS_DEBUG_PinValue4BitL(uint8_t value);
 void PIOS_DEBUG_Panic(const char *msg) __attribute__((noreturn));
 
 #ifdef DEBUG
-#define PIOS_DEBUG_Assert(test) if (!(test)) PIOS_DEBUG_Panic(PIOS_DEBUG_AssertMsg);
+#define PIOS_DEBUG_Assert(test) do { if (!(test)) PIOS_DEBUG_Panic(PIOS_DEBUG_AssertMsg); } while (0)
 #define PIOS_Assert(test) PIOS_DEBUG_Assert(test)
 #else
-#define PIOS_DEBUG_Assert(test)
-#define PIOS_Assert(test) if (!(test)) while (1);
+#define PIOS_DEBUG_Assert(test) do { } while(0)
+#define PIOS_Assert(test) do { if (!(test)) while (1); } while (0)
 #endif
 
 #endif /* PIOS_DEBUG_H */


### PR DESCRIPTION
Prevents confusion or problems with any future implementations of
assert.