### PR TITLE
Flight: Make ccache separate BUILD_CONFIG option as for GCS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ include $(ROOT_DIR)/flight/targets/*/target-defs.mk
 GCS_BUILD_CONF ?= debug ccache
 
 # And the flight build configuration (debug | default | release)
-export FLIGHT_BUILD_CONF ?= default
+export FLIGHT_BUILD_CONF ?= default ccache
 
 # Paths
 UAVOBJ_XML_DIR := $(ROOT_DIR)/shared/uavobjectdefinition
@@ -100,16 +100,6 @@ ifdef GCS_BUILD_CONF
  ifneq ($(filter release, $(GCS_BUILD_CONF)), release)
   ifneq ($(filter debug, $(GCS_BUILD_CONF)), debug)
    $(error Either debug or release are required for GCS_BUILD_CONF)
-  endif
- endif
-endif
-
-ifdef FLIGHT_BUILD_CONF
- ifneq ($(FLIGHT_BUILD_CONF), release)
-  ifneq ($(FLIGHT_BUILD_CONF), debug)
-   ifneq ($(FLIGHT_BUILD_CONF), default)
-    $(error Only debug or release are allowed for FLIGHT_BUILD_CONF)
-   endif
   endif
  endif
 endif

--- a/make/firmware-defs.mk
+++ b/make/firmware-defs.mk
@@ -32,17 +32,18 @@ endif
 TCHAIN_PREFIX ?= arm-none-eabi-
 
 CCACHE :=
+ifeq ($(filter ccache, $(FLIGHT_BUILD_CONF)), ccache)
+  CCACHE := $(CCACHE_BIN)
+endif
 
-ifeq ($(FLIGHT_BUILD_CONF), debug)
-export DEBUG:=YES
-CCACHE := $(CCACHE_BIN)
-else ifeq ($(FLIGHT_BUILD_CONF), default)
-# In the default case, keep the old "DEBUG"  variable handling
-CCACHE := $(CCACHE_BIN)
-else ifeq ($(FLIGHT_BUILD_CONF), release)
-export DEBUG:=NO
+ifeq ($(filter release, $(FLIGHT_BUILD_CONF)), release)
+  export DEBUG:=NO
+else ifeq ($(filter debug, $(FLIGHT_BUILD_CONF)), debug)
+  export DEBUG:=YES
+else ifeq ($(filter default, $(FLIGHT_BUILD_CONF)), default)
+  # In the default case, keep the old "DEBUG"  variable handling
 else
-$(error Only debug, release, or default allowed for FLIGHT_BUILD_CONF)
+  $(error Only debug, release, or default allowed for FLIGHT_BUILD_CONF)
 endif
 
 # Define toolchain component names.


### PR DESCRIPTION
Default action if FLIGHT_BUILD_CONF is unspecified is the same as before, and also FLIGHT_BUILD_CONF=release is the same. debug/default config on their own will not use ccache.