### PR TITLE
flightD: Fix external mag

### DIFF
--- a/flight/PiOS/posix/pios_sys.c
+++ b/flight/PiOS/posix/pios_sys.c
@@ -464,7 +464,7 @@ void PIOS_SYS_Args(int argc, char *argv[]) {
 
 	bool first_arg = true;
 
-	while ((opt = getopt(argc, argv, "yfrx:g:l:s:d:S:I:i:")) != -1) {
+	while ((opt = getopt(argc, argv, "yfrx:g:l:s:d:S:I:i:m:")) != -1) {
 		switch (opt) {
 #ifdef PIOS_INCLUDE_SIMSENSORS_YASIM
 			case 'y':
@@ -528,6 +528,7 @@ void PIOS_SYS_Args(int argc, char *argv[]) {
 					printf("Invalid mag orientation\n");
 					exit(1);
 				}
+				break;
 			}
 			case 'I':
 			{


### PR DESCRIPTION
Couple of small fixes to get external mag functioning on flightD/flyingPio.  Bench tested with an HMC5883 using the following commands:

./build/flightd/flightd -r -m 0 -s /dev/spidev0 -d ms5611:0:4 -d bmx055:0:1 -d flyingpio:0:0 -I /dev/i2c-1 -i hmc5883:0

and

./build/flightd/flightd -r -m 1 -s /dev/spidev0 -d ms5611:0:4 -d bmx055:0:1 -d flyingpio:0:0 -I /dev/i2c-1 -i hmc5883:0

The magnetometer x and y uavo's changed appropriately between the two execution commands.