### PR TITLE
flightd/posix: swap telem ids

### DIFF
--- a/flight/PiOS/posix/pios_sys.c
+++ b/flight/PiOS/posix/pios_sys.c
@@ -217,7 +217,7 @@ static int handle_serial_device(const char *optarg) {
 		PIOS_Modules_Enable(PIOS_MODULE_UAVOLIGHTTELEMETRYBRIDGE);
 		PIOS_COM_LIGHTTELEMETRY = com_id;
 	} else if (!strcmp(drv_name, "telemetry")) {
-		PIOS_COM_TELEM_USB = com_id;
+		PIOS_COM_TELEM_RF = com_id;
 #ifdef PIOS_INCLUDE_OMNIP
 	} else if (!strcmp(drv_name, "omnip")) {
 		omnip_dev_t dontcare;

--- a/flight/targets/flightd/fw/pios_board.c
+++ b/flight/targets/flightd/fw/pios_board.c
@@ -59,8 +59,8 @@ const struct pios_tcp_cfg pios_tcp_telem_cfg = {
   .port = 9000,
 };
 
-#define PIOS_COM_TELEM_RF_RX_BUF_LEN 384
-#define PIOS_COM_TELEM_RF_TX_BUF_LEN 384
+#define PIOS_COM_TELEM_TCP_RX_BUF_LEN 384
+#define PIOS_COM_TELEM_TCP_TX_BUF_LEN 384
 #define PIOS_COM_GPS_RX_BUF_LEN 96
 
 /**
@@ -136,14 +136,15 @@ void PIOS_Board_Init(void) {
 	HwSparkyInitialize();
 	HwSimulationInitialize();
 
-	uintptr_t pios_tcp_telem_rf_id;
-	if (PIOS_TCP_Init(&pios_tcp_telem_rf_id, &pios_tcp_telem_cfg)) {
+	uintptr_t pios_tcp_telem_id;
+	if (PIOS_TCP_Init(&pios_tcp_telem_id, &pios_tcp_telem_cfg)) {
 		PIOS_Assert(0);
 	}
 
-	if (PIOS_COM_Init(&pios_com_telem_rf_id, &pios_tcp_com_driver, pios_tcp_telem_rf_id,
-			PIOS_COM_TELEM_RF_RX_BUF_LEN,
-			PIOS_COM_TELEM_RF_TX_BUF_LEN)) {
+	if (PIOS_COM_Init(&pios_com_telem_usb_id,
+				&pios_tcp_com_driver, pios_tcp_telem_id,
+				PIOS_COM_TELEM_TCP_RX_BUF_LEN,
+				PIOS_COM_TELEM_TCP_TX_BUF_LEN)) {
 		PIOS_Assert(0);
 	}
 


### PR DESCRIPTION
Otherwise, initialization of serial baud rate doesn't happen properly
because we use the "USB" handle which is assumed to have fixed rate.

Addresses some issues in #2079