### PR TITLE
GCS:Eigen: Only use gcc Wno-int-in-bool-context flag on GCC

### DIFF
--- a/ground/gcs/src/libs/eigen/eigen.pri
+++ b/ground/gcs/src/libs/eigen/eigen.pri
@@ -1,4 +1,4 @@
 INCLUDEPATH *= $$PWD
 
 # work around Eigen's abuse of enums to allow compiling with recent compilers
-!win32-msvc*:QMAKE_CXXFLAGS += -Wno-int-in-bool-context
+*-g++:QMAKE_CXXFLAGS += -Wno-int-in-bool-context


### PR DESCRIPTION
Fix up some warnings with clang as it doesn't have this flag.