### PR TITLE
osd: show "arm.." for armed flag during arming hold

### DIFF
--- a/flight/Modules/OnScreenDisplay/onscreendisplay.c
+++ b/flight/Modules/OnScreenDisplay/onscreendisplay.c
@@ -1170,8 +1170,11 @@ void render_user_page(OnScreenDisplayPageSettingsData * page)
 	// Arming Status
 	if (page->ArmStatus) {
 		FlightStatusArmedGet(&tmp_uint8);
-		if (tmp_uint8 != FLIGHTSTATUS_ARMED_DISARMED)
+		if (tmp_uint8 == FLIGHTSTATUS_ARMED_ARMED)
 			write_string("ARMED", page->ArmStatusPosX, page->ArmStatusPosY, 0, 0, TEXT_VA_TOP, (int)page->ArmStatusAlign, 0,
+					page->ArmStatusFont);
+		else if (tmp_uint8 == FLIGHTSTATUS_ARMED_ARMING)
+			write_string("arm..", page->ArmStatusPosX, page->ArmStatusPosY, 0, 0, TEXT_VA_TOP, (int)page->ArmStatusAlign, 0,
 					page->ArmStatusFont);
 	}
 


### PR DESCRIPTION
@ufoDziner had an issue where he'd see "ARMED" on the screen and
throttle up, and this would cancel the arming.  Now only display "ARMED"
after actual arm, and "arm.." before that.