### PR TITLE
pios_servo: set maximum number of banks to 8

### DIFF
--- a/flight/PiOS/STM32/pios_servo.c
+++ b/flight/PiOS/STM32/pios_servo.c
@@ -868,7 +868,7 @@ void PIOS_Servo_Update(void)
 	// If some banks are oneshot and some are dshot (why would you do this?)
 	// get the oneshots firing first.
 	for (uint8_t i = 0; i < servo_cfg->num_channels; i++) {
-		if (channel_mask & (1 << 1)) {
+		if (channel_mask & (1 << i)) {
 			continue;
 		}
 

--- a/flight/PiOS/STM32/pios_servo.c
+++ b/flight/PiOS/STM32/pios_servo.c
@@ -336,12 +336,15 @@ int PIOS_Servo_SetMode(const uint16_t *out_rate, const int banks, const uint16_t
 				bank = j;
 		}
 
-		if (bank < 0)
+		if ((bank < 0) && (banks_found < PIOS_SERVO_MAX_BANKS)) {
 			bank = banks_found++;
+		}
 
-		timer_banks[bank].timer = chan->timer;
-		timer_banks[bank].max_pulse = MAX(timer_banks[bank].max_pulse, channel_max[i]);
-		timer_banks[bank].max_pulse = MAX(timer_banks[bank].max_pulse, channel_min[i]);
+		if (bank >= 0) {
+			timer_banks[bank].timer = chan->timer;
+			timer_banks[bank].max_pulse = MAX(timer_banks[bank].max_pulse, channel_max[i]);
+			timer_banks[bank].max_pulse = MAX(timer_banks[bank].max_pulse, channel_min[i]);
+		}
 	}
 
 	// configure timers/banks

--- a/flight/PiOS/inc/pios_servo.h
+++ b/flight/PiOS/inc/pios_servo.h
@@ -32,7 +32,7 @@
 
 #include <pios_dio.h>
 
-#define PIOS_SERVO_MAX_BANKS 6
+#define PIOS_SERVO_MAX_BANKS 8
 
 /* Used in out_rate.  If 65535, we really mean 65535Hz.  Values close to that
  * are reserved/abused for dshot support.  0 is used for sync pwm per legacy


### PR DESCRIPTION
Because Quanton in some modes has 8.  Never mind that we can't configure
more than 6.

Also cope with / avoid stack overflow in this case, and fix a small issue with channel masking.

Fixes #2088.
