### PR TITLE
pid: Schedule I-gain on antiwindup controller, based on P-term's proximity to clipping.

### DIFF
--- a/flight/Libraries/math/pid.h
+++ b/flight/Libraries/math/pid.h
@@ -54,11 +54,11 @@ struct pid {
 
 //! Methods to use the pid structures
 float pid_apply(struct pid *pid, const float err);
-float pid_apply_antiwindup(struct pid *pid, const float err, float min_bound, float max_bound);
+float pid_apply_antiwindup(struct pid *pid, const float err, float min_bound, float max_bound, float aw_bound);
 float pid_apply_setpoint(struct pid *pid, struct pid_deadband *deadband, const float setpoint, const float measured);
 float pid_apply_setpoint_antiwindup(struct pid *pid,
 		struct pid_deadband *deadband, const float setpoint,
-		const float measured, float min_bound, float max_bound);
+		const float measured, float min_bound, float max_bound, float aw_bound);
 void pid_zero(struct pid *pid);
 void pid_configure(struct pid *pid, float p, float i, float d, float iLim, float dT);
 void pid_configure_derivative(float cutoff, float gamma);

--- a/flight/Modules/AltitudeHold/altitudehold.c
+++ b/flight/Modules/AltitudeHold/altitudehold.c
@@ -219,8 +219,8 @@ static void altitudeHoldTask(void *parameters)
 			float velocity_desired = altitude_error * altitudeHoldSettings.PositionKp + altitudeHoldDesired.ClimbRate;
 			float throttle_desired = pid_apply_antiwindup(&velocity_pid, 
 			                    velocity_desired - velocity_z,
-			                    min_throttle, 1.0f // positive limits since this is throttle
-			                    );
+			                    min_throttle, 1.0f, // positive limits since this is throttle
+			                    0);
 
 			AltitudeHoldStateData altitudeHoldState;
 			altitudeHoldState.VelocityDesired = velocity_desired;

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -660,7 +660,7 @@ static void stabilizationTask(void* parameters)
 					rateDesiredAxis[i] = bound_sym(raw_input[i], settings.ManualRate[i]);
 
 					// Compute the inner loop
-					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f);
+					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f, 1.0f);
 
 					break;
 
@@ -704,7 +704,7 @@ static void stabilizationTask(void* parameters)
 					rateDesiredAxis[i] = bound_sym(curve_cmd * max_rate_filtered[i], max_rate_filtered[i]);
 
 					// Compute the inner loop
-					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f);
+					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f, 1.0f);
 
 					break;
 
@@ -728,7 +728,7 @@ static void stabilizationTask(void* parameters)
 							}
 
 					// Compute the inner loop
-					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f);
+					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f, 1.0f);
 					actuatorDesiredAxis[i] = factor * raw_input[i] + (1.0f - factor) * actuatorDesiredAxis[i];
 					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i], 1.0f);
 
@@ -745,7 +745,7 @@ static void stabilizationTask(void* parameters)
 					rateDesiredAxis[i] = bound_sym(rateDesiredAxis[i], settings.MaximumRate[i]);
 
 					// Compute the inner loop
-					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f);
+					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f, 1.0f);
 					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 
 					break;
@@ -770,7 +770,7 @@ static void stabilizationTask(void* parameters)
 
 					// Compute desired rate as input biased towards leveling
 					rateDesiredAxis[i] = raw_input[i] + weak_leveling;
-					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f);
+					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f, 1.0f);
 
 					break;
 				}
@@ -795,7 +795,7 @@ static void stabilizationTask(void* parameters)
 						rateDesiredAxis[i] = bound_sym(tmpRateDesired, settings.MaximumRate[i]);
 					}
 
-					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f);
+					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f, 1.0f);
 
 					break;
 
@@ -820,7 +820,7 @@ static void stabilizationTask(void* parameters)
 					rateDesiredAxis[i] = bound_sym(rateDesiredAxis[i], settings.ManualRate[i]);
 
 					// Compute the inner loop
-					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f);
+					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f, 1.0f);
 					actuatorDesiredAxis[i] = bound_sym(actuatorDesiredAxis[i],1.0f);
 
 					break;
@@ -870,13 +870,13 @@ static void stabilizationTask(void* parameters)
 						rateDesiredAxis[i] = bound_sym(rateDesiredAxis[i], settings.MaximumRate[i]);
 
 						// Compute the inner loop
-						actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f);
+						actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f, 1.0f);
 					} else {
 						// Get the desired rate. yaw is always in rate mode in system ident.
 						rateDesiredAxis[i] = bound_sym(raw_input[i], settings.ManualRate[i]);
 
 						// Compute the inner loop only for yaw
-						actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f);
+						actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f, 1.0f);
 					}
 
 					const float scale = settings.AutotuneActuationEffort[i];
@@ -1052,7 +1052,7 @@ static void stabilizationTask(void* parameters)
 					rateDesiredAxis[i] = bound_sym(rateDesiredAxis[i], settings.PoiMaximumRate[i]);
 
 					// Compute the inner loop
-					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f);
+					actuatorDesiredAxis[i] = pid_apply_setpoint_antiwindup(&pids[PID_GROUP_RATE + i], get_deadband(i),  rateDesiredAxis[i],  gyro_filtered[i], -1.0f, 1.0f, 1.0f);
 
 					break;
 				case STABILIZATIONDESIRED_STABILIZATIONMODE_DISABLED:

--- a/flight/Modules/VtolPathFollower/vtol_follower_control.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_control.c
@@ -166,7 +166,8 @@ int32_t vtol_follower_control_path(const PathDesiredData *pathDesired,
 
 	commands_ned[2] = pid_apply_antiwindup(&vtol_pids[DOWN_POSITION], downError,
 		-altitudeHoldSettings.MaxClimbRate * 0.1f,
-		altitudeHoldSettings.MaxDescentRate * 0.1f);
+		altitudeHoldSettings.MaxDescentRate * 0.1f,
+		0);
 
 	VelocityDesiredData velocityDesired;
 	VelocityDesiredGet(&velocityDesired);
@@ -240,17 +241,18 @@ static int32_t vtol_follower_control_impl(
 
 	// Compute desired north command velocity from position error
 	commands_ned[0] = pid_apply_antiwindup(&vtol_pids[NORTH_POSITION], damped_ne[0],
-	    -guidanceSettings.HorizontalVelMax, guidanceSettings.HorizontalVelMax);
+	    -guidanceSettings.HorizontalVelMax, guidanceSettings.HorizontalVelMax, 0);
 
 	// Compute desired east command velocity from position error
 	commands_ned[1] = pid_apply_antiwindup(&vtol_pids[EAST_POSITION], damped_ne[1],
-	    -guidanceSettings.HorizontalVelMax, guidanceSettings.HorizontalVelMax);
+	    -guidanceSettings.HorizontalVelMax, guidanceSettings.HorizontalVelMax, 0);
 
 	if (fabsf(alt_rate) < 0.001f) {
 		// Compute desired down comand velocity from the position difference
 		commands_ned[2] = pid_apply_antiwindup(&vtol_pids[DOWN_POSITION], errors_ned[2],
 				-altitudeHoldSettings.MaxClimbRate * 0.1f,
-				altitudeHoldSettings.MaxDescentRate * 0.1f);
+				altitudeHoldSettings.MaxDescentRate * 0.1f,
+				0);
 	} else {
 		// Just use the commanded rate
 		commands_ned[2] = alt_rate;
@@ -369,14 +371,14 @@ static int32_t vtol_follower_control_accel(float dT)
 	// Compute desired north command from velocity error
 	north_error = velocityDesired.North - velocityActual.North;
 	north_acceleration += pid_apply_antiwindup(&vtol_pids[NORTH_VELOCITY], north_error,
-	    -MAX_ACCELERATION, MAX_ACCELERATION) +
+	    -MAX_ACCELERATION, MAX_ACCELERATION, 0) +
 	    velocityDesired.North * guidanceSettings.VelocityFeedforward +
 	    -nedAccel.North * guidanceSettings.HorizontalVelPID[VTOLPATHFOLLOWERSETTINGS_HORIZONTALVELPID_KD];
 	
 	// Compute desired east command from velocity error
 	east_error = velocityDesired.East - velocityActual.East;
 	east_acceleration += pid_apply_antiwindup(&vtol_pids[EAST_VELOCITY], east_error,
-	    -MAX_ACCELERATION, MAX_ACCELERATION) +
+	    -MAX_ACCELERATION, MAX_ACCELERATION, 0) +
 	    velocityDesired.East * guidanceSettings.VelocityFeedforward +
 	    -nedAccel.East * guidanceSettings.HorizontalVelPID[VTOLPATHFOLLOWERSETTINGS_HORIZONTALVELPID_KD];
 
@@ -389,7 +391,7 @@ static int32_t vtol_follower_control_accel(float dT)
 	// Compute desired down command.  Using NED accel as the damping term
 	down_error = velocityDesired.Down - velocityActual.Down;
 	// Negative is critical here since throttle is negative with down
-	accelDesired.Down = -pid_apply_antiwindup(&vtol_pids[DOWN_VELOCITY], down_error, -1, 0);
+	accelDesired.Down = -pid_apply_antiwindup(&vtol_pids[DOWN_VELOCITY], down_error, -1, 0, 0);
 
 	// Store the desired acceleration
 	AccelDesiredSet(&accelDesired);


### PR DESCRIPTION
Reduces rebounding _a lot_, when actuators lack authority.

Only applied to the antiwindup version used in stab.c.