### PR TITLE
actuators: Leaky bucket time constant configuration, bucket content logging.

### DIFF
--- a/shared/uavobjectdefinition/actuatorcommand.xml
+++ b/shared/uavobjectdefinition/actuatorcommand.xml
@@ -14,5 +14,10 @@
     <field defaultvalue="0" elements="1" name="MaxUpdateTime" type="uint16" units="ms">
       <description/>
     </field>
+    <field defaultvalue="0" elements="1" name="LowPowerStabilizationReserve" type="float" units="s">
+      <description>
+        The power reserve available that can be added to actuators during negative clipping.
+      </description>
+    </field>
   </object>
 </xml>

--- a/shared/uavobjectdefinition/actuatorsettings.xml
+++ b/shared/uavobjectdefinition/actuatorsettings.xml
@@ -30,6 +30,9 @@
     <field defaultvalue="0.07" elements="1" limits="%BE:0.0:0.15" name="LowPowerStabilizationMaxPowerAdd" type="float" units="">
       <description>Maximum power to add to ensure stabilization at low power.  Always select a value well under hover power.</description>
     </field>
+    <field defaultvalue="0.3" elements="1" limits="%BE:0.1:1.0" name="LowPowerStabilizationTimeConstant" type="float" units="s">
+      <description>Sets the time constant for the power reserve management during low power stabilization.</description>
+    </field>
     <field defaultvalue="0.9" elements="1" name="MotorInputOutputCurveFit" type="float" units="">
       <description>Actuator mapping of input in [-1,1] to output on [-1,1], using power equation of type x^value. This is intended to correct for the non-linear relationship between input command and output power inherent in brushless ESC/motor combinations. A setting below 1.0 will improve high-throttle control stability.</description>
     </field>


### PR DESCRIPTION
Added the ability to configure the leaky bucket time constant via UAVO.

Also added logging of the bucket contents. After the throttle chop stuff we had with ufo's quad, it's probably prudent to record what hangtime's doing.