### PR TITLE
gcs: autotune: compute vertical autotune

### DIFF
--- a/ground/gcs/src/plugins/config/autotunesliders.ui
+++ b/ground/gcs/src/plugins/config/autotunesliders.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>521</width>
-    <height>439</height>
+    <width>561</width>
+    <height>557</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -158,6 +158,40 @@
      <property name="topMargin">
       <number>0</number>
      </property>
+     <item row="10" column="0">
+      <widget class="QLabel" name="label_20">
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Altitude PosK&lt;span style=&quot; vertical-align:sub;&quot;&gt;p&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QLabel" name="lblAltPosKp">
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="3">
+      <widget class="QLabel" name="wn">
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <spacer name="verticalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
      <item row="3" column="0">
       <widget class="QCheckBox" name="cbUseYaw">
        <property name="text">
@@ -175,7 +209,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="3">
+     <item row="6" column="3">
       <widget class="QLabel" name="lblOuterKi">
        <property name="text">
         <string>0</string>
@@ -189,7 +223,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="6" column="1">
       <widget class="QLabel" name="lblOuterKp">
        <property name="text">
         <string>0</string>
@@ -231,13 +265,6 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="label_18">
-       <property name="text">
-        <string>Derivative cutoff</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="1">
       <widget class="QLabel" name="rollRateKp">
        <property name="text">
@@ -245,7 +272,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="2">
+     <item row="6" column="2">
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
         <widget class="QCheckBox" name="cbUseOuterKi">
@@ -266,7 +293,7 @@
        <item>
         <widget class="QLabel" name="label_16">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Outer K&lt;span style=&quot; vertical-align:sub;&quot;&gt;i&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Attitude K&lt;span style=&quot; vertical-align:sub;&quot;&gt;i&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -286,24 +313,10 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="2">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Natural frequency</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>Roll</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QLabel" name="derivativeCutoff">
-       <property name="text">
-        <string>0</string>
        </property>
       </widget>
      </item>
@@ -314,14 +327,7 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="3">
-      <widget class="QLabel" name="wn">
-       <property name="text">
-        <string>0</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
+     <item row="5" column="0">
       <spacer name="verticalSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -348,10 +354,92 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="label_15">
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Outer K&lt;span style=&quot; vertical-align:sub;&quot;&gt;p&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Attitude K&lt;span style=&quot; vertical-align:sub;&quot;&gt;p&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLabel" name="derivativeCutoff">
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="0">
+      <spacer name="verticalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="4" column="2">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Natural frequency</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QCheckBox" name="cbTuneAlt">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_17">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Altitude VelK&lt;span style=&quot; vertical-align:sub;&quot;&gt;p&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="9" column="2">
+      <widget class="QLabel" name="label_19">
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Altitude VelK&lt;span style=&quot; vertical-align:sub;&quot;&gt;i&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_18">
+       <property name="text">
+        <string>Derivative cutoff</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QLabel" name="lblAltVelKp">
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="3">
+      <widget class="QLabel" name="lblAltVelKi">
+       <property name="text">
+        <string>0</string>
        </property>
       </widget>
      </item>

--- a/ground/gcs/src/plugins/config/configautotunewidget.cpp
+++ b/ground/gcs/src/plugins/config/configautotunewidget.cpp
@@ -38,6 +38,7 @@
 #include <uavobjectutil/devicedescriptorstruct.h>
 #include <uavobjectutil/uavobjectutilmanager.h>
 
+#include "altitudeholdsettings.h"
 #include "manualcontrolsettings.h"
 #include "mixersettings.h"
 #include "modulesettings.h"
@@ -48,6 +49,8 @@
 #include "coreplugin/generalsettings.h"
 #include "extensionsystem/pluginmanager.h"
 #include "coreplugin/iboardtype.h"
+
+#include "physical_constants.h"
 
 #include <QtAlgorithms>
 #include <QChartView>
@@ -257,7 +260,7 @@ QJsonDocument ConfigAutotuneWidget::getResultsJson(AutotuneFinalPage *autotuneSh
     computed["iterations"] = tuneState->iterations;
 
     QJsonObject gains;
-    QJsonObject roll_gain, pitch_gain, yaw_gain, outer_gain;
+    QJsonObject roll_gain, pitch_gain, yaw_gain, outer_gain, vert_gain;
     roll_gain["kp"] = tuneState->kp[0];
     roll_gain["ki"] = tuneState->ki[0];
     roll_gain["kd"] = tuneState->kd[0];
@@ -273,6 +276,9 @@ QJsonDocument ConfigAutotuneWidget::getResultsJson(AutotuneFinalPage *autotuneSh
     outer_gain["kp"] = tuneState->outerKp;
     outer_gain["ki"] = tuneState->outerKi;
     gains["outer"] = outer_gain;
+    vert_gain["kp"] = tuneState->vertSpeedKp;
+    vert_gain["ki"] = tuneState->vertSpeedKi;
+    vert_gain["poskp"] = tuneState->vertPosKp;
     computed["gains"] = gains;
     tuning["computed"] = computed;
     json["tuning"] = tuning;
@@ -441,6 +447,7 @@ void ConfigAutotuneWidget::openAutotuneDialog(bool autoOpened,
 
         saveObjectToSD(stabilizationSettings);
 
+
         SystemIdent *systemIdent = SystemIdent::GetInstance(getObjectManager());
         if (systemIdent) {
             SystemIdent::DataFields systemIdentData = systemIdent->getData();
@@ -454,6 +461,21 @@ void ConfigAutotuneWidget::openAutotuneDialog(bool autoOpened,
             systemIdent->updated();
 
             saveObjectToSD(systemIdent);
+        }
+
+        if (av.vertSpeedKp > 0) {
+            AltitudeHoldSettings *altSettings =
+                AltitudeHoldSettings::GetInstance(getObjectManager());
+
+            if (!altSettings) {
+                qWarning() << "Not committing alt hold data because obj not present";
+            } else {
+                altSettings->setPositionKp(av.vertPosKp);
+                altSettings->setVelocityKp(av.vertSpeedKp);
+                altSettings->setVelocityKi(av.vertSpeedKi);
+                altSettings->updated();
+                saveObjectToSD(altSettings);
+            }
         }
 
         if (pg->shareBox->isChecked()) {
@@ -544,6 +566,7 @@ AutotuneSlidersPage::AutotuneSlidersPage(QWidget *parent, AutotunedValues *autoV
     connect(rateNoise, &QAbstractSlider::valueChanged, this, &AutotuneSlidersPage::compute);
     connect(cbUseYaw, &QAbstractButton::toggled, this, &AutotuneSlidersPage::compute);
     connect(cbUseOuterKi, &QAbstractButton::toggled, this, &AutotuneSlidersPage::compute);
+    connect(cbTuneAlt, &QAbstractButton::toggled, this, &AutotuneSlidersPage::computeThrust);
 
     connect(btnResetSliders, &QAbstractButton::pressed, this, &AutotuneSlidersPage::resetSliders);
 }
@@ -560,6 +583,7 @@ void AutotuneSlidersPage::resetSliders()
     rateNoise->setValue(10);
 
     compute();
+    computeThrust();
 }
 
 bool AutotuneSlidersPage::isComplete() const
@@ -574,6 +598,68 @@ void AutotuneSlidersPage::setText(QLabel *lbl, double value, int precision)
     } else {
         lbl->setText(QString::number(value, 'f', precision));
     }
+}
+
+void AutotuneSlidersPage::computeThrust()
+{
+    const double baseKp = 0.5;
+    const double tauDerate = 0.025;
+    const double kiAdjust = 1.5;
+    const double outerSlowdown = 0.125;
+    const double okpCeiling = 0.9 * GRAVITY / 4.0;
+
+    double hoverThrust = 0;
+    double thrustTau = (tuneState->tau[0] + tuneState->tau[1]) / 2 +
+        tauDerate;
+    /*
+     * (Thrust tau is not guaranteed to be axis tau, but it's a pretty
+     * good approximation.  We derate it, mostly because we don't trust
+     * cfvert to be fast.)
+     */
+    ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
+
+    UAVObjectManager *objMngr = nullptr;
+    if (pm) {
+        objMngr = pm->getObject<UAVObjectManager>();
+    }
+
+    SystemIdent *systemIdent = nullptr;
+
+    if (objMngr) {
+        systemIdent = SystemIdent::GetInstance(objMngr);
+    }
+
+    if (systemIdent) {
+        hoverThrust = systemIdent->getHoverThrottle();
+    }
+
+    if ((hoverThrust < 0.05) ||
+            (hoverThrust > 0.6) ||
+            (thrustTau < 0.005) ||
+            (thrustTau > 0.200)) {
+        cbTuneAlt->setChecked(false);
+        cbTuneAlt->setEnabled(false);
+    }
+
+    if (cbTuneAlt->isChecked()) {
+        tuneState->vertSpeedKp = (baseKp * hoverThrust / GRAVITY) /
+                                    thrustTau;
+        tuneState->vertSpeedKi = tuneState->vertSpeedKp /
+                                    (kiAdjust * 2 * M_PI * thrustTau);
+        tuneState->vertPosKp = outerSlowdown / thrustTau;
+
+        if (tuneState->vertPosKp > okpCeiling) {
+            tuneState->vertPosKp = okpCeiling;
+        }
+    } else {
+        tuneState->vertSpeedKp = -1;
+        tuneState->vertSpeedKi = -1;
+        tuneState->vertPosKp = -1;
+    }
+
+    setText(lblAltVelKp, tuneState->vertSpeedKp, 3);
+    setText(lblAltVelKi, tuneState->vertSpeedKi, 3);
+    setText(lblAltPosKp, tuneState->vertSpeedKi, 3);
 }
 
 void AutotuneSlidersPage::compute()

--- a/ground/gcs/src/plugins/config/configautotunewidget.h
+++ b/ground/gcs/src/plugins/config/configautotunewidget.h
@@ -83,6 +83,10 @@ struct AutotunedValues
     float outerKp;
     float outerKi;
 
+    float vertSpeedKp;
+    float vertSpeedKi;
+    float vertPosKp;
+
     QLineSeries *model[3];
     QLineSeries *actual[3];
 };
@@ -178,6 +182,7 @@ private:
     void setText(QLabel *lbl, double value, int precision);
 
 private slots:
+    void computeThrust();
     void compute();
     void resetSliders();
 };


### PR DESCRIPTION
Use information on hover throttle (presuming this is 1G acceleration)
and roll/pitch tau (assuming this corresponds to thrust tau) in order to
calculate a conservative (but still more aggressive than stock tuning)
vertical tune.

Produces similar results to the defaults on things that use 50% hover
power with 65ms tau.