### PR TITLE
flight: attitude: use single set of config for level angles

### DIFF
--- a/flight/Modules/OnScreenDisplay/osd_menu.c
+++ b/flight/Modules/OnScreenDisplay/osd_menu.c
@@ -1824,10 +1824,16 @@ void pidatt_menu(void)
 	}
 }
 
+DONT_BUILD_IF(STABILIZATIONSETTINGS_MAXLEVELANGLE_ROLL != 0,
+		LevelAngleConstantRoll);
+DONT_BUILD_IF(STABILIZATIONSETTINGS_MAXLEVELANGLE_PITCH != 1,
+		LevelAngleConstantPitch);
+DONT_BUILD_IF(STABILIZATIONSETTINGS_MAXLEVELANGLE_YAW != 2,
+		LevelAngleConstantYaw);
+
 #define MAX_STICK_RATE 1440
 void sticklimits_menu(void)
 {
-	uint8_t angle;
 	int y_pos = MENU_LINE_Y;
 	enum menu_fsm_state my_state = FSM_STATE_STICKLIMITS_ROLLA;
 	bool data_changed = false;
@@ -1835,20 +1841,15 @@ void sticklimits_menu(void)
 
 	draw_menu_title("Stick Limits and Expo");
 
+	uint8_t level_angles[STABILIZATIONSETTINGS_MAXLEVELANGLE_NUMELEM];
+
+	StabilizationSettingsMaxLevelAngleGet(level_angles);
+
 	// Full Stick Angle
 	for (int i = 0; i < 3; i++) {
 		data_changed = false;
-		switch (i) {
-			case 0:
-				StabilizationSettingsRollMaxGet(&angle);
-				break;
-			case 1:
-				StabilizationSettingsPitchMaxGet(&angle);
-				break;
-			case 2:
-				StabilizationSettingsYawMaxGet(&angle);
-				break;
-		}
+
+		uint8_t angle = level_angles[i];
 
 		sprintf(tmp_str, "Max Stick Angle %s: %d", axis_strings[i], angle);
 		write_string(tmp_str, MENU_LINE_X, y_pos, 0, 0, TEXT_VA_TOP, TEXT_HA_LEFT, 0, MENU_FONT);
@@ -1856,25 +1857,15 @@ void sticklimits_menu(void)
 		if (my_state == current_state) {
 			draw_selected_icon(MENU_LINE_X - 4, y_pos + 4);
 			if (current_event == FSM_EVENT_RIGHT) {
-				angle = MIN(angle + 1, 90);
+				level_angles[i] = MIN(angle + 1, 90);
 				data_changed = true;
 			}
 			if (current_event == FSM_EVENT_LEFT) {
-				angle = MAX((int)angle - 1, 0);
+				level_angles[i] = MAX((int)angle - 1, 0);
 				data_changed = true;
 			}
 			if (data_changed) {
-				switch (i) {
-					case 0:
-						StabilizationSettingsRollMaxSet(&angle);
-						break;
-					case 1:
-						StabilizationSettingsPitchMaxSet(&angle);
-						break;
-					case 2:
-						StabilizationSettingsYawMaxSet(&angle);
-						break;
-				}
+				StabilizationSettingsMaxLevelAngleSet(level_angles);
 			}
 		}
 		my_state++;

--- a/flight/Modules/VtolPathFollower/vtol_follower_control.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_control.c
@@ -514,12 +514,6 @@ int32_t vtol_follower_control_attitude(float dT, const float *att_adj)
 		stabDesired.Yaw = stabSet.ManualRate[STABILIZATIONSETTINGS_MANUALRATE_YAW] * manual_control_command.Yaw;
 		stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_AXISLOCK;
 		break;
-	case VTOLPATHFOLLOWERSETTINGS_YAWMODE_ATTITUDE:
-	{
-		stabDesired.Yaw = stabSet.YawMax * manual_control_command.Yaw;
-		stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_YAW] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;
-	}
-		break;
 	case VTOLPATHFOLLOWERSETTINGS_YAWMODE_PATH:
 	{
 		// Face forward on the path

--- a/flight/Modules/VtolPathFollower/vtol_follower_control.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_control.c
@@ -485,8 +485,10 @@ int32_t vtol_follower_control_attitude(float dT, const float *att_adj)
 	stabDesired.Roll = bound_sym(RAD2DEG * atanf(right_accel_desired / GRAVITY), guidanceSettings.MaxRollPitch) + att_adj[0];
 
 	// Re-bound based on maximum attitude settings
-	stabDesired.Pitch = bound_sym(stabDesired.Pitch, stabSet.PitchMax);
-	stabDesired.Roll = bound_sym(stabDesired.Roll, stabSet.RollMax);
+	stabDesired.Pitch = bound_sym(stabDesired.Pitch,
+			stabSet.MaxLevelAngle[STABILIZATIONSETTINGS_MAXLEVELANGLE_PITCH]);
+	stabDesired.Roll = bound_sym(stabDesired.Roll,
+			stabSet.MaxLevelAngle[STABILIZATIONSETTINGS_MAXLEVELANGLE_ROLL]);
 	
 	stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_ROLL] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;
 	stabDesired.StabilizationMode[STABILIZATIONDESIRED_STABILIZATIONMODE_PITCH] = STABILIZATIONDESIRED_STABILIZATIONMODE_ATTITUDE;

--- a/shared/uavobjectdefinition/stabilizationsettings.xml
+++ b/shared/uavobjectdefinition/stabilizationsettings.xml
@@ -13,15 +13,6 @@
         <elementname>Yaw</elementname>
       </elementnames>
     </field>
-    <field defaultvalue="55" elements="1" limits="%BE:0:180" name="RollMax" type="uint8" units="degrees">
-      <description/>
-    </field>
-    <field defaultvalue="55" elements="1" limits="%BE:0:90" name="PitchMax" type="uint8" units="degrees">
-      <description/>
-    </field>
-    <field defaultvalue="35" elements="1" limits="%BE:0:180" name="YawMax" type="uint8" units="degrees">
-      <description/>
-    </field>
     <field defaultvalue="250.0,250.0,225.0" limits="%BE:0:1650,%BE:0:1650,%BE:0:1650" name="ManualRate" type="float" units="degrees/sec">
       <description>The rate to rotate on this axis at full stick deflection in rate/acro modeis.</description>
       <elementnames>

--- a/shared/uavobjectdefinition/vtolpathfollowersettings.xml
+++ b/shared/uavobjectdefinition/vtolpathfollowersettings.xml
@@ -74,7 +74,6 @@
       <options>
         <option>Rate</option>
         <option>AxisLock</option>
-        <option>Attitude</option>
         <option>Path</option>
         <option>POI</option>
       </options>


### PR DESCRIPTION
Fixes #1978 

Also remove the vtolpathfollower "attitude" yaw mode with stick scaling.