### PR TITLE
transmitter_control: improve collective check

### DIFF
--- a/flight/Modules/ManualControl/transmitter_control.c
+++ b/flight/Modules/ManualControl/transmitter_control.c
@@ -213,6 +213,21 @@ static bool is_low_throttle_for_arming(
 	return get_thrust_source(manual_control_command, false) == 0;
 }
 
+static bool channel_is_configured(int channel_num)
+{
+	if (settings.ChannelGroups[channel_num] >=
+			MANUALCONTROLSETTINGS_CHANNELGROUPS_NONE) {
+		return false;
+	}
+
+	if (settings.ChannelNumber[channel_num] == 0) {
+		/* Channel numbers are offset, 0 means "none" */
+		return false;
+	}
+
+	return true;
+}
+
 static void perform_tc_settings_update()
 {
 	settings_updated = false;
@@ -220,8 +235,7 @@ static void perform_tc_settings_update()
 
 	uint8_t thrust_channel;
 
-	if (settings.ChannelGroups[MANUALCONTROLSETTINGS_CHANNELGROUPS_COLLECTIVE]
-			< MANUALCONTROLSETTINGS_CHANNELGROUPS_NONE) {
+	if (channel_is_configured(MANUALCONTROLSETTINGS_CHANNELGROUPS_COLLECTIVE)) {
 		collective_is_thrust = true;
 		thrust_channel = MANUALCONTROLSETTINGS_CHANNELGROUPS_COLLECTIVE;
 	} else {


### PR DESCRIPTION
Some of the users that have tripped over #2101 have had the channel set
to e.g. SBus/None.  Don't just look at the channel type, but instead
look at the channel number, to see if the "whole thing" is configured,
so that it's possible to set everything to SBus without unanticipated
consequences.

Also factor the channel valid check to a static function, which may be
desirable to use elsewhere in transmitter_control.