### PR TITLE
Make baro work on omnibus f4 variants with it

### DIFF
--- a/flight/PiOS/Common/pios_bmp280.c
+++ b/flight/PiOS/Common/pios_bmp280.c
@@ -31,7 +31,7 @@
 /* Project Includes */
 #include "pios.h"
 
-#if defined(PIOS_INCLUDE_BMP280)
+#if defined(PIOS_INCLUDE_BMP280) || defined(PIOS_INCLUDE_BMP280_SPI)
 
 #include "pios_bmp280_priv.h"
 #include "pios_semaphore.h"

--- a/flight/targets/revolution/board-info/board_hw_defs.c
+++ b/flight/targets/revolution/board-info/board_hw_defs.c
@@ -275,6 +275,14 @@ static const struct pios_spi_cfg pios_spi_telem_flash_cfg = {
 	},
 };
 
+#ifdef PIOS_INCLUDE_BMP280_SPI
+#include "pios_bmp280_priv.h"
+
+static const struct pios_bmp280_cfg pios_bmp280_cfg = {
+	.oversampling = BMP280_HIGH_RESOLUTION,
+};
+#endif
+
 pios_spi_t pios_spi_telem_flash_id;
 
 #if defined(PIOS_INCLUDE_RFM22B)

--- a/flight/targets/revolution/fw/Makefile
+++ b/flight/targets/revolution/fw/Makefile
@@ -116,6 +116,7 @@ include $(PIOS)/STM32F4xx/library_chibios.mk
 include $(PIOS)/pios_flight_library.mk
 
 SRC += pios_mpu.c
+SRC += pios_bmp280.c
 SRC += pios_etasv3.c
 SRC += pios_mpxv5004.c
 SRC += pios_mpxv7002.c

--- a/flight/targets/revolution/fw/pios_board.c
+++ b/flight/targets/revolution/fw/pios_board.c
@@ -602,6 +602,18 @@ void PIOS_Board_Init(void) {
 
 #endif    /* PIOS_INCLUDE_I2C */
 
+#ifdef PIOS_INCLUDE_SPI
+#ifdef PIOS_INCLUDE_BMP280_SPI
+	// BMP280 support
+	if ((!flash_chip_ok) &&
+			(!PIOS_SENSORS_IsRegistered(PIOS_SENSOR_BARO))) {
+		/* Best effort */
+		PIOS_BMP280_SPI_Init(&pios_bmp280_cfg,
+				pios_spi_telem_flash_id, 1);
+	}
+#endif /* PIOS_INCLUDE_BMP280_SPI */
+#endif
+
 #if defined(PIOS_INCLUDE_ADC)
 	uintptr_t internal_adc_id;
 	PIOS_INTERNAL_ADC_Init(&internal_adc_id, &pios_adc_cfg);

--- a/flight/targets/revolution/fw/pios_config.h
+++ b/flight/targets/revolution/fw/pios_config.h
@@ -59,6 +59,7 @@
 #define PIOS_INCLUDE_MAX7456
 
 /* Select the sensors to include */
+#define PIOS_INCLUDE_BMP280_SPI
 #define PIOS_INCLUDE_HMC5883
 #define PIOS_INCLUDE_HMC5983_I2C
 #define PIOS_INCLUDE_MPU

--- a/flight/targets/seppuku/board-info/board_hw_defs.c
+++ b/flight/targets/seppuku/board-info/board_hw_defs.c
@@ -234,7 +234,7 @@ static const struct pios_lis3mdl_cfg pios_lis3mdl_cfg = {
 
 #endif /* PIOS_INCLUDE_LIS3MDL */
 
-#ifdef PIOS_INCLUDE_BMP280
+#ifdef PIOS_INCLUDE_BMP280_SPI
 #include "pios_bmp280_priv.h"
 
 static const struct pios_bmp280_cfg pios_bmp280_cfg = {


### PR DESCRIPTION
They have a SPI BMP280 instead of I2C MS5611.  Verified to work on my OmniF4 with it and a couple other variants without, and on acro Revo.  Needs verification on original Revo, which I no longer have.