### PR TITLE
Run system task in init task (to save task stack space)

### DIFF
--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -132,8 +132,8 @@ static PeriodicObjectList* objList;
 static struct pios_recursive_mutex *mutex;
 static EventStats stats;
 
-static uint32_t idleCounter;
-static uint32_t idleCounterClear;
+static volatile uint32_t idleCounter;
+static volatile uint32_t idleCounterClear;
 static struct pios_thread *systemTaskHandle;
 static struct pios_queue *objectPersistenceQueue;
 
@@ -234,9 +234,6 @@ static void systemTask(void *parameters)
 	PIOS_IAP_WriteBootCount(0);
 #endif
 
-	// Initialize vars
-	idleCounter = 0;
-	idleCounterClear = 0;
 
 	// Listen for SettingPersistance object updates, connect a callback function
 	ObjectPersistenceConnectQueue(objectPersistenceQueue);

--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -151,7 +151,8 @@ static int32_t eventPeriodicUpdate(UAVObjEvent* ev, UAVObjEventCallback cb, stru
 static void configurationUpdatedCb(UAVObjEvent * ev, void *ctx, void *obj, int len);
 #endif
 
-static void systemTask(void *parameters);
+void system_task();
+
 static inline void updateStats();
 static inline void updateSystemAlarms();
 static inline void updateRfm22bStats();
@@ -171,11 +172,6 @@ int32_t SystemModStart(void)
 	EventPeriodicCallbackCreate(&ev, systemPeriodicCb, SYSTEM_UPDATE_PERIOD_MS);
 
 	EventClearStats();
-
-	// Create system task
-	systemTaskHandle = PIOS_Thread_Create(systemTask, "System", STACK_SIZE_BYTES, NULL, TASK_PRIORITY);
-	// Register task
-	TaskMonitorAdd(TASKINFO_RUNNING_SYSTEM, systemTaskHandle);
 
 	return 0;
 }
@@ -219,7 +215,7 @@ int32_t SystemModInitialize(void)
 }
 
 MODULE_HIPRI_INITCALL(SystemModInitialize, SystemModStart)
-static void systemTask(void *parameters)
+void system_task()
 {
 	if (PIOS_heap_malloc_failed_p()) {
 		/* We failed to malloc during task creation,
@@ -234,6 +230,8 @@ static void systemTask(void *parameters)
 	PIOS_IAP_WriteBootCount(0);
 #endif
 
+	systemTaskHandle = PIOS_Thread_WrapCurrentThread("system");
+	TaskMonitorAdd(TASKINFO_RUNNING_SYSTEM, systemTaskHandle);
 
 	// Listen for SettingPersistance object updates, connect a callback function
 	ObjectPersistenceConnectQueue(objectPersistenceQueue);

--- a/flight/Modules/System/systemmod.c
+++ b/flight/Modules/System/systemmod.c
@@ -231,6 +231,8 @@ void system_task()
 #endif
 
 	systemTaskHandle = PIOS_Thread_WrapCurrentThread("system");
+	PIOS_Thread_ChangePriority(TASK_PRIORITY);
+
 	TaskMonitorAdd(TASKINFO_RUNNING_SYSTEM, systemTaskHandle);
 
 	// Listen for SettingPersistance object updates, connect a callback function

--- a/flight/PiOS/Common/pios_thread.c
+++ b/flight/PiOS/Common/pios_thread.c
@@ -71,6 +71,28 @@ static uint8_t * align8_alloc(uint32_t size)
 }
 
 /**
+ * @brief   Creates a handle for the current thread.
+ *
+ * @param[in] namep        pointer to thread name
+ *
+ * @returns instance of @p struct pios_thread or NULL on failure
+ */
+struct pios_thread *PIOS_Thread_WrapCurrentThread(const char *namep)
+{
+	struct pios_thread *thread = PIOS_malloc_no_dma(sizeof(struct pios_thread));
+
+	if (thread) {
+		thread->threadp = chThdSelf();
+	}
+
+#if CH_USE_REGISTRY
+	thread->threadp->p_name = namep;
+#endif /* CH_USE_REGISTRY */
+
+	return thread;
+}
+
+/**
  *
  * @brief   Creates a thread.
  *

--- a/flight/PiOS/Common/pios_thread.c
+++ b/flight/PiOS/Common/pios_thread.c
@@ -83,13 +83,22 @@ struct pios_thread *PIOS_Thread_WrapCurrentThread(const char *namep)
 
 	if (thread) {
 		thread->threadp = chThdSelf();
+#if CH_USE_REGISTRY
+		thread->threadp->p_name = namep;
+#endif /* CH_USE_REGISTRY */
 	}
 
-#if CH_USE_REGISTRY
-	thread->threadp->p_name = namep;
-#endif /* CH_USE_REGISTRY */
-
 	return thread;
+}
+
+/**
+ * @brief Changes the priority of this thread.
+ *
+ * @param[in] prio The new priority.
+ */
+void PIOS_Thread_ChangePriority(enum pios_thread_prio_e prio)
+{
+	chThdSetPriority(prio);
 }
 
 /**

--- a/flight/PiOS/Common/taskmonitor.c
+++ b/flight/PiOS/Common/taskmonitor.c
@@ -67,15 +67,15 @@ int32_t TaskMonitorInitialize(void)
 int32_t TaskMonitorAdd(TaskInfoRunningElem task, struct pios_thread *threadp)
 {
 	uint32_t task_idx = (uint32_t) task;
-	if (task_idx < TASKINFO_RUNNING_NUMELEM)
-	{
+
+	PIOS_Assert(threadp);
+
+	if (task_idx < TASKINFO_RUNNING_NUMELEM) {
 		PIOS_Mutex_Lock(lock, PIOS_MUTEX_TIMEOUT_MAX);
 		handles[task_idx] = threadp;
 		PIOS_Mutex_Unlock(lock);
 		return 0;
-	}
-	else
-	{
+	} else {
 		return -1;
 	}
 }

--- a/flight/PiOS/STM32/chibi_main.c
+++ b/flight/PiOS/STM32/chibi_main.c
@@ -115,6 +115,8 @@ void check_bor()
 }
 #endif
 
+void system_task();
+
 /**
  * Initialisation task.
  *
@@ -147,6 +149,9 @@ void initTask(void)
 
 	/* create all modules thread */
 	MODULE_TASKCREATE_ALL;
+
+	/* Explicitly invoke system task, in this thread stack. */
+	system_task();
 }
 
 /**

--- a/flight/PiOS/inc/pios_thread.h
+++ b/flight/PiOS/inc/pios_thread.h
@@ -88,6 +88,7 @@ void PIOS_Thread_Scheduler_Resume(void);
  * @retval true if period has elapsed, false otherwise
  */
 bool PIOS_Thread_Period_Elapsed(const uint32_t prev_systime, const uint32_t increment_ms);
+struct pios_thread *PIOS_Thread_WrapCurrentThread(const char *namep);
 
 #endif /* PIOS_THREAD_H_ */
 

--- a/flight/PiOS/inc/pios_thread.h
+++ b/flight/PiOS/inc/pios_thread.h
@@ -89,6 +89,7 @@ void PIOS_Thread_Scheduler_Resume(void);
  */
 bool PIOS_Thread_Period_Elapsed(const uint32_t prev_systime, const uint32_t increment_ms);
 struct pios_thread *PIOS_Thread_WrapCurrentThread(const char *namep);
+void PIOS_Thread_ChangePriority(enum pios_thread_prio_e prio);
 
 #endif /* PIOS_THREAD_H_ */
 

--- a/flight/PiOS/posix/pios_thread.c
+++ b/flight/PiOS/posix/pios_thread.c
@@ -34,8 +34,44 @@ struct pios_thread
 {
 	pthread_t thread;
 
-	char *name;
+	const char *name;
 };
+
+/**
+ * @brief   Creates a handle for the current thread.
+ *
+ * @param[in] namep        pointer to thread name
+ *
+ * @returns instance of @p struct pios_thread or NULL on failure
+ */
+struct pios_thread *PIOS_Thread_WrapCurrentThread(const char *namep)
+{
+	struct pios_thread *thread = PIOS_malloc_no_dma(sizeof(struct pios_thread));
+
+	extern bool are_realtime;
+
+	if (!thread) {
+		abort();
+	}
+
+	thread->thread = pthread_self();
+
+	thread->name = namep;
+
+	if (are_realtime) {
+		struct sched_param param = {
+			.sched_priority = 30 + PIOS_THREAD_PRIO_HIGHEST * 5
+		};
+
+		pthread_setschedparam(thread->thread, SCHED_RR, &param);
+	}
+
+#ifdef __linux__
+	pthread_setname_np(thread->thread, thread->name);
+#endif
+
+	return thread;
+}
 
 struct pios_thread *PIOS_Thread_Create(void (*fp)(void *), const char *namep, size_t stack_bytes, void *argp, enum pios_thread_prio_e prio)
 {
@@ -60,7 +96,7 @@ struct pios_thread *PIOS_Thread_Create(void (*fp)(void *), const char *namep, si
 		pthread_attr_setschedparam(&attr, &param);
 	}
 
-	thread->name = strdup(namep);
+	thread->name = namep;
 
 	void *(*thr_func)(void *) = (void *) fp;
 
@@ -69,7 +105,6 @@ struct pios_thread *PIOS_Thread_Create(void (*fp)(void *), const char *namep, si
 	if (ret) {
 		printf("Couldn't start thr (%s) ret=%d\n", namep, ret);
 
-		free(thread->name);
 		free(thread);
 		return NULL;
 	}

--- a/flight/PiOS/posix/pios_thread.c
+++ b/flight/PiOS/posix/pios_thread.c
@@ -73,6 +73,18 @@ struct pios_thread *PIOS_Thread_WrapCurrentThread(const char *namep)
 	return thread;
 }
 
+void PIOS_Thread_ChangePriority(enum pios_thread_prio_e prio)
+{
+	(void) prio;
+	extern bool are_realtime;
+#ifdef __linux__
+	if (are_realtime) {
+		int pri_val = 30 + prio * 5;
+		pthread_setschedprio(pthread_self(), pri_val);
+	}
+#endif
+}
+
 struct pios_thread *PIOS_Thread_Create(void (*fp)(void *), const char *namep, size_t stack_bytes, void *argp, enum pios_thread_prio_e prio)
 {
 	struct pios_thread *thread = malloc(sizeof(*thread));
@@ -196,7 +208,6 @@ bool PIOS_Thread_Period_Elapsed(const uint32_t prev_systime,
 
 	return increment_ms <= interval;
 }
-
 
 /**
   * @}

--- a/flight/targets/flightd/fw/main.c
+++ b/flight/targets/flightd/fw/main.c
@@ -42,13 +42,8 @@
 extern void PIOS_Board_Init(void);
 extern void Stack_Change(void);
 
-/* Local Variables */
-#define INIT_TASK_PRIORITY	PIOS_THREAD_PRIO_HIGHEST
-#define INIT_TASK_STACK		262144
-static struct pios_thread *initTaskHandle;
-
 /* Function Prototypes */
-static void initTask(void *parameters);
+static void initTask();
 
 static int g_argc;
 static char **g_argv;
@@ -83,24 +78,21 @@ int main(int argc, char *argv[]) {
 	boardInit();
 #endif /* defined(PIOS_INCLUDE_CHIBIOS) */
 
-	initTaskHandle = PIOS_Thread_Create(initTask, "init", INIT_TASK_STACK, NULL, INIT_TASK_PRIORITY);
-	PIOS_Assert(initTaskHandle != NULL);
-
-	PIOS_Thread_Sleep(PIOS_THREAD_TIMEOUT_MAX);
-
-	printf("Reached end of main\n");
+	initTask();
 
 	return 0;
 }
 
 MODULE_INITSYSTEM_DECLS;
 
+void system_task();
+
 /**
  * Initialization task.
  *
  * Runs board and module initialization, then terminates.
  */
-void initTask(void *parameters)
+void initTask()
 {
 	printf("Initialization task running\n");
 
@@ -120,10 +112,11 @@ void initTask(void *parameters)
 	/* create all modules thread */
 	MODULE_TASKCREATE_ALL;
 
-	printf("Initialization task completed\n");
+	printf("Initialization task completed-- invoking system task\n");
 
-	/* terminate this task */
-	PIOS_Thread_Delete(NULL);
+	system_task();
+
+	printf("System task exited?  Shouldn't happen.\n");
 }
 
 /**


### PR DESCRIPTION
Fix #1879.

Saves a bunch of RAM.  Requires analysis of system task priority under this new scheme.  (Both posix & not).  Other small fixes.

Needs test on hardware (tested sim with and without realtime).