### PR TITLE
setupwizard: don't show anything except USB devices

### DIFF
--- a/ground/gcs/src/plugins/boards_dronin/simulation.h
+++ b/ground/gcs/src/plugins/boards_dronin/simulation.h
@@ -48,6 +48,7 @@ public:
     virtual int queryMaxGyroRate();
     QWidget *getBoardConfiguration(QWidget *parent, bool connected);
     virtual bool hasAnnunciator(AnnunciatorType annunc);
+    virtual bool isUSBSupported() { return false; }
 };
 
 #endif // SIMULATION_H_

--- a/ground/gcs/src/plugins/coreplugin/connectionmanager.h
+++ b/ground/gcs/src/plugins/coreplugin/connectionmanager.h
@@ -88,6 +88,11 @@ public:
         return connection == rhs.connection && device == rhs.device;
     }
 
+    bool operator!=(const DevListItem &rhs)
+    {
+        return !(this == &rhs);
+    }
+
     IConnection *connection;
     QPointer<IDevice> device;
 };

--- a/ground/gcs/src/plugins/setupwizard/pages/controllerpage.cpp
+++ b/ground/gcs/src/plugins/setupwizard/pages/controllerpage.cpp
@@ -47,11 +47,14 @@ ControllerPage::ControllerPage(SetupWizard *wizard, QWidget *parent)
 
     ExtensionSystem::PluginManager *pluginManager = ExtensionSystem::PluginManager::instance();
     Q_ASSERT(pluginManager);
-    m_telemtryManager = pluginManager->getObject<TelemetryManager>();
-    Q_ASSERT(m_telemtryManager);
-    connect(m_telemtryManager, &TelemetryManager::connected, this,
+    m_telemetryManager = pluginManager->getObject<TelemetryManager>();
+    Q_ASSERT(m_telemetryManager);
+    connect(m_telemetryManager, &TelemetryManager::connected, this,
             &ControllerPage::connectionStatusChanged);
-    connect(m_telemtryManager, &TelemetryManager::disconnected, this,
+    /* Consider us "connected" when telemetry manager says so, but
+     * disconnected the instant connection manager knows the conn is down.
+     */
+    connect(m_connectionManager, &Core::ConnectionManager::deviceDisconnected, this,
             &ControllerPage::connectionStatusChanged);
 
     connect(ui->connectButton, &QAbstractButton::clicked, this, &ControllerPage::connectDisconnect);
@@ -100,7 +103,7 @@ bool ControllerPage::validatePage()
 
 bool ControllerPage::anyControllerConnected()
 {
-    return m_telemtryManager->isConnected();
+    return m_telemetryManager->isConnected();
 }
 
 void ControllerPage::setupDeviceList()

--- a/ground/gcs/src/plugins/setupwizard/pages/controllerpage.h
+++ b/ground/gcs/src/plugins/setupwizard/pages/controllerpage.h
@@ -57,7 +57,7 @@ private:
     void setupDeviceList();
     void setControllerType(Core::IBoardType *);
     Core::ConnectionManager *m_connectionManager;
-    TelemetryManager *m_telemtryManager;
+    TelemetryManager *m_telemetryManager;
 
 private slots:
     void devicesChanged(QLinkedList<Core::DevListItem> devices);


### PR DESCRIPTION
(Because nothing else makes sense-- setup wizard over radio etc is silly, and all normal targets have USB, and you can always pre-connect the device you want if you are really the rare exception).

Fixes #1911 