### PR TITLE
flight: in debug mode, skip targets that don't build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,12 @@ include $(ROOT_DIR)/flight/targets/*/target-defs.mk
 # OpenPilot GCS build configuration (debug | release)
 GCS_BUILD_CONF ?= debug ccache
 
-# And the flight build configuration (debug | default | release)
-export FLIGHT_BUILD_CONF ?= default ccache
+# And the flight build configuration (debug | release)
+ifeq ($(DEBUG),YES)
+export FLIGHT_BUILD_CONF ?= debug ccache
+else
+export FLIGHT_BUILD_CONF ?= release ccache
+endif
 
 # Paths
 UAVOBJ_XML_DIR := $(ROOT_DIR)/shared/uavobjectdefinition
@@ -950,8 +954,13 @@ all_$(1)_clean: $$(addsuffix _clean, $$(filter bu_$(1), $$(BU_TARGETS)))
 all_$(1)_clean: $$(addsuffix _clean, $$(filter ef_$(1), $$(EF_TARGETS)))
 endef
 
-# Some boards don't use the bootloader
+ifeq ($(filter debug, $(FLIGHT_BUILD_CONF)), debug)
+# Don't build boards that overflow with debugging
+ALL_BOARDS     := $(filter-out $(NODEBUG_BOARDS), $(ALL_BOARDS))
+endif
+
 FW_BOARDS      := $(ALL_BOARDS)
+# Some boards don't use the bootloader
 NOBL_BOARDS    := $(strip $(foreach BOARD, $(ALL_BOARDS),$(if $(filter no,$($(BOARD)_bootloader)),$(BOARD))))
 BL_BOARDS      := $(filter-out $(NOBL_BOARDS), $(ALL_BOARDS))
 BU_BOARDS      := $(BL_BOARDS)

--- a/Makefile
+++ b/Makefile
@@ -957,6 +957,8 @@ endef
 ifeq ($(filter debug, $(FLIGHT_BUILD_CONF)), debug)
 # Don't build boards that overflow with debugging
 ALL_BOARDS     := $(filter-out $(NODEBUG_BOARDS), $(ALL_BOARDS))
+
+$(warning Removing targets with inoperable debug mode: $(NODEBUG_BOARDS))
 endif
 
 FW_BOARDS      := $(ALL_BOARDS)

--- a/flight/targets/omnibusf3/target-defs.mk
+++ b/flight/targets/omnibusf3/target-defs.mk
@@ -1,5 +1,6 @@
 # Add this board to the list of buildable boards
 ALL_BOARDS += omnibusf3
+NODEBUG_BOARDS += omnibusf3
 
 # Set the cpu architecture here that matches your STM32
 # Should be one of: f1,f3,f4

--- a/flight/targets/pikoblx/target-defs.mk
+++ b/flight/targets/pikoblx/target-defs.mk
@@ -1,5 +1,6 @@
 # Add this board to the list of buildable boards
 ALL_BOARDS += pikoblx
+NODEBUG_BOARDS += pikoblx
 
 # Set the cpu architecture here that matches your STM32
 # Should be one of: f1,f3,f4

--- a/flight/targets/sparky/target-defs.mk
+++ b/flight/targets/sparky/target-defs.mk
@@ -1,5 +1,6 @@
 # Add this board to the list of buildable boards
 ALL_BOARDS += sparky
+NODEBUG_BOARDS += sparky
 
 # Set the cpu architecture here that matches your STM32
 # Should be one of: f1,f3,f4

--- a/flight/targets/sprf3e/target-defs.mk
+++ b/flight/targets/sprf3e/target-defs.mk
@@ -1,5 +1,6 @@
 # Add this board to the list of buildable boards
 ALL_BOARDS += sprf3e
+NODEBUG_BOARDS += sprf3e
 
 # Set the cpu architecture here that matches your STM32
 # Should be one of: f1,f3,f4

--- a/make/firmware-defs.mk
+++ b/make/firmware-defs.mk
@@ -40,10 +40,8 @@ ifeq ($(filter release, $(FLIGHT_BUILD_CONF)), release)
   export DEBUG:=NO
 else ifeq ($(filter debug, $(FLIGHT_BUILD_CONF)), debug)
   export DEBUG:=YES
-else ifeq ($(filter default, $(FLIGHT_BUILD_CONF)), default)
-  # In the default case, keep the old "DEBUG"  variable handling
 else
-  $(error Only debug, release, or default allowed for FLIGHT_BUILD_CONF)
+  $(error Only debug or release allowed for FLIGHT_BUILD_CONF)
 endif
 
 # Define toolchain component names.


### PR DESCRIPTION
Allow to build all with debug, but "all" doesn't encompass these
flash-constrained F3 targets.