### PR TITLE
vtolpathfollower: improve config path

### DIFF
--- a/flight/Modules/VtolPathFollower/vtol_follower_fsm.c
+++ b/flight/Modules/VtolPathFollower/vtol_follower_fsm.c
@@ -406,7 +406,7 @@ static float vtol_hold_position_ned[3];
 static int32_t do_hold()
 {
 	if (vtol_follower_control_endpoint(vtol_hold_position_ned) == 0) {
-		if (vtol_follower_control_attitude(DT, NULL) == 0) {
+		if (vtol_follower_control_attitude(vtol_dT, NULL) == 0) {
 			return 0;
 		}
 	}
@@ -431,7 +431,7 @@ static int32_t do_path()
 {
 	struct path_status progress;
 	if (vtol_follower_control_path(&vtol_fsm_path_desired, &progress) == 0) {
-		if (vtol_follower_control_attitude(DT, NULL) == 0) {
+		if (vtol_follower_control_attitude(vtol_dT, NULL) == 0) {
 
 			if (progress.fractional_progress >= 1.0f) {
 				vtol_fsm_inject_event(FSM_EVENT_HIT_TARGET);
@@ -482,7 +482,7 @@ static int32_t do_land()
 {
 	bool landed;
 	if (vtol_follower_control_land(vtol_hold_position_ned, &landed) == 0) {
-		if (vtol_follower_control_attitude(DT, NULL) == 0) {
+		if (vtol_follower_control_attitude(vtol_dT, NULL) == 0) {
 			return 0;
 		}
 	}
@@ -504,7 +504,7 @@ static int32_t do_loiter()
 
 	float alt_adj = 0;
 
-	if (vtol_follower_control_loiter(DT, hold_pos, att_adj, &alt_adj)) {
+	if (vtol_follower_control_loiter(vtol_dT, hold_pos, att_adj, &alt_adj)) {
 		// If hold position changed, use it!
 		// We follow this conditional just to avoid unnecessarily
 		// spamming updates to the PositionDesired object.
@@ -514,7 +514,7 @@ static int32_t do_loiter()
 
 	if (vtol_follower_control_altrate(vtol_hold_position_ned,
 				alt_adj) == 0) {
-		if (vtol_follower_control_attitude(DT, att_adj) == 0) {
+		if (vtol_follower_control_attitude(vtol_dT, att_adj) == 0) {
 			return 0;
 		}
 	}
@@ -534,7 +534,7 @@ static int32_t do_slow_altitude_change(float descent_rate)
 {
 	if (vtol_follower_control_altrate(vtol_hold_position_ned,
 				descent_rate) == 0) {
-		if (vtol_follower_control_attitude(DT, NULL) == 0) {
+		if (vtol_follower_control_attitude(vtol_dT, NULL) == 0) {
 			return 0;
 		}
 	}

--- a/flight/Modules/VtolPathFollower/vtol_follower_priv.h
+++ b/flight/Modules/VtolPathFollower/vtol_follower_priv.h
@@ -31,8 +31,7 @@
 #include "openpilot.h"
 #include "pathdesired.h"
 #include "paths.h"
-
-const static float DT               = 0.05f; // TODO: make the self monitored
+#include "vtolpathfollowersettings.h"
 
 /**
  * The set of goals the VTOL follower will attempt to achieve this selects
@@ -58,6 +57,9 @@ enum vtol_pid {
 	VTOL_PID_NUM
 };
 
+extern VtolPathFollowerSettingsData vtol_guidanceSettings;
+extern float vtol_dT;
+
 // Control code public API methods
 int32_t vtol_follower_control_path(const PathDesiredData *pathDesired, struct path_status *progress);
 int32_t vtol_follower_control_endpoint(const float *hold_pos_ned);
@@ -67,8 +69,7 @@ int32_t vtol_follower_control_attitude(const float dT, const float *att_adj);
 int32_t vtol_follower_control_land(const float *hold_pos_ned, bool *landed);
 bool vtol_follower_control_loiter(float dT, float *hold_pos, float *att_adj,
 		float *alt_adj);
-void vtol_follower_control_settings_updated(UAVObjEvent * ev, void *ctx,
-		void *obj, int len);
+void vtol_follower_control_settings_updated();
 
 // Follower FSM public API methods
 


### PR DESCRIPTION
1. Use user-configured dT, so tuning doesn't vary with update period.
(no verification is made that the task actually hits desired timing
though.  Fixes #706 
2. Use proper callback-flag based mechanism.
3. Only have one copy of the guidance settings, instead of two-- save a
little bit of ram.