### PR TITLE
mcuconf: for now put back the STM32_NO_INIT code

### DIFF
--- a/flight/PiOS/STM32F30x/inc/mcuconf.h
+++ b/flight/PiOS/STM32F30x/inc/mcuconf.h
@@ -44,7 +44,7 @@
 /*
  * HAL driver system settings.
  */
-#define STM32_NO_INIT                       TRUE
+#define STM32_NO_INIT                       FALSE
 #define STM32_PVD_ENABLE                    FALSE
 #define STM32_PLS                           STM32_PLS_LEV0
 #define STM32_HSI_ENABLED                   TRUE

--- a/flight/PiOS/STM32F4xx/inc/mcuconf.h
+++ b/flight/PiOS/STM32F4xx/inc/mcuconf.h
@@ -42,7 +42,7 @@
 /*
  * HAL driver system settings.
  */
-#define STM32_NO_INIT                       TRUE
+#define STM32_NO_INIT                       FALSE
 #define STM32_HSI_ENABLED                   TRUE
 #define STM32_LSI_ENABLED                   TRUE
 #define STM32_HSE_ENABLED                   TRUE


### PR DESCRIPTION
F1 was always NO_INIT--- don't mess with it.

F3 seems to work, but put it back anyways.

F4 relies on the init code to turn on clock to some subsystems, since
PIOS_SYS_Init isn't as burly on it as F1/F3.