### PR TITLE
pios_tim/PPM:  correct F0 problem

### DIFF
--- a/flight/PiOS/STM32F0xx/pios_tim.c
+++ b/flight/PiOS/STM32F0xx/pios_tim.c
@@ -250,7 +250,7 @@ static void PIOS_TIM_generic_irq_handler(TIM_TypeDef * timer)
 			}
 
 			/* Generate the appropriate callbacks */
-			if (overflow_event & edge_event) {
+			if (overflow_event && edge_event) {
 				/*
 				 * When both edge and overflow happen in the same interrupt, we
 				 * need a heuristic to determine the order of the edge and overflow

--- a/flight/PiOS/STM32F10x/pios_tim.c
+++ b/flight/PiOS/STM32F10x/pios_tim.c
@@ -198,9 +198,8 @@ static void PIOS_TIM_generic_irq_handler(TIM_TypeDef * timer)
 {
 	uint16_t flags = timer->SR;
 
-	/* While the datasheet is not 100% clear that this (very common
-	 * paradigm) is correct TIM_ClearITPendingBit from stdperiph shows
-	 * that software is unable to set bits in this register.
+	/* Reference manual indicates these are rc_w0-- can only be
+	 * written to 0.
 	 *
 	 * Therefore, clear only the events we're going to process. 
 	 * Otherwise we could lose an overflow just after a rising edge,
@@ -289,7 +288,7 @@ static void PIOS_TIM_generic_irq_handler(TIM_TypeDef * timer)
 			}
 
 			/* Generate the appropriate callbacks */
-			if (overflow_event & edge_event) {
+			if (overflow_event && edge_event) {
 				/*
 				 * When both edge and overflow happen in the same interrupt, we
 				 * need a heuristic to determine the order of the edge and overflow
@@ -301,7 +300,7 @@ static void PIOS_TIM_generic_irq_handler(TIM_TypeDef * timer)
 				 * assume it happened before the overflow.
 				 */
 
-				if (edge_count < chan->timer->ARR / 2) {
+				if (edge_count < (chan->timer->ARR / 2)) {
 					/* Call the overflow callback first */
 					if (tim_dev->callbacks->overflow) {
 						(*tim_dev->callbacks->overflow)((uintptr_t)tim_dev,

--- a/flight/PiOS/STM32F30x/pios_tim.c
+++ b/flight/PiOS/STM32F30x/pios_tim.c
@@ -249,7 +249,7 @@ static void PIOS_TIM_generic_irq_handler(TIM_TypeDef * timer)
 			}
 
 			/* Generate the appropriate callbacks */
-			if (overflow_event & edge_event) {
+			if (overflow_event && edge_event) {
 				/*
 				 * When both edge and overflow happen in the same interrupt, we
 				 * need a heuristic to determine the order of the edge and overflow

--- a/flight/PiOS/STM32F4xx/pios_tim.c
+++ b/flight/PiOS/STM32F4xx/pios_tim.c
@@ -250,7 +250,7 @@ static void PIOS_TIM_generic_irq_handler(TIM_TypeDef * timer)
 			}
 
 			/* Generate the appropriate callbacks */
-			if (overflow_event & edge_event) {
+			if (overflow_event && edge_event) {
 				/*
 				 * When both edge and overflow happen in the same interrupt, we
 				 * need a heuristic to determine the order of the edge and overflow


### PR DESCRIPTION
1. The STM32F0xx implementation didn't work because it checked and reset the update event in a loop over multiple client device structures.  If the wrong client structure came up first, we lost the update event.  Boohoo.
2. ~~The STM32F1xx implementation didn't work~~  Pretty sure this was test methodology and I was smoking crack.  Apologies.
3. Also improved some comments, and used && instead of & (though & was safe here, it's subtle, and just askin' to be broken in the future).

We really need to unify these, the implementations vary a lot (e.g. the thresholding).