### PR TITLE
GPS: Small changes for simulator, NMEA

### DIFF
--- a/flight/Modules/GPS/GPS.c
+++ b/flight/Modules/GPS/GPS.c
@@ -215,6 +215,8 @@ static void gpsConfigure(uint8_t gpsProtocol)
 		}
 		break;
 #endif
+		default:
+			break;
 	}
 }
 

--- a/flight/Modules/GPS/GPS.c
+++ b/flight/Modules/GPS/GPS.c
@@ -76,7 +76,7 @@ static void updateSettings();
 // ****************
 // Private variables
 
-static uint32_t gpsPort;
+static uintptr_t gpsPort;
 static bool module_enabled = false;
 
 static struct pios_thread *gpsTaskHandle;

--- a/flight/Modules/GPS/NMEA.c
+++ b/flight/Modules/GPS/NMEA.c
@@ -414,7 +414,7 @@ bool NMEA_update_position(char *nmea_sentence, GPSPositionData *GpsData)
 	}
 
 	#ifdef DEBUG_MGSID_IN
-		DEBUG_MSG("%s %d ", params[0]);
+		DEBUG_MSG("%s ", params[0]);
 	#endif
 	// Send the message to the parser and get it update the GpsData
 	// Information from various different NMEA messages are temporarily
@@ -467,7 +467,7 @@ static bool nmeaProcessGPGGA(GPSPositionData * GpsData, bool* gpsDataUpdated, ch
 	DEBUG_MSG(" Sat=%s\n", param[7]);
 	DEBUG_MSG(" HDOP=%s\n", param[8]);
 	DEBUG_MSG(" Alt=%s %s\n", param[9], param[10]);
-	DEBUG_MSG(" GeoidSep=%s %s\n\n", param[11]);
+	DEBUG_MSG(" GeoidSep=%s\n\n", param[11]);
 #endif
 
 	*gpsDataUpdated = true;

--- a/flight/Modules/GPS/NMEA.c
+++ b/flight/Modules/GPS/NMEA.c
@@ -44,16 +44,16 @@
 
 // Debugging
 #ifdef ENABLE_DEBUG_MSG
-//#define DEBUG_MSG_IN			///< define to display the incoming NMEA messages
+#define DEBUG_MSG_IN			///< define to display the incoming NMEA messages
 //#define DEBUG_PARAMS			///< define to display the incoming NMEA messages split into its parameters
-//#define DEBUG_MGSID_IN		///< define to display the the names of the incoming NMEA messages
-//#define NMEA_DEBUG_PKT		///< define to enable debug of all NMEA messages
-//#define NMEA_DEBUG_GGA		///< define to enable debug of GGA messages
-//#define NMEA_DEBUG_VTG		///< define to enable debug of VTG messages
-//#define NMEA_DEBUG_RMC		///< define to enable debug of RMC messages
-//#define NMEA_DEBUG_GSA		///< define to enable debug of GSA messages
-//#define NMEA_DEBUG_GSV		///< define to enable debug of GSV messages
-//#define NMEA_DEBUG_ZDA		///< define to enable debug of ZDA messages
+#define DEBUG_MGSID_IN		///< define to display the the names of the incoming NMEA messages
+#define NMEA_DEBUG_PKT		///< define to enable debug of all NMEA messages
+#define NMEA_DEBUG_GGA		///< define to enable debug of GGA messages
+#define NMEA_DEBUG_VTG		///< define to enable debug of VTG messages
+#define NMEA_DEBUG_RMC		///< define to enable debug of RMC messages
+#define NMEA_DEBUG_GSA		///< define to enable debug of GSA messages
+#define NMEA_DEBUG_GSV		///< define to enable debug of GSV messages
+#define NMEA_DEBUG_ZDA		///< define to enable debug of ZDA messages
 #define DEBUG_MSG(format, ...) DEBUG_PRINTF(2, format, ## __VA_ARGS__)
 #else
 #define DEBUG_MSG(format, ...)

--- a/flight/Modules/GPS/NMEA.c
+++ b/flight/Modules/GPS/NMEA.c
@@ -39,7 +39,6 @@
 #include "GPS.h"
 
 //#define ENABLE_DEBUG_MSG						///< define to enable debug-messages
-#define DEBUG_PORT		PIOS_COM_TELEM_RF		///< defines which serial port is ued for debug-messages
 
 
 
@@ -55,7 +54,7 @@
 //#define NMEA_DEBUG_GSA		///< define to enable debug of GSA messages
 //#define NMEA_DEBUG_GSV		///< define to enable debug of GSV messages
 //#define NMEA_DEBUG_ZDA		///< define to enable debug of ZDA messages
-#define DEBUG_MSG(format, ...) PIOS_COM_SendFormattedString(DEBUG_PORT, format, ## __VA_ARGS__)
+#define DEBUG_MSG(format, ...) DEBUG_PRINTF(2, format, ## __VA_ARGS__)
 #else
 #define DEBUG_MSG(format, ...)
 #endif


### PR DESCRIPTION
1. Prevented invoking autoconfigure logic on NMEA even if autoconfigure is turned on.
2. Allow GPS to work on 64 bit architectures (e.g. linux-amd64)
3. Fix up debugging on NMEA to work nicely.