### PR TITLE
posix: add "faketick" infrastructure

### DIFF
--- a/flight/Modules/Actuator/actuator.c
+++ b/flight/Modules/Actuator/actuator.c
@@ -1069,7 +1069,6 @@ static float channel_failsafe_value(int idx)
 		/* Other channel types-- camera.  Center them. */
 		return 0;
 	}
-
 }
 
 /**

--- a/flight/Modules/Stabilization/sensors.c
+++ b/flight/Modules/Stabilization/sensors.c
@@ -302,6 +302,13 @@ bool sensors_step()
 
 	// Check total time to get the sensors wasn't over the limit
 	uint32_t dT_us = PIOS_DELAY_DiffuS(timeval);
+
+#ifdef FLIGHT_POSIX
+	if (PIOS_Thread_FakeClock_IsActive()) {
+		dT_us = 0;
+	}
+#endif
+
 	if (dT_us > (MAX_SENSOR_PERIOD * 1000)) {
 		good_run = false;
 	}

--- a/flight/Modules/Stabilization/simulated/simsensors.c
+++ b/flight/Modules/Stabilization/simulated/simsensors.c
@@ -610,25 +610,25 @@ static void simulateYasim()
 	}
 
 	uint32_t last_mag_time = 0;
-	if (PIOS_DELAY_DiffuS(last_mag_time) / 1.0e6 > MAG_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_mag_time, MAG_PERIOD)) {
 		simsensors_mag_set(homeLocation.Be, &Rbe);
 
-		last_mag_time = PIOS_DELAY_GetRaw();
+		last_mag_time = PIOS_Thread_Systime();
 	}
 
 	simsensors_baro_drift(&baro_offset);
 
 	// Update baro periodically
 	static uint32_t last_baro_time = 0;
-	if (PIOS_DELAY_DiffuS(last_baro_time) / 1.0e6 > BARO_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_baro_time, BARO_PERIOD)) {
 		simsensors_baro_set(status.alt, baro_offset);
-		last_baro_time = PIOS_DELAY_GetRaw();
+		last_baro_time = PIOS_Thread_Systime();
 	}
 
 	// Update GPS periodically
 	static uint32_t last_gps_time = 0;
 	static float gps_vel_drift[3] = {0,0,0};
-	if(PIOS_DELAY_DiffuS(last_gps_time) / 1.0e6 > GPS_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_gps_time, GPS_PERIOD)) {
 		// Use double precision here as simulating what GPS produces
 		double T[3];
 		T[0] = homeLocation.Altitude+6.378137E6f * DEG2RAD;
@@ -652,12 +652,12 @@ static void simulateYasim()
 		gpsPosition.Accuracy = 3.0;
 		gpsPosition.Status = GPSPOSITION_STATUS_FIX3D;
 		GPSPositionSet(&gpsPosition);
-		last_gps_time = PIOS_DELAY_GetRaw();
+		last_gps_time = PIOS_Thread_Systime();
 	}
 
 	// Update GPS Velocity measurements
 	static uint32_t last_gps_vel_time = 1000; // Delay by a millisecond
-	if(PIOS_DELAY_DiffuS(last_gps_vel_time) / 1.0e6 > GPS_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_gps_vel_time, GPS_PERIOD)) {
 		gps_vel_drift[0] = gps_vel_drift[0] * 0.65 + rand_gauss() / 5.0;
 		gps_vel_drift[1] = gps_vel_drift[1] * 0.65 + rand_gauss() / 5.0;
 		gps_vel_drift[2] = gps_vel_drift[2] * 0.65 + rand_gauss() / 5.0;
@@ -669,7 +669,7 @@ static void simulateYasim()
 		gpsVelocity.Down = status.vel[2] + gps_vel_drift[2];
 		gpsVelocity.Accuracy = 0.75;
 		GPSVelocitySet(&gpsVelocity);
-		last_gps_vel_time = PIOS_DELAY_GetRaw();
+		last_gps_vel_time = PIOS_Thread_Systime();
 	}
 
 	AttitudeSimulatedData attitudeSimulated;
@@ -767,9 +767,9 @@ static void simulateModelQuadcopter()
 
 	// Update baro periodically
 	static uint32_t last_baro_time = 0;
-	if(PIOS_DELAY_DiffuS(last_baro_time) / 1.0e6 > BARO_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_baro_time, BARO_PERIOD)) {
 		simsensors_baro_set(pos[2], baro_offset);
-		last_baro_time = PIOS_DELAY_GetRaw();
+		last_baro_time = PIOS_Thread_Systime();
 	}
 
 	HomeLocationData homeLocation;
@@ -790,7 +790,7 @@ static void simulateModelQuadcopter()
 
 	// Update GPS periodically
 	static uint32_t last_gps_time = 0;
-	if(PIOS_DELAY_DiffuS(last_gps_time) / 1.0e6 > GPS_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_gps_time, GPS_PERIOD)) {
 		// Use double precision here as simulating what GPS produces
 		double T[3];
 		T[0] = homeLocation.Altitude+6.378137E6f * DEG2RAD;
@@ -814,12 +814,12 @@ static void simulateModelQuadcopter()
 		gpsPosition.Accuracy = 3.0;
 		gpsPosition.Status = GPSPOSITION_STATUS_FIX3D;
 		GPSPositionSet(&gpsPosition);
-		last_gps_time = PIOS_DELAY_GetRaw();
+		last_gps_time = PIOS_Thread_Systime();
 	}
 
 	// Update GPS Velocity measurements
 	static uint32_t last_gps_vel_time = 1000; // Delay by a millisecond
-	if(PIOS_DELAY_DiffuS(last_gps_vel_time) / 1.0e6 > GPS_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_gps_vel_time, GPS_PERIOD)) {
 		GPSVelocityData gpsVelocity;
 		GPSVelocityGet(&gpsVelocity);
 		gpsVelocity.North = vel[0] + gps_vel_drift[0];
@@ -827,14 +827,14 @@ static void simulateModelQuadcopter()
 		gpsVelocity.Down = vel[2] + gps_vel_drift[2];
 		gpsVelocity.Accuracy = 0.75;
 		GPSVelocitySet(&gpsVelocity);
-		last_gps_vel_time = PIOS_DELAY_GetRaw();
+		last_gps_vel_time = PIOS_Thread_Systime();
 	}
 
 	// Update mag periodically
 	static uint32_t last_mag_time = 0;
-	if(PIOS_DELAY_DiffuS(last_mag_time) / 1.0e6 > MAG_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_mag_time, MAG_PERIOD)) {
 		simsensors_mag_set(homeLocation.Be, &Rbe);
-		last_mag_time = PIOS_DELAY_GetRaw();
+		last_mag_time = PIOS_Thread_Systime();
 	}
 
 	AttitudeSimulatedData attitudeSimulated;
@@ -992,21 +992,21 @@ static void simulateModelAirplane()
 
 	// Update baro periodically
 	static uint32_t last_baro_time = 0;
-	if(PIOS_DELAY_DiffuS(last_baro_time) / 1.0e6 > BARO_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_baro_time, BARO_PERIOD)) {
 		simsensors_baro_set(pos[2], baro_offset);
-		last_baro_time = PIOS_DELAY_GetRaw();
+		last_baro_time = PIOS_Thread_Systime();
 	}
 
 	// Update baro airpseed periodically
 	static uint32_t last_airspeed_time = 0;
-	if(PIOS_DELAY_DiffuS(last_airspeed_time) / 1.0e6 > BARO_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_airspeed_time, BARO_PERIOD)) {
 		BaroAirspeedData baroAirspeed;
 		baroAirspeed.BaroConnected = BAROAIRSPEED_BAROCONNECTED_TRUE;
 		baroAirspeed.CalibratedAirspeed = forwardAirspeed;
 		baroAirspeed.GPSAirspeed = forwardAirspeed;
 		baroAirspeed.TrueAirspeed = forwardAirspeed;
 		BaroAirspeedSet(&baroAirspeed);
-		last_airspeed_time = PIOS_DELAY_GetRaw();
+		last_airspeed_time = PIOS_Thread_Systime();
 	}
 
 	HomeLocationData homeLocation;
@@ -1027,7 +1027,7 @@ static void simulateModelAirplane()
 
 	// Update GPS periodically
 	static uint32_t last_gps_time = 0;
-	if(PIOS_DELAY_DiffuS(last_gps_time) / 1.0e6 > GPS_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_gps_time, GPS_PERIOD)) {
 		// Use double precision here as simulating what GPS produces
 		double T[3];
 		T[0] = homeLocation.Altitude+6.378137E6f * DEG2RAD;
@@ -1049,26 +1049,26 @@ static void simulateModelAirplane()
 		gpsPosition.Satellites = 7;
 		gpsPosition.PDOP = 1;
 		GPSPositionSet(&gpsPosition);
-		last_gps_time = PIOS_DELAY_GetRaw();
+		last_gps_time = PIOS_Thread_Systime();
 	}
 
 	// Update GPS Velocity measurements
 	static uint32_t last_gps_vel_time = 1000; // Delay by a millisecond
-	if(PIOS_DELAY_DiffuS(last_gps_vel_time) / 1.0e6 > GPS_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_gps_vel_time, GPS_PERIOD)) {
 		GPSVelocityData gpsVelocity;
 		GPSVelocityGet(&gpsVelocity);
 		gpsVelocity.North = vel[0] + gps_vel_drift[0];
 		gpsVelocity.East = vel[1] + gps_vel_drift[1];
 		gpsVelocity.Down = vel[2] + gps_vel_drift[2];
 		GPSVelocitySet(&gpsVelocity);
-		last_gps_vel_time = PIOS_DELAY_GetRaw();
+		last_gps_vel_time = PIOS_Thread_Systime();
 	}
 
 	// Update mag periodically
 	static uint32_t last_mag_time = 0;
-	if(PIOS_DELAY_DiffuS(last_mag_time) / 1.0e6 > MAG_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_mag_time, MAG_PERIOD)) {
 		simsensors_mag_set(homeLocation.Be, &Rbe);
-		last_mag_time = PIOS_DELAY_GetRaw();
+		last_mag_time = PIOS_Thread_Systime();
 	}
 
 	AttitudeSimulatedData attitudeSimulated;
@@ -1190,9 +1190,9 @@ static void simulateModelCar()
 
 	// Update baro periodically
 	static uint32_t last_baro_time = 0;
-	if(PIOS_DELAY_DiffuS(last_baro_time) / 1.0e6 > BARO_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_baro_time, BARO_PERIOD)) {
 		simsensors_baro_set(pos[2], baro_offset);
-		last_baro_time = PIOS_DELAY_GetRaw();
+		last_baro_time = PIOS_Thread_Systime();
 	}
 
 	HomeLocationData homeLocation;
@@ -1213,7 +1213,7 @@ static void simulateModelCar()
 
 	// Update GPS periodically
 	static uint32_t last_gps_time = 0;
-	if(PIOS_DELAY_DiffuS(last_gps_time) / 1.0e6 > GPS_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_gps_time, GPS_PERIOD)) {
 		// Use double precision here as simulating what GPS produces
 		double T[3];
 		T[0] = homeLocation.Altitude+6.378137E6f * DEG2RAD;
@@ -1235,26 +1235,26 @@ static void simulateModelCar()
 		gpsPosition.Satellites = 7;
 		gpsPosition.PDOP = 1;
 		GPSPositionSet(&gpsPosition);
-		last_gps_time = PIOS_DELAY_GetRaw();
+		last_gps_time = PIOS_Thread_Systime();
 	}
 
 	// Update GPS Velocity measurements
 	static uint32_t last_gps_vel_time = 1000; // Delay by a millisecond
-	if(PIOS_DELAY_DiffuS(last_gps_vel_time) / 1.0e6 > GPS_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_gps_vel_time, GPS_PERIOD)) {
 		GPSVelocityData gpsVelocity;
 		GPSVelocityGet(&gpsVelocity);
 		gpsVelocity.North = vel[0] + gps_vel_drift[0];
 		gpsVelocity.East = vel[1] + gps_vel_drift[1];
 		gpsVelocity.Down = vel[2] + gps_vel_drift[2];
 		GPSVelocitySet(&gpsVelocity);
-		last_gps_vel_time = PIOS_DELAY_GetRaw();
+		last_gps_vel_time = PIOS_Thread_Systime();
 	}
 
 	// Update mag periodically
 	static uint32_t last_mag_time = 0;
-	if(PIOS_DELAY_DiffuS(last_mag_time) / 1.0e6 > MAG_PERIOD) {
+	if (PIOS_Thread_Period_Elapsed(last_mag_time, MAG_PERIOD)) {
 		simsensors_mag_set(homeLocation.Be, &Rbe);
-		last_mag_time = PIOS_DELAY_GetRaw();
+		last_mag_time = PIOS_Thread_Systime();
 	}
 
 	AttitudeSimulatedData attitudeSimulated;

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -828,7 +828,12 @@ static void stabilizationTask(void* parameters)
 					(dT_measured < dT_expected * 0.85f)) {
 				frequency_wrong = true;
 #ifdef FLIGHT_POSIX
-				printf("Stabilization: frequency wrong.  dT_measured=%f, expected=%f\n", dT_measured, dT_expected);
+				if (!PIOS_Thread_FakeClock_IsActive()) {
+					printf("Stabilization: frequency wrong.  dT_measured=%f, expected=%f\n",
+							dT_measured, dT_expected);
+				} else {
+					frequency_wrong = false;
+				}
 #endif
 			}
 		}

--- a/flight/PiOS/Common/pios_gcsrcvr.c
+++ b/flight/PiOS/Common/pios_gcsrcvr.c
@@ -86,7 +86,9 @@ static void gcsreceiver_updated(UAVObjEvent * ev, void *ctx, void *obj, int len)
 {
 	struct pios_gcsrcvr_dev *gcsrcvr_dev = global_gcsrcvr_dev;
 	if (ev->obj == GCSReceiverHandle()) {
+		PIOS_RCVR_Active();
 		GCSReceiverGet(&gcsreceiverdata);
+
 		gcsrcvr_dev->Fresh = true;
 	}
 }

--- a/flight/PiOS/Common/pios_gcsrcvr.c
+++ b/flight/PiOS/Common/pios_gcsrcvr.c
@@ -59,7 +59,7 @@ struct pios_gcsrcvr_dev {
 	enum pios_gcsrcvr_dev_magic magic;
 
 	uint16_t supv_timer;
-	bool Fresh;
+	volatile bool Fresh;
 };
 
 static struct pios_gcsrcvr_dev *global_gcsrcvr_dev;
@@ -148,10 +148,9 @@ static void PIOS_gcsrcvr_Supervisor(uintptr_t gcsrcvr_id) {
 		return;
 	}
 
-	/* 
-	 * RTC runs at 625Hz.
-	 */
-	if ((++gcsrcvr_dev->supv_timer) < (PIOS_GCSRCVR_TIMEOUT_MS * 1000 / 625)) {
+	/* Compare RTC ticks to timeout in ms */
+	if ((++gcsrcvr_dev->supv_timer) <
+			(PIOS_GCSRCVR_TIMEOUT_MS * 1000 / PIOS_RTC_Rate())) {
 		return;
 	}
 	gcsrcvr_dev->supv_timer = 0;

--- a/flight/PiOS/Common/pios_gcsrcvr.c
+++ b/flight/PiOS/Common/pios_gcsrcvr.c
@@ -36,6 +36,10 @@
 
 #include "pios_gcsrcvr_priv.h"
 
+#ifndef PIOS_GCSRCVR_TIMEOUT_MS
+#define PIOS_GCSRCVR_TIMEOUT_MS			350
+#endif
+
 static GCSReceiverData gcsreceiverdata;
 
 /* Provide a RCVR driver */

--- a/flight/PiOS/Common/pios_rcvr.c
+++ b/flight/PiOS/Common/pios_rcvr.c
@@ -145,13 +145,7 @@ void PIOS_RCVR_Active() {
     }
 #ifdef FLIGHT_POSIX
     if (PIOS_Thread_FakeClock_IsActive()) {
-      static bool not_first;
-
-      if (not_first) {
-        PIOS_Thread_FakeClock_UpdateBarrier(95);
-      }
-
-      not_first = true;
+      PIOS_Thread_FakeClock_UpdateBarrier(100);
     }
 #endif
   }

--- a/flight/PiOS/Common/pios_rcvr.c
+++ b/flight/PiOS/Common/pios_rcvr.c
@@ -143,6 +143,17 @@ void PIOS_RCVR_Active() {
       rcvr_last_wake = PIOS_DELAY_GetRaw();
       PIOS_Semaphore_Give(rcvr_activity);
     }
+#ifdef FLIGHT_POSIX
+    if (PIOS_Thread_FakeClock_IsActive()) {
+      static bool not_first;
+
+      if (not_first) {
+        PIOS_Thread_FakeClock_UpdateBarrier(95);
+      }
+
+      not_first = true;
+    }
+#endif
   }
 }
 

--- a/flight/PiOS/inc/pios_thread.h
+++ b/flight/PiOS/inc/pios_thread.h
@@ -91,6 +91,11 @@ bool PIOS_Thread_Period_Elapsed(const uint32_t prev_systime, const uint32_t incr
 struct pios_thread *PIOS_Thread_WrapCurrentThread(const char *namep);
 void PIOS_Thread_ChangePriority(enum pios_thread_prio_e prio);
 
+#ifdef FLIGHT_POSIX
+void PIOS_Thread_FakeClock_Tick(void);
+bool PIOS_Thread_FakeClock_IsActive(void);
+#endif
+
 #endif /* PIOS_THREAD_H_ */
 
 /**

--- a/flight/PiOS/inc/pios_thread.h
+++ b/flight/PiOS/inc/pios_thread.h
@@ -94,6 +94,7 @@ void PIOS_Thread_ChangePriority(enum pios_thread_prio_e prio);
 #ifdef FLIGHT_POSIX
 void PIOS_Thread_FakeClock_Tick(void);
 bool PIOS_Thread_FakeClock_IsActive(void);
+void PIOS_Thread_FakeClock_UpdateBarrier(uint32_t increment);
 #endif
 
 #endif /* PIOS_THREAD_H_ */

--- a/flight/PiOS/posix/pios_sys.c
+++ b/flight/PiOS/posix/pios_sys.c
@@ -104,10 +104,11 @@ int orig_stdout;
 static void Usage(char *cmdName) {
 	printf( "usage: %s [-f] [-r] [-m orientation] [-s spibase]\n"
 		"\t\t[-d drvname:bus:id] [-l logfile] [-I i2cdev] [-i drvname:bus]\n"
-		"\t\t[-g port] [-c confflash]\n"
+		"\t\t[-g port] [-c confflash] [-x time] -!\n"
 		"\n"
 		"\t-f\t\t\tEnables floating point exception trapping mode\n"
 		"\t-r\t\t\tGoes realtime and pins all memory (requires root)\n"
+		"\t-!\t\t\tUse a fake clock timebase gated by gcs/simsensors\n"
 		"\t-l log\t\t\tWrites simulation data to a log\n"
 		"\t-g port\t\t\tStarts FlightGear driver on port\n"
 #ifdef PIOS_INCLUDE_SIMSENSORS_YASIM
@@ -465,13 +466,16 @@ void PIOS_SYS_Args(int argc, char *argv[]) {
 
 	bool first_arg = true;
 
-	while ((opt = getopt(argc, argv, "yfrx:g:l:s:d:S:I:i:m:c:")) != -1) {
+	while ((opt = getopt(argc, argv, "!yfrx:g:l:s:d:S:I:i:m:c:")) != -1) {
 		switch (opt) {
 #ifdef PIOS_INCLUDE_SIMSENSORS_YASIM
 			case 'y':
 				use_yasim = true;
 				break;
 #endif
+			case '!':
+				PIOS_Thread_FakeClock_Tick();
+				break;
 			case 'c':
 				PIOS_Flash_Posix_SetFName(optarg);
 				break;

--- a/flight/targets/aq32/board-info/pios_board.h
+++ b/flight/targets/aq32/board-info/pios_board.h
@@ -177,7 +177,6 @@ extern ws2811_dev_t pios_ws2811;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS			12
-#define PIOS_GCSRCVR_TIMEOUT_MS			100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/brain/board-info/pios_board.h
+++ b/flight/targets/brain/board-info/pios_board.h
@@ -174,7 +174,6 @@ extern uintptr_t pios_com_debug_id;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS			12
-#define PIOS_GCSRCVR_TIMEOUT_MS			100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/brainre1/board-info/pios_board.h
+++ b/flight/targets/brainre1/board-info/pios_board.h
@@ -183,7 +183,6 @@ extern ws2811_dev_t pios_ws2811;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS			12
-#define PIOS_GCSRCVR_TIMEOUT_MS			100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/dtfc/board-info/pios_board.h
+++ b/flight/targets/dtfc/board-info/pios_board.h
@@ -173,7 +173,6 @@ extern uintptr_t pios_com_debug_id;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS			12
-#define PIOS_GCSRCVR_TIMEOUT_MS			100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/flightd/fw/pios_board.h
+++ b/flight/targets/flightd/fw/pios_board.h
@@ -69,8 +69,6 @@ extern uintptr_t pios_com_msp_id;
 #define PIOS_COM_OPENLOG                        (pios_com_openlog_id)
 #define PIOS_COM_LIGHTTELEMETRY                 (pios_com_lighttelemetry_id)
 
-#define PIOS_GCSRCVR_TIMEOUT_MS 200
-
 #ifndef DEBUG_LEVEL
 #define DEBUG_LEVEL 2
 #endif

--- a/flight/targets/flyingpio/board-info/pios_board.h
+++ b/flight/targets/flyingpio/board-info/pios_board.h
@@ -64,7 +64,6 @@
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS			12
-#define PIOS_GCSRCVR_TIMEOUT_MS			100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/lux/board-info/pios_board.h
+++ b/flight/targets/lux/board-info/pios_board.h
@@ -161,7 +161,6 @@ extern ws2811_dev_t pios_ws2811;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS			12
-#define PIOS_GCSRCVR_TIMEOUT_MS			100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/omnibusf3/board-info/pios_board.h
+++ b/flight/targets/omnibusf3/board-info/pios_board.h
@@ -166,7 +166,6 @@ extern ws2811_dev_t pios_ws2811;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS			12
-#define PIOS_GCSRCVR_TIMEOUT_MS			100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/pikoblx/board-info/pios_board.h
+++ b/flight/targets/pikoblx/board-info/pios_board.h
@@ -155,7 +155,6 @@ extern uintptr_t pios_com_debug_id;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS			12
-#define PIOS_GCSRCVR_TIMEOUT_MS			100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/pipxtreme/board-info/pios_board.h
+++ b/flight/targets/pipxtreme/board-info/pios_board.h
@@ -223,7 +223,6 @@ extern uintptr_t pios_com_frsky_sport_id;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS      12
-#define PIOS_GCSRCVR_TIMEOUT_MS     100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/quanton/board-info/pios_board.h
+++ b/flight/targets/quanton/board-info/pios_board.h
@@ -171,7 +171,6 @@ extern ws2811_dev_t pios_ws2811;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS			12
-#define PIOS_GCSRCVR_TIMEOUT_MS			100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/revolution/board-info/pios_board.h
+++ b/flight/targets/revolution/board-info/pios_board.h
@@ -193,7 +193,6 @@ extern max7456_dev_t pios_max7456_id;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS       12
-#define PIOS_GCSRCVR_TIMEOUT_MS      100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/seppuku/board-info/pios_board.h
+++ b/flight/targets/seppuku/board-info/pios_board.h
@@ -175,7 +175,6 @@ extern ws2811_dev_t pios_ws2811;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS			12
-#define PIOS_GCSRCVR_TIMEOUT_MS			100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/sparky/board-info/pios_board.h
+++ b/flight/targets/sparky/board-info/pios_board.h
@@ -154,7 +154,6 @@ extern uintptr_t pios_com_debug_id;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS			12
-#define PIOS_GCSRCVR_TIMEOUT_MS			100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/sparky2/board-info/pios_board.h
+++ b/flight/targets/sparky2/board-info/pios_board.h
@@ -170,7 +170,6 @@ extern uintptr_t pios_rfm22b_id;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS       12
-#define PIOS_GCSRCVR_TIMEOUT_MS      100
 
 //-------------------------
 // Receiver PPM input

--- a/flight/targets/sprf3e/board-info/pios_board.h
+++ b/flight/targets/sprf3e/board-info/pios_board.h
@@ -166,7 +166,6 @@ extern ws2811_dev_t pios_ws2811;
 // See also pios_board.c
 //------------------------
 #define PIOS_RCVR_MAX_CHANNELS			12
-#define PIOS_GCSRCVR_TIMEOUT_MS			100
 
 //-------------------------
 // Receiver PPM input

--- a/ground/gcs/src/plugins/gcscontrolplugin/gcscontrol.cpp
+++ b/ground/gcs/src/plugins/gcscontrolplugin/gcscontrol.cpp
@@ -147,8 +147,12 @@ bool GCSControl::beginGCSControl()
     manControlSettingsUAVO->updated();
     connect(manControlSettingsUAVO, &UAVObject::objectUpdated, this, &GCSControl::objectsUpdated);
     hasControl = true;
-    for (quint8 x = 0; x < GCSReceiver::CHANNEL_NUMELEM; ++x)
-        setChannel(x, 0);
+
+    for (quint8 x = 0; x < NUM_CHANNELS; ++x) {
+        setChannel(channels[x], 0);
+    }
+
+    setChannel(ManualControlSettings::CHANNELGROUPS_ARMING, -1);
     receiverActivity.start();
     return true;
 }

--- a/shared/uavobjectdefinition/hwsimulation.xml
+++ b/shared/uavobjectdefinition/hwsimulation.xml
@@ -16,5 +16,12 @@
         <option>On</option>
       </options>
     </field>
+    <field defaultvalue="FALSE" elements="1" name="FakeTickBlocked" type="enum" units="">
+      <description>TRUE if the fake tick system is blocking the clock waiting for control input</description>
+      <options>
+        <option>FALSE</option>
+        <option>TRUE</option>
+      </options>
+    </field>
   </object>
 </xml>


### PR DESCRIPTION
Now the clock can represent (monotonic) system time, or it can represent
a value controlled by the sensors subsystem.  The latter case allows us
to run the simulator without it ever "falling behind".

The sensor ticking is gated by control updates, so
that integration tests can get (somewhat) repeatable results.  It won't
be perfect because there will be nondeterministic scheduling between
different (non-realtime) tasks.

Depends/based on #2149.