### PR TITLE
Lots of small changes to hardware support

### DIFF
--- a/flight/PiOS/Common/pios_hal.c
+++ b/flight/PiOS/Common/pios_hal.c
@@ -281,9 +281,9 @@ static inline void PIOS_HAL_Err2811(bool on) {
 		} else {
 			PIOS_WS2811_set_all(pios_ws2811, 0, 32, 0);
 		}
-	}
 
-	PIOS_WS2811_trigger_update(pios_ws2811);
+		PIOS_WS2811_trigger_update(pios_ws2811);
+	}
 #endif
 }
 

--- a/flight/PiOS/Common/pios_mpu.c
+++ b/flight/PiOS/Common/pios_mpu.c
@@ -664,12 +664,17 @@ void PIOS_MPU_SetGyroBandwidth(uint16_t bandwidth)
 			filter = PIOS_ICM20608G_GYRO_LOWPASS_20_HZ;
 		else if (bandwidth <= 92)
 			filter = PIOS_ICM20608G_GYRO_LOWPASS_92_HZ;
+		else
+			filter = PIOS_ICM20608G_GYRO_LOWPASS_176_HZ;
+#if 0
+		/* Unsupported/higher sample rates */
 		else if (bandwidth <= 176)
 			filter = PIOS_ICM20608G_GYRO_LOWPASS_176_HZ;
 		else if (bandwidth <= 250)
 			filter = PIOS_ICM20608G_GYRO_LOWPASS_250_HZ;
 		else
 			filter = PIOS_ICM20608G_GYRO_LOWPASS_3281_HZ;
+#endif
 	}
 
 	PIOS_MPU_WriteReg(PIOS_MPU_DLPF_CFG_REG, filter);

--- a/flight/PiOS/inc/pios_bmp280.h
+++ b/flight/PiOS/inc/pios_bmp280.h
@@ -33,7 +33,7 @@
 
 #include <pios.h>
 
-#if defined(PIOS_INCLUDE_BMP280)
+#if defined(PIOS_INCLUDE_BMP280) || defined(PIOS_INCLUDE_BMP280_SPI)
 #ifndef TARGET_MAY_HAVE_BARO
 #define TARGET_MAY_HAVE_BARO
 #endif

--- a/flight/PiOS/pios.h
+++ b/flight/PiOS/pios.h
@@ -125,7 +125,7 @@
 #if defined(PIOS_INCLUDE_ETASV3)
 #include <pios_etasv3.h>
 #endif
-#if defined(PIOS_INCLUDE_BMP280)
+#if defined(PIOS_INCLUDE_BMP280) || defined(PIOS_INCLUDE_BMP280_SPI)
 #include <pios_bmp280.h>
 #endif
 #if defined(PIOS_INCLUDE_HCSR04)

--- a/flight/targets/revolution/fw/pios_board.c
+++ b/flight/targets/revolution/fw/pios_board.c
@@ -237,14 +237,18 @@ void PIOS_Board_Init(void) {
 	/* Configure IO ports */
 
 #if defined(PIOS_INCLUDE_I2C)
-	if (PIOS_I2C_Init(&pios_i2c_mag_pressure_adapter_id, &pios_i2c_mag_pressure_adapter_cfg))
-		PIOS_DEBUG_Assert(0);
-
-	if (PIOS_I2C_CheckClear(pios_i2c_mag_pressure_adapter_id) != 0)
+	if ((!is_modified_clone) && PIOS_I2C_Init(&pios_i2c_mag_pressure_adapter_id, &pios_i2c_mag_pressure_adapter_cfg)) {
 		PIOS_HAL_CriticalError(PIOS_LED_HEARTBEAT, PIOS_HAL_PANIC_I2C_INT);
-	else
-		if (AlarmsGet(SYSTEMALARMS_ALARM_I2C) == SYSTEMALARMS_ALARM_UNINITIALISED)
+	}
+
+	if ((!is_modified_clone) &&
+			(PIOS_I2C_CheckClear(pios_i2c_mag_pressure_adapter_id) != 0)) {
+		PIOS_HAL_CriticalError(PIOS_LED_HEARTBEAT, PIOS_HAL_PANIC_I2C_INT);
+	} else if (!is_modified_clone) {
+		if (AlarmsGet(SYSTEMALARMS_ALARM_I2C) == SYSTEMALARMS_ALARM_UNINITIALISED) {
 			AlarmsSet(SYSTEMALARMS_ALARM_I2C, SYSTEMALARMS_ALARM_OK);
+		}
+	}
 #endif  // PIOS_INCLUDE_I2C
 
 	HwRevolutionDSMxModeOptions hw_DSMxMode;
@@ -557,6 +561,10 @@ void PIOS_Board_Init(void) {
 	uint8_t hw_magnetometer;
 	HwRevolutionMagnetometerGet(&hw_magnetometer);
 
+	if (!pios_i2c_mag_pressure_adapter_id) {
+		hw_magnetometer = HWREVOLUTION_MAGNETOMETER_NONE;
+	}
+
 	switch (hw_magnetometer) {
 		case HWREVOLUTION_MAGNETOMETER_NONE:
 			break;
@@ -590,7 +598,7 @@ void PIOS_Board_Init(void) {
 	PIOS_WDG_Clear();
 
 #if defined(PIOS_INCLUDE_MS5611)
-	if ((PIOS_MS5611_Init(&pios_ms5611_cfg, pios_i2c_mag_pressure_adapter_id) != 0) || (PIOS_MS5611_Test() != 0)) {
+	if ((!pios_i2c_mag_pressure_adapter_id) || (PIOS_MS5611_Init(&pios_ms5611_cfg, pios_i2c_mag_pressure_adapter_id) != 0) || (PIOS_MS5611_Test() != 0)) {
 		if (!is_modified_clone) {
 			PIOS_HAL_CriticalError(PIOS_LED_HEARTBEAT, PIOS_HAL_PANIC_BARO);
 		}

--- a/shared/uavobjectdefinition/hwrevolution.xml
+++ b/shared/uavobjectdefinition/hwrevolution.xml
@@ -5,7 +5,7 @@
     <logging updatemode="manual" period="0"/>
     <telemetrygcs acked="true" updatemode="onchange" period="0"/>
     <telemetryflight acked="true" updatemode="onchange" period="0"/>
-    <field defaultvalue="PWM" elements="1" name="RxPort" type="enum" units="function">
+    <field defaultvalue="Disabled" elements="1" name="RxPort" type="enum" units="function">
       <description/>
       <options>
         <option>Disabled</option>


### PR DESCRIPTION
* Support panic blinks on targets with optional '2811 (before we'd crash and not blink)
* Revolution: Don't init internal I2C bus on cheapo clones.
* pios_mpu: Woops, don't enter high output rate modes on icm-20608
* Revolution: Don't config RX port by default-- this isn't necessary but it seems we shouldn't, just in case there's a conflict on subsequent crummy hardware.
* pios_bmp280: Make sure that the SPI version, counts alone, for "could have baro". This is another future trap averted.