### PR TITLE
posix: use native assert instead of infinite loop

### DIFF
--- a/flight/PiOS/posix/inc/pios_debug.h
+++ b/flight/PiOS/posix/inc/pios_debug.h
@@ -30,6 +30,8 @@
 #ifndef PIOS_DEBUG_H
 #define PIOS_DEBUG_H
 
+#include <assert.h>
+
 extern const char *PIOS_DEBUG_AssertMsg;
 
 void PIOS_DEBUG_Init(void);
@@ -39,12 +41,12 @@ void PIOS_DEBUG_PinValue8Bit(uint8_t value);
 void PIOS_DEBUG_PinValue4BitL(uint8_t value);
 void PIOS_DEBUG_Panic(const char *msg);
 
+#define PIOS_Assert(test) assert(test)
+
 #ifdef DEBUG
-#define PIOS_DEBUG_Assert(test) if (!(test)) PIOS_DEBUG_Panic(PIOS_DEBUG_AssertMsg);
-#define PIOS_Assert(test) PIOS_DEBUG_Assert(test)
+#define PIOS_DEBUG_Assert(test) PIOS_Assert(test)
 #else
 #define PIOS_DEBUG_Assert(test)
-#define PIOS_Assert(test) if (!(test)) while (1);
 #endif
 
 #endif /* PIOS_DEBUG_H */

--- a/flight/PiOS/posix/pios_spi.c
+++ b/flight/PiOS/posix/pios_spi.c
@@ -128,7 +128,7 @@ int32_t PIOS_SPI_SetClockSpeed(pios_spi_t spi_dev, uint32_t spi_speed)
 int32_t PIOS_SPI_ClaimBus(pios_spi_t spi_dev)
 {
 	bool valid = PIOS_SPI_validate(spi_dev);
-	PIOS_Assert(valid)
+	PIOS_Assert(valid);
 
 	if (PIOS_Semaphore_Take(spi_dev->busy, 65535) != true)
 		return -1;
@@ -139,7 +139,7 @@ int32_t PIOS_SPI_ClaimBus(pios_spi_t spi_dev)
 int32_t PIOS_SPI_ReleaseBus(pios_spi_t spi_dev)
 {
 	bool valid = PIOS_SPI_validate(spi_dev);
-	PIOS_Assert(valid)
+	PIOS_Assert(valid);
 
 	PIOS_Semaphore_Give(spi_dev->busy);
 
@@ -149,8 +149,8 @@ int32_t PIOS_SPI_ReleaseBus(pios_spi_t spi_dev)
 int32_t PIOS_SPI_RC_PinSet(pios_spi_t spi_dev, uint32_t slave_id, bool pin_value)
 {
 	bool valid = PIOS_SPI_validate(spi_dev);
-	PIOS_Assert(valid)
-	PIOS_Assert(slave_id < spi_dev->slave_count)
+	PIOS_Assert(valid);
+	PIOS_Assert(slave_id < spi_dev->slave_count);
 
         struct spi_ioc_transfer xfer = {
 		.delay_usecs = 1,
@@ -193,8 +193,8 @@ int32_t PIOS_SPI_TransferBlock(pios_spi_t spi_dev, const uint8_t *send_buffer, u
 
 	int slave_id = spi_dev->selected;
 
-	PIOS_Assert(valid)
-	PIOS_Assert(slave_id < spi_dev->slave_count)
+	PIOS_Assert(valid);
+	PIOS_Assert(slave_id < spi_dev->slave_count);
 	PIOS_Assert(slave_id >= 0);
 
         struct spi_ioc_transfer xfer = {


### PR DESCRIPTION
There's been multiple things, e.g. the integration test fail... that would have been easier to run down with this.