### PR TITLE
gcs: qmessagebox needs a valid widget parent

### DIFF
--- a/ground/gcs/src/libs/tlmapcontrol/core/urlfactory.h
+++ b/ground/gcs/src/libs/tlmapcontrol/core/urlfactory.h
@@ -42,7 +42,6 @@
 #include "cache.h"
 #include <QTextCodec>
 #include "cmath"
-#include <QtWidgets/QMessageBox>
 #include "QDomElement"
 
 namespace core {

--- a/ground/gcs/src/plugins/config/calibration.cpp
+++ b/ground/gcs/src/plugins/config/calibration.cpp
@@ -445,12 +445,10 @@ void Calibration::timeout()
 
     disconnect(&timer, &QTimer::timeout, this, &Calibration::timeout);
 
-    int reply =
-        QMessageBox::information((QWidget *)Core::ICore::instance()->mainWindow(),
-                tr("Calibration failed"),
-                tr("Calibration timed out before receiving required updates."));
-
-    (void) reply;
+    (void) QMessageBox::information(
+            (QWidget *)Core::ICore::instance()->mainWindow(),
+            tr("Calibration failed"),
+            tr("Calibration timed out before receiving required updates."));
 }
 
 /**

--- a/ground/gcs/src/plugins/config/calibration.cpp
+++ b/ground/gcs/src/plugins/config/calibration.cpp
@@ -34,6 +34,8 @@
 
 #include "physical_constants.h"
 
+#include <coreplugin/icore.h>
+
 #include "utils/coordinateconversions.h"
 #include <QMessageBox>
 #include <QDebug>
@@ -443,11 +445,12 @@ void Calibration::timeout()
 
     disconnect(&timer, &QTimer::timeout, this, &Calibration::timeout);
 
-    QMessageBox msgBox;
-    msgBox.setText(tr("Calibration timed out before receiving required updates."));
-    msgBox.setStandardButtons(QMessageBox::Ok);
-    msgBox.setDefaultButton(QMessageBox::Ok);
-    msgBox.exec();
+    int reply =
+        QMessageBox::information((QWidget *)Core::ICore::instance()->mainWindow(),
+                tr("Calibration failed"),
+                tr("Calibration timed out before receiving required updates."));
+
+    (void) reply;
 }
 
 /**

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configccpmwidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configccpmwidget.cpp
@@ -1012,11 +1012,8 @@ void ConfigCcpmWidget::showEvent(QShowEvent *event)
 
 void ConfigCcpmWidget::SwashLvlStartButtonPressed()
 {
-    QMessageBox msgBox;
-    int i;
-    msgBox.setText("<h1>Swashplate Leveling Routine</h1>");
-    msgBox.setInformativeText(
-        "<b>You are about to start the Swashplate levelling routine.</b><p>This process will start "
+    QMessageBox msgBox(QMessageBox::Information, tr("Swashplate Leveling Routine"),
+        tr("<b>You are about to start the Swashplate levelling routine.</b><p>This process will start "
         "by downloading the current configuration from the GCS to the OP hardware and will adjust "
         "your configuration at various stages.<p>The final state of your system should match the "
         "current configuration in the GCS config gadget.<p>Please ensure all ccpm settings in the "
@@ -1024,10 +1021,9 @@ void ConfigCcpmWidget::SwashLvlStartButtonPressed()
         "your OP board may not match the GCS configuration.<p><i>After completing this process, "
         "please check all settings before attempting to fly.</i><p><font color=red><b>Please "
         "disconnect your motor to ensure it will not spin up.</b></font><p><hr><i>Do you wish to "
-        "proceed?</i>");
-    msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
+        "proceed?</i>"), QMessageBox::Yes | QMessageBox::Cancel, this);
+
     msgBox.setDefaultButton(QMessageBox::Cancel);
-    msgBox.setIcon(QMessageBox::Information);
     int ret = msgBox.exec();
 
     UAVObjectField *MinField;
@@ -1094,7 +1090,7 @@ void ConfigCcpmWidget::SwashLvlStartButtonPressed()
         }
 
         // min,neutral,max values for the servos
-        for (i = 0; i < CCPM_MAX_SWASH_SERVOS; i++) {
+        for (uint8_t i = 0; i < CCPM_MAX_SWASH_SERVOS; i++) {
             oldSwashLvlConfiguration.Min[i] =
                 MinField->getValue(oldSwashLvlConfiguration.ServoChannels[i]).toInt();
             oldSwashLvlConfiguration.Neutral[i] =

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configfixedwingwidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configfixedwingwidget.cpp
@@ -36,7 +36,6 @@
 #include <QPushButton>
 #include <QBrush>
 #include <math.h>
-#include <QMessageBox>
 
 /**
  Constructor

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configgroundvehiclewidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configgroundvehiclewidget.cpp
@@ -37,7 +37,6 @@
 #include <QPushButton>
 #include <QBrush>
 #include <math.h>
-#include <QMessageBox>
 
 /**
  Constructor

--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configmultirotorwidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configmultirotorwidget.cpp
@@ -34,7 +34,6 @@
 #include <QComboBox>
 #include <QBrush>
 #include <math.h>
-#include <QMessageBox>
 
 #include "actuatorcommand.h"
 #include "mixersettings.h"

--- a/ground/gcs/src/plugins/config/configautotunewidget.cpp
+++ b/ground/gcs/src/plugins/config/configautotunewidget.cpp
@@ -60,7 +60,6 @@
 #include <QDesktopServices>
 #include <QFileDialog>
 #include <QList>
-#include <QMessageBox>
 #include <QPushButton>
 #include <QStringList>
 #include <QTextEdit>

--- a/ground/gcs/src/plugins/config/configgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.cpp
@@ -46,6 +46,7 @@
 #include "uavobjectutil/uavobjectutilmanager.h"
 
 #include <QDebug>
+#include <QMessageBox>
 #include <QStringList>
 #include <QWidget>
 #include <QTextEdit>

--- a/ground/gcs/src/plugins/config/configgadgetwidget.h
+++ b/ground/gcs/src/plugins/config/configgadgetwidget.h
@@ -36,7 +36,6 @@
 #include <QList>
 #include <QTextBrowser>
 #include "utils/pathutils.h"
-#include <QMessageBox>
 #include "utils/mytabbedstackwidget.h"
 #include "../uavobjectwidgetutils/configtaskwidget.h"
 

--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -43,7 +43,6 @@
 #include <QDesktopServices>
 #include <QUrl>
 #include <QMessageBox>
-#include <QMessageBox>
 
 #include <extensionsystem/pluginmanager.h>
 #include <uavobjectutil/uavobjectutilmanager.h>
@@ -407,7 +406,7 @@ void ConfigInputWidget::goToWizard()
     // Monitor for connection loss to reset wizard safely
     connect(telMngr, &TelemetryManager::disconnected, this, &ConfigInputWidget::wzCancel);
 
-    QMessageBox msgBox;
+    QMessageBox msgBox(this);
     msgBox.setText(tr("Arming Settings will be set to Always Disarmed for your safety."));
     msgBox.setDetailedText(tr("You will have to reconfigure the arming settings manually "
                               "when the wizard is finished. After the last step of the "

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -171,12 +171,10 @@ void ConfigOutputWidget::runChannelTests(bool state)
     if (state && ((systemAlarms.Alarm[SystemAlarms::ALARM_ACTUATOR] == SystemAlarms::ALARM_ERROR)
                   || (systemAlarms.Alarm[SystemAlarms::ALARM_ACTUATOR]
                       == SystemAlarms::ALARM_CRITICAL))) {
-        QMessageBox mbox;
-        mbox.setText(
-            QString(tr("The actuator module is in an error state.  This can also occur because "
-                       "there are no inputs.  Please fix these before testing outputs.")));
-        mbox.setStandardButtons(QMessageBox::Ok);
-        mbox.exec();
+        int ignored = QMessageBox::critical(this, tr("Actuator error"),
+            tr("The actuator module is in an error state. "
+                "Please fix these before testing outputs."));
+        (void) ignored;
 
         // Unfortunately must cache this since callback will reoccur
         accInitialData = ActuatorCommand::GetInstance(getObjectManager())->getMetadata();
@@ -187,12 +185,12 @@ void ConfigOutputWidget::runChannelTests(bool state)
 
     // Confirm this is definitely what they want
     if (state) {
-        QMessageBox mbox;
-        mbox.setText(QString(tr("This option will start your motors by the amount selected on the "
-                                "sliders regardless of transmitter.  It is recommended to remove "
-                                "any blades from motors.  Are you sure you want to do this?")));
-        mbox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        int retval = mbox.exec();
+        int retval = QMessageBox::warning(this, tr("Actuator test"),
+                tr("This option will start your motors by the amount selected on the "
+                    "sliders regardless of transmitter.  It is recommended to remove "
+                    "any blades from motors.  Are you sure you want to do this?"),
+                QMessageBox::Yes | QMessageBox::No);
+
         if (retval != QMessageBox::Yes) {
             state = false;
             m_config->channelOutTest->setChecked(false);
@@ -330,7 +328,7 @@ void ConfigOutputWidget::startESCCalibration()
     if (!showOutputChannelSelectWindow(channelsToCalibrate))
         return;
 
-    QMessageBox mbox;
+    QMessageBox mbox(this);
     mbox.setText(QString(tr("Starting ESC calibration.<br/><b>Please remove all propellers and "
                             "disconnect battery from ESCs.</b>")));
     mbox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);

--- a/ground/gcs/src/plugins/config/configoutputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configoutputwidget.cpp
@@ -171,10 +171,9 @@ void ConfigOutputWidget::runChannelTests(bool state)
     if (state && ((systemAlarms.Alarm[SystemAlarms::ALARM_ACTUATOR] == SystemAlarms::ALARM_ERROR)
                   || (systemAlarms.Alarm[SystemAlarms::ALARM_ACTUATOR]
                       == SystemAlarms::ALARM_CRITICAL))) {
-        int ignored = QMessageBox::critical(this, tr("Actuator error"),
+        (void) QMessageBox::critical(this, tr("Actuator error"),
             tr("The actuator module is in an error state. "
                 "Please fix these before testing outputs."));
-        (void) ignored;
 
         // Unfortunately must cache this since callback will reoccur
         accInitialData = ActuatorCommand::GetInstance(getObjectManager())->getMetadata();

--- a/ground/gcs/src/plugins/config/configplugin.cpp
+++ b/ground/gcs/src/plugins/config/configplugin.cpp
@@ -139,7 +139,7 @@ void ConfigPlugin::onAutopilotDisconnect()
   */
 void ConfigPlugin::eraseAllSettings()
 {
-    QMessageBox msgBox;
+    QMessageBox msgBox((QWidget *)Core::ICore::instance()->mainWindow());
     msgBox.setText(tr("Are you sure you want to erase all board settings?."));
     msgBox.setInformativeText(tr("All settings stored in your board flash will be deleted."));
     msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
@@ -181,19 +181,18 @@ void ConfigPlugin::eraseFailed()
     ObjectPersistence *objper = ObjectPersistence::GetInstance(getObjectManager());
 
     disconnect(objper, &UAVObject::objectUpdated, this, &ConfigPlugin::eraseDone);
-    QMessageBox msgBox;
-    msgBox.setText(tr("Error trying to erase settings."));
-    msgBox.setInformativeText(
-        tr("Power-cycle your board after removing all blades. Settings might be inconsistent."));
-    msgBox.setStandardButtons(QMessageBox::Ok);
-    msgBox.setDefaultButton(QMessageBox::Ok);
-    msgBox.exec();
+
+    int ignored = QMessageBox::critical((QWidget *)Core::ICore::instance()->mainWindow(),
+            tr("Error erasing settings"),
+            tr("Power-cycle your board after removing all blades. Settings might be inconsistent."), QMessageBox::Ok);
+
+    (void) ignored;
 }
 
 void ConfigPlugin::eraseDone(UAVObject *obj)
 {
     Q_UNUSED(obj)
-    QMessageBox msgBox;
+    QMessageBox msgBox((QWidget *)Core::ICore::instance()->mainWindow());
     ObjectPersistence *objper = ObjectPersistence::GetInstance(getObjectManager());
     ObjectPersistence::DataFields data = objper->getData();
     Q_ASSERT(obj->getInstID() == objper->getInstID());

--- a/ground/gcs/src/plugins/config/configplugin.cpp
+++ b/ground/gcs/src/plugins/config/configplugin.cpp
@@ -182,11 +182,9 @@ void ConfigPlugin::eraseFailed()
 
     disconnect(objper, &UAVObject::objectUpdated, this, &ConfigPlugin::eraseDone);
 
-    int ignored = QMessageBox::critical((QWidget *)Core::ICore::instance()->mainWindow(),
+    (void) QMessageBox::critical((QWidget *)Core::ICore::instance()->mainWindow(),
             tr("Error erasing settings"),
             tr("Power-cycle your board after removing all blades. Settings might be inconsistent."), QMessageBox::Ok);
-
-    (void) ignored;
 }
 
 void ConfigPlugin::eraseDone(UAVObject *obj)

--- a/ground/gcs/src/plugins/coreplugin/coreimpl.cpp
+++ b/ground/gcs/src/plugins/coreplugin/coreimpl.cpp
@@ -59,14 +59,6 @@ bool CoreImpl::showOptionsDialog(const QString &group, const QString &page, QWid
     return m_mainwindow->showOptionsDialog(group, page, parent);
 }
 
-bool CoreImpl::showWarningWithOptions(const QString &title, const QString &text,
-                                      const QString &details, const QString &settingsCategory,
-                                      const QString &settingsId, QWidget *parent)
-{
-    return m_mainwindow->showWarningWithOptions(title, text, details, settingsCategory, settingsId,
-                                                parent);
-}
-
 ActionManager *CoreImpl::actionManager() const
 {
     return m_mainwindow->actionManager();

--- a/ground/gcs/src/plugins/coreplugin/coreimpl.h
+++ b/ground/gcs/src/plugins/coreplugin/coreimpl.h
@@ -44,11 +44,6 @@ namespace Internal {
 
         bool showOptionsDialog(const QString &group = QString(), const QString &page = QString(),
                                QWidget *parent = nullptr);
-        bool showWarningWithOptions(const QString &title, const QString &text,
-                                    const QString &details = QString(),
-                                    const QString &settingsCategory = QString(),
-                                    const QString &settingsId = QString(), QWidget *parent = nullptr);
-
         ActionManager *actionManager() const;
         UniqueIDManager *uniqueIDManager() const;
         ConnectionManager *connectionManager() const;

--- a/ground/gcs/src/plugins/coreplugin/icore.cpp
+++ b/ground/gcs/src/plugins/coreplugin/icore.cpp
@@ -76,19 +76,6 @@
 */
 
 /*!
-    \fn bool ICore::showWarningWithOptions(const QString &title, const QString &text,
-                                   const QString &details = QString(),
-                                   const QString &settingsCategory = QString(),
-                                   const QString &settingsId = QString(),
-                                   QWidget *parent = 0);
-
-    \brief Show a warning message with a button that opens a settings page.
-
-    Should be used to display configuration errors and point users to the setting.
-    Returns true if the settings dialog was accepted.
-*/
-
-/*!
     \fn ActionManager *ICore::actionManager() const
     \brief Returns the application's action manager.
 

--- a/ground/gcs/src/plugins/coreplugin/icore.h
+++ b/ground/gcs/src/plugins/coreplugin/icore.h
@@ -68,12 +68,6 @@ public:
     virtual bool showOptionsDialog(const QString &group = QString(),
                                    const QString &page = QString(), QWidget *parent = nullptr) = 0;
 
-    virtual bool showWarningWithOptions(const QString &title, const QString &text,
-                                        const QString &details = QString(),
-                                        const QString &settingsCategory = QString(),
-                                        const QString &settingsId = QString(),
-                                        QWidget *parent = nullptr) = 0;
-
     virtual ActionManager *actionManager() const = 0;
     virtual UniqueIDManager *uniqueIDManager() const = 0;
     virtual ModeManager *modeManager() const = 0;

--- a/ground/gcs/src/plugins/coreplugin/mainwindow.cpp
+++ b/ground/gcs/src/plugins/coreplugin/mainwindow.cpp
@@ -149,7 +149,8 @@ MainWindow::MainWindow()
             QMessageBox msgBox(QMessageBox::Warning, tr("Settings Not Saved"),
                                tr("Your settings file (%0) is not writable! "
                                   "All GCS configuration changes will be lost!")
-                                   .arg(Utils::PathUtils().getSettingsFilename()));
+                                   .arg(Utils::PathUtils().getSettingsFilename()),
+                                   QMessageBox::Ok, this);
             msgBox.exec();
         }
     }
@@ -1447,26 +1448,4 @@ void MainWindow::setFullScreen(bool on)
         // menuBar()->show();
         // statusBar()->show();
     }
-}
-
-// Display a warning with an additional button to open
-// the debugger settings dialog if settingsId is nonempty.
-
-bool MainWindow::showWarningWithOptions(const QString &title, const QString &text,
-                                        const QString &details, const QString &settingsCategory,
-                                        const QString &settingsId, QWidget *parent)
-{
-    if (parent == nullptr)
-        parent = this;
-    QMessageBox msgBox(QMessageBox::Warning, title, text, QMessageBox::Ok, parent);
-    if (details.isEmpty())
-        msgBox.setDetailedText(details);
-    QAbstractButton *settingsButton = nullptr;
-    if (!settingsId.isEmpty() || !settingsCategory.isEmpty())
-        settingsButton = msgBox.addButton(tr("Settings..."), QMessageBox::AcceptRole);
-    msgBox.exec();
-    if (settingsButton && msgBox.clickedButton() == settingsButton) {
-        return showOptionsDialog(settingsCategory, settingsId);
-    }
-    return false;
 }

--- a/ground/gcs/src/plugins/coreplugin/mainwindow.h
+++ b/ground/gcs/src/plugins/coreplugin/mainwindow.h
@@ -133,11 +133,6 @@ namespace Internal {
         bool showOptionsDialog(const QString &category = QString(), const QString &page = QString(),
                                QWidget *parent = nullptr);
 
-        bool showWarningWithOptions(const QString &title, const QString &text,
-                                    const QString &details = QString(),
-                                    const QString &settingsCategory = QString(),
-                                    const QString &settingsId = QString(), QWidget *parent = nullptr);
-
     protected:
         virtual void changeEvent(QEvent *e);
         virtual void closeEvent(QCloseEvent *event);

--- a/ground/gcs/src/plugins/coreplugin/uavconfiginfo.cpp
+++ b/ground/gcs/src/plugins/coreplugin/uavconfiginfo.cpp
@@ -104,6 +104,7 @@
 */
 
 #include "uavconfiginfo.h"
+#include "icore.h"
 #include <QMessageBox>
 
 #define VERSION_DEFAULT "0.0.0"
@@ -173,7 +174,7 @@ void UAVConfigInfo::read(QSettings *qs)
 
 bool UAVConfigInfo::askToAbort(int compat, QString message)
 {
-    QMessageBox msgBox;
+    QMessageBox msgBox((QWidget *) Core::ICore::instance()->mainWindow());
     msgBox.setInformativeText(tr("Do you want to continue the import?"));
     msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
 
@@ -221,7 +222,7 @@ bool UAVConfigInfo::askToAbort(int compat, QString message)
 
 void UAVConfigInfo::notify(QString message)
 {
-    QMessageBox msgBox;
+    QMessageBox msgBox((QWidget *) Core::ICore::instance()->mainWindow());
     msgBox.setText(message);
     msgBox.exec();
 }

--- a/ground/gcs/src/plugins/coreplugin/uavgadgetinstancemanager.cpp
+++ b/ground/gcs/src/plugins/coreplugin/uavgadgetinstancemanager.cpp
@@ -39,7 +39,6 @@
 #include <QtCore/QStringList>
 #include <QtCore/QSettings>
 #include <QtCore/QDebug>
-#include <QMessageBox>
 
 using namespace Core;
 

--- a/ground/gcs/src/plugins/coreplugin/uavgadgetmanager/uavgadgetmanager.cpp
+++ b/ground/gcs/src/plugins/coreplugin/uavgadgetmanager/uavgadgetmanager.cpp
@@ -59,7 +59,6 @@
 #include <QLayout>
 #include <QMainWindow>
 #include <QMenu>
-#include <QMessageBox>
 #include <QPushButton>
 #include <QSplitter>
 #include <QStackedLayout>

--- a/ground/gcs/src/plugins/debuggadget/debuggadgetwidget.cpp
+++ b/ground/gcs/src/plugins/debuggadget/debuggadgetwidget.cpp
@@ -70,7 +70,7 @@ void DebugGadgetWidget::saveLog()
         && (file.write(m_config->plainTextEdit->toHtml().toLatin1()) != -1)) {
         file.close();
     } else {
-        QMessageBox::critical(nullptr, tr("Log Save"), tr("Unable to save log: ") + fileName,
+        QMessageBox::critical(this, tr("Log Save"), tr("Unable to save log: ") + fileName,
                               QMessageBox::Ok);
         return;
     }

--- a/ground/gcs/src/plugins/importexport/importexportgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/importexport/importexportgadgetwidget.cpp
@@ -88,7 +88,7 @@ void ImportExportGadgetWidget::on_exportButton_clicked()
 
     qDebug() << "Export pressed! Write to file " << QFileInfo(file).absoluteFilePath();
 
-    QMessageBox msgBox;
+    QMessageBox msgBox(this);
     QDir dir = QFileInfo(file).absoluteDir();
     if (!dir.exists()) {
         msgBox.setText(tr("Can't write file ") + QFileInfo(file).absoluteFilePath()
@@ -163,7 +163,7 @@ void ImportExportGadgetWidget::on_importButton_clicked()
 
     qDebug() << "Import pressed! Read from file " << QFileInfo(file).absoluteFilePath();
 
-    QMessageBox msgBox;
+    QMessageBox msgBox(this);
     if (!QFileInfo(file).isReadable()) {
         msgBox.setText(tr("Can't read file ") + QFileInfo(file).absoluteFilePath());
         msgBox.exec();
@@ -210,7 +210,7 @@ void ImportExportGadgetWidget::on_helpButton_clicked()
 
 void ImportExportGadgetWidget::on_resetButton_clicked()
 {
-    QMessageBox msgBox;
+    QMessageBox msgBox(this);
     msgBox.setText(tr("All your settings will be deleted!"));
     msgBox.setInformativeText(tr("You must restart the GCS in order to activate the changes."));
     msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);

--- a/ground/gcs/src/plugins/ipconnection/ipconnectionplugin.cpp
+++ b/ground/gcs/src/plugins/ipconnection/ipconnectionplugin.cpp
@@ -155,7 +155,9 @@ QIODevice *IPConnection::openDevice(Core::IDevice *device)
         delete ipSocket;
         ipSocket = nullptr;
 
-        QMessageBox msgBox(QMessageBox::Critical, tr("Connection Failed"), errorMsg);
+        QMessageBox msgBox(QMessageBox::Critical, tr("Connection Failed"),
+                errorMsg, QMessageBox::Ok,
+                (QWidget *) Core::ICore::instance()->mainWindow());
         msgBox.exec();
     }
 

--- a/ground/gcs/src/plugins/kmlexport/kmlexport.cpp
+++ b/ground/gcs/src/plugins/kmlexport/kmlexport.cpp
@@ -183,19 +183,21 @@ bool KmlExport::exportToKML()
     if (QFileInfo(outputFileName).suffix().toLower() == "kmz") {
         if (!kmlengine::KmzFile::WriteKmz(outputFileName.toStdString().c_str(), kml_data)) {
             qDebug() << "KMZ write failed: " << outputFileName;
-            QMessageBox::critical(new QWidget(), "KMZ write failed", "Failed to write KMZ file.");
+            QMessageBox::critical(Core::ICore::instance()->mainWindow(),
+                    "KMZ write failed", "Failed to write KMZ file.");
             return false;
         }
     } else if (QFileInfo(outputFileName).suffix().toLower() == "kml") {
         if (!kmlbase::File::WriteStringToFile(kml_data, outputFileName.toStdString())) {
             qDebug() << "KML write failed: " << outputFileName;
-            QMessageBox::critical(new QWidget(), "KML write failed", "Failed to write KML file.");
+            QMessageBox::critical(Core::ICore::instance()->mainWindow(),
+                    "KML write failed", "Failed to write KML file.");
             return false;
         }
     } else {
         qDebug() << "Write failed. Invalid file name:" << outputFileName;
-        QMessageBox::critical(new QWidget(), "Write failed",
-                              "Failed to write file. Invalid filename");
+        QMessageBox::critical(Core::ICore::instance()->mainWindow(),
+                "Write failed", "Failed to write file. Invalid filename");
         return false;
     }
 
@@ -235,7 +237,7 @@ bool KmlExport::open()
             .replace("0x", ""); // See comment above for necessity for string replacements
 
     if (logUAVOHashString != uavoHash) {
-        QMessageBox msgBox;
+        QMessageBox msgBox(Core::ICore::instance()->mainWindow());
         msgBox.setText("Likely log file incompatibility.");
         msgBox.setInformativeText(QString("The log file was made with branch %1, UAVO hash %2. GCS "
                                           "will attempt to export the file.")
@@ -243,7 +245,7 @@ bool KmlExport::open()
                                       .arg(logUAVOHashString));
         msgBox.exec();
     } else if (logGitHashString != gitHash) {
-        QMessageBox msgBox;
+        QMessageBox msgBox(Core::ICore::instance()->mainWindow());
         msgBox.setText("Possible log file incompatibility.");
         msgBox.setInformativeText(
             QString("The log file was made with branch %1. GCS will attempt to export the file.")
@@ -260,7 +262,7 @@ bool KmlExport::open()
 
     // Check if we reached the end of the file before finding the separation string
     if (cnt >= 10 || logFile.atEnd()) {
-        QMessageBox msgBox;
+        QMessageBox msgBox(Core::ICore::instance()->mainWindow());
         msgBox.setText("Corrupted file.");
         msgBox.setInformativeText("GCS cannot find the separation byte. GCS will attempt to export "
                                   "the file."); //<--TODO: add hyperlink to webpage with better
@@ -314,7 +316,7 @@ bool KmlExport::preparseLogFile()
 
         // Check if timestamps are sequential.
         if (!timestampBuffer.isEmpty() && lastTimeStamp < timestampBuffer.last()) {
-            QMessageBox msgBox;
+            QMessageBox msgBox(Core::ICore::instance()->mainWindow());
             msgBox.setText("Corrupted file.");
             msgBox.setInformativeText("Timestamps are not sequential. Playback may have unexpected "
                                       "behavior"); //<--TODO: add hyperlink to webpage with better
@@ -331,7 +333,7 @@ bool KmlExport::preparseLogFile()
 
     // Check if any timestamps were successfully read
     if (timestampBuffer.size() == 0) {
-        QMessageBox msgBox;
+        QMessageBox msgBox(Core::ICore::instance()->mainWindow());
         msgBox.setText("Empty logfile.");
         msgBox.setInformativeText("No log data can be found.");
         msgBox.exec();
@@ -377,8 +379,8 @@ void KmlExport::parseLogFile()
 
         if (packetSize < 1 || packetSize > (1024 * 1024)) {
             qDebug() << "Error: Logfile corrupted! Unlikely packet size: " << packetSize << "\n";
-            QMessageBox::critical(
-                new QWidget(), "Corrupted file",
+            QMessageBox::critical(Core::ICore::instance()->mainWindow(),
+                "Corrupted file",
                 "Incorrect packet size. Stopping export. Data up to this point will be saved.");
 
             break;

--- a/ground/gcs/src/plugins/logging/logfile.cpp
+++ b/ground/gcs/src/plugins/logging/logfile.cpp
@@ -30,6 +30,7 @@
 #include <QTextStream>
 #include <QMessageBox>
 
+#include <coreplugin/icore.h>
 #include <coreplugin/coreconstants.h>
 
 LogFile::LogFile(QObject *parent)
@@ -106,7 +107,7 @@ bool LogFile::open(OpenMode mode)
                 .replace("0x", ""); // See comment above for necessity for string replacements
 
         if (logUAVOHashString != uavoHash) {
-            QMessageBox msgBox;
+            QMessageBox msgBox((QWidget *) Core::ICore::instance()->mainWindow());
             msgBox.setText("Likely log file incompatibility.");
             msgBox.setInformativeText(QString("The log file was made with branch %1, UAVO hash %2. "
                                               "GCS will attempt to play the file.")
@@ -114,7 +115,7 @@ bool LogFile::open(OpenMode mode)
                                           .arg(logUAVOHashString));
             msgBox.exec();
         } else if (logGitHashString != gitHash) {
-            QMessageBox msgBox;
+            QMessageBox msgBox((QWidget *) Core::ICore::instance()->mainWindow());
             msgBox.setText("Possible log file incompatibility.");
             msgBox.setInformativeText(
                 QString("The log file was made with branch %1. GCS will attempt to play the file.")
@@ -131,7 +132,7 @@ bool LogFile::open(OpenMode mode)
 
         // Check if we reached the end of the file before finding the separation string
         if (cnt >= 10 || file.atEnd()) {
-            QMessageBox msgBox;
+            QMessageBox msgBox((QWidget *) Core::ICore::instance()->mainWindow());
             msgBox.setText("Corrupted file.");
             msgBox.setInformativeText("GCS cannot find the separation byte. GCS will attempt to "
                                       "play the file."); //<--TODO: add hyperlink to webpage with
@@ -292,7 +293,7 @@ bool LogFile::startReplay()
 
         // Check if timestamps are sequential.
         if (!timestampBuffer.isEmpty() && lastTimeStamp < timestampBuffer.last()) {
-            QMessageBox msgBox;
+            QMessageBox msgBox((QWidget *) Core::ICore::instance()->mainWindow());
             msgBox.setText("Corrupted file.");
             msgBox.setInformativeText("Timestamps are not sequential. Playback may have unexpected "
                                       "behavior"); //<--TODO: add hyperlink to webpage with better
@@ -309,7 +310,7 @@ bool LogFile::startReplay()
 
     // Check if any timestamps were successfully read
     if (timestampBuffer.size() == 0) {
-        QMessageBox msgBox;
+        QMessageBox msgBox((QWidget *) Core::ICore::instance()->mainWindow());
         msgBox.setText("Empty logfile.");
         msgBox.setInformativeText("No log data can be found.");
         msgBox.exec();

--- a/ground/gcs/src/plugins/magicwaypoint/positionfield.cpp
+++ b/ground/gcs/src/plugins/magicwaypoint/positionfield.cpp
@@ -32,7 +32,6 @@
 #include <QTextEdit>
 #include <QVBoxLayout>
 #include <QPushButton>
-#include <QMessageBox>
 #include <QMouseEvent>
 #include <QtGlobal>
 

--- a/ground/gcs/src/plugins/opmap/opmapgadgetwidget.cpp
+++ b/ground/gcs/src/plugins/opmap/opmapgadgetwidget.cpp
@@ -1953,7 +1953,7 @@ void OPMapGadgetWidget::onClearWayPointsAct_triggered()
 {
 
     // First, ask to ensure this is what the user wants to do
-    QMessageBox msgBox;
+    QMessageBox msgBox(this);
     msgBox.setText(tr("Are you sure you want to clear waypoints?"));
     msgBox.setInformativeText(tr("All associated data will be lost."));
     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);

--- a/ground/gcs/src/plugins/pathplanner/flightdatamodel.cpp
+++ b/ground/gcs/src/plugins/pathplanner/flightdatamodel.cpp
@@ -31,6 +31,7 @@
 #include <QDomDocument>
 #include <QMessageBox>
 #include <waypoint.h>
+#include <coreplugin/icore.h>
 #include "extensionsystem/pluginmanager.h"
 #include "uavobjects/uavobjectmanager.h"
 #include "uavobjects/uavobject.h"
@@ -350,7 +351,8 @@ bool FlightDataModel::writeToFile(QString fileName)
     QFile file(fileName);
 
     if (!file.open(QIODevice::WriteOnly)) {
-        QMessageBox::information(NULL, tr("Unable to open file"), file.errorString());
+        QMessageBox::information((QWidget *)Core::ICore::instance()->mainWindow(),
+                tr("Unable to open file"), file.errorString());
         return false;
     }
     QDataStream out(&file);
@@ -439,7 +441,7 @@ bool FlightDataModel::writeToFile(QString fileName)
 
 void FlightDataModel::showErrorDialog(const char *title, const char *message)
 {
-    QMessageBox msgBox;
+    QMessageBox msgBox((QWidget *)Core::ICore::instance()->mainWindow());
     msgBox.setText(tr(title));
     msgBox.setInformativeText(tr(message));
     msgBox.setStandardButtons(QMessageBox::Ok);

--- a/ground/gcs/src/plugins/scope/scopegadgetoptionspage.cpp
+++ b/ground/gcs/src/plugins/scope/scopegadgetoptionspage.cpp
@@ -27,6 +27,7 @@
 
 #include "scopegadgetoptionspage.h"
 
+#include <coreplugin/icore.h>
 #include "extensionsystem/pluginmanager.h"
 #include "uavobjects/uavobjectmanager.h"
 #include "uavobjects/uavdataobject.h"
@@ -525,7 +526,7 @@ void ScopeGadgetOptionsPage::on_btnApply2dCurve_clicked()
     // Apply curve settings
     QListWidgetItem *listWidgetItem = options_page->lst2dCurves->currentItem();
     if (listWidgetItem == NULL) {
-        QMessageBox msgBox;
+        QMessageBox msgBox((QWidget *) Core::ICore::instance()->mainWindow());
         msgBox.setText(tr("No curve selected."));
         msgBox.setInformativeText(tr("Please select a curve or generate one with the "
                                      "+"

--- a/ground/gcs/src/plugins/setupwizard/pages/biascalibrationpage.cpp
+++ b/ground/gcs/src/plugins/setupwizard/pages/biascalibrationpage.cpp
@@ -70,7 +70,7 @@ void BiasCalibrationPage::enableButtons(bool enable)
 void BiasCalibrationPage::performCalibration()
 {
     if (!getWizard()->getConnectionManager()->isConnected()) {
-        QMessageBox msgBox;
+        QMessageBox msgBox(this);
         msgBox.setText(tr("A flight controller must be connected to your computer to perform bias "
                           "calculations.\nPlease connect your flight controller to your computer "
                           "and try again."));
@@ -128,7 +128,7 @@ void BiasCalibrationPage::calibrationTimeout()
 {
     stopCalibration();
 
-    QMessageBox msgBox;
+    QMessageBox msgBox(this);
     msgBox.setText(tr("Calibration timed out"));
     msgBox.setStandardButtons(QMessageBox::Ok);
     msgBox.setDefaultButton(QMessageBox::Ok);

--- a/ground/gcs/src/plugins/setupwizard/pages/savepage.cpp
+++ b/ground/gcs/src/plugins/setupwizard/pages/savepage.cpp
@@ -58,7 +58,7 @@ bool SavePage::isComplete() const
 void SavePage::writeToController()
 {
     if (!getWizard()->getConnectionManager()->isConnected()) {
-        QMessageBox msgBox;
+        QMessageBox msgBox(this);
         msgBox.setText(tr("An OpenPilot controller must be connected to your computer to save the "
                           "configuration.\nPlease connect your OpenPilot controller to your "
                           "computer and try again."));

--- a/ground/gcs/src/plugins/setupwizard/pages/tlendpage.cpp
+++ b/ground/gcs/src/plugins/setupwizard/pages/tlendpage.cpp
@@ -55,7 +55,7 @@ void TLEndPage::openInputWizard()
         getWizard()->close();
         configGadgetFactory->startInputWizard();
     } else {
-        QMessageBox msgBox;
+        QMessageBox msgBox(this);
         msgBox.setText(tr("Unable to open Input Wizard since the Config Plugin is not\nloaded in "
                           "the current workspace."));
         msgBox.setStandardButtons(QMessageBox::Ok);

--- a/ground/gcs/src/plugins/setupwizard/setupwizard.cpp
+++ b/ground/gcs/src/plugins/setupwizard/setupwizard.cpp
@@ -376,7 +376,7 @@ void SetupWizard::boardIgnorePrompt()
 
     QMessageBox prompt(QMessageBox::Question, tr("Setup Wizard Cancelled"),
                        tr("Would you like to prevent the setup wizard from automatically opening"
-                       " for the remainder of this session?"), QMessageBox::Yes | QMessageBox::No);
+                       " for the remainder of this session?"), QMessageBox::Yes | QMessageBox::No, this);
     if (prompt.exec() == QMessageBox::No)
         return;
 

--- a/ground/gcs/src/plugins/telemetryscheduler/telemetryschedulergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/telemetryscheduler/telemetryschedulergadgetwidget.cpp
@@ -371,7 +371,7 @@ void TelemetrySchedulerGadgetWidget::saveTelemetryToFile()
         if (file.open(QIODevice::WriteOnly) && (file.write(xml.toLatin1()) != -1)) {
             file.close();
         } else {
-            QMessageBox::critical(nullptr, tr("UAV Data Export"), tr("Unable to save data: ") + filename,
+            QMessageBox::critical(this, tr("UAV Data Export"), tr("Unable to save data: ") + filename,
                                   QMessageBox::Ok);
             return;
         }
@@ -532,7 +532,7 @@ void TelemetrySchedulerGadgetWidget::loadTelemetryFromFile()
 
     filename = file;
 
-    QMessageBox msgBox;
+    QMessageBox msgBox(this);
     if (!QFileInfo(file).isReadable()) {
         msgBox.setText(tr("Can't read file ") + QFileInfo(file).absoluteFilePath());
         msgBox.exec();
@@ -548,7 +548,7 @@ void TelemetrySchedulerGadgetWidget::importTelemetryConfiguration(const QString 
     QDomDocument doc("TelemetryScheduler");
     file.open(QFile::ReadOnly | QFile::Text);
     if (!doc.setContent(file.readAll())) {
-        QMessageBox msgBox;
+        QMessageBox msgBox(this);
         msgBox.setText(tr("File Parsing Failed."));
         msgBox.setInformativeText(tr("This file is not a correct XML file"));
         msgBox.setStandardButtons(QMessageBox::Ok);
@@ -566,7 +566,7 @@ void TelemetrySchedulerGadgetWidget::importTelemetryConfiguration(const QString 
 
     // Check that this a good file
     if (root.isNull() || (root.tagName() != "headings")) {
-        QMessageBox msgBox;
+        QMessageBox msgBox(this);
         msgBox.setText(tr("Wrong file contents"));
         msgBox.setInformativeText(tr("This file does not contain correct telemetry settings"));
         msgBox.setStandardButtons(QMessageBox::Ok);
@@ -610,7 +610,7 @@ void TelemetrySchedulerGadgetWidget::importTelemetryConfiguration(const QString 
         root = root.firstChildElement("settings");
     }
     if (root.isNull() || (root.tagName() != "settings")) {
-        QMessageBox msgBox;
+        QMessageBox msgBox(this);
         msgBox.setText(tr("Wrong file contents"));
         msgBox.setInformativeText(tr("This file does not contain correct telemetry settings"));
         msgBox.setStandardButtons(QMessageBox::Ok);
@@ -729,7 +729,7 @@ void TelemetrySchedulerGadgetWidget::customMenuRequested(QPoint pos)
         return;
     text.toInt(&ok);
     if (!ok) {
-        QMessageBox msgBox;
+        QMessageBox msgBox(this);
         msgBox.setText("Value must be numeric");
         msgBox.exec();
         return;

--- a/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.cpp
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/importsummary.cpp
@@ -198,7 +198,7 @@ void ImportSummaryDialog::doTheApplySaving()
     hide();
 
     if (!quiet) {
-        QMessageBox msgBox;
+        QMessageBox msgBox(this);
 
         msgBox.setText(tr("Settings saved to flash."));
 

--- a/ground/gcs/src/plugins/uavsettingsimportexport/uavsettingsimportexportmanager.cpp
+++ b/ground/gcs/src/plugins/uavsettingsimportexport/uavsettingsimportexportmanager.cpp
@@ -112,7 +112,7 @@ bool UAVSettingsImportExportManager::importUAVSettings(const QByteArray &setting
     QDomDocument doc("UAVObjects");
 
     if (!doc.setContent(settings)) {
-        QMessageBox msgBox;
+        QMessageBox msgBox((QWidget *) Core::ICore::instance()->mainWindow());
         msgBox.setText(tr("File Parsing Failed."));
         msgBox.setInformativeText(tr("This file is not a correct XML file"));
         msgBox.setStandardButtons(QMessageBox::Ok);
@@ -128,7 +128,7 @@ bool UAVSettingsImportExportManager::importUAVSettings(const QByteArray &setting
         root = root.firstChildElement("settings");
     }
     if (root.isNull() || (root.tagName() != "settings")) {
-        QMessageBox msgBox;
+        QMessageBox msgBox((QWidget *) Core::ICore::instance()->mainWindow());
         msgBox.setText(tr("Wrong file contents"));
         msgBox.setInformativeText(tr("This file does not contain correct UAVSettings"));
         msgBox.setStandardButtons(QMessageBox::Ok);
@@ -228,8 +228,9 @@ bool UAVSettingsImportExportManager::importUAVSettings(const QByteArray &setting
     qDebug() << "End import";
 
     if (swui.numLines() < 1) {
-        QMessageBox::critical(nullptr, tr("Unable to import settings"),
-                              tr("No settings found in XML dump; the flight controller settings may have been blank."), QMessageBox::Ok);
+        QMessageBox::critical((QWidget *)Core::ICore::instance()->mainWindow(),
+                tr("Unable to import settings"),
+                tr("No settings found in XML dump; the flight controller settings may have been blank."), QMessageBox::Ok);
         /* This is a termination condition-- no settings found. */
         return true;
     }
@@ -482,12 +483,13 @@ void UAVSettingsImportExportManager::exportUAVSettings()
     if (file.open(QIODevice::WriteOnly) && (file.write(xml.toLatin1()) != -1)) {
         file.close();
     } else {
-        QMessageBox::critical(nullptr, tr("UAV Settings Export"),
-                              tr("Unable to save settings: ") + fileName, QMessageBox::Ok);
+        QMessageBox::critical((QWidget *)Core::ICore::instance()->mainWindow(),
+                tr("UAV Settings Export"),
+                tr("Unable to save settings: ") + fileName, QMessageBox::Ok);
         return;
     }
 
-    QMessageBox msgBox;
+    QMessageBox msgBox((QWidget *) Core::ICore::instance()->mainWindow());
     msgBox.setText(tr("Settings saved."));
     msgBox.setStandardButtons(QMessageBox::Ok);
     msgBox.exec();
@@ -496,15 +498,6 @@ void UAVSettingsImportExportManager::exportUAVSettings()
 // Slot called by the menu manager on user action
 void UAVSettingsImportExportManager::exportUAVData()
 {
-    if (QMessageBox::question(nullptr, tr("Are you sure?"),
-                              tr("This option is only useful for passing your current "
-                                 "system data to the technical support staff. "
-                                 "Do you really want to export?"),
-                              QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Ok)
-        != QMessageBox::Ok) {
-        return;
-    }
-
     // ask for file name
     QString fileName;
     QString filters = tr("UAVObjects XML files (*.uav)");
@@ -530,12 +523,13 @@ void UAVSettingsImportExportManager::exportUAVData()
     if (file.open(QIODevice::WriteOnly) && (file.write(xml.toLatin1()) != -1)) {
         file.close();
     } else {
-        QMessageBox::critical(nullptr, tr("UAV Data Export"), tr("Unable to save data: ") + fileName,
+        QMessageBox::critical((QWidget *)Core::ICore::instance()->mainWindow(),
+                tr("UAV Data Export"), tr("Unable to save data: ") + fileName,
                               QMessageBox::Ok);
         return;
     }
 
-    QMessageBox msgBox;
+    QMessageBox msgBox((QWidget *) Core::ICore::instance()->mainWindow());
     msgBox.setText(tr("Data saved."));
     msgBox.setStandardButtons(QMessageBox::Ok);
     msgBox.exec();

--- a/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
+++ b/ground/gcs/src/plugins/uploader/uploadergadgetwidget.cpp
@@ -642,7 +642,7 @@ bool UploaderGadgetWidget::downloadSettings()
 
 bool UploaderGadgetWidget::askIfShouldContinue()
 {
-    QMessageBox msgBox;
+    QMessageBox msgBox(this);
     msgBox.setText(tr("Proceed without saving a configuration backup?"));
     msgBox.setInformativeText(tr("It is strongly encouraged that you save a backup of the "
                                  "configuration before proceeding with upgrade."));
@@ -830,7 +830,7 @@ void UploaderGadgetWidget::upgradeError(QString why)
     setUploaderStatus(uploader::DISCONNECTED);
 
     /* Pop up a proper error dialog */
-    QMessageBox msgBox;
+    QMessageBox msgBox(this);
 
     msgBox.setIcon(QMessageBox::Critical);
     msgBox.setText(tr("Automatic upgrade failed."));
@@ -1255,7 +1255,7 @@ void UploaderGadgetWidget::onExportButtonClick()
 
     /* make sure there's a setting partition */
     if (!haveSettingsPart()) {
-        QMessageBox msgBox;
+        QMessageBox msgBox(this);
 
         msgBox.setText(tr("No settings partition accessible; can't export."));
         msgBox.setInformativeText(tr("Please upgrade your bootloader."));
@@ -1268,7 +1268,7 @@ void UploaderGadgetWidget::onExportButtonClick()
     }
 
     /* get confirmation from user that using the cloud service is OK */
-    QMessageBox msgBox;
+    QMessageBox msgBox(this);
     msgBox.setText(tr("Do you wish to export the settings partition as an XML settings file?"));
     msgBox.setInformativeText(tr("This will send the raw configuration information to a dRonin "
                                  "cloud service for translation."));
@@ -1367,7 +1367,7 @@ void UploaderGadgetWidget::onBootloaderDetected()
                         break;
                     }
                 } else {
-                    QMessageBox msgBox;
+                    QMessageBox msgBox(this);
                     msgBox.setText(tr("There appears to be no valid firmware on your device.."));
                     msgBox.setInformativeText(tr("Do you want to install firmware?"));
                     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);

--- a/ground/gcs/src/plugins/welcome/welcomeplugin.cpp
+++ b/ground/gcs/src/plugins/welcome/welcomeplugin.cpp
@@ -41,7 +41,6 @@
 #include <QtCore/QtPlugin>
 #include <QAction>
 #include <QMenu>
-#include <QMessageBox>
 #include <QPushButton>
 
 using namespace Welcome::Internal;


### PR DESCRIPTION
Make sure it's always sane.  Use the main window if we're not a widget
ourselves.

Fixes #1285.

There's a close cousin of issues with file dialogs, which I'll try to get to next.  Also, some unused calls and a couple of useless dialogs were removed.