### PR TITLE
GCS:SetupWizard: Add plugin dependency on Uploader

### DIFF
--- a/ground/gcs/src/plugins/setupwizard/SetupWizard.pluginspec
+++ b/ground/gcs/src/plugins/setupwizard/SetupWizard.pluginspec
@@ -8,5 +8,6 @@
         <dependency name="Core" version="1.0.0"/>
         <dependency name="Config" version="1.0.0"/>
         <dependency name="UAVObjects" version="1.0.0"/>
+        <dependency name="Uploader" version="1.0.0"/>
     </dependencyList>
 </plugin>    


### PR DESCRIPTION
Before it was just luck that somebody else loaded Uploader.dll before
SetupWizard.dll was loaded. Dynamic linkers on macOS/Linux must be able to
sort this out themselves.

Fixes #2166 