### PR TITLE
GCS: Fail unit tests if plugins failed to load

### DIFF
--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -451,11 +451,17 @@ int main(int argc, char **argv)
             QString msg(QCoreApplication::tr(
                         "Some problems were encountered whilst loading the following plugins: "));
             msg.append(plugins.join(QStringLiteral(", ")));
-            QMessageBox msgBox(QMessageBox::Warning,
-                               QCoreApplication::tr("Plugin loader messages"),
-                               msg, QMessageBox::Ok);
-            msgBox.setDetailedText(errors.join(QStringLiteral("\n\n")));
-            msgBox.exec();
+
+            if (parser.values(doTestsOption).isEmpty()) {
+                QMessageBox msgBox(QMessageBox::Warning,
+                                   QCoreApplication::tr("Plugin loader messages"),
+                                   msg, QMessageBox::Ok);
+                msgBox.setDetailedText(errors.join(QStringLiteral("\n\n")));
+                msgBox.exec();
+            } else {
+                const char *errorstr = errors.join(QStringLiteral("\n\n")).toLocal8Bit().data();
+                qFatal("ERROR: Some plugins failed to load:\n%s\n", errorstr);
+            }
         }
     }
 

--- a/ground/gcs/src/app/main.cpp
+++ b/ground/gcs/src/app/main.cpp
@@ -442,7 +442,7 @@ int main(int argc, char **argv)
         QStringList errors, plugins;
         for (const auto p : pluginManager.plugins()) {
             if (p->hasError()) {
-                errors.append(p->errorString());
+                errors.append(QStringLiteral("%0:\n%1").arg(p->name(), p->errorString()));
                 plugins.append(p->name());
             }
         }


### PR DESCRIPTION
Good for things like #2166 (although we don't currently run regular CI tests on Windows).