### PR TITLE
sprf3e: deal with crappy brushed clones

### DIFF
--- a/flight/targets/sprf3e/bl/pios_board.c
+++ b/flight/targets/sprf3e/bl/pios_board.c
@@ -56,7 +56,10 @@ void PIOS_Board_Init()
 			.GPIO_PuPd  = GPIO_PuPd_DOWN
 		};
 
-		/* Nail all servo channels as outputs, LOW */
+		/* Nail all servo channels as outputs, LOW.
+		 * Mostly for brushed clones of SPRF3E to ensure we don't
+		 * spin up (they should provide pulldowns, but meh.)
+		 */
 		channels[i].pin.gpio->BSRR = channels[i].pin.init.GPIO_Pin << 16;
 		GPIO_Init(channels[i].pin.gpio, &init);
 		channels[i].pin.gpio->BSRR = channels[i].pin.init.GPIO_Pin << 16;

--- a/flight/targets/sprf3e/bl/pios_board.c
+++ b/flight/targets/sprf3e/bl/pios_board.c
@@ -44,6 +44,24 @@ uintptr_t pios_com_telem_usb_id;
 
 void PIOS_Board_Init()
 {
+	const struct pios_servo_cfg * servo_cfg = &pios_servo_cfg;
+	const struct pios_tim_channel * channels = servo_cfg->channels;
+	uint8_t num_channels = servo_cfg->num_channels;
+	for (int i = 0; i < num_channels; i++) {
+		GPIO_InitTypeDef init = {
+			.GPIO_Pin = channels[i].pin.init.GPIO_Pin,
+			.GPIO_Speed = GPIO_Speed_2MHz,
+			.GPIO_Mode  = GPIO_Mode_OUT,
+			.GPIO_OType = GPIO_OType_PP,
+			.GPIO_PuPd  = GPIO_PuPd_DOWN
+		};
+
+		/* Nail all servo channels as outputs, LOW */
+		channels[i].pin.gpio->BSRR = channels[i].pin.init.GPIO_Pin << 16;
+		GPIO_Init(channels[i].pin.gpio, &init);
+		channels[i].pin.gpio->BSRR = channels[i].pin.init.GPIO_Pin << 16;
+	}
+
 	/* Delay system */
 	PIOS_DELAY_Init();
 

--- a/flight/targets/sprf3e/board-info/board-info.mk
+++ b/flight/targets/sprf3e/board-info/board-info.mk
@@ -1,6 +1,6 @@
 BOARD_TYPE          := 0xCF
 BOARD_REVISION      := 0x02
-BOOTLOADER_VERSION  := 0x88
+BOOTLOADER_VERSION  := 0x89
 HW_TYPE             := 0x00		# seems to be unused
 
 CHIP                := STM32F303CCT

--- a/flight/targets/sprf3e/board-info/board_hw_defs.c
+++ b/flight/targets/sprf3e/board-info/board_hw_defs.c
@@ -747,8 +747,6 @@ static const struct pios_tim_channel pios_tim_servoport_pins[] = {
 	},
 };
 
-
-#if defined(PIOS_INCLUDE_SERVO) && defined(PIOS_INCLUDE_TIM)
 /*
  * Servo outputs
  */
@@ -769,6 +767,7 @@ static const struct pios_servo_cfg pios_servo_cfg = {
 	.num_channels = NELEMENTS(pios_tim_servoport_pins),
 };
 
+#if defined(PIOS_INCLUDE_SERVO) && defined(PIOS_INCLUDE_TIM)
 struct pios_servo_cfg pios_servo_slow_cfg = {
 	.tim_oc_init = {
 		.TIM_OCMode = TIM_OCMode_PWM1,


### PR DESCRIPTION
Make sure pins are nailed low during bootloader, since there's no
pulldowns!  Whatta kludge.  Even with this one of four motors twitches.

We should consider something like this globally in the bootloader across
all targets.