### PR TITLE
PiOS:Debug: Use MSVC noreturn decl for panic

### DIFF
--- a/flight/PiOS/inc/pios_debug.h
+++ b/flight/PiOS/inc/pios_debug.h
@@ -42,7 +42,11 @@ void PIOS_DEBUG_PinHigh(uint8_t pin);
 void PIOS_DEBUG_PinLow(uint8_t pin);
 void PIOS_DEBUG_PinValue8Bit(uint8_t value);
 void PIOS_DEBUG_PinValue4BitL(uint8_t value);
+#if defined(_MSC_VER) && !defined(__GNUC__)
+__declspec(noreturn) void PIOS_DEBUG_Panic(const char *msg);
+#else
 void PIOS_DEBUG_Panic(const char *msg) __attribute__((noreturn));
+#endif
 
 #ifdef DEBUG
 #define PIOS_DEBUG_Assert(test) do { if (!(test)) PIOS_DEBUG_Panic(PIOS_DEBUG_AssertMsg); } while (0)


### PR DESCRIPTION
Windows build currently gacked:
```
C:/Jenkins/workspace/dronin/Nodes/winx86-neo/flight/PiOS/Common/pios_flash.c: In function 'PIOS_FLASH_register_partition_table':

C:/Jenkins/workspace/dronin/Nodes/winx86-neo/flight/PiOS/Common/pios_flash.c:120:12: error: 'chip_end_offset' may be used uninitialized in this function [-Werror=maybe-uninitialized]

   uint32_t chip_end_offset;

            ^

C:/Jenkins/workspace/dronin/Nodes/winx86-neo/flight/PiOS/Common/pios_flash.c:127:71: error: 'chip_start_offset' may be used uninitialized in this function [-Werror=maybe-uninitialized]

   PIOS_Assert(partition->size == (chip_end_offset - chip_start_offset + 1));

                                                                       ^
```
This is a shot in the dark..