### PR TITLE
lqg: Expose control cost on LQR, remove beta offset for yaw.

### DIFF
--- a/flight/Libraries/math/lqg.h
+++ b/flight/Libraries/math/lqg.h
@@ -42,11 +42,11 @@ extern rtkf_t rtkf_create(float beta, float tau, float Ts, float R, float Q1, fl
 extern void rtkf_stabilize_covariance(rtkf_t rtkf, int iterations);
 extern bool rtkf_is_solved(rtkf_t rtkf);
 
-extern lqr_t lqr_create(float beta, float tau, float Ts, float q1, float q2);
+extern lqr_t lqr_create(float beta, float tau, float Ts, float q1, float q2, float r);
 extern void lqr_stabilize_covariance(lqr_t lqr, int iterations);
 extern bool lqr_is_solved(lqr_t lqr);
 
-extern void lqr_update(lqr_t lqr, float q1, float q2);
+extern void lqr_update(lqr_t lqr, float q1, float q2, float r);
 extern void lqr_get_gains(lqr_t lqg, float K[2]);
 
 extern lqg_t lqg_create(rtkf_t rtkf, lqr_t lqr);

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -438,9 +438,9 @@ static void initialize_lqg_controllers(float dT)
 				/* Update Q matrix. */
 				lqr_t lqr = lqg_get_lqr(lqg[i]);
 				lqr_update(lqr, 
-						lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWQ1 : LQGSETTINGS_LQR_Q1],
-						lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWQ2 : LQGSETTINGS_LQR_Q2],
-						lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWR : LQGSETTINGS_LQR_R]
+						lqgSettings.LQRegulator[i == YAW ? LQGSETTINGS_LQREGULATOR_YAWQ1 : LQGSETTINGS_LQREGULATOR_Q1],
+						lqgSettings.LQRegulator[i == YAW ? LQGSETTINGS_LQREGULATOR_YAWQ2 : LQGSETTINGS_LQREGULATOR_Q2],
+						lqgSettings.LQRegulator[i == YAW ? LQGSETTINGS_LQREGULATOR_YAWR : LQGSETTINGS_LQREGULATOR_R]
 					);
 			} else {
 				/* Initial setup. */
@@ -456,9 +456,9 @@ static void initialize_lqg_controllers(float dT)
 							lqgSettings.RTKF[LQGSETTINGS_RTKF_BIASLIMIT]
 						);
 					lqr_t lqr = lqr_create(beta, tau, dT,
-							lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWQ1 : LQGSETTINGS_LQR_Q1],
-							lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWQ2 : LQGSETTINGS_LQR_Q2],
-							lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWR : LQGSETTINGS_LQR_R]
+							lqgSettings.LQRegulator[i == YAW ? LQGSETTINGS_LQREGULATOR_YAWQ1 : LQGSETTINGS_LQREGULATOR_Q1],
+							lqgSettings.LQRegulator[i == YAW ? LQGSETTINGS_LQREGULATOR_YAWQ2 : LQGSETTINGS_LQREGULATOR_Q2],
+							lqgSettings.LQRegulator[i == YAW ? LQGSETTINGS_LQREGULATOR_YAWR : LQGSETTINGS_LQREGULATOR_R]
 						);
 					lqg[i] = lqg_create(rtkf, lqr);
 				}

--- a/flight/Modules/Stabilization/stabilization.c
+++ b/flight/Modules/Stabilization/stabilization.c
@@ -439,17 +439,13 @@ static void initialize_lqg_controllers(float dT)
 				lqr_t lqr = lqg_get_lqr(lqg[i]);
 				lqr_update(lqr, 
 						lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWQ1 : LQGSETTINGS_LQR_Q1],
-						lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWQ2 : LQGSETTINGS_LQR_Q2]
+						lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWQ2 : LQGSETTINGS_LQR_Q2],
+						lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWR : LQGSETTINGS_LQR_R]
 					);
 			} else {
 				/* Initial setup. */
 				float beta = sysIdent.Beta[i];
 				float tau = (sysIdent.Tau[0] + sysIdent.Tau[1]) * 0.5f;
-
-				if (i == YAW)
-				{
-					beta += lqgSettings.LQR[LQGSETTINGS_LQR_YAWBETAOFFSET];
-				}
 
 				if (tau > 0.001f && beta > 6) {
 					rtkf_t rtkf = rtkf_create(beta, tau, dT, 
@@ -461,7 +457,8 @@ static void initialize_lqg_controllers(float dT)
 						);
 					lqr_t lqr = lqr_create(beta, tau, dT,
 							lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWQ1 : LQGSETTINGS_LQR_Q1],
-							lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWQ2 : LQGSETTINGS_LQR_Q2]
+							lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWQ2 : LQGSETTINGS_LQR_Q2],
+							lqgSettings.LQR[i == YAW ? LQGSETTINGS_LQR_YAWR : LQGSETTINGS_LQR_R]
 						);
 					lqg[i] = lqg_create(rtkf, lqr);
 				}

--- a/shared/uavobjectdefinition/lqgsettings.xml
+++ b/shared/uavobjectdefinition/lqgsettings.xml
@@ -8,7 +8,7 @@
     <field defaultvalue="25, 75, 1, 0.000003, 0.000001, 0.3" name="RTKF" type="float" units="" elementnames="R, YawR, Q1, Q2, Q3, BiasLimit">
         <description>Weights for the Rate-Torque Kalman filter.</description>
     </field>
-    <field defaultvalue="0.000025, 0.0001, 0, 0.000025, 0.0001" name="LQR" type="float" units="" elementnames="Q1, Q2, YawBetaOffset, YawQ1, YawQ2">
+    <field defaultvalue="1, 0.000025, 0.0001, 1, 0.000025, 0.0001" name="LQR" type="float" units="" elementnames="R, Q1, Q2, YawR, YawQ1, YawQ2">
         <description>Weights for the LQ-regulator.</description>
     </field>
   </object>

--- a/shared/uavobjectdefinition/lqgsettings.xml
+++ b/shared/uavobjectdefinition/lqgsettings.xml
@@ -8,7 +8,7 @@
     <field defaultvalue="25, 75, 1, 0.000003, 0.000001, 0.3" name="RTKF" type="float" units="" elementnames="R, YawR, Q1, Q2, Q3, BiasLimit">
         <description>Weights for the Rate-Torque Kalman filter.</description>
     </field>
-    <field defaultvalue="1, 0.000025, 0.0001, 1, 0.000025, 0.0001" name="LQR" type="float" units="" elementnames="R, Q1, Q2, YawR, YawQ1, YawQ2">
+    <field defaultvalue="1, 0.000025, 0.0001, 1, 0.000025, 0.0001" name="LQRegulator" type="float" units="" elementnames="R, Q1, Q2, YawR, YawQ1, YawQ2">
         <description>Weights for the LQ-regulator.</description>
     </field>
   </object>


### PR DESCRIPTION
Expose the control cost on the LQR, because why not, and also because I anticipate needing it for fixing yaw on brushed and eventually large copters. R defaults to 1, which was the constant used in lqg.c before.

Removed beta offset on yaw axis. This was a hack from the very beginning to imply a direct torque beta component, that TauLabs' newest EKF based autotune evaluates. It defaults to zero, anyway, and I don't intend to use it in future (it'd need a plant specific value anyway, instead of a static offset, to make sense).