### PR TITLE
gcs: Fix Curve2 UI.

### DIFF
--- a/ground/gcs/src/plugins/config/cfg_vehicletypes/configccpmwidget.cpp
+++ b/ground/gcs/src/plugins/config/cfg_vehicletypes/configccpmwidget.cpp
@@ -167,7 +167,7 @@ ConfigCcpmWidget::ConfigCcpmWidget(QWidget *parent)
     // refreshAirframeWidgetsValues triggers a whole cascade of curve-related calls
     // need set the collective curve info after this point to make it stick
     // tell mixercurve this is a pitch curve
-    m_ccpm->PitchCurve->setMixerType(MixerCurve::MIXERCURVE_OTHER);
+    m_ccpm->PitchCurve->setMixerType(MixerCurve::MIXERCURVE_OTHER, false);
     m_ccpm->PitchCurve->initLinearCurve(5, 1.0, -1.0);
 
     UpdateType();

--- a/ground/gcs/src/plugins/config/mixercurve.ui
+++ b/ground/gcs/src/plugins/config/mixercurve.ui
@@ -335,7 +335,14 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="CBCurve2Source"/>
+      <widget class="QComboBox" name="CBCurve2Source">
+       <property name="objrelation" stdset="0">
+        <stringlist>
+         <string>objname:MixerSettings</string>
+         <string>fieldname:Curve2Source</string>
+        </stringlist>
+       </property>
+      </widget>
      </item>
      <item>
       <spacer name="horizontalSpacer">


### PR DESCRIPTION
The curve 2 widget was never told it's actually curve 2, so it hid the dropdown and showed a label instead.

Also, the dropdown was never hooked up to the MixerSettings.Curve2Source to begin with.

Should deal with #513?

Fixes #513