### PR TITLE
python-api: default request callback needs to accept (unused) second parameter

### DIFF
--- a/python/dronin/telemetry.py
+++ b/python/dronin/telemetry.py
@@ -300,7 +300,7 @@ class TelemetryBase(metaclass=ABCMeta):
 
         response = []
 
-        def default_cb(val):
+        def default_cb(val, id_val):
             with self.cond:
                 response.append(val)
                 # cond is awfully overloaded, but... the number of waiters


### PR DESCRIPTION
Callbacks are constantly invoked with two parameters.
As such, default_cb needs a second parameter (although unused) to enable correct functionality when issuing object requests.

As it is right now, the telemetry thread will throw an exception when an object request is completed:
https://imgur.com/a/Xlm0kEY