### PR TITLE
tests: request an object using sync interface

### DIFF
--- a/python/integrationtests-basic
+++ b/python/integrationtests-basic
@@ -90,6 +90,17 @@ class AAConfTests(SimulationTestCase):
         t_stream.save_objects(objs.values(), send_first=True)
 
 class SimpleSimTests(SimulationTestCase):
+    def test_retrieve_object(self):
+        t_stream = self.t_stream
+
+        sepp_obj = t_stream.uavo_defs.find_by_name("HwSeppuku")
+
+        hw_sepp = t_stream.request_object(sepp_obj)
+
+        self.assertIsNotNone(hw_sepp)
+        self.assertEqual(hw_sepp.USB_HIDPort,
+                sepp_obj.ENUM_USB_HIDPort['USBTelemetry'])
+
     def test_fifty_ticks_of_disarm(self):
         t_stream = self.t_stream
 


### PR DESCRIPTION
Catches the issue that #2198 fixes.

Hat tip to @nunohumberto for reporting / fixing the underlying issue; this just adds test coverage.