### PR TITLE
flight,uavomanager: Misplaced now, wasted ~3% CPU on F3.

### DIFF
--- a/flight/UAVObjects/uavobjectmanager.c
+++ b/flight/UAVObjects/uavobjectmanager.c
@@ -1734,15 +1734,13 @@ static int32_t pumpOneEvent(UAVObjEvent msg, void *obj_data, int len) {
 				struct ObjectEventEntryThrottled *throtInfo =
 					(struct ObjectEventEntryThrottled *) event;
 
-				uint32_t now = PIOS_Thread_Systime();
-
 				if (!PIOS_Thread_Period_Elapsed(throtInfo->when,
 							throtInfo->interval)) {
 					continue;
 				}
 
 				// Set time for next callback
-				throtInfo->when = now;
+				throtInfo->when = PIOS_Thread_Systime();
 
 				if (throtInfo->inhibited) {
 					continue;


### PR DESCRIPTION
Related to #2200.

Brings CPU overhead introduced in https://github.com/d-ronin/dRonin/commit/5388fe3e5a86f43d75de4d264dc63c2df8e2308c down to less than half of it (4-5% -> 1.5-2% on F3).