### PR TITLE
lqg: RTKF needs way way more cycles to stabilize with low beta.

### DIFF
--- a/flight/Libraries/math/lqg.h
+++ b/flight/Libraries/math/lqg.h
@@ -33,6 +33,10 @@
 #include <pios.h>
 #include <misc_math.h>
 
+#define LQG_SOLVER_FAILED -1
+#define LQG_SOLVER_RUNNING 0
+#define LQG_SOLVER_DONE 1
+
 typedef struct rtkf_state* rtkf_t;
 typedef struct lqr_state* lqr_t;
 
@@ -40,17 +44,17 @@ typedef struct lqg_state* lqg_t;
 
 extern rtkf_t rtkf_create(float beta, float tau, float Ts, float R, float Q1, float Q2, float Q3, float biaslim);
 extern void rtkf_stabilize_covariance(rtkf_t rtkf, int iterations);
-extern bool rtkf_is_solved(rtkf_t rtkf);
+extern int rtkf_solver_status(rtkf_t rtkf);
 
 extern lqr_t lqr_create(float beta, float tau, float Ts, float q1, float q2, float r);
 extern void lqr_stabilize_covariance(lqr_t lqr, int iterations);
-extern bool lqr_is_solved(lqr_t lqr);
+extern int lqr_solver_status(lqr_t lqr);
 
 extern void lqr_update(lqr_t lqr, float q1, float q2, float r);
 extern void lqr_get_gains(lqr_t lqg, float K[2]);
 
 extern lqg_t lqg_create(rtkf_t rtkf, lqr_t lqr);
-extern bool lqg_is_solved(lqg_t lqg);
+extern int lqg_solver_status(lqg_t lqg);
 extern lqr_t lqg_get_lqr(lqg_t lqg);
 extern rtkf_t lqg_get_rtkf(lqg_t lqg);
 

--- a/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-LQG.html
+++ b/ground/gcs/src/plugins/systemhealth/html/SystemConfiguration-Error-LQG.html
@@ -6,6 +6,6 @@
   </head>
   <body style="color: black">
     <h1>System Configuration: Error</h1>
-    <p>At least one LQG-controller based flight mode has been configured, but no valid system identification has been data found. Please rerun the autotune wizard, or if necessary, or not done yet, the complete autotune procedure.</p>
+    <p>At least one LQG-controller based flight mode has been configured, but either bad or no valid system identification has been data found. Please rerun the autotune wizard, or if necessary, or not done yet, the complete autotune procedure.</p>
   </body>
 </html>


### PR DESCRIPTION
I was graphing convergence of things, when I tried typical beta and tau from weak yaw axes, like those micro brushed and the large ones that seem to have yaw drift. Turns out that low beta requires a lot more cycles for the RTKF to stabilize. It was capped to 150 cycles, which works fine for quads with a beta of 10, but yaw drifty problem quads usually have a beta below 8, which seems to require like 2000-2500 cycles to get stable.

A typical value that causes problems is beta 7.5 tau 0.028s. When you cap the RTKF at 150 cycles, the Kalman gains for torque and bias are just 15% and 11% of what they'd be when stabilized. Bias and external torque is way way slower with that, which is what I'm suspecting is giving it a hard time with the yaw axis, while stabilizing higher beta pitch and roll just fine.