### PR TITLE
GCS:Config: Add warning for collective channel assigned on non-heli

### DIFF
--- a/ground/gcs/src/plugins/config/configinputwidget.cpp
+++ b/ground/gcs/src/plugins/config/configinputwidget.cpp
@@ -2082,6 +2082,6 @@ void ConfigInputWidget::checkCollective()
 
     if (vehicle != SystemSettings::AIRFRAMETYPE_HELICP) {
         addWarning(m_config->gbChannelWarnings, inputForm,
-                   QStringLiteral("Collective is normally not used for this vehicle type, are you sure?"));
+                   tr("Collective is normally not used for this vehicle type, are you sure?"));
     }
 }

--- a/ground/gcs/src/plugins/config/configinputwidget.h
+++ b/ground/gcs/src/plugins/config/configinputwidget.h
@@ -248,6 +248,7 @@ private slots:
     void checkReprojection();
     void updateArmingConfig(UAVObject *manualControlSettings);
     void timeoutCheckboxChanged();
+    void checkCollective();
 
 protected:
     void resizeEvent(QResizeEvent *event);

--- a/ground/gcs/src/plugins/config/input.ui
+++ b/ground/gcs/src/plugins/config/input.ui
@@ -64,8 +64,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>865</width>
-            <height>589</height>
+            <width>867</width>
+            <height>580</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout">
@@ -108,7 +108,7 @@
               <item>
                <widget class="QStackedWidget" name="stackedWidget">
                 <property name="currentIndex">
-                 <number>1</number>
+                 <number>0</number>
                 </property>
                 <widget class="QWidget" name="advancedPage">
                  <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -299,6 +299,14 @@
                    </layout>
                   </item>
                   <item>
+                   <widget class="QGroupBox" name="gbChannelWarnings">
+                    <property name="title">
+                     <string>Warnings</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="verticalLayout_14"/>
+                   </widget>
+                  </item>
+                  <item>
                    <spacer name="verticalSpacer_2">
                     <property name="orientation">
                      <enum>Qt::Vertical</enum>
@@ -456,8 +464,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>865</width>
-            <height>589</height>
+            <width>867</width>
+            <height>580</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -1590,8 +1598,8 @@ margin:1px;</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>865</width>
-            <height>589</height>
+            <width>867</width>
+            <height>580</height>
            </rect>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_2">

--- a/ground/gcs/src/plugins/config/input.ui
+++ b/ground/gcs/src/plugins/config/input.ui
@@ -300,6 +300,11 @@
                   </item>
                   <item>
                    <widget class="QGroupBox" name="gbChannelWarnings">
+                    <property name="styleSheet">
+                     <string notr="true">* &gt; QLabel {
+	color: red;
+}</string>
+                    </property>
                     <property name="title">
                      <string>Warnings</string>
                     </property>

--- a/ground/gcs/src/plugins/config/inputchannelform.cpp
+++ b/ground/gcs/src/plugins/config/inputchannelform.cpp
@@ -246,6 +246,8 @@ void inputChannelForm::groupUpdated()
         if (selected > 0 && selected <= count)
             ui->channelNumberDropdown->setCurrentIndex(selected);
     }
+
+    Q_EMIT assignmentChanged();
 }
 
 /**
@@ -262,6 +264,7 @@ void inputChannelForm::channelDropdownUpdated(int newval)
 void inputChannelForm::channelNumberUpdated(int newval)
 {
     ui->channelNumberDropdown->setCurrentIndex(newval);
+    Q_EMIT assignmentChanged();
 }
 
 /**
@@ -277,4 +280,13 @@ void inputChannelForm::reverseChannel()
     if (ui->channelName->text() == "Throttle") // this is bad... but...
         neutral = max - (neutral - min);
     ui->channelNeutral->setValue(neutral);
+}
+
+/**
+ * @brief Is an input assigned to this channel?
+ */
+bool inputChannelForm::assigned()
+{
+    return ui->channelGroup->currentIndex() != ManualControlSettings::CHANNELGROUPS_NONE
+            && ui->channelNumber->value() > 0;
 }

--- a/ground/gcs/src/plugins/config/inputchannelform.h
+++ b/ground/gcs/src/plugins/config/inputchannelform.h
@@ -19,6 +19,11 @@ public:
     ~inputChannelForm();
     friend class ConfigInputWidget;
     void setName(QString &name);
+    bool assigned();
+
+Q_SIGNALS:
+    void assignmentChanged();
+
 private slots:
     void minMaxUpdated();
     void groupUpdated();


### PR DESCRIPTION
This warning appears when collective is assigned a type and channel number for anything that isn't a CP heli. Is that too broad?

Fixes #2101
Supersedes #2207

![screenshot from 2018-05-20 17-05-13](https://user-images.githubusercontent.com/9995998/40275876-0432a006-5c50-11e8-9368-5c2650df1436.png)
