### PR TITLE
UAVOMSPBridge: Use memcpy instead of strncpy where src len >= dest

### DIFF
--- a/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
+++ b/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
@@ -384,8 +384,7 @@ static void msp_send_fc_variant(struct msp_bridge *m)
 
 	memset(&data, 0, sizeof(data));
 
-	/* strncpy(data.var.name, "BTFL", 4);*/
-	strncpy(data.var.name, "DRON", 4);
+	memcpy(data.var.name, "DRON", 4);
 
 	msp_send(m, MSP_FC_VARIANT, data.buf, sizeof(data));
 }
@@ -402,7 +401,7 @@ static void msp_send_board_info(struct msp_bridge *m)
 
 	memset(&data, 0, sizeof(data));
 
-	strncpy(data.board.name, DRONIN_TARGET, 4);
+	memcpy(data.board.name, DRONIN_TARGET, MIN(4, strlen(DRONIN_TARGET)));
 
 	msp_send(m, MSP_BOARD_INFO, data.buf, sizeof(data));
 }


### PR DESCRIPTION
GCC8 doesn't like it otherwise:

```/home/mike/dev/dronin/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c: In function ‘msp_send_fc_variant’:
/home/mike/dev/dronin/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c:388:2: error: ‘strncpy’ output truncated before terminating nul
copying 4 bytes from a string of the same length [-Werror=stringop-truncation]
  strncpy(data.var.name, "DRON", 4);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/mike/dev/dronin/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c: In function ‘msp_send_board_info’:
/home/mike/dev/dronin/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c:405:2: error: ‘strncpy’ output truncated copying 4 bytes from a
string of length 7 [-Werror=stringop-truncation]
  strncpy(data.board.name, DRONIN_TARGET, 4);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors```