### PR TITLE
uavobjectmanager: Pack UAVObjEvent, saves 4% CPU for whatever the hell.

### DIFF
--- a/flight/UAVObjects/inc/uavobjectmanager.h
+++ b/flight/UAVObjects/inc/uavobjectmanager.h
@@ -120,7 +120,7 @@ typedef struct {
 	struct ObjectEventEntryThrottled *throttle;
 
 	uint16_t instId;
-} UAVObjEvent;
+} __attribute__((packed)) UAVObjEvent;
 
 /**
  * Event callback, this function is called when an event is invoked. The function


### PR DESCRIPTION
This and #2210 brings CPU on F3 back to old levels of a few weeks back.

It works. Why? I have no idea.