### PR TITLE
gcs,build: Stop the fucking AVs from freaking out.

### DIFF
--- a/ground/gcs/src/app/app.pro
+++ b/ground/gcs/src/app/app.pro
@@ -27,7 +27,8 @@ win32 {
     INSTALLS += target
     win32-msvc* {
         # set stack size to 8mb, default is 1mb (vs. 8mb for main thread on osx and linux)
-        QMAKE_LFLAGS   += /STACK:8388608
+        QMAKE_LFLAGS   += /STACK:8388608 /LTCG
+        QMAKE_CXXFLAGS += -GL
     }
 } else:macx {
     LIBS += -framework CoreFoundation


### PR DESCRIPTION
Using link-time code generation on MSVC for building drgcs.exe seems to shut up practically all scanners over on VirusTotal.com. At least when built over here. This PR is currently for Jenkins.