### PR TITLE
charosd: Rename LQG-A to LQG-L to actually fit the respective flightmode, plus readability.

### DIFF
--- a/flight/Modules/CharacterOSD/panel.c
+++ b/flight/Modules/CharacterOSD/panel.c
@@ -220,7 +220,7 @@ static void FLIGHTMODE_update(charosd_state_t state, uint8_t x, uint8_t y)
 		mode = "LQGR";
 		break;
 	case FLIGHTSTATUS_FLIGHTMODE_LQGLEVELING:
-		mode = "LQGA";
+		mode = "LQGL";
 		break;
 	case FLIGHTSTATUS_FLIGHTMODE_FLIPREVERSED:
 		mode = "FLIP";


### PR DESCRIPTION
LQGA stood for AttitudeLQG, but the mode got renamed to LQGLeveling eventually. Is already LQG-L in the graphical OSD. This updates things. Makes it also better to discern from LQG-R, because A and R look apparently too similar in CharOSD.

Still keeping the acro mode as LQG-R, because -R is cooler, and looks loosely like an A, anyway.

Addresses #2223.