### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [dronin.org](http://dronin.org) for more details.
 
 ### Full Support
 
-- [AeroQuad32](http://aeroquad.com/showwiki.php?title=AeroQuad32-Flight-Control-Board-v2)
+- AeroQuad32
 - [BrainFPV](http://brainfpv.com/)
 - [BrainFPV RE1](http://brainfpv.com/) (no nav sensors on board)
 - [DTFAir DTFc](http://www.dtfuhf.com/) (no nav sensors on board)  Also Colibri Race / TBS PowerCube.


### PR DESCRIPTION
The hyperlink for Aeroquad32 takes you to an unhosted domain.  The Aeroquad github doesn't look like it has been touched for almost 2 years.  Figured it would be best to just take the link out.