### PR TITLE
attitude: Implement sensor decimation.

### DIFF
--- a/shared/uavobjectdefinition/attitudesettings.xml
+++ b/shared/uavobjectdefinition/attitudesettings.xml
@@ -53,5 +53,8 @@
         <option>PREMERLANI_GPS</option>
       </options>
     </field>
+    <field defaultvalue="100" elements="1" name="DesiredUpdateRate" type="uint16" units="Hz">
+      <description>The update rate the attitude filter is supposed to run at. Values below 100Hz will run the estimator at gyro rates.</description>
+    </field>
   </object>
 </xml>


### PR DESCRIPTION
Moves the collection of the gyro samples from the updateAttitudeINSGPS/updateAttitudeComplementary functions to the task function, and collects samples averaging them based on a decimator value calculated. Current default runtime for the attitude filter in this patch is 100hz, which drops the CPU usage in TaskInfo from 15% to about 2-3%. It still flies good (at least in the living room, rain and all).

PR for Maquiabelo, for artifacts.