### PR TITLE
Flight - Fix Pikoblx bootloop.

### DIFF
--- a/flight/targets/pikoblx/board-info/board_hw_defs.c
+++ b/flight/targets/pikoblx/board-info/board_hw_defs.c
@@ -756,6 +756,16 @@ static const struct pios_ppm_cfg pios_ppm_cfg = {
  * Vsense: PA5 ADC2_CH2
  */
  
+uintptr_t pios_internal_adc_id;
+
+void DMA2_Channel1_IRQHandler(void) __attribute__((alias("PIOS_ADC_DMA_irq_handler")));
+
+void PIOS_ADC_DMA_irq_handler(void)
+{
+	/* Call into the generic code to handle the IRQ for this specific device */
+	PIOS_INTERNAL_ADC_DMA_Handler(pios_internal_adc_id);
+}
+
 static const struct pios_internal_adc_cfg internal_adc_cfg = {
 	.dma = {
 		.irq = {

--- a/flight/targets/pikoblx/board-info/board_hw_defs.c
+++ b/flight/targets/pikoblx/board-info/board_hw_defs.c
@@ -157,92 +157,6 @@ static const struct pios_spi_cfg pios_spi_gyro_cfg = {
 };
 #endif
 
-#if defined(PIOS_INCLUDE_I2C)
-
-#include <pios_i2c_priv.h>
-
-/*
- * I2C Adapters
- */
-
-/* External I2C shared with UART1 */
-
-void PIOS_I2C_u1_ev_irq_handler(void);
-void PIOS_I2C_u1_er_irq_handler(void);
-void I2C1_EV_EXTI23_IRQHandler() __attribute__ ((alias ("PIOS_I2C_u1_ev_irq_handler")));
-void I2C1_ER_IRQHandler() __attribute__ ((alias ("PIOS_I2C_u1_er_irq_handler")));
-
-static const struct pios_i2c_adapter_cfg pios_i2c_u1_cfg = {
-  .regs = I2C1,
-  .remap = GPIO_AF_4,
-  .init = {
-    .I2C_Mode                = I2C_Mode_I2C,
-    .I2C_OwnAddress1         = 0,
-    .I2C_Ack                 = I2C_Ack_Enable,
-    .I2C_AcknowledgedAddress = I2C_AcknowledgedAddress_7bit,
-    .I2C_DigitalFilter       = 0x00,
-    .I2C_AnalogFilter        = I2C_AnalogFilter_Enable,
-    .I2C_Timing              = 0x70310309,			//50kHz I2C @ 8MHz input -> PRESC=0x7, SCLDEL=0x3, SDADEL=0x1, SCLH=0x03, SCLL=0x09
-  },
-  .transfer_timeout_ms = 50,
-  .scl = {
-    .gpio = GPIOB,
-    .init = {
-	    .GPIO_Pin = GPIO_Pin_6,
-            .GPIO_Mode  = GPIO_Mode_AF,
-            .GPIO_Speed = GPIO_Speed_50MHz,
-            .GPIO_OType = GPIO_OType_PP,
-            .GPIO_PuPd  = GPIO_PuPd_NOPULL,
-    },
-	.pin_source = GPIO_PinSource6,
-  },
-  .sda = {
-    .gpio = GPIOB,
-    .init = {
-			.GPIO_Pin = GPIO_Pin_7,
-            .GPIO_Mode  = GPIO_Mode_AF,
-            .GPIO_Speed = GPIO_Speed_50MHz,
-            .GPIO_OType = GPIO_OType_PP,
-            .GPIO_PuPd  = GPIO_PuPd_NOPULL,
-    },
-	.pin_source = GPIO_PinSource7,
-  },
-  .event = {
-    .flags   = 0,		/* FIXME: check this */
-    .init = {
-			.NVIC_IRQChannel = I2C1_EV_IRQn,
-			.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_HIGHEST,
-			.NVIC_IRQChannelSubPriority = 0,
-			.NVIC_IRQChannelCmd = ENABLE,
-    },
-  },
-  .error = {
-    .flags   = 0,		/* FIXME: check this */
-    .init = {
-			.NVIC_IRQChannel = I2C1_ER_IRQn,
-			.NVIC_IRQChannelPreemptionPriority = PIOS_IRQ_PRIO_HIGHEST,
-			.NVIC_IRQChannelSubPriority = 0,
-			.NVIC_IRQChannelCmd = ENABLE,
-    },
-  },
-};
-
-pios_i2c_t pios_i2c_u1_id;
-
-void PIOS_I2C_u1_ev_irq_handler(void)
-{
-  /* Call into the generic code to handle the IRQ for this specific device */
-  PIOS_I2C_EV_IRQ_Handler(pios_i2c_u1_id);
-}
-
-void PIOS_I2C_u1_er_irq_handler(void)
-{
-  /* Call into the generic code to handle the IRQ for this specific device */
-  PIOS_I2C_ER_IRQ_Handler(pios_i2c_u1_id);
-}
-
-#endif /* PIOS_INCLUDE_I2C */
-
 #if defined(PIOS_INCLUDE_FLASH)
 #include "pios_flashfs_logfs_priv.h"
 
@@ -978,7 +892,7 @@ static const struct pios_exti_cfg pios_exti_mpu_cfg __exti_config = {
 
 static struct pios_mpu_cfg pios_mpu_cfg = {
     .exti_cfg = &pios_exti_mpu_cfg,
-    .default_samplerate = 1000,
+    .default_samplerate = 500,
     .orientation = PIOS_MPU_TOP_90DEG
 };
 #endif /* PIOS_INCLUDE_MPU */

--- a/flight/targets/pikoblx/fw/Makefile
+++ b/flight/targets/pikoblx/fw/Makefile
@@ -41,18 +41,14 @@ MODULES += FirmwareIAP
 MODULES += Telemetry
 
 OPTMODULES += GPS
-OPTMODULES += CameraStab
 OPTMODULES += Autotune
 OPTMODULES += TxPID
-OPTMODULES += PathPlanner
-OPTMODULES += VtolPathFollower
-OPTMODULES += FixedWingPathFollower
+OPTMODULES += VibrationAnalysis
 OPTMODULES += UAVOMavlinkBridge
 OPTMODULES += UAVOMSPBridge
 OPTMODULES += UAVOLighttelemetryBridge
 OPTMODULES += Battery
 OPTMODULES += ComUsbBridge
-#OPTMODULES += Airspeed
 OPTMODULES += UAVOHoTTBridge
 OPTMODULES += UAVOFrSKYSensorHubBridge
 OPTMODULES += UAVOFrSKYSPortBridge
@@ -109,12 +105,6 @@ include $(PIOS)/STM32F30x/library_chibios.mk
 include $(PIOS)/pios_flight_library.mk
 
 SRC += pios_mpu.c
-SRC += pios_ms5611.c
-SRC += pios_etasv3.c
-SRC += pios_mpxv5004.c
-SRC += pios_mpxv7002.c
-SRC += pios_hmc5883.c
-SRC += pios_hmc5983_i2c.c
 SRC += pios_usbhook.c
 
 # List C++ source files here.

--- a/flight/targets/pikoblx/fw/pios_board.c
+++ b/flight/targets/pikoblx/fw/pios_board.c
@@ -205,46 +205,46 @@ void PIOS_Board_Init(void)
 	HwSharedPortTypesOptions hw_uart1;
 	HwPikoBLXUart1Get(&hw_uart1);
 	PIOS_HAL_ConfigurePort(hw_uart1,            // port_type
-						&pios_uart1_usart_cfg,  // usart_port_cfg
-						&pios_usart_com_driver, // com_driver
-						NULL,                   //&pios_i2c_u1_id, // i2c_id
-						NULL,                   //&pios_i2c_u1_cfg, // i2c_cfg
-						NULL,                   // ppm_cfg
-						NULL,                   // pwm_cfg
-						PIOS_LED_ALARM,         // led_id
-						&pios_uart1_dsm_cfg,    // dsm_cfg
-						hw_DSMxMode,            // dsm_mode
-						NULL);                  // sbus_cfg
+	                    &pios_uart1_usart_cfg,  // usart_port_cfg
+	                    &pios_usart_com_driver, // com_driver
+	                    NULL,                   // i2c_id
+	                    NULL,                   // i2c_cfg
+	                    NULL,                   // ppm_cfg
+	                    NULL,                   // pwm_cfg
+	                    PIOS_LED_ALARM,         // led_id
+	                    &pios_uart1_dsm_cfg,    // dsm_cfg
+	                    hw_DSMxMode,            // dsm_mode
+	                    NULL);                  // sbus_cfg
 	
 	/* Configure Uart2 */
 	HwSharedPortTypesOptions hw_uart2;
 	HwPikoBLXUart2Get(&hw_uart2);
 	PIOS_HAL_ConfigurePort(hw_uart2,            // port_type
-						&pios_uart2_usart_cfg,  // usart_port_cfg
-						&pios_usart_com_driver, // com_driver
-						NULL,                   // i2c_id
-						NULL,                   // i2c_cfg
-						NULL,                   // ppm_cfg
-						NULL,                   // pwm_cfg
-						PIOS_LED_ALARM,         // led_id
-						&pios_uart2_dsm_cfg,    // dsm_cfg
-						hw_DSMxMode,            // dsm_mode
-						NULL);                  // sbus_cfg
+	                    &pios_uart2_usart_cfg,  // usart_port_cfg
+	                    &pios_usart_com_driver, // com_driver
+	                    NULL,                   // i2c_id
+	                    NULL,                   // i2c_cfg
+	                    NULL,                   // ppm_cfg
+	                    NULL,                   // pwm_cfg
+	                    PIOS_LED_ALARM,         // led_id
+	                    &pios_uart2_dsm_cfg,    // dsm_cfg
+	                    hw_DSMxMode,            // dsm_mode
+	                    NULL);                  // sbus_cfg
 
 	/* Configure Uart3 */
 	HwSharedPortTypesOptions hw_rxp;
 	HwPikoBLXRxPortGet(&hw_rxp);
 	PIOS_HAL_ConfigurePort(hw_rxp,              // port_type
-						&pios_uart3_usart_cfg,  // usart_port_cfg
-						&pios_usart_com_driver, // com_driver
-						NULL,                   // i2c_id
-						NULL,                   // i2c_cfg
-						&pios_ppm_cfg,          // ppm_cfg
-						NULL,                   // pwm_cfg
-						PIOS_LED_ALARM,         // led_id
-						&pios_uart3_dsm_cfg,    // dsm_cfg
-						hw_DSMxMode,            // dsm_mode
-						NULL);                  // sbus_cfg
+	                    &pios_uart3_usart_cfg,  // usart_port_cfg
+	                    &pios_usart_com_driver, // com_driver
+	                    NULL,                   // i2c_id
+	                    NULL,                   // i2c_cfg
+	                    &pios_ppm_cfg,          // ppm_cfg
+	                    NULL,                   // pwm_cfg
+	                    PIOS_LED_ALARM,         // led_id
+	                    &pios_uart3_dsm_cfg,    // dsm_cfg
+	                    hw_DSMxMode,            // dsm_mode
+	                    NULL);                  // sbus_cfg
 
 #ifndef PIOS_DEBUG_ENABLE_DEBUG_PINS
 #ifdef PIOS_INCLUDE_SERVO
@@ -255,11 +255,12 @@ void PIOS_Board_Init(void)
 #endif
 
 #if defined(PIOS_INCLUDE_ADC)
-	uintptr_t internal_adc_id;
-	if (PIOS_INTERNAL_ADC_Init(&internal_adc_id, &internal_adc_cfg) < 0)
+	uintptr_t unused_adc;
+	if (PIOS_INTERNAL_ADC_Init(&pios_internal_adc_id, &internal_adc_cfg) < 0)
 		PIOS_Assert(0);
-	PIOS_ADC_Init(&pios_internal_adc_id, &pios_internal_adc_driver, internal_adc_id);
+	PIOS_ADC_Init(&unused_adc, &pios_internal_adc_driver, pios_internal_adc_id);
 #endif /* PIOS_INCLUDE_ADC */
+
 	PIOS_WDG_Clear();
 	PIOS_DELAY_WaitmS(200);
 	PIOS_WDG_Clear();

--- a/flight/targets/pikoblx/fw/pios_board.c
+++ b/flight/targets/pikoblx/fw/pios_board.c
@@ -204,47 +204,47 @@ void PIOS_Board_Init(void)
 
 	HwSharedPortTypesOptions hw_uart1;
 	HwPikoBLXUart1Get(&hw_uart1);
-	PIOS_HAL_ConfigurePort(hw_uart1, // port_type
-						&pios_uart1_usart_cfg, // usart_port_cfg
+	PIOS_HAL_ConfigurePort(hw_uart1,            // port_type
+						&pios_uart1_usart_cfg,  // usart_port_cfg
 						&pios_usart_com_driver, // com_driver
-						&pios_i2c_u1_id, // i2c_id
-						&pios_i2c_u1_cfg, // i2c_cfg
-						NULL, // ppm_cfg
-						NULL, // pwm_cfg
-						PIOS_LED_ALARM, // led_id
-						&pios_uart1_dsm_cfg, // dsm_cfg
-						hw_DSMxMode, // dsm_mode
-						NULL); // sbus_cfg
+						NULL,                   //&pios_i2c_u1_id, // i2c_id
+						NULL,                   //&pios_i2c_u1_cfg, // i2c_cfg
+						NULL,                   // ppm_cfg
+						NULL,                   // pwm_cfg
+						PIOS_LED_ALARM,         // led_id
+						&pios_uart1_dsm_cfg,    // dsm_cfg
+						hw_DSMxMode,            // dsm_mode
+						NULL);                  // sbus_cfg
 	
 	/* Configure Uart2 */
 	HwSharedPortTypesOptions hw_uart2;
 	HwPikoBLXUart2Get(&hw_uart2);
-	PIOS_HAL_ConfigurePort(hw_uart2, // port_type
-						&pios_uart2_usart_cfg, // usart_port_cfg
+	PIOS_HAL_ConfigurePort(hw_uart2,            // port_type
+						&pios_uart2_usart_cfg,  // usart_port_cfg
 						&pios_usart_com_driver, // com_driver
-						NULL, // i2c_id
-						NULL, // i2c_cfg
-						NULL, // ppm_cfg
-						NULL, // pwm_cfg
-						PIOS_LED_ALARM, // led_id
-						&pios_uart2_dsm_cfg, // dsm_cfg
-						hw_DSMxMode, // dsm_mode
-						NULL); // sbus_cfg
+						NULL,                   // i2c_id
+						NULL,                   // i2c_cfg
+						NULL,                   // ppm_cfg
+						NULL,                   // pwm_cfg
+						PIOS_LED_ALARM,         // led_id
+						&pios_uart2_dsm_cfg,    // dsm_cfg
+						hw_DSMxMode,            // dsm_mode
+						NULL);                  // sbus_cfg
 
 	/* Configure Uart3 */
 	HwSharedPortTypesOptions hw_rxp;
 	HwPikoBLXRxPortGet(&hw_rxp);
-	PIOS_HAL_ConfigurePort(hw_rxp, // port_type
-						&pios_uart3_usart_cfg, // usart_port_cfg
+	PIOS_HAL_ConfigurePort(hw_rxp,              // port_type
+						&pios_uart3_usart_cfg,  // usart_port_cfg
 						&pios_usart_com_driver, // com_driver
-						NULL, // i2c_id
-						NULL, // i2c_cfg
-						&pios_ppm_cfg, // ppm_cfg
-						NULL, // pwm_cfg
-						PIOS_LED_ALARM, // led_id
-						&pios_uart3_dsm_cfg, // dsm_cfg
-						hw_DSMxMode, // dsm_mode
-						NULL); // sbus_cfg
+						NULL,                   // i2c_id
+						NULL,                   // i2c_cfg
+						&pios_ppm_cfg,          // ppm_cfg
+						NULL,                   // pwm_cfg
+						PIOS_LED_ALARM,         // led_id
+						&pios_uart3_dsm_cfg,    // dsm_cfg
+						hw_DSMxMode,            // dsm_mode
+						NULL);                  // sbus_cfg
 
 #ifndef PIOS_DEBUG_ENABLE_DEBUG_PINS
 #ifdef PIOS_INCLUDE_SERVO

--- a/flight/targets/pikoblx/fw/pios_config.h
+++ b/flight/targets/pikoblx/fw/pios_config.h
@@ -26,12 +26,7 @@
  * with this program; if not, see <http://www.gnu.org/licenses/>
  */
 
-
- 
- 
- 
- 
- #ifndef PIOS_CONFIG_H
+#ifndef PIOS_CONFIG_H
 #define PIOS_CONFIG_H
 
 #include <pios_flight_config.h>

--- a/flight/targets/pikoblx/fw/pios_config.h
+++ b/flight/targets/pikoblx/fw/pios_config.h
@@ -26,7 +26,12 @@
  * with this program; if not, see <http://www.gnu.org/licenses/>
  */
 
-#ifndef PIOS_CONFIG_H
+
+ 
+ 
+ 
+ 
+ #ifndef PIOS_CONFIG_H
 #define PIOS_CONFIG_H
 
 #include <pios_flight_config.h>
@@ -38,13 +43,9 @@
 #define PIOS_INCLUDE_DMA_CB_SUBSCRIBING_FUNCTION
 
 #define PIOS_INCLUDE_SPI
-#define PIOS_INCLUDE_I2C
 
 /* Select the sensors to include */
 #define PIOS_INCLUDE_MPU
-#define PIOS_INCLUDE_HMC5883
-#define PIOS_INCLUDE_HMC5983_I2C
-#define PIOS_TOLERATE_MISSING_SENSORS
 
 /* Com systems to include */
 #define PIOS_INCLUDE_MAVLINK
@@ -52,9 +53,7 @@
 
 /* Supported receiver interfaces */
 
-
 /* Flags that alter behaviors */
-//#define PIOS_TELEM_PRIORITY_QUEUE       /* Enable a priority queue in telemetry */
 #define AUTOTUNE_AVERAGING_DECIMATION 2
 
 /* Alarm Thresholds */
@@ -74,8 +73,6 @@
  * A change in the cpu load calculation or the idle task handler will invalidate this as well.
  */
 #define IDLE_COUNTS_PER_SEC_AT_NO_LOAD (2175780)
-
-#define CAMERASTAB_POI_MODE
 
 #define PIOS_INCLUDE_FASTHEAP
 

--- a/shared/uavobjectdefinition/hwpikoblx.xml
+++ b/shared/uavobjectdefinition/hwpikoblx.xml
@@ -17,7 +17,6 @@
         <option>FrSKY SPort Non Inverted</option>
         <option>GPS</option>
         <option>HoTT Telemetry</option>
-        <option>I2C</option>
         <option>LighttelemetryTx</option>
         <option>SRXL</option>
         <option>MavLinkTX</option>


### PR DESCRIPTION
PikoBlx was missing some of the necessary ADC rework from the F3 ADC re-work PR.  This PR adds those changes, along with changing the loop rate from 1000 Hz to 500 Hz to improve CPU throughput, and removes some unnecessary modules to improve memory usage.