### PR TITLE
GCS:UAVTalk: Don't check backlog for QFileDevices

### DIFF
--- a/ground/gcs/src/plugins/kmlexport/kmlexport.cpp
+++ b/ground/gcs/src/plugins/kmlexport/kmlexport.cpp
@@ -55,7 +55,7 @@ KmlExport::KmlExport(QString inputLogFileName, QString outputKmlFileName)
     UAVObjectsInitialize(kmlUAVObjectManager);
 
     // Connect new UAVO manager to a UAVTalk instance
-    kmlTalk = new UAVTalk(&logFile, kmlUAVObjectManager);
+    kmlTalk = new UAVTalk(&logFile, kmlUAVObjectManager, false);
 
     // Get the UAVObjects
     airspeedActual = AirspeedActual::GetInstance(kmlUAVObjectManager);

--- a/ground/gcs/src/plugins/logging/loggingplugin.cpp
+++ b/ground/gcs/src/plugins/logging/loggingplugin.cpp
@@ -138,7 +138,7 @@ bool LoggingThread::openFile(QString file, LoggingPlugin *parent)
     ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();
     UAVObjectManager *objManager = pm->getObject<UAVObjectManager>();
 
-    uavTalk = new UAVTalk(&logFile, objManager);
+    uavTalk = new UAVTalk(&logFile, objManager, false);
     connect(parent, SIGNAL(stopLoggingSignal()), this, SLOT(stopLogging()));
 
     return true;

--- a/ground/gcs/src/plugins/uavtalk/uavtalk.h
+++ b/ground/gcs/src/plugins/uavtalk/uavtalk.h
@@ -60,7 +60,7 @@ public:
         quint32 rxErrors;
     };
 
-    UAVTalk(QIODevice *iodev, UAVObjectManager *objMngr);
+    UAVTalk(QIODevice *iodev, UAVObjectManager *objMngr, bool canBlock = true);
     ~UAVTalk();
     bool sendObject(UAVObject *obj, bool acked, bool allInstances);
     bool sendObjectRequest(UAVObject *obj, bool allInstances);
@@ -134,6 +134,7 @@ protected:
     // Variables
     QPointer<QIODevice> io;
     UAVObjectManager *objMngr;
+    bool canBlock;
 
     // This is a tradeoff between the frequency of the need to
     // compact/copy left and buffer size.


### PR DESCRIPTION
It has quite a large buffer, larger than our backlog limit for telemetry, thus it always got blocked by our internal backlog check and stopped working entirely.

Fixes #2237 