### PR TITLE
disable '-Werror' on linux too. Fix issue #2205

### DIFF
--- a/ground/gcs/gcs.pri
+++ b/ground/gcs/gcs.pri
@@ -130,11 +130,6 @@ linux {
     QMAKE_LFLAGS += -Wl,--allow-shlib-undefined -Wl,--no-undefined
 }
 
-linux-g++* {
-    # Enable -Werror on Linux, should do this for all platforms once warnings are all eliminated
-    QMAKE_CXXFLAGS_WARN_ON += -Werror
-}
-
 win32 {
     # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=52991
     !win32-msvc*:QMAKE_CXXFLAGS += -mno-ms-bitfields


### PR DESCRIPTION
This solution was proposed by @tracernz on https://forum.dronin.org/forum/d/596-compiling-jihlein-s-gcs-fork-on-ubuntu-amd-2400g/ .
Tested on Fedora with GCC 8.3.1