### PR TITLE
UAVOMSPBridge: Send ! instead of | for MSP error

### DIFF
--- a/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
+++ b/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c
@@ -235,7 +235,7 @@ static void msp_send_error(struct msp_bridge *m, uint8_t cmd)
 
 	buf[0] = '$';
 	buf[1] = 'M';
-	buf[2] = '|';
+	buf[2] = '!'; /* original multiwii spec says '|', everyone uses '!' */
 	buf[3] = 0;
 	buf[4] = cmd;
 	buf[5] = cmd;	// Checksum == cmd


### PR DESCRIPTION
This was raised in a BLHeli issue[6]. The MSP code sends a message with `|` in
the case of an unknown message type[1]. That is consistent with the Multiwii
protocol spec[2], but differs from the actual multiwii/baseflight/betaflight
implementations, which send `!`[3][4][5]. Since we're on our own here, I think
we need to disregard the original protocol spec. Fixes #2247 

[1] https://github.com/d-ronin/dRonin/blob/7b44093d461d073eba52d8d9558a4e56769fd4b3/flight/Modules/UAVOMSPBridge/UAVOMSPBridge.c#L238
[2] http://www.multiwii.com/forum/viewtopic.php?f=8&t=1516
[3] https://github.com/multiwii/multiwii-firmware/blob/upstream_shared/Protocol.cpp#L127
[4] https://github.com/multiwii/baseflight/blob/master/src/serial.c#L214
[5] https://github.com/betaflight/betaflight/blob/8e10e735807945dcf53a3a563085a2df91100355/src/main/msp/msp_serial.c#L305
[6] https://github.com/bitdump/BLHeli/issues/324#issuecomment-477249163