### PR TITLE
GCS:Config: Allow zero battery cells to disable auto-detect

### DIFF
--- a/ground/gcs/src/plugins/config/modules.ui
+++ b/ground/gcs/src/plugins/config/modules.ui
@@ -635,7 +635,7 @@
                     <bool>false</bool>
                    </property>
                    <property name="minimum">
-                    <number>1</number>
+                    <number>0</number>
                    </property>
                    <property name="objrelation" stdset="0">
                     <stringlist>


### PR DESCRIPTION
Allow a value of 0 cells so automatic cell detection isn't forced to report a battery fault when powered by USB alone.
Setting 0  is allowed in UAVO browser but applying changes in modules tab always updated FlightbatterySettings > NbCells to 1