### PR TITLE
Flight: Add CF Accel Cutoff (Experimental - Not for merge)

### DIFF
--- a/flight/Modules/Attitude/attitude.c
+++ b/flight/Modules/Attitude/attitude.c
@@ -162,6 +162,7 @@ static float dT_expected = 0.001f;	// assume 1KHz if we don't know.
 
 #define ACCEL_ONE_G (9.8065f)
 static float accel_confidence_decay = 2; /* 1 / sqrt(0.25) */
+float accel_confidence;
 
 // Private functions
 static void AttitudeTask(void *parameters);
@@ -774,7 +775,7 @@ static int32_t updateAttitudeComplementary(float dT, bool first_run, bool second
 	/* Computes confidence in accelerometers when aircraft is being accelerated over
 	   and above that due to gravity. (c) G.K. Egan */
 
-	float accel_confidence = bound_min_max(1.0f - (accel_confidence_decay * sqrtf(fabs(accel_mag / ACCEL_ONE_G - 1.0f))), 0.0f, 1.0f);
+	accel_confidence = bound_min_max(1.0f - (accel_confidence_decay * sqrtf(fabs(accel_mag / ACCEL_ONE_G - 1.0f))), 0.0f, 1.0f);
 	
 	// Accumulate integral of error.  Scale here so that units are (deg/s) but Ki has units of s
 	GyrosBiasData gyrosBias;
@@ -1001,6 +1002,7 @@ static int32_t setAttitudeComplementary()
 	AttitudeActualData attitude;
 	quat_copy(cf_q, &attitude.q1);
 	Quaternion2RPY(&attitude.q1,&attitude.Roll);
+	attitude.AccelConfidence = accel_confidence;
 	AttitudeActualSet(&attitude);
 
 	return 0;

--- a/shared/uavobjectdefinition/attitudeactual.xml
+++ b/shared/uavobjectdefinition/attitudeactual.xml
@@ -26,5 +26,8 @@
     <field defaultvalue="0" elements="1" name="Yaw" type="float" units="degrees">
       <description/>
     </field>
+    <field defaultvalue="0" elements="1" name="AccelConfidence" type="float" units="">
+      <description/>
+    </field>
   </object>
 </xml>

--- a/shared/uavobjectdefinition/attitudesettings.xml
+++ b/shared/uavobjectdefinition/attitudesettings.xml
@@ -25,6 +25,9 @@
     <field defaultvalue="0.4" elements="1" name="AccKi" type="float" units="channel">
       <description>Accelerometer integral gain for the attitude filter.</description>
     </field>
+    <field defaultvalue="0.1" elements="1" name="AccCutoff" type="float" units="">
+      <description>Accelerometer cutoff value.</description>
+    </field>
     <field defaultvalue="0.1" elements="1" name="AccelTau" type="float" units="">
       <description/>
     </field>

--- a/shared/uavobjectdefinition/attitudesettings.xml
+++ b/shared/uavobjectdefinition/attitudesettings.xml
@@ -25,7 +25,7 @@
     <field defaultvalue="0.4" elements="1" name="AccKi" type="float" units="channel">
       <description>Accelerometer integral gain for the attitude filter.</description>
     </field>
-    <field defaultvalue="0.1" elements="1" name="AccCutoff" type="float" units="">
+    <field defaultvalue="0.25" elements="1" name="AccCutoff" type="float" units="" limits="%BE:0.1:1">
       <description>Accelerometer cutoff value.</description>
     </field>
     <field defaultvalue="0.1" elements="1" name="AccelTau" type="float" units="">


### PR DESCRIPTION
This PR adds an accel cutoff to the complementary attitude filter.  It's purpose is to prevent the bias calculations from running away when the aircraft is subjected to flight loads above and below 1 G.

There is a new UAVObject, AccCutoff, in the attitude settings that defines how sharp the cutoff is.  It defaults to 0.1.  An accel confidence factor is calculated from the cutoff and current magnitude of the accel vector.  The accel confidence ranges from 0 to 1, and is multiplied against accKi and accKp, effectively freezing the bias terms during dynamic maneuvering.

This has not been flight tested.  On the bench it does not do anything strange.  Comments and flight test help appreciated.  I used this concept on a different project quite a few years back.  It seemed to work as desired.  But as always, test carefully.