### PR TITLE
Updated QT url location in tools.mk

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -118,7 +118,9 @@ endef
 .PHONY: qt_sdk_install
 
 # QT SDK download URL
-QT_URL_PREFIX := http://download.qt.io/$(QT_VERSION_SOURCE)_releases/qt/$(QT_VERSION_SHORT)/$(QT_VERSION_FULL)/qt-opensource-
+# QT_URL_PREFIX := http://download.qt.io/$(QT_VERSION_SOURCE)_releases/qt/$(QT_VERSION_SHORT)/$(QT_VERSION_FULL)/qt-opensource-
+QT_URL_PREFIX := https://download.qt.io/archive/qt/$(QT_VERSION_SHORT)/$(QT_VERSION_FULL)/qt-opensource-
+$(info $$QT_URL_PREFIX is [${QT_URL_PREFIX}])
 ifdef LINUX
   ifdef AMD64
     # Linux 64-bit


### PR DESCRIPTION
QT changed URL for QT package download, breaking 'make qt_sdk_install'

This pull updattes QT url location in tools.mk in case others want to fix.